### PR TITLE
fix(components): fix Sidebar Footer padding bug on Safari

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -8701,8 +8701,26 @@ exports[`Storyshots Components|ProgressBar With Percentage 1`] = `
 `;
 
 exports[`Storyshots Components|Sidebar Base 1`] = `
-HTMLCollection [
-  .circuit-37 {
+.circuit-41 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-45 {
+  height: 100vh;
+}
+
+.circuit-37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8945,23 +8963,73 @@ HTMLCollection [
 }
 
 .circuit-35 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  margin-top: auto;
   padding: 24px;
   background-color: #212933;
   color: #FAFBFC;
 }
 
-<nav
+.circuit-39 {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  background-color: #212933;
+  -webkit-transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 700;
+  visibility: visible;
+  opacity: 0.56;
+}
+
+@media (min-width:960px) {
+  .circuit-39 {
+    visibility: hidden;
+  }
+}
+
+.circuit-43 {
+  cursor: pointer;
+  outline: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 40px;
+  width: 40px;
+  border-radius: 50%;
+  background-color: #FAFBFC;
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  z-index: 800;
+  visibility: visible;
+  opacity: 1;
+}
+
+@media (min-width:960px) {
+  .circuit-43 {
+    visibility: hidden;
+  }
+}
+
+<div
+  class="circuit-45 circuit-46"
+>
+  <nav
     class="circuit-37 circuit-38"
     open=""
   >
@@ -9066,89 +9134,17 @@ HTMLCollection [
     >
       Footer
     </footer>
-  </nav>,
-  .circuit-0 {
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  background-color: #212933;
-  -webkit-transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out,visibility 200ms ease-in-out;
-  visibility: hidden;
-  opacity: 0;
-  z-index: 700;
-  visibility: visible;
-  opacity: 0.56;
-}
-
-@media (min-width:960px) {
-  .circuit-0 {
-    visibility: hidden;
-  }
-}
-
-<div
-    class="circuit-0 circuit-1"
+  </nav>
+  <div
+    class="circuit-39 circuit-40"
     data-testid="sidebar-backdrop"
-  />,
-  .circuit-0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-2 {
-  cursor: pointer;
-  outline: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 40px;
-  width: 40px;
-  border-radius: 50%;
-  background-color: #FAFBFC;
-  position: absolute;
-  bottom: 16px;
-  right: 16px;
-  -webkit-transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
-  transition: opacity 150ms ease-in-out,visibility 150ms ease-in-out;
-  visibility: hidden;
-  opacity: 0;
-  z-index: 800;
-  visibility: visible;
-  opacity: 1;
-}
-
-@media (min-width:960px) {
-  .circuit-2 {
-    visibility: hidden;
-  }
-}
-
-<button
-    class="circuit-2 circuit-3"
+  />
+  <button
+    class="circuit-43 circuit-44"
     data-testid="sidebar-close-button"
   >
     <span
-      class="circuit-0 circuit-1"
+      class="circuit-41 circuit-42"
     >
       close-button
     </span>
@@ -9157,8 +9153,8 @@ HTMLCollection [
     >
       closeIcon.svg
     </div>
-  </button>,
-]
+  </button>
+</div>
 `;
 
 exports[`Storyshots Components|Spinner Base 1`] = `

--- a/src/components/Sidebar/Sidebar.story.js
+++ b/src/components/Sidebar/Sidebar.story.js
@@ -14,6 +14,7 @@
  */
 
 import React, { useState } from 'react';
+import styled from '@emotion/styled';
 import { boolean } from '@storybook/addon-knobs/react';
 
 import docs from './Sidebar.docs.mdx';
@@ -25,6 +26,10 @@ import { ReactComponent as MeEmpty } from './icons/me-empty.svg';
 import { ReactComponent as HomeFull } from './icons/home-full.svg';
 import { ReactComponent as ListFull } from './icons/list-full.svg';
 import { ReactComponent as MeFull } from './icons/me-full.svg';
+
+const Viewport = styled.div`
+  height: 100vh;
+`;
 
 export default {
   title: 'Components|Sidebar',
@@ -39,52 +44,54 @@ const SidebarWithState = () => {
   const [selected, setSelected] = useState(1);
 
   return (
-    <Sidebar open={true} onClose={() => null} closeButtonLabel="close-button">
-      <Sidebar.Header>Header</Sidebar.Header>
-      <Sidebar.NavList>
-        <Sidebar.NavItem
-          key="home"
-          label="Home"
-          selected={selected === 1}
-          onClick={() => setSelected(1)}
-          defaultIcon={<HomeEmpty />}
-          selectedIcon={<HomeFull />}
-        />
-        <Sidebar.Aggregator
-          key="list"
-          selected={selected === 2}
-          label="List"
-          defaultIcon={<ListEmpty />}
-          selectedIcon={<ListFull />}
-        >
+    <Viewport>
+      <Sidebar open={true} onClose={() => null} closeButtonLabel="close-button">
+        <Sidebar.Header>Header</Sidebar.Header>
+        <Sidebar.NavList>
           <Sidebar.NavItem
-            label={`First`}
-            selected={selected === 4}
-            onClick={() => setSelected(4)}
+            key="home"
+            label="Home"
+            selected={selected === 1}
+            onClick={() => setSelected(1)}
+            defaultIcon={<HomeEmpty />}
+            selectedIcon={<HomeFull />}
           />
+          <Sidebar.Aggregator
+            key="list"
+            selected={selected === 2}
+            label="List"
+            defaultIcon={<ListEmpty />}
+            selectedIcon={<ListFull />}
+          >
+            <Sidebar.NavItem
+              label={`First`}
+              selected={selected === 4}
+              onClick={() => setSelected(4)}
+            />
+            <Sidebar.NavItem
+              label={`Second`}
+              selected={selected === 5}
+              onClick={() => setSelected(5)}
+            />
+            <Sidebar.NavItem
+              label={`Third`}
+              selected={selected === 6}
+              onClick={() => setSelected(6)}
+            />
+          </Sidebar.Aggregator>
           <Sidebar.NavItem
-            label={`Second`}
-            selected={selected === 5}
-            onClick={() => setSelected(5)}
+            key="me"
+            label="Me"
+            disabled={boolean('Disabled item', false)}
+            selected={selected === 3}
+            defaultIcon={<MeEmpty />}
+            selectedIcon={<MeFull />}
+            onClick={() => setSelected(3)}
           />
-          <Sidebar.NavItem
-            label={`Third`}
-            selected={selected === 6}
-            onClick={() => setSelected(6)}
-          />
-        </Sidebar.Aggregator>
-        <Sidebar.NavItem
-          key="me"
-          label="Me"
-          disabled={boolean('Disabled item', false)}
-          selected={selected === 3}
-          defaultIcon={<MeEmpty />}
-          selectedIcon={<MeFull />}
-          onClick={() => setSelected(3)}
-        />
-      </Sidebar.NavList>
-      <Sidebar.Footer>Footer</Sidebar.Footer>
-    </Sidebar>
+        </Sidebar.NavList>
+        <Sidebar.Footer>Footer</Sidebar.Footer>
+      </Sidebar>
+    </Viewport>
   );
 };
 

--- a/src/components/Sidebar/components/Footer/Footer.js
+++ b/src/components/Sidebar/components/Footer/Footer.js
@@ -19,9 +19,7 @@ import { css } from '@emotion/core';
 
 const baseStyles = ({ theme }) => css`
   label: sidebar-footer;
-  display: flex;
-  flex: 1;
-  align-items: flex-end;
+  margin-top: auto;
   padding: ${theme.spacings.giga};
   background-color: ${theme.colors.n900};
   color: ${theme.colors.n100};

--- a/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
@@ -2,17 +2,7 @@
 
 exports[`Footer styles should render with default styles 1`] = `
 .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  margin-top: auto;
   padding: 24px;
   background-color: #212933;
   color: #FAFBFC;


### PR DESCRIPTION
## Purpose

The Sidebar Footer top padding is squashed on Safari when Nav Items stack up to a height bigger than the parent:

<img width="254" alt="Screenshot 2019-10-31 at 15 01 44" src="https://user-images.githubusercontent.com/35560568/67953418-68789800-fbef-11e9-817e-bee4a7cbc243.png">

This is particularly a problem on older iPhones with a small viewport using Safari.

## Approach and changes

Remove `display: flex;` from the Sidebar Footer as it is only ever used to display one child element (often a logo). Then the Sidebar Footer can be positioned to the bottom of the viewport with `margin-top: auto;`.

This PR also adds a parent `Viewport` element to the Sidebar story in order to make the component there behave more like a production app. With the current story, the bug can't be reproduced.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
