### PR TITLE
fix(components): fix Sidebar NavItem bug on Safari

### DIFF
--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -106,7 +106,12 @@ const NavItem = ({
   const Link = StyledLink.withComponent(components.Link);
 
   return (
-    <li>
+    <li
+      css={css`
+        /* the default display: list-item breaks spacing on Safari */
+        display: block;
+      `}
+    >
       <Link
         onClick={disabled ? null : onClick}
         selected={selected}

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NavItem styles should render with default styles and match the snapshot 1`] = `
+.circuit-4 {
+  display: block;
+}
+
 .circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -39,7 +43,9 @@ exports[`NavItem styles should render with default styles and match the snapshot
   margin-left: 12px;
 }
 
-<li>
+<li
+  class="circuit-4"
+>
   <a
     class="circuit-2 circuit-3"
   >
@@ -51,6 +57,10 @@ exports[`NavItem styles should render with default styles and match the snapshot
 `;
 
 exports[`NavItem styles should render with default styles and match the snapshot for a secondary NavItem 1`] = `
+.circuit-4 {
+  display: block;
+}
+
 .circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -98,7 +108,9 @@ exports[`NavItem styles should render with default styles and match the snapshot
   margin-top: 0px;
 }
 
-<li>
+<li
+  class="circuit-4"
+>
   <a
     class="circuit-2 circuit-3"
   >
@@ -110,6 +122,10 @@ exports[`NavItem styles should render with default styles and match the snapshot
 `;
 
 exports[`NavItem styles should render with disabled state styles and match the snapshot 1`] = `
+.circuit-4 {
+  display: block;
+}
+
 .circuit-0 {
   margin-left: 12px;
 }
@@ -146,7 +162,9 @@ exports[`NavItem styles should render with disabled state styles and match the s
   fill: #5C656F;
 }
 
-<li>
+<li
+  class="circuit-4"
+>
   <a
     class="circuit-2 circuit-3"
     disabled=""
@@ -159,6 +177,10 @@ exports[`NavItem styles should render with disabled state styles and match the s
 `;
 
 exports[`NavItem styles should render with selected state styles and match the snapshot 1`] = `
+.circuit-4 {
+  display: block;
+}
+
 .circuit-0 {
   margin-left: 12px;
 }
@@ -195,7 +217,9 @@ exports[`NavItem styles should render with selected state styles and match the s
   fill: #FAFBFC;
 }
 
-<li>
+<li
+  class="circuit-4"
+>
   <a
     class="circuit-2 circuit-3"
   >


### PR DESCRIPTION
## Purpose

The introduction of an extra anchor element in the NavItem component (#490, #492) caused a spacing bug in Safari (there is too much space between the items):

<img width="1202" alt="Screenshot 2019-10-28 at 15 20 34" src="https://user-images.githubusercontent.com/35560568/67694939-87371e80-f9a4-11e9-8c02-b23c130fa9ff.png">

## Approach and changes

Make the NavItem `li` element `display: block;` to prevent Safari from giving them the default properties of an item with `display: list-item;`.

This bug is happening now, because the `display: flex;` rule was moved from the parent `li` element to the newly created `a` element.

ℹ️ Reviewers: I've also refactored the Sidebar story to use hooks. I though this could fix a weird bug in the Story where the rendered icons are not correct (see image above, they all have the `icon-full.svg` icon, where the story clearly assigns different ones). This should be investigated further and fixed in another PR.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
