### PR TITLE
feat(components): expose sidebar context

### DIFF
--- a/src/components/Sidebar/SidebarContext.js
+++ b/src/components/Sidebar/SidebarContext.js
@@ -16,7 +16,10 @@
 import React, { createContext } from 'react';
 import PropTypes from 'prop-types';
 
-const SidebarContext = createContext();
+const SidebarContext = createContext({
+  isSidebarOpen: false,
+  toggleSidebar: () => {}
+});
 
 const SidebarContextConsumer = SidebarContext.Consumer;
 
@@ -48,4 +51,4 @@ SidebarContextProvider.propTypes = {
   children: PropTypes.node
 };
 
-export { SidebarContextProvider, SidebarContextConsumer };
+export { SidebarContext, SidebarContextProvider, SidebarContextConsumer };

--- a/src/components/Sidebar/SidebarContext.spec.js
+++ b/src/components/Sidebar/SidebarContext.spec.js
@@ -13,11 +13,24 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import {
+  SidebarContext,
   SidebarContextProvider,
   SidebarContextConsumer
 } from './SidebarContext';
+
+const ToggleSidebarButton = () => {
+  const { toggleSidebar, isSidebarOpen } = useContext(SidebarContext);
+
+  return (
+    <button
+      data-testid="button"
+      onClick={toggleSidebar}
+      data-open={isSidebarOpen}
+    />
+  );
+};
 
 describe('SidebarContext', () => {
   it('should change Provider open state when using toggleSidebar', () => {
@@ -44,5 +57,23 @@ describe('SidebarContext', () => {
     });
 
     expect(buttonEl).toHaveAttribute('data-open', 'true');
+  });
+
+  it('should be able to consume context, along with useContext hook', () => {
+    const { getByTestId } = render(
+      <SidebarContextProvider>
+        <ToggleSidebarButton />
+      </SidebarContextProvider>
+    );
+
+    const buttonElement = getByTestId('button');
+
+    expect(buttonElement).toHaveAttribute('data-open', 'false');
+
+    act(() => {
+      fireEvent.click(buttonElement);
+    });
+
+    expect(buttonElement).toHaveAttribute('data-open', 'true');
   });
 });

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -15,9 +15,10 @@
 
 import Sidebar from './Sidebar';
 import {
+  SidebarContext,
   SidebarContextProvider,
   SidebarContextConsumer
 } from './SidebarContext';
 
 export default Sidebar;
-export { SidebarContextProvider, SidebarContextConsumer };
+export { SidebarContext, SidebarContextProvider, SidebarContextConsumer };


### PR DESCRIPTION
## Purpose

Expose sidebar context that allows it to be used with the useContext hook.
Currently the sideBar context is accessed using the render props method like so.

```jsx
<SidebarContextConsumer>
  {({ isSidebarOpen, toggleSidebar } = {}) =>
    <SideNavToggle
      onClick={toggleSidebar}
    />
  )}
</SidebarContextConsumer>
```
This method of accessing was necessary in the past, however with the availability of the useContext hook it makes things a lot more simpler and elegant.

## Approach and changes

With this PR, we also enable consuming the context with the useContext hook, however we still support the older render props access method so we don't break things. 

```javascript
 import { SidebarContext } from '@sumup/circuit-ui';
 
 const { toggleSidebar, isSidebarOpen } = useContext(SidebarContext);

```

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
