### PR TITLE
fix(docs): stories fail to render

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -71,7 +71,7 @@ addDecorator(withKnobs);
 
 // These decorators need to be disabled for StoryShots to work.
 if (!__TEST__) {
-  const withTests = require('./util/withTests');
+  const withTests = require('./util/withTests').default;
   addDecorator(withTests);
   addDecorator(withStoryStyles);
 }


### PR DESCRIPTION
## Purpose

Normal stories are currently broken on [circuit.sumup.com](https://circuit.sumup.com). They show the following error: `fn.apply is not a function`. 

## Approach and changes

- require `withTest` decorator correctly

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
