### PR TITLE
chore: add "label" as a valid property to fix vscode warning

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "typescript-styled-plugin",
+        "lint": {
+          "validProperties": ["label"]
+        }
+      }
+    ]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Purpose

Emotion ships with the [`ts-styled-plugin`](https://github.com/microsoft/typescript-styled-plugin) plugin, which according to its README, enables:

> - IntelliSense for CSS property names and values.
> - Syntax error reporting.
> - Quick fixes for misspelled property names.

However, the plugin throws a warning in VS Code because it doesn't recognize Emotion's `label` property:

![Screenshot 2020-01-06 at 11 21 23](https://user-images.githubusercontent.com/35560568/71813561-39acf100-307a-11ea-9afc-6e42aee176f1.png)

![Screenshot 2020-01-06 at 11 22 50](https://user-images.githubusercontent.com/35560568/71813569-403b6880-307a-11ea-8c40-95e199509638.png)

## Approach and changes

Add a `jsconfig.json` file at the repo's root and configure `ts-styled-plugin` to accept `label` as a valid property.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
