### PR TITLE
fix: adds Select margin top when label above

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -17711,7 +17711,7 @@ HTMLCollection [
 ]
 `;
 
-exports[`Storyshots Forms/Select Base 1`] = `
+exports[`Storyshots Forms/Select Invalid 1`] = `
 .circuit-6 {
   font-size: 13px;
   line-height: 20px;
@@ -17723,6 +17723,11 @@ exports[`Storyshots Forms/Select Base 1`] = `
   display: block;
   position: relative;
   margin-bottom: 16px;
+}
+
+label > .circuit-4,
+label + .circuit-4 {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -17778,14 +17783,13 @@ exports[`Storyshots Forms/Select Base 1`] = `
 
 <label
   class="circuit-6 circuit-7"
-  for="38"
 >
+  Country
   <div
     class="circuit-4 circuit-5"
   >
     <select
       class="circuit-0 circuit-1"
-      id="38"
       name="select"
     >
       <option
@@ -17814,18 +17818,17 @@ exports[`Storyshots Forms/Select Base 1`] = `
 </label>
 `;
 
-exports[`Storyshots Forms/Select Invalid 1`] = `
-.circuit-6 {
-  font-size: 13px;
-  line-height: 20px;
-  display: block;
-}
-
+exports[`Storyshots Forms/Select Render Base 1`] = `
 .circuit-4 {
   color: #212933;
   display: block;
   position: relative;
   margin-bottom: 16px;
+}
+
+label > .circuit-4,
+label + .circuit-4 {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -17879,42 +17882,36 @@ exports[`Storyshots Forms/Select Invalid 1`] = `
   margin: 12px;
 }
 
-<label
-  class="circuit-6 circuit-7"
-  for="39"
+<div
+  class="circuit-4 circuit-5"
 >
-  <div
-    class="circuit-4 circuit-5"
+  <select
+    class="circuit-0 circuit-1"
+    name="select"
   >
-    <select
-      class="circuit-0 circuit-1"
-      id="39"
-      name="select"
+    <option
+      value="US"
     >
-      <option
-        value="US"
-      >
-        United States
-      </option>
-      <option
-        value="DE"
-      >
-        Germany
-      </option>
-      <option
-        value="FR"
-      >
-        France
-      </option>
-    </select>
-    <div
-      class="circuit-2 circuit-3"
+      United States
+    </option>
+    <option
+      value="DE"
     >
-      arrows.svg
-    </div>
-    
+      Germany
+    </option>
+    <option
+      value="FR"
+    >
+      France
+    </option>
+  </select>
+  <div
+    class="circuit-2 circuit-3"
+  >
+    arrows.svg
   </div>
-</label>
+  
+</div>
 `;
 
 exports[`Storyshots Forms/Select With Prefix 1`] = `
@@ -17931,6 +17928,11 @@ exports[`Storyshots Forms/Select With Prefix 1`] = `
   margin-bottom: 16px;
 }
 
+label > .circuit-4,
+label + .circuit-4 {
+  margin-top: 4px;
+}
+
 .circuit-0 {
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -17984,14 +17986,13 @@ exports[`Storyshots Forms/Select With Prefix 1`] = `
 
 <label
   class="circuit-6 circuit-7"
-  for="40"
 >
+  Country
   <div
     class="circuit-4 circuit-5"
   >
     <select
       class="circuit-0 circuit-1"
-      id="40"
       name="select"
     >
       <option
@@ -18192,7 +18193,7 @@ label + .circuit-4 {
 
 <label
   class="circuit-6 circuit-7"
-  for="41"
+  for="38"
 >
   Label
   <div
@@ -18201,7 +18202,7 @@ label + .circuit-4 {
     <textarea
       aria-invalid="false"
       class="circuit-0 circuit-1"
-      id="41"
+      id="38"
       placeholder="Write your text here..."
     />
     <div
@@ -18283,7 +18284,7 @@ label + .circuit-2 {
 
 <label
   class="circuit-4 circuit-5"
-  for="45"
+  for="42"
 >
   Label
   <div
@@ -18294,7 +18295,7 @@ label + .circuit-2 {
       aria-invalid="false"
       class="circuit-0 circuit-1"
       disabled=""
-      id="45"
+      id="42"
       placeholder="Write your text here..."
     >
       You cannot edit the text because the textarea is disabled
@@ -18453,7 +18454,7 @@ label + .circuit-7 {
 
 <label
   class="circuit-9 circuit-10"
-  for="42"
+  for="39"
 >
   Label
   <div
@@ -18462,7 +18463,7 @@ label + .circuit-7 {
     <textarea
       aria-invalid="true"
       class="circuit-0 circuit-1"
-      id="42"
+      id="39"
       placeholder="Write your text here..."
     />
     <div
@@ -18569,7 +18570,7 @@ label + .circuit-4 {
 
 <label
   class="circuit-6 circuit-7"
-  for="44"
+  for="41"
 >
   Label
   <div
@@ -18578,7 +18579,7 @@ label + .circuit-4 {
     <textarea
       aria-invalid="false"
       class="circuit-0 circuit-1"
-      id="44"
+      id="41"
       placeholder="Write your text here..."
     />
     <div
@@ -18738,7 +18739,7 @@ label + .circuit-7 {
 
 <label
   class="circuit-9 circuit-10"
-  for="43"
+  for="40"
 >
   Label
   <div
@@ -18747,7 +18748,7 @@ label + .circuit-7 {
     <textarea
       aria-invalid="false"
       class="circuit-0 circuit-1"
-      id="43"
+      id="40"
       placeholder="Write your text here..."
     />
     <div
@@ -18864,9 +18865,9 @@ exports[`Storyshots Forms/Toggle Base 1`] = `
 >
   <button
     aria-checked="false"
-    aria-labelledby="toggle-label_47"
+    aria-labelledby="toggle-label_44"
     class="circuit-4 circuit-5"
-    id="toggle-switch_46"
+    id="toggle-switch_43"
     role="switch"
     type="button"
   >
@@ -18881,8 +18882,8 @@ exports[`Storyshots Forms/Toggle Base 1`] = `
   </button>
   <label
     class="circuit-9 circuit-10"
-    for="toggle-switch_46"
-    id="toggle-label_47"
+    for="toggle-switch_43"
+    id="toggle-label_44"
   >
     <p
       class=" circuit-6 circuit-7 circuit-8"
@@ -19004,9 +19005,9 @@ exports[`Storyshots Forms/Toggle With Explanation 1`] = `
 >
   <button
     aria-checked="false"
-    aria-labelledby="toggle-label_49"
+    aria-labelledby="toggle-label_46"
     class="circuit-4 circuit-5"
-    id="toggle-switch_48"
+    id="toggle-switch_45"
     role="switch"
     type="button"
   >
@@ -19021,8 +19022,8 @@ exports[`Storyshots Forms/Toggle With Explanation 1`] = `
   </button>
   <label
     class="circuit-12 circuit-13"
-    for="toggle-switch_48"
-    id="toggle-label_49"
+    for="toggle-switch_45"
+    id="toggle-label_46"
   >
     <p
       class=" circuit-6 circuit-7 circuit-8"

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -17711,6 +17711,102 @@ HTMLCollection [
 ]
 `;
 
+exports[`Storyshots Forms/Select Base 1`] = `
+.circuit-4 {
+  color: #212933;
+  display: block;
+  position: relative;
+  margin-bottom: 16px;
+}
+
+label > .circuit-4,
+label + .circuit-4 {
+  margin-top: 4px;
+}
+
+.circuit-0 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: #FFFFFF;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #D8DDE1;
+  border-radius: 4px;
+  box-shadow: inset 0 1px 2px 0 rgba(102,113,123,0.12);
+  color: #212933;
+  padding: 8px 32px 8px 12px;
+  max-height: 42px;
+  position: relative;
+  width: 100%;
+  z-index: 20;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.circuit-0:focus,
+.circuit-0:hover,
+.circuit-0:active {
+  outline: none;
+}
+
+.circuit-0:focus {
+  border-color: #3388FF;
+}
+
+.circuit-0:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.circuit-2 {
+  fill: #5C656F;
+  display: block;
+  z-index: 40;
+  pointer-events: none;
+  position: absolute;
+  height: 16px;
+  width: 16px;
+  top: 1px;
+  right: 1px;
+  margin: 12px;
+}
+
+<div
+  class="circuit-4 circuit-5"
+>
+  <select
+    class="circuit-0 circuit-1"
+    name="select"
+  >
+    <option
+      value="US"
+    >
+      United States
+    </option>
+    <option
+      value="DE"
+    >
+      Germany
+    </option>
+    <option
+      value="FR"
+    >
+      France
+    </option>
+  </select>
+  <div
+    class="circuit-2 circuit-3"
+  >
+    arrows.svg
+  </div>
+  
+</div>
+`;
+
 exports[`Storyshots Forms/Select Invalid 1`] = `
 .circuit-6 {
   font-size: 13px;
@@ -17816,102 +17912,6 @@ label + .circuit-4 {
     
   </div>
 </label>
-`;
-
-exports[`Storyshots Forms/Select Render Base 1`] = `
-.circuit-4 {
-  color: #212933;
-  display: block;
-  position: relative;
-  margin-bottom: 16px;
-}
-
-label > .circuit-4,
-label + .circuit-4 {
-  margin-top: 4px;
-}
-
-.circuit-0 {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: #FFFFFF;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #D8DDE1;
-  border-radius: 4px;
-  box-shadow: inset 0 1px 2px 0 rgba(102,113,123,0.12);
-  color: #212933;
-  padding: 8px 32px 8px 12px;
-  max-height: 42px;
-  position: relative;
-  width: 100%;
-  z-index: 20;
-  overflow-x: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 16px;
-  line-height: 24px;
-}
-
-.circuit-0:focus,
-.circuit-0:hover,
-.circuit-0:active {
-  outline: none;
-}
-
-.circuit-0:focus {
-  border-color: #3388FF;
-}
-
-.circuit-0:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
-.circuit-2 {
-  fill: #5C656F;
-  display: block;
-  z-index: 40;
-  pointer-events: none;
-  position: absolute;
-  height: 16px;
-  width: 16px;
-  top: 1px;
-  right: 1px;
-  margin: 12px;
-}
-
-<div
-  class="circuit-4 circuit-5"
->
-  <select
-    class="circuit-0 circuit-1"
-    name="select"
-  >
-    <option
-      value="US"
-    >
-      United States
-    </option>
-    <option
-      value="DE"
-    >
-      Germany
-    </option>
-    <option
-      value="FR"
-    >
-      France
-    </option>
-  </select>
-  <div
-    class="circuit-2 circuit-3"
-  >
-    arrows.svg
-  </div>
-  
-</div>
 `;
 
 exports[`Storyshots Forms/Select With Prefix 1`] = `

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -106,6 +106,11 @@ const containerBaseStyles = ({ theme }) => css`
   display: block;
   position: relative;
   margin-bottom: ${theme.spacings.mega};
+
+  label > &,
+  label + & {
+    margin-top: ${theme.spacings.bit};
+  }
 `;
 
 const containerDisabledStyles = ({ disabled }) =>

--- a/src/components/Select/Select.story.js
+++ b/src/components/Select/Select.story.js
@@ -16,7 +16,6 @@
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs/react';
-import { uniqueId } from '../../util/id';
 
 import docs from './Select.docs.mdx';
 import Select from './Select';
@@ -51,30 +50,31 @@ const options = [
 ];
 const flagIconMap = { DE, US, FR };
 
+export const renderBase = (value, onChange) => (
+  <Select
+    name="select"
+    options={options}
+    value={value}
+    onChange={e => {
+      action('Option selected')(e);
+      onChange(e.target.value);
+    }}
+    disabled={boolean('Disabled', false)}
+    invalid={boolean('Invalid', false)}
+    validationHint={text('Validation hint', '')}
+  />
+);
+
 // Selects always need labels for accessibility.
 const SelectWithLabelAndState = () => {
   const [value, setValue] = useState('US');
-  const id = uniqueId();
   return (
-    <Label htmlFor={id}>
-      <Select
-        id={id}
-        name="select"
-        options={options}
-        value={value}
-        onChange={e => {
-          action('Option selected')(e);
-          setValue(e.target.value);
-        }}
-        disabled={boolean('Disabled', false)}
-        invalid={boolean('Invalid', false)}
-        validationHint={text('Validation hint', '')}
-      />
+    <Label>
+      Country
+      {renderBase(value, setValue)}
     </Label>
   );
 };
-
-export const base = () => <SelectWithLabelAndState />;
 
 export const invalid = () => (
   <SelectWithLabelAndState

--- a/src/components/Select/Select.story.js
+++ b/src/components/Select/Select.story.js
@@ -50,7 +50,7 @@ const options = [
 ];
 const flagIconMap = { DE, US, FR };
 
-export const renderBase = (value, onChange) => (
+export const base = (value, onChange) => (
   <Select
     name="select"
     options={options}
@@ -71,7 +71,7 @@ const SelectWithLabelAndState = () => {
   return (
     <Label>
       Country
-      {renderBase(value, setValue)}
+      {base(value, setValue)}
     </Label>
   );
 };

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -62,6 +62,11 @@ exports[`Select should not render with invalid styles when also passed the disab
   box-shadow: none;
 }
 
+label > .circuit-4,
+label + .circuit-4 {
+  margin-top: 4px;
+}
+
 <div
   class="circuit-4 circuit-5"
   disabled=""
@@ -105,6 +110,11 @@ exports[`Select should render with a prefix when passed the prefix prop 1`] = `
   display: block;
   position: relative;
   margin-bottom: 16px;
+}
+
+label > .circuit-5,
+label + .circuit-5 {
+  margin-top: 4px;
 }
 
 .circuit-3 {
@@ -216,6 +226,11 @@ exports[`Select should render with a tooltip when passed a validation hint 1`] =
   display: block;
   position: relative;
   margin-bottom: 16px;
+}
+
+label > .circuit-6,
+label + .circuit-6 {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -356,6 +371,11 @@ exports[`Select should render with default styles 1`] = `
   display: block;
   position: relative;
   margin-bottom: 16px;
+}
+
+label > .circuit-4,
+label + .circuit-4 {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -506,6 +526,11 @@ exports[`Select should render with disabled styles when passed the disabled prop
   box-shadow: none;
 }
 
+label > .circuit-4,
+label + .circuit-4 {
+  margin-top: 4px;
+}
+
 <div
   class="circuit-4 circuit-5"
   disabled=""
@@ -604,6 +629,11 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
   margin-right: 16px;
 }
 
+label > .circuit-4,
+label + .circuit-4 {
+  margin-top: 4px;
+}
+
 <div
   class="circuit-4 circuit-5"
 >
@@ -645,6 +675,11 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
   display: block;
   position: relative;
   margin-bottom: 16px;
+}
+
+label > .circuit-6,
+label + .circuit-6 {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -812,6 +847,11 @@ exports[`Select should render with no margin styles when passed the noMargin pro
   position: relative;
   margin-bottom: 16px;
   margin-bottom: 0;
+}
+
+label > .circuit-4,
+label + .circuit-4 {
+  margin-top: 4px;
 }
 
 <div


### PR DESCRIPTION
Addresses https://github.com/sumup-oss/circuit-ui/issues/530

## Purpose

Fix alignment issues in forms caused by inconsistency between the behaviors of the Input and Select components

## Approach and changes

I used the same approach that is used on other components. The code applies the top margin from the previous sibling / parent if it is a label, otherwise it does not apply it.

## Definition of done

* [X] Development completed
* [X] Reviewers assigned
* [X] Unit and integration tests
* [X] Meets minimum browser support
* [X] Meets accessibility requirements
