### PR TITLE
feat(components): add sidebar separator component

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -8701,7 +8701,7 @@ exports[`Storyshots Components|ProgressBar With Percentage 1`] = `
 `;
 
 exports[`Storyshots Components|Sidebar Base 1`] = `
-.circuit-41 {
+.circuit-43 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -8716,11 +8716,11 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
   width: 1px;
 }
 
-.circuit-45 {
+.circuit-47 {
   height: 100vh;
 }
 
-.circuit-37 {
+.circuit-39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8745,7 +8745,7 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
 }
 
 @media (min-width:960px) {
-  .circuit-37 {
+  .circuit-39 {
     -webkit-transform: translateX(0);
     -ms-transform: translateX(0);
     transform: translateX(0);
@@ -8754,7 +8754,7 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
 }
 
 @media (min-width:960px) {
-  .circuit-37 {
+  .circuit-39 {
     -webkit-transform: translateX(0);
     -ms-transform: translateX(0);
     transform: translateX(0);
@@ -8784,7 +8784,7 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
   color: #FAFBFC;
 }
 
-.circuit-33 {
+.circuit-35 {
   height: auto;
   justify-self: flex-start;
   overflow-y: auto;
@@ -8928,7 +8928,16 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
   transition: margin-top 300ms ease-in-out;
 }
 
-.circuit-30 {
+.circuit-28 {
+  display: block;
+  width: 100%;
+  border: 1px solid #D8DDE1;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  border: 1px solid #323E49;
+}
+
+.circuit-32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -8950,26 +8959,26 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
   text-decoration: none;
 }
 
-.circuit-30 * {
+.circuit-32 * {
   fill: #9DA7B1;
 }
 
-.circuit-30:hover {
+.circuit-32:hover {
   color: #D8DDE1;
 }
 
-.circuit-30:hover * {
+.circuit-32:hover * {
   fill: #D8DDE1;
 }
 
-.circuit-35 {
+.circuit-37 {
   margin-top: auto;
   padding: 24px;
   background-color: #212933;
   color: #FAFBFC;
 }
 
-.circuit-39 {
+.circuit-41 {
   width: 100%;
   height: 100%;
   position: absolute;
@@ -8984,12 +8993,12 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
 }
 
 @media (min-width:960px) {
-  .circuit-39 {
+  .circuit-41 {
     visibility: hidden;
   }
 }
 
-.circuit-43 {
+.circuit-45 {
   cursor: pointer;
   outline: none;
   display: -webkit-box;
@@ -9021,16 +9030,16 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
 }
 
 @media (min-width:960px) {
-  .circuit-43 {
+  .circuit-45 {
     visibility: hidden;
   }
 }
 
 <div
-  class="circuit-45 circuit-46"
+  class="circuit-47 circuit-48"
 >
   <nav
-    class="circuit-37 circuit-38"
+    class="circuit-39 circuit-40"
     open=""
   >
     <header
@@ -9039,7 +9048,7 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
       Header
     </header>
     <ul
-      class="circuit-33 circuit-34"
+      class="circuit-35 circuit-36"
     >
       <li
         class="circuit-6"
@@ -9112,11 +9121,14 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
           </a>
         </li>
       </ul>
+      <hr
+        class="circuit-28 circuit-29"
+      />
       <li
         class="circuit-6"
       >
         <a
-          class="circuit-30 circuit-5"
+          class="circuit-32 circuit-5"
         >
           <div>
             me-empty.svg
@@ -9130,21 +9142,21 @@ exports[`Storyshots Components|Sidebar Base 1`] = `
       </li>
     </ul>
     <footer
-      class="circuit-35 circuit-36"
+      class="circuit-37 circuit-38"
     >
       Footer
     </footer>
   </nav>
   <div
-    class="circuit-39 circuit-40"
+    class="circuit-41 circuit-42"
     data-testid="sidebar-backdrop"
   />
   <button
-    class="circuit-43 circuit-44"
+    class="circuit-45 circuit-46"
     data-testid="sidebar-close-button"
   >
     <span
-      class="circuit-41 circuit-42"
+      class="circuit-43 circuit-44"
     >
       close-button
     </span>

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -25,6 +25,7 @@ import NavItem from './components/NavItem';
 import Backdrop from './components/Backdrop';
 import CloseButton from './components/CloseButton';
 import Aggregator from './components/Aggregator';
+import Separator from './components/Separator';
 
 const SIDEBAR_WIDTH = 256;
 
@@ -106,5 +107,6 @@ Sidebar.Footer = Footer;
 Sidebar.NavList = NavList;
 Sidebar.NavItem = NavItem;
 Sidebar.Aggregator = Aggregator;
+Sidebar.Separator = Separator;
 
 export default Sidebar;

--- a/src/components/Sidebar/Sidebar.story.js
+++ b/src/components/Sidebar/Sidebar.story.js
@@ -19,6 +19,7 @@ import { boolean } from '@storybook/addon-knobs/react';
 
 import docs from './Sidebar.docs.mdx';
 import Sidebar from '.';
+import Separator from './components/Separator';
 
 import { ReactComponent as HomeEmpty } from './icons/home-empty.svg';
 import { ReactComponent as ListEmpty } from './icons/list-empty.svg';
@@ -79,6 +80,7 @@ const SidebarWithState = () => {
               onClick={() => setSelected(6)}
             />
           </Sidebar.Aggregator>
+          <Separator />
           <Sidebar.NavItem
             key="me"
             label="Me"

--- a/src/components/Sidebar/components/Separator/Separator.js
+++ b/src/components/Sidebar/components/Separator/Separator.js
@@ -19,7 +19,7 @@ import { css } from '@emotion/core';
 import Hr from '../../../Hr';
 
 const baseStyles = ({ theme }) => css`
-  label: separator;
+  label: sidebar-separator;
   border: 1px solid ${theme.colors.n800};
 `;
 

--- a/src/components/Sidebar/components/Separator/Separator.js
+++ b/src/components/Sidebar/components/Separator/Separator.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from '@emotion/styled';
+import { css } from '@emotion/core';
+
+import Hr from '../../../Hr';
+
+const baseStyles = ({ theme }) => css`
+  label: separator;
+  border: 1px solid ${theme.colors.n800};
+`;
+
+/**
+ * A separator for the Sidebar. Extends the Hr component.
+ */
+const Separator = styled(Hr)(baseStyles);
+
+/**
+ * @component
+ */
+export default Separator;

--- a/src/components/Sidebar/components/Separator/Separator.spec.js
+++ b/src/components/Sidebar/components/Separator/Separator.spec.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import Separator from './Separator';
+
+describe('Separator', () => {
+  /**
+   * Style tests.
+   */
+  it('should render with default styles', () => {
+    const actual = create(<Separator />);
+    expect(actual).toMatchSnapshot();
+  });
+
+  /**
+   * Accessibility tests.
+   */
+  it('should meet accessibility guidelines', async () => {
+    const wrapper = renderToHtml(<Separator />);
+    const actual = await axe(wrapper);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/src/components/Sidebar/components/Separator/__snapshots__/Separator.spec.js.snap
+++ b/src/components/Sidebar/components/Separator/__snapshots__/Separator.spec.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Separator should render with default styles 1`] = `
+.circuit-0 {
+  display: block;
+  width: 100%;
+  border: 1px solid #D8DDE1;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  border: 1px solid #323E49;
+}
+
+<hr
+  class="circuit-0 circuit-1"
+/>
+`;

--- a/src/components/Sidebar/components/Separator/index.js
+++ b/src/components/Sidebar/components/Separator/index.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Separator from './Separator';
+
+export default Separator;


### PR DESCRIPTION
## Purpose

Add a horizontal separator component to the Sidebar. This will be used to group items together and is particularly useful when information architectures become more complex.

![Screenshot_2019-12-05 Components Sidebar - Base ⋅ Storybook(1)](https://user-images.githubusercontent.com/35560568/70224259-45d92200-174d-11ea-8084-ea6258cfb695.png)

## Approach and changes

Add a styled component in the Sidebar that extends the Circuit `Hr` component, just changing the color.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
