### PR TITLE
fix: Move minus symbol in front of the currency symbol

### DIFF
--- a/src/util/currency.js
+++ b/src/util/currency.js
@@ -192,7 +192,7 @@ export function formatCurrency(amount, currency, locale) {
     currencyFormat
   );
 
-  return sign + currencyString;
+  return `${sign}${currencyString}`;
 }
 
 function toCurrencyNumberFormat(number, currencyFormat) {

--- a/src/util/currency.js
+++ b/src/util/currency.js
@@ -181,14 +181,18 @@ export function formatCurrency(amount, currency, locale) {
     get(currency)
   )(CURRENCY_SYMBOLS);
   const currencyFormat = getCurrencyFormat(currency, locale);
-  const formattedAmount = toCurrencyNumberFormat(amount, currencyFormat);
+
+  const absAmount = Math.abs(amount);
+  const sign = amount < 0 ? '-' : '';
+
+  const formattedAmount = toCurrencyNumberFormat(absAmount, currencyFormat);
   const currencyString = addSymbol(
     formattedAmount,
     currencySymbol,
     currencyFormat
   );
 
-  return currencyString;
+  return sign + currencyString;
 }
 
 function toCurrencyNumberFormat(number, currencyFormat) {

--- a/src/util/currency.spec.js
+++ b/src/util/currency.spec.js
@@ -274,17 +274,19 @@ describe('currency', () => {
       });
     });
 
-    it('should place minus sign in front', () => {
-      const negativeInputs = [-11.23, '-1000', -0.98];
+    describe('handling negative amounts', () => {
+      it('should place a minus sign in front of the currency', () => {
+        const negativeInputs = [-11.23, '-1000', -0.98];
 
-      const eurOutputs = ['-11,23\xA0€', '-1.000,00\xA0€', '-0,98\xA0€'];
-      testCurrency(negativeInputs, 'EUR', 'de-DE', eurOutputs);
+        const eurOutputs = ['-11,23\xA0€', '-1.000,00\xA0€', '-0,98\xA0€'];
+        testCurrency(negativeInputs, 'EUR', 'de-DE', eurOutputs);
 
-      const usdOutputs = ['-$11.23', '-$1,000.00', '-$0.98'];
-      testCurrency(negativeInputs, 'USD', 'en-US', usdOutputs);
+        const usdOutputs = ['-$11.23', '-$1,000.00', '-$0.98'];
+        testCurrency(negativeInputs, 'USD', 'en-US', usdOutputs);
 
-      const gbpOutputs = ['-£11.23', '-£1,000.00', '-£0.98'];
-      testCurrency(negativeInputs, 'GBP', 'en-GB', gbpOutputs);
+        const gbpOutputs = ['-£11.23', '-£1,000.00', '-£0.98'];
+        testCurrency(negativeInputs, 'GBP', 'en-GB', gbpOutputs);
+      });
     });
   });
 

--- a/src/util/currency.spec.js
+++ b/src/util/currency.spec.js
@@ -273,6 +273,19 @@ describe('currency', () => {
         testCurrency(inputs, ccy, 'de-DE', outputs);
       });
     });
+
+    it('should place minus sign in front', () => {
+      const negativeInputs = [-11.23, '-1000', -0.98];
+
+      const eurOutputs = ['-11,23\xA0€', '-1.000,00\xA0€', '-0,98\xA0€'];
+      testCurrency(negativeInputs, 'EUR', 'de-DE', eurOutputs);
+
+      const usdOutputs = ['-$11.23', '-$1,000.00', '-$0.98'];
+      testCurrency(negativeInputs, 'USD', 'en-US', usdOutputs);
+
+      const gbpOutputs = ['-£11.23', '-£1,000.00', '-£0.98'];
+      testCurrency(negativeInputs, 'GBP', 'en-GB', gbpOutputs);
+    });
   });
 
   describe('formatAmountForLocale()', () => {


### PR DESCRIPTION
## Purpose

The minus symbol is put in front of the amount and currency symbol.
Before this change negative GBP and USD amounts were rendered
as `£-1.71` and `$-5.00` (basically every currency that appears before
the number amount) and after this change they are
rendered as `-£1.71` and `-$5.00`.

Some examples using the same approach to negative currency amounts:

https://docs.microsoft.com/en-us/globalization/locale/currency-formatting
https://english.stackexchange.com/a/124804

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
