### PR TITLE
fix(components): fill invalid radio button with red to match checkbox

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -17675,6 +17675,7 @@ HTMLCollection [
 
 .circuit-0:not(:focus)::before {
   border-color: #DB4D4D;
+  background-color: #F4CBCB;
 }
 
 .circuit-0:not(:focus)::after {

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -85,6 +85,7 @@ const labelInvalidStyles = ({ theme, invalid }) =>
     label: radio-button--error;
     &:not(:focus)::before {
       border-color: ${theme.colors.r500};
+      background-color: ${theme.colors.r100};
     }
 
     &:not(:focus)::after {

--- a/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
+++ b/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
@@ -347,6 +347,7 @@ HTMLCollection [
 
 .circuit-0:not(:focus)::before {
   border-color: #DB4D4D;
+  background-color: #F4CBCB;
 }
 
 .circuit-0:not(:focus)::after {


### PR DESCRIPTION
Addresses issue https://github.com/sumup-oss/circuit-ui/issues/543

## Purpose

Fill invalid radio button with red to match the current invalid checkbox style, thus creating a more accessible feedback.

## Approach and changes

**Before** | **After**
-|-
<img width="115" alt="Screen Shot 2020-03-10 at 16 28 01" src="https://user-images.githubusercontent.com/25252211/76351455-41904800-62ec-11ea-934f-2e0f324c925d.png">|<img width="133" alt="Screen Shot 2020-03-10 at 16 27 51" src="https://user-images.githubusercontent.com/25252211/76351454-405f1b00-62ec-11ea-8714-4ca25dc8d9e6.png">

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
