### PR TITLE
fix(components): show border styles when CardList.Item component is selected

### DIFF
--- a/src/components/CardList/__snapshots__/CardList.spec.js.snap
+++ b/src/components/CardList/__snapshots__/CardList.spec.js.snap
@@ -83,7 +83,7 @@ exports[`CardList should render with default styles 1`] = `
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
   background: #EDF4FC;
-  color: #003C8B;
+  outline: none;
 }
 
 .circuit-2:first-child {
@@ -94,6 +94,17 @@ exports[`CardList should render with default styles 1`] = `
 .circuit-2:last-child {
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
+}
+
+.circuit-2::after {
+  content: ' ';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  box-shadow: 0px 0px 0px 2px #3388FF;
+  border-radius: 4px;
 }
 
 @media (hover:hover) {

--- a/src/components/CardList/components/Item/Item.js
+++ b/src/components/CardList/components/Item/Item.js
@@ -51,21 +51,6 @@ const baseStyles = ({ theme }) => css`
   }
 `;
 
-const paddingStyles = ({ theme, padding }) =>
-  padding &&
-  css`
-    padding: ${theme.spacings[sizeMap[padding]]};
-  `;
-
-const selectedStyles = ({ theme, selected }) =>
-  selected &&
-  css`
-    label: cardlist__item--selected;
-
-    background: ${theme.colors.p100};
-    color: ${theme.colors.p900};
-  `;
-
 const getBorderStyles = theme => css`
   outline: none;
 
@@ -80,6 +65,22 @@ const getBorderStyles = theme => css`
     border-radius: ${theme.borderRadius.mega};
   }
 `;
+
+const paddingStyles = ({ theme, padding }) =>
+  padding &&
+  css`
+    padding: ${theme.spacings[sizeMap[padding]]};
+  `;
+
+const selectedStyles = ({ theme, selected }) =>
+  selected &&
+  css`
+    label: cardlist__item--selected;
+
+    background: ${theme.colors.p100};
+
+    ${getBorderStyles(theme)};
+  `;
 
 const hoverStyles = ({ theme }) => css`
   @media (hover: hover) {


### PR DESCRIPTION
Addresses [PMNTSS-205](https://sumupteam.atlassian.net/browse/PMNTSS-205)

## Purpose

Currently the `CardList.Item` component is not styled with bordered styles when the corresponding `selected` prop is true.  
In some cases, this can result in a confusing experience for the user.

In the following example, the Payouts history page has just been loaded, the first `CardList.Item` is selected but it's not showing the borders:

![Screen Shot 2019-11-01 at 15 44 54](https://user-images.githubusercontent.com/6237296/68028932-ba3c2380-fcbe-11e9-94cf-e54f7566ef58.png)

After the user clicks on the first `CardList.Item` the outcome is the following:

![Screen Shot 2019-11-01 at 15 44 57](https://user-images.githubusercontent.com/6237296/68028967-cb853000-fcbe-11e9-9407-9064c5f697fc.png)


## Approach and changes

Include bordered styles to the `CardList.Item` when `selected` prop is true.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
