### PR TITLE
docs: show addons panel by default

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -6,7 +6,7 @@ import { theme, components } from './util/theme';
 addons.setConfig({
   theme,
   isFullscreen: false,
-  showPanel: false,
+  showPanel: true,
   panelPosition: 'bottom',
   isToolshown: true
 });


### PR DESCRIPTION
## Purpose

This should make it easier to find code samples.

## Approach and changes

- modify Storybook config

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] ~Unit and integration tests~
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
