### PR TITLE
fix: use correct license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "url": "git+https://github.com/sumup-oss/circuit-ui.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/sumup-oss/circuit-ui/issues"
   },


### PR DESCRIPTION
## Purpose

Circuit UI's official [license](https://github.com/sumup-oss/circuit-ui/blob/canary/LICENSE) is Apache 2.0. The `license` field in the package.json file doesn't currently match that.

## Approach and changes

- Change `license` field to Apache 2.0

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
