### PR TITLE
fix(components): prevent background from scrolling when modal is open

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -157,6 +157,7 @@ const Modal = ({
         const reactModalProps = {
           className: getClassValues(modalClassName(css)),
           overlayClassName: getClassValues(overlayClassName(css)),
+          htmlOpenClassName: 'ReactModal__Html--open',
           contentLabel,
           onAfterOpen: () => IS_IOS && noScroll.on(),
           onAfterClose: () => IS_IOS && noScroll.off(),

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -16,7 +16,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactModal from 'react-modal';
-import { Global, ClassNames } from '@emotion/core';
+import { ClassNames } from '@emotion/core';
 import { withTheme } from 'emotion-theming';
 import noScroll from 'no-scroll';
 
@@ -167,16 +167,6 @@ const Modal = ({
         };
         return (
           <ReactModal {...reactModalProps}>
-            <Global
-              styles={css`
-                /* Remove scroll on the body when react-modal is open */
-                .ReactModal__Html--open {
-                  height: 100%;
-                  overflow-y: hidden;
-                  -webkit-overflow-scrolling: auto;
-                }
-              `}
-            />
             {isFunction(children) ? children() : children}
           </ReactModal>
         );

--- a/src/components/Modal/ModalProvider.js
+++ b/src/components/Modal/ModalProvider.js
@@ -14,6 +14,7 @@
  */
 
 import React, { Component, createContext } from 'react';
+import { Global, css } from '@emotion/core';
 
 import Modal, { TRANSITION_DURATION } from './Modal';
 import { childrenPropType } from '../../util/shared-prop-types';
@@ -89,6 +90,18 @@ export class ModalProvider extends Component {
       <ContextProvider value={this.contextValue}>
         {this.props.children}
         {modal && <Modal {...modalProps} />}
+        {isOpen && (
+          <Global
+            styles={css`
+              /* Remove scroll on the body when react-modal is open */
+              .ReactModal__Html--open {
+                height: 100%;
+                overflow-y: hidden;
+                -webkit-overflow-scrolling: auto;
+              }
+            `}
+          />
+        )}
       </ContextProvider>
     );
   }


### PR DESCRIPTION
Addresses #211.

**Big shoutout to @larimaza for getting to the bottom of this issue** 👏👏👏

## Purpose

When the modal is open, the content underneath should remain fixed. Any scrolling should be contained in the modal itself.

## Approach and changes

- add class to `html` when the Modal is open 
- move global styles to ModalProvider (they were being scoped for some reason)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
