### PR TITLE
docs: fix Storybook links

### DIFF
--- a/.storybook/components/Teaser.js
+++ b/.storybook/components/Teaser.js
@@ -20,6 +20,10 @@ import { ThemeProvider } from 'emotion-theming';
 
 import { theme as themes, Heading, Text, Card } from '../../src';
 
+// HACK: This prevents the cards from awkwardly wrapping if one of them
+//       only has one line of text.
+const CARD_HEIGHT = '185px';
+
 const Wrapper = styled(Card)(
   ({ theme }) => css`
     width: 100%;
@@ -29,6 +33,7 @@ const Wrapper = styled(Card)(
     ${theme.mq.mega} {
       width: calc(50% - ${theme.spacings.giga});
       margin-right: ${theme.spacings.giga};
+      min-height: ${CARD_HEIGHT};
     }
   `
 );

--- a/docs/advanced/grid.story.mdx
+++ b/docs/advanced/grid.story.mdx
@@ -7,7 +7,7 @@ import { Meta, Preview, Grid, Row, Col } from '../../.storybook/components';
 The grid provided by Circuit UI is a float-based grid. We use
 this grid in applications where we need to support older browsers, such as Android and iOS webviews.
 
-The [static CSS](Advanced|Static-CSS) does not include a grid system.
+The [static CSS](Advanced/Static-CSS) does not include a grid system.
 
 ## Static columns
 
@@ -34,7 +34,7 @@ scenario, you can use the normal `span` attribute of the grid.
 
 ## Responsive columns
 
-You can use the following [breakpoints](Advanced|Theme) to define the
+You can use the following [breakpoints](Advanced/Theme) to define the
 responsive behavior of your grid:
 
 - `untilKilo`

--- a/docs/advanced/theme.story.mdx
+++ b/docs/advanced/theme.story.mdx
@@ -195,7 +195,7 @@ theme.borderWidth.[kilo|mega]
 theme.typography.[headings|subHeadings|text].<SIZE_NAME>.[fontSize|lineHeight]
 ```
 
-Avoid using `theme.typography` directly in your styles, rather use the specialized components [`Heading`](Typography|Heading/Base), [`SubHeading`](Typography|SubHeading/Base), and [`Text`](Typography|Text/Base).
+Avoid using `theme.typography` directly in your styles, rather use the specialized components [`Heading`](Typography/Heading/Base), [`SubHeading`](Typography/SubHeading/Base), and [`Text`](Typography/Text/Base).
 
 #### Headings
 
@@ -230,7 +230,7 @@ Avoid using `theme.typography` directly in your styles, rather use the specializ
 theme.fontStack.[default|mono]
 ```
 
-Refer to the [Fonts](Advanced|Fonts) documentation to learn how to define and load custom fonts in a performant way.
+Refer to the [Fonts](Advanced/Fonts) documentation to learn how to define and load custom fonts in a performant way.
 
 ### Font weight
 
@@ -254,9 +254,9 @@ theme.grid.<BREAKPOINT>.[priority|breakpoint|cols|maxWidth|gutter]
 The grid provided by Circuit UI is a float-based grid. We use
 this grid in applications where we need to support older browsers, such as Android and iOS webviews.
 
-The [static CSS](Advanced|Static-CSS) does not include a grid system.
+The [static CSS](Advanced/Static-CSS) does not include a grid system.
 
-Refer to the [grid](Advanced|Grid) documentation for an overview of the grid system.
+Refer to the [grid](Advanced/Grid) documentation for an overview of the grid system.
 
 ### Breakpoints and media queries
 

--- a/docs/introduction/contributing.story.mdx
+++ b/docs/introduction/contributing.story.mdx
@@ -10,7 +10,7 @@ import { Meta, Intro, Image } from '../../.storybook/components';
   or become a core contributor. Here's how.
 </Intro>
 
-**In the interest of fostering an open and welcoming environment, we expect all participants to read and adhere to our [Code of Conduct](Introduction|Code-of-Conduct).**
+**In the interest of fostering an open and welcoming environment, we expect all participants to read and adhere to our [Code of Conduct](Introduction/Code-of-Conduct).**
 
 ## Filing an issue
 

--- a/docs/introduction/getting-started.story.mdx
+++ b/docs/introduction/getting-started.story.mdx
@@ -67,4 +67,4 @@ const App = () => (
 export default App;
 ```
 
-Refer to the [Theme documentation](Advanced|Theme) to learn how to use and customize the theme.
+Refer to the [Theme documentation](Advanced/Theme) to learn how to use and customize the theme.

--- a/docs/introduction/welcome.story.mdx
+++ b/docs/introduction/welcome.story.mdx
@@ -29,7 +29,7 @@ import {
 
 Set up a new app with Circuit UI or add it to an existing project.
 
-[Get started](Introduction|Getting-started)
+[Get started](Introduction/Getting-started)
 
 </Teaser>
 
@@ -37,7 +37,7 @@ Set up a new app with Circuit UI or add it to an existing project.
 
 Discover the guiding principles behind Circuit UI's design.
 
-[Read design guidelines](Introduction|Design-Principles)
+[Read design guidelines](Introduction/Design-Principles)
 
 </Teaser>
 
@@ -45,7 +45,7 @@ Discover the guiding principles behind Circuit UI's design.
 
 Learn about our foundations such as colors, spacing, and typography.
 
-[Browse theme reference](Advanced|Theme)
+[Browse theme reference](Advanced/Theme)
 
 </Teaser>
 
@@ -53,7 +53,7 @@ Learn about our foundations such as colors, spacing, and typography.
 
 File a bug report, suggest a change, or open a pull request.
 
-[Contribute](Introduction|Contributing)
+[Contribute](Introduction/Contributing)
 
 </Teaser>
 


### PR DESCRIPTION
## Purpose

The upgrade to Storybook v5.3 (https://github.com/sumup-oss/circuit-ui/pull/521) changed the width of the docs container, which caused the teaser cards on the homepage to be misaligned. It also changed the story hierarchy separators which caused the custom markdown links in the docs to break.

## Approach and changes

- update story hierarchy separators in links
- prevent awkward wrapping on the homepage 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
