### PR TITLE
feat(components): improve clear button on inputs

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -12707,9 +12707,9 @@ label + .circuit-14 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -12943,9 +12943,9 @@ HTMLCollection [
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -13236,9 +13236,9 @@ label + .circuit-14 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -13613,9 +13613,9 @@ HTMLCollection [
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -13717,9 +13717,9 @@ HTMLCollection [
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -13823,9 +13823,9 @@ HTMLCollection [
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -13931,9 +13931,9 @@ HTMLCollection [
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -14103,9 +14103,9 @@ HTMLCollection [
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -14382,9 +14382,9 @@ exports[`Storyshots Forms/Input Base 1`] = `
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -14564,9 +14564,9 @@ exports[`Storyshots Forms/Input Inline 1`] = `
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -14640,9 +14640,9 @@ label + .circuit-7 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -14816,9 +14816,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -14937,9 +14937,9 @@ exports[`Storyshots Forms/Input Optional 1`] = `
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -15039,9 +15039,9 @@ exports[`Storyshots Forms/Input Right Aligned 1`] = `
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -15199,9 +15199,9 @@ label + .circuit-7 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -15355,9 +15355,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -15424,9 +15424,9 @@ label + .circuit-7 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -15600,9 +15600,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -15741,9 +15741,9 @@ label + .circuit-3 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -15860,9 +15860,9 @@ label + .circuit-3 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -15979,9 +15979,9 @@ label + .circuit-3 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -16092,9 +16092,9 @@ label + .circuit-3 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -16247,9 +16247,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -16305,9 +16305,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -16459,9 +16459,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -16568,9 +16568,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -16622,9 +16622,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -16774,9 +16774,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -16868,9 +16868,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -16912,9 +16912,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -17040,9 +17040,9 @@ exports[`Storyshots Forms/Input/MaskedInput Base 1`] = `
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -17126,9 +17126,9 @@ exports[`Storyshots Forms/Input/RestrictedInput Base 1`] = `
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -17168,9 +17168,9 @@ exports[`Storyshots Forms/Input/SearchInput Base 1`] = `
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -17237,7 +17237,7 @@ label + .circuit-3 {
   class="circuit-5 circuit-6"
   for="38"
 >
-  Label
+  Search
   <div
     class="circuit-3 circuit-4"
   >
@@ -17269,9 +17269,9 @@ exports[`Storyshots Forms/Input/SearchInput Clearable 1`] = `
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -17370,9 +17370,9 @@ exports[`Storyshots Forms/Input/SearchInput Disabled 1`] = `
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -17442,7 +17442,7 @@ label + .circuit-3 {
   class="circuit-5 circuit-6"
   for="39"
 >
-  Label
+  Search
   <div
     class="circuit-3 circuit-4"
     disabled=""
@@ -18448,9 +18448,9 @@ exports[`Storyshots Forms/TextArea Base 1`] = `
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -18654,9 +18654,9 @@ label + .circuit-7 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -18822,9 +18822,9 @@ exports[`Storyshots Forms/TextArea Optional 1`] = `
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -18939,9 +18939,9 @@ label + .circuit-7 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 

--- a/src/components/AutoCompleteInput/AutoCompleteInput.js
+++ b/src/components/AutoCompleteInput/AutoCompleteInput.js
@@ -129,9 +129,19 @@ export default class AutoCompleteInput extends Component {
      */
     clearOnSelect: PropTypes.bool,
     /**
-     * Whether to show a button that clears the selection when clicked
+     * Callback function that is called when the user clears the input
      */
-    showClear: PropTypes.bool,
+    onClear: PropTypes.func,
+    /**
+     * @deprecated
+     */
+    showClear: deprecatedPropType(
+      PropTypes.bool,
+      [
+        'The "showClear" prop has been deprecated.',
+        `Use the "onClear" callback prop instead.`
+      ].join(' ')
+    ),
     /**
      * @deprecated
      */
@@ -167,6 +177,9 @@ export default class AutoCompleteInput extends Component {
     if (this.downshiftRef) {
       this.downshiftRef.clearSelection();
     }
+    if (this.props.onClear) {
+      this.props.onClear();
+    }
   };
 
   handleDownShiftRef = ref => {
@@ -182,11 +195,12 @@ export default class AutoCompleteInput extends Component {
       onInputValueChange,
       filterOptions,
       maxNumberOfOptions,
+      onClear,
       showClear,
       ...inputProps
     } = this.props;
 
-    const onClear = showClear ? this.handleClear : null;
+    const handleClear = showClear || onClear ? this.handleClear : null;
 
     return (
       <Downshift
@@ -209,7 +223,7 @@ export default class AutoCompleteInput extends Component {
             <AutoCompleteWrapper {...getRootProps({ refKey: 'innerRef' })}>
               <SearchInput
                 {...getInputProps(inputProps)}
-                onClear={onClear}
+                onClear={handleClear}
                 noMargin
               />
               {isOpen && !isEmpty(maxOptions) && (

--- a/src/components/AutoCompleteInput/AutoCompleteInput.spec.js
+++ b/src/components/AutoCompleteInput/AutoCompleteInput.spec.js
@@ -18,9 +18,9 @@ import React from 'react';
 import AutoCompleteInput from './AutoCompleteInput';
 
 const options = [
-  { value: '1111111111111', 'data-testid': 'autocomplete-input-option' },
-  { value: '2222222222222', 'data-testid': 'autocomplete-input-option' },
-  { value: '3333333333333', 'data-testid': 'autocomplete-input-option' }
+  { value: 'Apple', 'data-testid': 'autocomplete-input-option' },
+  { value: 'Mango', 'data-testid': 'autocomplete-input-option' },
+  { value: 'Banana', 'data-testid': 'autocomplete-input-option' }
 ];
 
 describe('AutoCompleteInput', () => {
@@ -37,9 +37,34 @@ describe('AutoCompleteInput', () => {
   /**
    * Logic tests.
    */
-  it('should filter options when input is changed', () => {
+  it('should filter options as the user types', () => {
     const onChange = jest.fn();
+    const onInputValueChange = jest.fn();
     const { getByTestId } = render(
+      <AutoCompleteInput
+        onChange={onChange}
+        onInputValueChange={onInputValueChange}
+        options={options}
+        data-testid="autocomplete-input"
+      />
+    );
+
+    const inputEl = getByTestId('autocomplete-input');
+
+    act(() => {
+      userEvent.type(inputEl, 'app');
+    });
+
+    const optionEl = getByTestId('autocomplete-input-option');
+
+    expect(optionEl).toHaveTextContent('Apple');
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onInputValueChange).toHaveBeenCalledTimes(3);
+  });
+
+  it('should select on option from the list', () => {
+    const onChange = jest.fn();
+    const { getByTestId, getAllByTestId } = render(
       <AutoCompleteInput
         onChange={onChange}
         options={options}
@@ -50,11 +75,50 @@ describe('AutoCompleteInput', () => {
     const inputEl = getByTestId('autocomplete-input');
 
     act(() => {
-      userEvent.type(inputEl, '222');
+      userEvent.type(inputEl, 'an');
     });
 
-    const optionEl = getByTestId('autocomplete-input-option');
+    const optionEls = getAllByTestId('autocomplete-input-option');
 
-    expect(optionEl).toHaveTextContent('2222222222222');
+    expect(optionEls).toHaveLength(2);
+
+    act(() => {
+      userEvent.click(optionEls[0]);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('Mango');
+  });
+
+  it('should reset the value when the user clears the field', () => {
+    const onChange = jest.fn();
+    const onClear = jest.fn();
+    const { getByTestId, getAllByTestId } = render(
+      <AutoCompleteInput
+        onChange={onChange}
+        onClear={onClear}
+        options={options}
+        data-testid="autocomplete-input"
+      />
+    );
+
+    const inputEl = getByTestId('autocomplete-input');
+
+    act(() => {
+      userEvent.type(inputEl, 'an');
+    });
+
+    const optionEls = getAllByTestId('autocomplete-input-option');
+    const clearEl = getByTestId('input-clear');
+
+    expect(optionEls).toHaveLength(2);
+
+    act(() => {
+      userEvent.click(optionEls[0]);
+      userEvent.click(clearEl);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onClear).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/AutoCompleteInput/AutoCompleteInput.story.js
+++ b/src/components/AutoCompleteInput/AutoCompleteInput.story.js
@@ -62,7 +62,6 @@ const AutoCompleteInputWithLabel = props => {
       {"What's your favourite fruit?"}
       <AutoCompleteInput
         clearOnSelect={boolean('clearOnSelect', false)}
-        showClear={boolean('showClear', false)}
         {...props}
         id={id}
       />
@@ -73,8 +72,9 @@ const AutoCompleteInputWithLabel = props => {
 export const base = () => (
   <AutoCompleteInputWithLabel
     options={items}
-    onChange={action('handleChange')}
-    onInputValueChange={action('handleInputValueChange')}
+    onChange={action('onChange')}
+    onInputValueChange={action('onInputValueChange')}
+    onClear={action('onClear')}
   />
 );
 
@@ -90,8 +90,9 @@ export const customOptions = () => {
   return (
     <AutoCompleteInputWithLabel
       options={options}
-      onChange={action('handleChange')}
-      onInputValueChange={action('handleInputValueChange')}
+      onChange={action('onChange')}
+      onInputValueChange={action('onInputValueChange')}
+      onClear={action('onClear')}
     />
   );
 };
@@ -99,7 +100,8 @@ export const customOptions = () => {
 const AsyncAutoCompleteInput = () => {
   const [options, setOptions] = useState([]);
 
-  const handleInputValueChange = debounce(100, inputValue =>
+  const handleInputValueChange = debounce(100, inputValue => {
+    action('onInputValueChange')(inputValue);
     setTimeout(() => {
       const filteredOptions = inputValue
         ? items.filter(option =>
@@ -107,16 +109,16 @@ const AsyncAutoCompleteInput = () => {
           )
         : options;
       setOptions(filteredOptions);
-    }, 500)
-  );
+    }, 500);
+  });
 
   return (
     <AutoCompleteInputWithLabel
       options={options}
-      onChange={action('handleChange')}
+      onChange={action('onChange')}
       onInputValueChange={handleInputValueChange}
       filterOptions={opts => opts}
-      showClear
+      onClear={action('onClear')}
     />
   );
 };

--- a/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
+++ b/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
@@ -28,9 +28,9 @@ label + .circuit-3 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 

--- a/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
+++ b/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
@@ -28,9 +28,9 @@ label + .circuit-3 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 

--- a/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
+++ b/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
@@ -120,9 +120,9 @@ label + .circuit-14 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -370,9 +370,9 @@ label + .circuit-14 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -586,9 +586,9 @@ HTMLCollection [
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 

--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
@@ -70,9 +70,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -167,9 +167,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -301,9 +301,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -400,9 +400,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -513,9 +513,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -630,9 +630,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -677,9 +677,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -164,8 +164,8 @@ const prefixStyles = theme => css`
   position: absolute;
   top: 1px;
   left: 1px;
-  ${size(theme.spacings.mega)};
-  margin: ${theme.spacings.kilo};
+  ${size(theme.spacings.peta)};
+  padding: ${theme.spacings.kilo};
   pointer-events: none;
 `;
 
@@ -178,8 +178,8 @@ const suffixStyles = theme => css`
   position: absolute;
   top: 1px;
   right: 1px;
-  ${size(theme.spacings.mega)};
-  margin: ${theme.spacings.kilo};
+  ${size(theme.spacings.peta)};
+  padding: ${theme.spacings.kilo};
   pointer-events: none;
 `;
 

--- a/src/components/Input/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__snapshots__/Input.spec.js.snap
@@ -95,9 +95,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -234,9 +234,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -401,9 +401,9 @@ label + .circuit-6 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -486,9 +486,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -635,9 +635,9 @@ exports[`Input should render with custom styles 1`] = `
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -780,9 +780,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -927,9 +927,9 @@ exports[`Input should render with inline styles when passed the inline prop 1`] 
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -981,9 +981,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -1133,9 +1133,9 @@ exports[`Input should render with no margin styles when passed the noMargin prop
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -1185,9 +1185,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -1273,9 +1273,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -1406,9 +1406,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -1525,9 +1525,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 

--- a/src/components/SearchInput/SearchInput.docs.mdx
+++ b/src/components/SearchInput/SearchInput.docs.mdx
@@ -14,8 +14,14 @@ to search information on the screen.
 
 ## Component variations
 
-### Disabled
+## Disabled
 
 The search input can be disabled.
 
 <Story id="forms-input-searchinput--disabled" />
+
+## Clearable
+
+A small 'x' appears once a users starts typing in the field. When clicked, the button clears the field.
+
+<Story id="forms-input-searchinput--clearable" />

--- a/src/components/SearchInput/SearchInput.js
+++ b/src/components/SearchInput/SearchInput.js
@@ -18,13 +18,12 @@ import PropTypes from 'prop-types';
 
 import styled from '@emotion/styled';
 
-import { childrenPropType } from '../../util/shared-prop-types';
-
 import Input from '../Input';
+import IconButton from '../IconButton';
 import { ReactComponent as SearchIcon } from './icons/search.svg';
 import { ReactComponent as ClearIcon } from './icons/clear.svg';
 
-const StyledClearIcon = styled(ClearIcon)`
+const ClearButton = styled(IconButton)`
   pointer-events: all !important;
   cursor: pointer !important;
 `;
@@ -32,14 +31,21 @@ const StyledClearIcon = styled(ClearIcon)`
 /**
  * SearchInput component for forms.
  */
-const SearchInput = ({ children, value, onClear, ...props }) => (
+const SearchInput = ({ children, value, onClear, clearLabel, ...props }) => (
   <Input
     value={value}
     type="text"
-    renderPrefix={({ className }) => <SearchIcon {...{ className }} />}
-    renderSuffix={({ className }) =>
+    renderPrefix={renderProps => <SearchIcon {...renderProps} />}
+    renderSuffix={renderProps =>
       value && onClear ? (
-        <StyledClearIcon onClick={onClear} {...{ className }} />
+        <ClearButton
+          onClick={onClear}
+          label={clearLabel}
+          data-testid="input-clear"
+          {...renderProps}
+        >
+          <ClearIcon />
+        </ClearButton>
       ) : null
     }
     {...props}
@@ -50,13 +56,20 @@ const SearchInput = ({ children, value, onClear, ...props }) => (
 
 SearchInput.propTypes = {
   ...Input.propTypes,
-  children: childrenPropType,
-  onClear: PropTypes.func
+  /**
+   * Callback function when the user clears the field.
+   */
+  onClear: PropTypes.func,
+  /**
+   * Visually hidden text label on the clear button for screen readers.
+   * Crucial for accessibility.
+   */
+  clearLabel: PropTypes.string
 };
 
 SearchInput.defaultProps = {
-  children: null,
-  onClear: null
+  onClear: null,
+  clearLabel: 'Clear'
 };
 
 /**

--- a/src/components/SearchInput/SearchInput.spec.js
+++ b/src/components/SearchInput/SearchInput.spec.js
@@ -36,10 +36,10 @@ describe('SearchInput', () => {
   it('should display a clear icon when not empty and an onClear callback is provided', () => {
     const onClear = jest.fn(identity);
 
-    const actual = create(
+    const { getByTestId } = render(
       <SearchInput value="search value" onClear={onClear} />
     );
-    expect(actual).toMatchSnapshot();
+    expect(getByTestId('input-clear')).toBeVisible();
   });
 
   /**

--- a/src/components/SearchInput/SearchInput.story.js
+++ b/src/components/SearchInput/SearchInput.story.js
@@ -36,7 +36,7 @@ const SearchInputWithLabel = props => {
   const id = uniqueId();
   return (
     <Label htmlFor={id}>
-      Label
+      Search
       <SearchInput placeholder="Search..." {...props} id={id} />
     </Label>
   );

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
@@ -1,117 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SearchInput should display a clear icon when not empty and an onClear callback is provided 1`] = `
-.circuit-5 {
-  color: #212933;
-  display: block;
-  position: relative;
-  margin-bottom: 16px;
-}
-
-label > .circuit-5,
-label + .circuit-5 {
-  margin-top: 4px;
-}
-
-.circuit-0 {
-  position: absolute;
-  top: 1px;
-  left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
-  pointer-events: none;
-}
-
-.circuit-1 {
-  background-color: #FFFFFF;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #D8DDE1;
-  border-radius: 4px;
-  box-shadow: inset 0 1px 2px 0 rgba(102,113,123,0.12);
-  padding: 8px 12px;
-  -webkit-transition: border-color 200ms ease-in-out;
-  transition: border-color 200ms ease-in-out;
-  width: 100%;
-  font-size: 16px;
-  line-height: 24px;
-  padding-left: calc( 12px + 16px + 12px );
-  padding-right: calc( 12px + 16px + 12px );
-}
-
-.circuit-1:focus,
-.circuit-1:active {
-  border: 1px solid #3388FF;
-  outline: none;
-}
-
-.circuit-1::-webkit-input-placeholder {
-  color: #9DA7B1;
-  -webkit-transition: color 200ms ease-in-out;
-  transition: color 200ms ease-in-out;
-}
-
-.circuit-1::-moz-placeholder {
-  color: #9DA7B1;
-  -webkit-transition: color 200ms ease-in-out;
-  transition: color 200ms ease-in-out;
-}
-
-.circuit-1:-ms-input-placeholder {
-  color: #9DA7B1;
-  -webkit-transition: color 200ms ease-in-out;
-  transition: color 200ms ease-in-out;
-}
-
-.circuit-1::placeholder {
-  color: #9DA7B1;
-  -webkit-transition: color 200ms ease-in-out;
-  transition: color 200ms ease-in-out;
-}
-
-.circuit-3 {
-  pointer-events: all !important;
-  cursor: pointer !important;
-  position: absolute;
-  top: 1px;
-  right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
-  pointer-events: none;
-}
-
-<div
-  class="circuit-5 circuit-6"
->
-  <div
-    class="circuit-0"
-  >
-    search.svg
-  </div>
-  <input
-    aria-invalid="false"
-    class="circuit-1 circuit-2"
-    type="text"
-    value="search value"
-  />
-  <div
-    class="circuit-3 circuit-4"
-  >
-    clear.svg
-  </div>
-</div>
-`;
-
 exports[`SearchInput should grey out icon when disabled 1`] = `
 .circuit-0 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -213,9 +109,9 @@ label + .circuit-3 {
   position: absolute;
   top: 1px;
   left: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 

--- a/src/components/SearchInput/icons/clear.svg
+++ b/src/components/SearchInput/icons/clear.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M7 7L17 17M17 7C13.0948 10.9052 10.9052 13.0948 7 17" stroke="#212933" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
@@ -97,9 +97,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -238,9 +238,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -409,9 +409,9 @@ label + .circuit-6 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -542,9 +542,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -629,9 +629,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -716,9 +716,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -867,9 +867,9 @@ exports[`TextArea should render with inline styles when passed the inline prop 1
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -921,9 +921,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -1077,9 +1077,9 @@ exports[`TextArea should render with no margin styles when passed the noMargin p
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -1129,9 +1129,9 @@ label + .circuit-4 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -1268,9 +1268,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 
@@ -1389,9 +1389,9 @@ label + .circuit-5 {
   position: absolute;
   top: 1px;
   right: 1px;
-  height: 16px;
-  width: 16px;
-  margin: 12px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
   pointer-events: none;
 }
 


### PR DESCRIPTION
Follow-up to #555 and #558.

## Purpose

My previous PR (#558) didn't make the clear button work for the AutocompleteInput. I thought it would call the `onChange` prop, but it didn't. This PR implements an alternative approach. While I was at it, I also improved the usability and accessibility of the clear button.

## Approach and changes

- **Increase tap target size on input prefix and suffix**: By switching from margin to padding for the spacing, the prefix and suffix elements get a much larger tap target size: 16px to 40px. This is especially important on touchscreen devices, but also improves usability for mouse users.
- **Improve accessibility of the SearchInput clear button**: The clear icon is really a button, so made it one. I also added a visually hidden label for screen readers.
- **Deprecate `showClear` in favor of `onClear` prop**: This brings the AutocompleteInput API in line with the SearchInput API. It also fixes the functionality of the clear button on the AutocompleteInput.

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
