### PR TITLE
fix(components): sort layout columns by priority

### DIFF
--- a/src/components/Col/utils.js
+++ b/src/components/Col/utils.js
@@ -94,7 +94,7 @@ export const getBreakPointStyles = theme =>
  * defined on the grid config.
  */
 export const sortByPriority = curry((grid, iteratee) =>
-  iteratee.sort((a, b) => grid[head(a)].priority >= grid[head(b)].priority)
+  iteratee.sort((a, b) => grid[head(a)].priority - grid[head(b)].priority)
 );
 
 /**


### PR DESCRIPTION
## Purpose

The `compareFn` provided to [`Array.sort()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) should return an integer less than, greater or equal to zero. Booleans seem to work as well, however, they're treated differently by newer versions of Node.

## Approach and changes

- replace comparison with substraction

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
