### PR TITLE
chore(deploy): fix automatic deployment to GitHub Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-sudo: required
-
 dist: trusty
+
+os: linux
 
 language: node_js
 
@@ -32,16 +32,14 @@ jobs:
       deploy:
         # Publish Circuit UI to NPM
         - provider: script
-          skip_cleanup: true
           on:
             all_branches: true
           script: yarn release
         # Deploy Storybook to GitHub Pages
         - provider: pages
-          skip_cleanup: true
-          github_token: $GITHUB_TOKEN
+          token: $GITHUB_TOKEN
           on:
             all_branches: true
             # branch: master
-          local-dir: public
+          local_dir: public
           target_branch: gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,7 @@ jobs:
         - provider: pages
           token: $GITHUB_TOKEN
           on:
-            all_branches: true
-            # branch: master
+            branch: master
           local_dir: public
           target_branch: gh-pages
           edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ jobs:
           on:
             all_branches: true
           script: yarn release
+          edge: true
         # Deploy Storybook to GitHub Pages
         - provider: pages
           token: $GITHUB_TOKEN
@@ -43,3 +44,4 @@ jobs:
             # branch: master
           local_dir: public
           target_branch: gh-pages
+          edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,23 +28,20 @@ jobs:
     - stage: publish
       script: skip
       # Publish package to NPM
-      deploy:
-        provider: script
-        skip_cleanup: true
-        on:
-          all_branches: true
-        script: yarn release
-      # Increase number of watchers
-    - script: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-      if: branch = master
-      # Deploy Storybook to GitHub Pages
       before_deploy: yarn predeploy
       deploy:
-        provider: script
-        script: yarn deploy
-        skip_cleanup: true
-        github_token: $GITHUB_TOKEN
-        on:
-          branch: master
-        local-dir: public
-        target_branch: gh-pages
+        # Publish Circuit UI to NPM
+        - provider: script
+          skip_cleanup: true
+          on:
+            all_branches: true
+          script: yarn release
+        # Deploy Storybook to GitHub Pages
+        - provider: pages
+          skip_cleanup: true
+          github_token: $GITHUB_TOKEN
+          on:
+            all_branches: true
+            # branch: master
+          local-dir: public
+          target_branch: gh-pages

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib --ignore *.spec.js,*.story.js,*.docs.mdx",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir lib/es --ignore *.spec.js,*.story.js,*.docs.mdx",
     "build:docs": "yarn build:storybook && yarn build:stylesheets",
-    "prebuild:storybook": "yarn test:unit:output",
     "build:storybook": "build-storybook -c .storybook -o public -s .storybook/public",
     "build:stylesheets": "mkdir -p public/static && yarn static-styles --global --filePath=./public/static/circuit-ui-v1.css",
     "test": "yarn test:lint && yarn test:unit",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir lib --ignore *.spec.js,*.story.js,*.docs.mdx",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir lib/es --ignore *.spec.js,*.story.js,*.docs.mdx",
     "build:docs": "yarn build:storybook && yarn build:stylesheets",
+    "prebuild:storybook": "yarn test:unit:output",
     "build:storybook": "build-storybook -c .storybook -o public -s .storybook/public",
     "build:stylesheets": "mkdir -p public/static && yarn static-styles --global --filePath=./public/static/circuit-ui-v1.css",
     "test": "yarn test:lint && yarn test:unit",


### PR DESCRIPTION
## Purpose

The automatic deployment of Storybook to GitHub Pages on the `master` branch is currently broken due to an invalid configuration for Travis CI.

## Approach and changes

- merge the two deploy steps into one according to the [docs](https://docs.travis-ci.com/user/deployment#deploying-to-multiple-providers) 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
