### PR TITLE
fix(components): make AutocompleteInput compatible with new clear option

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -15818,6 +15818,7 @@ label + .circuit-3 {
         class="circuit-1 circuit-2"
         id="3"
         role="combobox"
+        type="text"
         value=""
       />
     </div>
@@ -15936,6 +15937,7 @@ label + .circuit-3 {
         class="circuit-1 circuit-2"
         id="1"
         role="combobox"
+        type="text"
         value=""
       />
     </div>
@@ -16054,6 +16056,7 @@ label + .circuit-3 {
         class="circuit-1 circuit-2"
         id="2"
         role="combobox"
+        type="text"
         value=""
       />
     </div>
@@ -16161,6 +16164,7 @@ label + .circuit-3 {
       class="circuit-1 circuit-2"
       id="downshift-3-input"
       role="combobox"
+      type="text"
       value=""
     />
   </div>
@@ -17247,6 +17251,7 @@ label + .circuit-3 {
       class="circuit-1 circuit-2"
       id="38"
       placeholder="Search..."
+      type="text"
       value=""
     />
   </div>
@@ -17347,6 +17352,7 @@ label + .circuit-3 {
       class="circuit-1 circuit-2"
       id="40"
       placeholder="Search..."
+      type="text"
       value=""
     />
   </div>
@@ -17452,6 +17458,7 @@ label + .circuit-3 {
       disabled=""
       id="39"
       placeholder="Search..."
+      type="text"
       value=""
     />
   </div>

--- a/src/components/AutoCompleteInput/AutoCompleteInput.js
+++ b/src/components/AutoCompleteInput/AutoCompleteInput.js
@@ -21,7 +21,6 @@ import Downshift from 'downshift';
 import { includes, isString, isEmpty } from 'lodash/fp';
 
 import SearchInput from '../SearchInput';
-import CloseButton from '../CloseButton';
 import Card from '../Card';
 import Text from '../Text';
 import {
@@ -43,11 +42,6 @@ const autoCompleteWrapperStyles = ({ theme }) => css`
 `;
 
 const AutoCompleteWrapper = styled('div')(autoCompleteWrapperStyles);
-
-const ClearButton = styled(CloseButton)`
-  label: input__button-clear;
-  pointer-events: all !important;
-`;
 
 const optionsStyles = ({ theme }) => css`
   label: input__options;
@@ -192,8 +186,7 @@ export default class AutoCompleteInput extends Component {
       ...inputProps
     } = this.props;
 
-    const renderSuffix = props =>
-      showClear ? <ClearButton {...props} onClick={this.handleClear} /> : null;
+    const onClear = showClear && this.handleClear;
 
     return (
       <Downshift
@@ -216,8 +209,8 @@ export default class AutoCompleteInput extends Component {
             <AutoCompleteWrapper {...getRootProps({ refKey: 'innerRef' })}>
               <SearchInput
                 {...getInputProps(inputProps)}
+                onClear={onClear}
                 noMargin
-                renderSuffix={renderSuffix}
               />
               {isOpen && !isEmpty(maxOptions) && (
                 <Options spacing={Card.MEGA}>

--- a/src/components/AutoCompleteInput/AutoCompleteInput.js
+++ b/src/components/AutoCompleteInput/AutoCompleteInput.js
@@ -186,7 +186,7 @@ export default class AutoCompleteInput extends Component {
       ...inputProps
     } = this.props;
 
-    const onClear = showClear && this.handleClear;
+    const onClear = showClear ? this.handleClear : null;
 
     return (
       <Downshift

--- a/src/components/AutoCompleteInput/AutoCompleteInput.story.js
+++ b/src/components/AutoCompleteInput/AutoCompleteInput.story.js
@@ -116,6 +116,7 @@ const AsyncAutoCompleteInput = () => {
       onChange={action('handleChange')}
       onInputValueChange={handleInputValueChange}
       filterOptions={opts => opts}
+      showClear
     />
   );
 };

--- a/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
+++ b/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
@@ -100,6 +100,7 @@ label + .circuit-3 {
       class="circuit-1 circuit-2"
       id="downshift-0-input"
       role="combobox"
+      type="text"
       value=""
     />
   </div>

--- a/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
+++ b/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
@@ -100,6 +100,7 @@ label + .circuit-3 {
       class="circuit-1 circuit-2"
       id="downshift-0-input"
       role="combobox"
+      type="text"
       value=""
     />
   </div>

--- a/src/components/SearchInput/SearchInput.js
+++ b/src/components/SearchInput/SearchInput.js
@@ -35,6 +35,7 @@ const StyledClearIcon = styled(ClearIcon)`
 const SearchInput = ({ children, value, onClear, ...props }) => (
   <Input
     value={value}
+    type="text"
     renderPrefix={({ className }) => <SearchIcon {...{ className }} />}
     renderSuffix={({ className }) =>
       value && onClear ? (

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
@@ -93,6 +93,7 @@ label + .circuit-5 {
   <input
     aria-invalid="false"
     class="circuit-1 circuit-2"
+    type="text"
     value="search value"
   />
   <div
@@ -189,6 +190,7 @@ label + .circuit-3 {
     aria-invalid="false"
     class="circuit-1 circuit-2"
     disabled=""
+    type="text"
     value=""
   />
 </div>
@@ -275,6 +277,7 @@ label + .circuit-3 {
   <input
     aria-invalid="false"
     class="circuit-1 circuit-2"
+    type="text"
     value=""
   />
 </div>


### PR DESCRIPTION
Follow-up to #555.

## Purpose

The AutocompleteInput wraps the SearchInput. The new clear button introduced in #555 wasn't compatible with the `showClear` option of the AutocompleteInput. This PR fixes this.

## Approach and changes

- use the clear button from the SearchInput instead of providing a custom one in AutocompleteInput

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
