### PR TITLE
fix(docs): update favicon path

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,11 +15,7 @@
     <meta name="description" content="{{ description }}" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <link
-      rel="icon"
-      type="image/png"
-      href="/storybook/images/circuit-logo.png"
-    />
+    <link rel="icon" type="image/png" href="/storybook/images/logo-icon.png" />
     <style>
       @font-face {
         font-family: 'aktiv-grotesk';


### PR DESCRIPTION
## Purpose

Deployments currently fail because the HTMLMinifier Webpack plugin used by Docz doesn't handle the multiline favicon node correctly (it removes too much whitespace). Also, the favicon path is points to a non-existant file. 

## Approach and changes

- Update favicon path. This also fixes the line wrapping. 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
