### PR TITLE
feat(components): forward custom props on all components

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -1831,9 +1831,7 @@ exports[`Storyshots Components/Calendar/CalendarTag Base 1`] = `
   box-shadow: 0px 0px 0px 1px #D8DDE1;
 }
 
-<div
-  class="circuit-2 circuit-3"
->
+<div>
   <span
     class="circuit-0 circuit-1"
   >
@@ -1859,9 +1857,7 @@ exports[`Storyshots Components/Calendar/CalendarTagTwoStep Base 1`] = `
   box-shadow: 0px 0px 0px 1px #D8DDE1;
 }
 
-<div
-  class="circuit-2 circuit-3"
->
+<div>
   <span
     class="circuit-0 circuit-1"
   >
@@ -9952,6 +9948,8 @@ exports[`Storyshots Components/ProgressBar Base 1`] = `
   -ms-flex-align: center;
   align-items: center;
   margin-bottom: 16px;
+  min-width: 500px;
+  max-width: 90%;
 }
 
 .circuit-0 {
@@ -9962,8 +9960,6 @@ exports[`Storyshots Components/ProgressBar Base 1`] = `
   width: 100%;
   height: 8px;
   overflow: hidden;
-  min-width: 500px;
-  max-width: 90%;
 }
 
 .circuit-0::after {
@@ -10020,6 +10016,8 @@ HTMLCollection [
   -ms-flex-align: center;
   align-items: center;
   margin-bottom: 16px;
+  min-width: 500px;
+  max-width: 90%;
 }
 
 .circuit-2 {
@@ -10036,8 +10034,6 @@ HTMLCollection [
   width: 100%;
   height: 8px;
   overflow: hidden;
-  min-width: 500px;
-  max-width: 90%;
 }
 
 .circuit-0::after {
@@ -10086,6 +10082,8 @@ HTMLCollection [
   -ms-flex-align: center;
   align-items: center;
   margin-bottom: 16px;
+  min-width: 500px;
+  max-width: 90%;
 }
 
 .circuit-2 {
@@ -10102,8 +10100,6 @@ HTMLCollection [
   width: 100%;
   height: 16px;
   overflow: hidden;
-  min-width: 500px;
-  max-width: 90%;
 }
 
 .circuit-0::after {
@@ -10152,6 +10148,8 @@ HTMLCollection [
   -ms-flex-align: center;
   align-items: center;
   margin-bottom: 16px;
+  min-width: 500px;
+  max-width: 90%;
 }
 
 .circuit-2 {
@@ -10168,8 +10166,6 @@ HTMLCollection [
   width: 100%;
   height: 32px;
   overflow: hidden;
-  min-width: 500px;
-  max-width: 90%;
 }
 
 .circuit-0::after {
@@ -10222,6 +10218,8 @@ exports[`Storyshots Components/ProgressBar With Fraction 1`] = `
   -ms-flex-align: center;
   align-items: center;
   margin-bottom: 16px;
+  min-width: 500px;
+  max-width: 90%;
 }
 
 .circuit-2 {
@@ -10238,8 +10236,6 @@ exports[`Storyshots Components/ProgressBar With Fraction 1`] = `
   width: 100%;
   height: 8px;
   overflow: hidden;
-  min-width: 500px;
-  max-width: 90%;
 }
 
 .circuit-0::after {
@@ -10291,6 +10287,8 @@ exports[`Storyshots Components/ProgressBar With Percentage 1`] = `
   -ms-flex-align: center;
   align-items: center;
   margin-bottom: 16px;
+  min-width: 500px;
+  max-width: 90%;
 }
 
 .circuit-2 {
@@ -10307,8 +10305,6 @@ exports[`Storyshots Components/ProgressBar With Percentage 1`] = `
   width: 100%;
   height: 8px;
   overflow: hidden;
-  min-width: 500px;
-  max-width: 90%;
 }
 
 .circuit-0::after {
@@ -11071,18 +11067,6 @@ label + .circuit-14 {
   pointer-events: none;
 }
 
-.circuit-6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-bottom: 16px;
-}
-
 .circuit-4 {
   font-size: 13px;
   line-height: 20px;
@@ -11093,6 +11077,18 @@ label + .circuit-14 {
   margin: 0 auto;
   width: 90%;
   max-width: 300px;
+}
+
+.circuit-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  margin-bottom: 16px;
 }
 
 .circuit-2 {

--- a/src/components/AspectRatio/AspectRatio.js
+++ b/src/components/AspectRatio/AspectRatio.js
@@ -60,7 +60,7 @@ const childAspectRatioStyles = (cssClassName, { aspectRatio }) =>
   `;
 
 const AspectRatio = React.forwardRef(
-  ({ aspectRatio, children, className }, ref) => {
+  ({ aspectRatio, children, ...props }, ref) => {
     if (!children) {
       return null;
     }
@@ -68,7 +68,7 @@ const AspectRatio = React.forwardRef(
     const [child, ...restChildren] = Children.toArray(children);
 
     return (
-      <Wrapper ref={ref} aspectRatio={aspectRatio} className={className}>
+      <Wrapper ref={ref} aspectRatio={aspectRatio} {...props}>
         <ClassNames>
           {({ css: cssClassName, cx }) =>
             React.cloneElement(child, {

--- a/src/components/Button/components/PlainButton/PlainButton.js
+++ b/src/components/Button/components/PlainButton/PlainButton.js
@@ -55,13 +55,13 @@ const ButtonLinkWrapper = styled(StyledText)(
 ).withComponent('button');
 
 /* eslint-disable react/prop-types */
-const PlainButton = ({ components, href, ...rest }) => {
+const PlainButton = ({ components, href, ...props }) => {
   const PlainButtonWrapper = ButtonLinkWrapper.withComponent(components.Link);
 
   return href ? (
-    <PlainButtonWrapper noMargin {...{ ...rest, href }} />
+    <PlainButtonWrapper noMargin {...{ ...props, href }} />
   ) : (
-    <ButtonLinkWrapper noMargin {...rest} />
+    <ButtonLinkWrapper noMargin {...props} />
   );
 };
 

--- a/src/components/Button/components/RegularButton/RegularButton.js
+++ b/src/components/Button/components/RegularButton/RegularButton.js
@@ -19,7 +19,7 @@ import { css } from '@emotion/core';
 
 import { textMega, calculatePadding } from '../../../../styles/style-helpers';
 
-const baseStyles = ({ theme, ...otherProps }) => css`
+const baseStyles = ({ theme, ...props }) => css`
   label: button;
   background-color: ${theme.colors.n100};
   border-color: ${theme.colors.n300};
@@ -47,7 +47,7 @@ const baseStyles = ({ theme, ...otherProps }) => css`
     border-color: ${theme.colors.n500};
     border-width: 2px;
     outline: 0;
-    padding: ${calculatePadding({ theme, ...otherProps })('1px')};
+    padding: ${calculatePadding({ theme, ...props })('1px')};
   }
 
   &:hover {
@@ -58,7 +58,7 @@ const baseStyles = ({ theme, ...otherProps }) => css`
   &:active {
     border-color: ${theme.colors.n500};
     border-width: 1px;
-    padding: ${calculatePadding({ theme, ...otherProps })()};
+    padding: ${calculatePadding({ theme, ...props })()};
   }
 
   &[href] {
@@ -108,7 +108,7 @@ const stretchStyles = ({ stretch }) =>
     display: block;
   `;
 
-const flatStyles = ({ theme, flat, secondary, ...otherProps }) =>
+const flatStyles = ({ theme, flat, secondary, ...props }) =>
   flat &&
   !secondary &&
   css`
@@ -128,18 +128,16 @@ const flatStyles = ({ theme, flat, secondary, ...otherProps }) =>
     &:active:focus,
     &:hover:focus {
       border-width: 0;
-      padding: ${calculatePadding({ theme, flat, secondary, ...otherProps })()};
+      padding: ${calculatePadding({ theme, flat, secondary, ...props })()};
     }
 
     &:focus {
       border-width: 2px;
-      padding: ${calculatePadding({ theme, flat, secondary, ...otherProps })(
-        '2px'
-      )};
+      padding: ${calculatePadding({ theme, flat, secondary, ...props })('2px')};
     }
   `;
 
-const secondaryStyles = ({ theme, secondary, flat, ...otherProps }) =>
+const secondaryStyles = ({ theme, secondary, flat, ...props }) =>
   secondary &&
   css`
     label: button--secondary;
@@ -160,9 +158,7 @@ const secondaryStyles = ({ theme, secondary, flat, ...otherProps }) =>
       border-color: ${theme.colors.n900};
       border-width: 2px;
       box-shadow: none;
-      padding: ${calculatePadding({ theme, flat, secondary, ...otherProps })(
-        '2px'
-      )};
+      padding: ${calculatePadding({ theme, flat, secondary, ...props })('2px')};
     }
 
     &:hover {
@@ -175,7 +171,7 @@ const secondaryStyles = ({ theme, secondary, flat, ...otherProps }) =>
     &:hover,
     &:hover:focus,
     &:active:focus {
-      padding: ${calculatePadding({ theme, flat, secondary, ...otherProps })()};
+      padding: ${calculatePadding({ theme, flat, secondary, ...props })()};
     }
 
     &:active,
@@ -189,9 +185,7 @@ const secondaryStyles = ({ theme, secondary, flat, ...otherProps }) =>
       border-color: ${theme.colors.n900};
       border-width: 2px;
       box-shadow: none;
-      padding: ${calculatePadding({ theme, flat, secondary, ...otherProps })(
-        '2px'
-      )};
+      padding: ${calculatePadding({ theme, flat, secondary, ...props })('2px')};
     }
   `;
 

--- a/src/components/CalendarTag/CalendarTag.js
+++ b/src/components/CalendarTag/CalendarTag.js
@@ -17,14 +17,24 @@ import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 
 import { START_DATE } from 'react-dates/constants';
 
 import { RangePickerController } from '../Calendar';
 import Tag from '../Tag';
 
+const CalendarWrap = styled.div`
+  margin-top: ${({ theme }) => theme.spacings.byte};
+`;
+
 class CalendarTag extends Component {
+  static propTypes = {
+    /**
+     * Callback to receive the set of dates when the user selects them.
+     */
+    onDatesRangeChange: PropTypes.func.isRequired
+  };
+
   state = { startDate: null, endDate: null, focusedInput: null };
 
   buttonRef = null; // eslint-disable-line react/sort-comp
@@ -75,11 +85,12 @@ class CalendarTag extends Component {
   };
 
   render() {
+    const { onDatesRangeChange, ...props } = this.props;
     const { focusedInput, startDate, endDate } = this.state;
     const isOpen = focusedInput !== null;
 
     return (
-      <CalendarButtonWrap>
+      <div {...props}>
         <Tag
           selected={isOpen}
           ref={this.handleButtonRef}
@@ -99,33 +110,10 @@ class CalendarTag extends Component {
             />
           </CalendarWrap>
         )}
-      </CalendarButtonWrap>
+      </div>
     );
   }
 }
-
-const baseStyles = () => css`
-  label: button_calendar;
-`;
-
-const CalendarWrap = styled.div`
-  margin-top: ${({ theme }) => theme.spacings.byte};
-`;
-
-const CalendarButtonWrap = styled('div')`
-  ${baseStyles};
-`;
-
-/**
- * Describe your component here.
- */
-
-CalendarTag.propTypes = {
-  /**
-   * Callback to receive the set of dates when the user selects them.
-   */
-  onDatesRangeChange: PropTypes.func.isRequired
-};
 
 /**
  * @component

--- a/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -17,9 +17,7 @@ exports[`CalendarTag should render with default styles 1`] = `
   box-shadow: 0px 0px 0px 1px #D8DDE1;
 }
 
-<div
-  class="circuit-2 circuit-3"
->
+<div>
   <span
     class="circuit-0 circuit-1"
   >

--- a/src/components/CalendarTagTwoStep/CalendarTagTwoStep.js
+++ b/src/components/CalendarTagTwoStep/CalendarTagTwoStep.js
@@ -44,16 +44,8 @@ const buttonBase = ({ theme, primary }) => css`
 
 const InfoButton = styled('span')(buttonBase);
 
-const baseStyles = () => css`
-  label: button_calendar;
-`;
-
 const CalendarWrapper = styled.div`
   margin-top: ${({ theme }) => theme.spacings.byte};
-`;
-
-const CalendarTagWrapper = styled('div')`
-  ${baseStyles};
 `;
 
 /**
@@ -143,13 +135,13 @@ export default class CalendarTagTwoStep extends Component {
   };
 
   render() {
-    const { clearText, confirmText } = this.props;
+    const { clearText, confirmText, onDatesRangeChange, ...props } = this.props;
     const { focusedInput, startDate, endDate } = this.state;
     const isOpen = focusedInput !== null;
     const isFilled = !!(startDate && endDate);
 
     return (
-      <CalendarTagWrapper>
+      <div {...props}>
         <Tag
           selected={isOpen || isFilled}
           ref={this.handleButtonRef}
@@ -180,7 +172,7 @@ export default class CalendarTagTwoStep extends Component {
             />
           </CalendarWrapper>
         )}
-      </CalendarTagWrapper>
+      </div>
     );
   }
 }

--- a/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -17,9 +17,7 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
   box-shadow: 0px 0px 0px 1px #D8DDE1;
 }
 
-<div
-  class="circuit-2 circuit-3"
->
+<div>
   <span
     class="circuit-0 circuit-1"
   >

--- a/src/components/CardSchemes/CardSchemes.js
+++ b/src/components/CardSchemes/CardSchemes.js
@@ -42,13 +42,13 @@ const PaymentMethodIconWrap = styled('li')(CardSchemeBaseStyles);
 /**
  *   Displays a row of available or active card scheme icons
  */
-const CardSchemes = ({ iconIds, size }) => {
+const CardSchemes = ({ iconIds, size, ...props }) => {
   if (isEmpty(iconIds)) {
     return null;
   }
 
   return (
-    <CardSchemeWrapper>
+    <CardSchemeWrapper {...props}>
       {iconIds.map(iconId => (
         <PaymentMethodIconWrap key={iconId}>
           <PaymentMethodIcon size={size} iconId={iconId} />

--- a/src/components/Hamburger/Hamburger.js
+++ b/src/components/Hamburger/Hamburger.js
@@ -126,6 +126,7 @@ const HamburgerLayers = styled('span')`
   ${layersActiveStyles}
   ${layersBaseLightStyles};
 `;
+
 const HamburgerLabel = styled('span')`
   ${labelBaseStyles};
 `;
@@ -139,9 +140,9 @@ const Hamburger = ({
   labelActive,
   labelInActive,
   light,
-  ...rest
+  ...props
 }) => (
-  <HamburgerButton {...rest} onClick={onClick} light={light}>
+  <HamburgerButton {...props} onClick={onClick} light={light}>
     <HamburgerLayers isActive={isActive} light={light} />
     <HamburgerLabel>{isActive ? labelActive : labelInActive}</HamburgerLabel>
   </HamburgerButton>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -41,8 +41,8 @@ const mobileOnlyStyles = ({ theme, mobileOnly }) =>
 
 const Container = styled('div')(baseStyles, mobileOnlyStyles);
 
-const Header = ({ title, mobileOnly, children }) => (
-  <Container mobileOnly={mobileOnly}>
+const Header = ({ title, mobileOnly, children, ...props }) => (
+  <Container mobileOnly={mobileOnly} {...props}>
     {children}
     <Title>{title}</Title>
   </Container>

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -91,8 +91,8 @@ const StyledList = styled('ol', {
 /**
  * A list, which can be ordered or unordered
  */
-const List = ({ ordered, ...otherProps }) => (
-  <StyledList as={ordered ? 'ol' : 'ul'} {...otherProps} />
+const List = ({ ordered, ...props }) => (
+  <StyledList as={ordered ? 'ol' : 'ul'} {...props} />
 );
 
 List.KILO = KILO;

--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -147,7 +147,7 @@ const Modal = ({
   contentLabel,
   theme,
   appElement,
-  ...otherProps
+  ...props
 }) => {
   ReactModal.setAppElement(appElement);
   const getClassValues = mapValues(styleFn => styleFn({ theme }));
@@ -162,7 +162,7 @@ const Modal = ({
           onAfterClose: () => IS_IOS && noScroll.off(),
           onRequestClose: onClose,
           closeTimeoutMS: TRANSITION_DURATION,
-          ...otherProps
+          ...props
         };
         return (
           <ReactModal {...reactModalProps}>

--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -64,7 +64,7 @@ const Pagination = ({
   nextLabel,
   previousLabel,
   footer,
-  ...rest
+  ...props
 }) => {
   const totalPages = PaginationService.calculatePages(total, perPage);
 
@@ -81,7 +81,7 @@ const Pagination = ({
         nextLabel={nextLabel}
         previousLabel={previousLabel}
         footer={footer}
-        {...rest}
+        {...props}
       >
         {Array.from({ length: totalPages }).map((item, index) => (
           <PaginationButtonContainer
@@ -118,7 +118,7 @@ const Pagination = ({
       nextLabel={nextLabel}
       previousLabel={previousLabel}
       footer={footer}
-      {...rest}
+      {...props}
     >
       <PaginationButtonContainer
         currentPage={1}

--- a/src/components/Popover/Popover.js
+++ b/src/components/Popover/Popover.js
@@ -18,6 +18,7 @@ import PropTypes from 'prop-types';
 import { Manager, Reference, Popper } from 'react-popper';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+
 import Portal from '../Portal';
 
 import {
@@ -220,7 +221,7 @@ class Popover extends Component {
       zIndex,
       modifiers,
       usePortal,
-      ...rest
+      ...props
     } = this.props;
 
     const reference = !referenceElement && (
@@ -241,7 +242,7 @@ class Popover extends Component {
     const popper = isOpen && (
       <Popper
         {...{
-          ...rest,
+          ...props,
           // Only pass referenceElement if it's truthy
           ...(referenceElement && { referenceElement })
         }}

--- a/src/components/Portal/Portal.js
+++ b/src/components/Portal/Portal.js
@@ -20,10 +20,10 @@ import PropTypes from 'prop-types';
 import ownerDocument from '../../util/ownerDocument';
 
 function getContainer(container, defaultContainer) {
-  // eslint-disable-next-line no-param-reassign
-  container = typeof container === 'function' ? container() : container;
+  const customContainer =
+    typeof container === 'function' ? container() : container;
   // eslint-disable-next-line react/no-find-dom-node
-  return ReactDOM.findDOMNode(container) || defaultContainer;
+  return ReactDOM.findDOMNode(customContainer) || defaultContainer;
 }
 
 function getOwnerDocument(element) {

--- a/src/components/ProgressBar/ProgressBar.js
+++ b/src/components/ProgressBar/ProgressBar.js
@@ -98,17 +98,19 @@ const ProgressBarLabel = styled('span')`
 /**
  * Progress bar component to indicate progress
  */
-const ProgressBar = ({ children, max, value, ...props }) => {
+const ProgressBar = ({ children, max, value, size, ...props }) => {
   const ariaId = uniqueId('progress-bar_');
   return (
-    <ProgressBarWrapper>
+    <ProgressBarWrapper {...props}>
       <ProgressBarProgress
         role="progressbar"
         aria-valuenow={value}
         aria-valuemin="0"
         aria-valuemax={max}
         aria-labelledby={ariaId}
-        {...{ ...props, max, value }}
+        size={size}
+        max={max}
+        value={value}
       />
       <ProgressBarLabel id={ariaId}>{children}</ProgressBarLabel>
     </ProgressBarWrapper>
@@ -141,7 +143,7 @@ ProgressBar.propTypes = {
 
 ProgressBar.defaultProps = {
   size: ProgressBar.KILO,
-  max: 1.0,
+  max: 1,
   value: 0,
   children: null
 };

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -58,9 +58,9 @@ const openStyles = ({ theme, open }) =>
 
 const Drawer = styled('nav')(baseStyles, openStyles);
 
-const Sidebar = ({ children, open, closeButtonLabel, onClose, className }) => (
+const Sidebar = ({ children, open, closeButtonLabel, onClose, ...props }) => (
   <Fragment>
-    <Drawer open={open} className={className}>
+    <Drawer open={open} {...props}>
       {children}
     </Drawer>
     <Backdrop visible={open} onClick={onClose} data-testid="sidebar-backdrop" />
@@ -89,11 +89,7 @@ Sidebar.propTypes = {
   /**
    * A function to handle the sidebar close
    */
-  onClose: PropTypes.func,
-  /**
-   * A className to allow custom styles with Emotion's css prop
-   */
-  className: PropTypes.string
+  onClose: PropTypes.func
 };
 
 Sidebar.defaultProps = {

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -100,7 +100,7 @@ const NavItem = ({
   disabled,
   onClick,
   components,
-  ...rest
+  ...props
 }) => {
   const icon = getIcon({ defaultIcon, selected, selectedIcon, disabled });
   const Link = StyledLink.withComponent(components.Link);
@@ -118,7 +118,7 @@ const NavItem = ({
         secondary={secondary}
         visible={visible}
         disabled={disabled}
-        {...rest}
+        {...props}
       >
         {icon}
         <NavLabel secondary={secondary} visible={visible}>

--- a/src/components/Sidebar/components/SubNavList/SubNavList.js
+++ b/src/components/Sidebar/components/SubNavList/SubNavList.js
@@ -86,10 +86,11 @@ const SubNavigationContainer = styled.ul(
   visibleStyles
 );
 
-const SubNavList = ({ children, visible }) => (
+const SubNavList = ({ children, visible, ...props }) => (
   <SubNavigationContainer
     visible={visible}
     selectedChildIndex={getSelectedChildIndex(children)}
+    {...props}
   >
     {getSecondaryChild(children, visible)}
   </SubNavigationContainer>

--- a/src/components/Sidebar/components/SubNavList/SubNavList.js
+++ b/src/components/Sidebar/components/SubNavList/SubNavList.js
@@ -88,9 +88,9 @@ const SubNavigationContainer = styled.ul(
 
 const SubNavList = ({ children, visible, ...props }) => (
   <SubNavigationContainer
+    {...props}
     visible={visible}
     selectedChildIndex={getSelectedChildIndex(children)}
-    {...props}
   >
     {getSecondaryChild(children, visible)}
   </SubNavigationContainer>

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -243,7 +243,8 @@ class Table extends Component {
       borderCollapsed,
       condensed,
       scrollable,
-      onRowClick
+      onRowClick,
+      ...props
     } = this.props;
     const {
       sortDirection,
@@ -261,6 +262,7 @@ class Table extends Component {
         scrollable={scrollable}
         rowHeaders={rowHeaders}
         noShadow={noShadow}
+        {...props}
       >
         <ScrollContainer
           rowHeaders={rowHeaders}

--- a/src/components/Table/components/TableHeader/TableHeader.js
+++ b/src/components/Table/components/TableHeader/TableHeader.js
@@ -132,13 +132,13 @@ const TableHeader = ({
   children,
   sortDirection,
   condensed,
-  ...rest
+  ...props
 }) => (
   <StyledHeader
     sortable={sortable}
     condensed={condensed}
     aria-sort={getAriaSort(sortable, sortDirection)}
-    {...rest}
+    {...props}
   >
     {sortable && <SortArrow condensed={condensed} direction={sortDirection} />}
     {children}

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -69,7 +69,7 @@ class Tabs extends Component {
   };
 
   render() {
-    const { items } = this.props;
+    const { items, ...props } = this.props;
     const { selectedIndex } = this.state;
     const { tabs, panels } = items.reduce(
       (aggr, { id, tab, panel }, index) => {
@@ -111,7 +111,7 @@ class Tabs extends Component {
 
     return (
       <Fragment>
-        <TabList>{tabs}</TabList>
+        <TabList {...props}>{tabs}</TabList>
         {panels}
       </Fragment>
     );


### PR DESCRIPTION
Closes #527.

## Purpose

Functional and class components should forward any additional props to their outermost child component. This is important for `data-testid`s and custom styles using Emotion's `styled` function.

## Approach and changes

- capture all additional props and spread them on a component's outermost child node

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
