### PR TITLE
feat(components): refactor AutoCompleteTags

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -11385,6 +11385,21 @@ exports[`Storyshots Components/Tag Clickable 1`] = `
 `;
 
 exports[`Storyshots Components/Tag Removable 1`] = `
+.circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 .circuit-4 {
   padding: 0;
   margin: 0;
@@ -11408,21 +11423,6 @@ exports[`Storyshots Components/Tag Removable 1`] = `
 .circuit-4 > svg {
   height: 100%;
   width: 100%;
-}
-
-.circuit-0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
 }
 
 .circuit-6 {
@@ -16159,6 +16159,7 @@ label + .circuit-8 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -16388,7 +16389,7 @@ label + .circuit-3 {
         aria-invalid="false"
         autocomplete="off"
         class="circuit-1 circuit-2"
-        id="downshift-3-input"
+        id="downshift-4-input"
         placeholder="Search by email"
         role="combobox"
         type="text"
@@ -16481,6 +16482,21 @@ label + .circuit-3 {
   transition: color 200ms ease-in-out;
 }
 
+.circuit-7 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 .circuit-16 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -16536,21 +16552,6 @@ label + .circuit-3 {
   width: 100%;
 }
 
-.circuit-7 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
 <div
   style="height: 20vh;"
 >
@@ -16571,7 +16572,7 @@ label + .circuit-3 {
         aria-invalid="false"
         autocomplete="off"
         class="circuit-1 circuit-2"
-        id="downshift-4-input"
+        id="downshift-5-input"
         placeholder="Search by email"
         role="combobox"
         type="text"

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -11385,31 +11385,6 @@ exports[`Storyshots Components/Tag Clickable 1`] = `
 `;
 
 exports[`Storyshots Components/Tag Removable 1`] = `
-.circuit-0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  -webkit-clip-path: inset(50%);
-  clip-path: inset(50%);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-6 {
-  border-radius: 4px;
-  font-size: 16px;
-  line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
-  padding: 4px 12px;
-  cursor: default;
-  display: inline-block;
-}
-
 .circuit-4 {
   padding: 0;
   margin: 0;
@@ -11433,6 +11408,31 @@ exports[`Storyshots Components/Tag Removable 1`] = `
 .circuit-4 > svg {
   height: 100%;
   width: 100%;
+}
+
+.circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-6 {
+  border-radius: 4px;
+  font-size: 16px;
+  line-height: 24px;
+  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  padding: 4px 12px;
+  cursor: default;
+  display: inline-block;
 }
 
 <span
@@ -12687,6 +12687,7 @@ label + .circuit-14 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -12923,6 +12924,7 @@ HTMLCollection [
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -13216,6 +13218,7 @@ label + .circuit-14 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -13593,6 +13596,7 @@ HTMLCollection [
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -13697,6 +13701,7 @@ HTMLCollection [
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -13803,6 +13808,7 @@ HTMLCollection [
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -13911,6 +13917,7 @@ HTMLCollection [
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -14083,6 +14090,7 @@ HTMLCollection [
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -14362,6 +14370,7 @@ exports[`Storyshots Forms/Input Base 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -14461,6 +14470,7 @@ exports[`Storyshots Forms/Input Disabled 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -14544,6 +14554,7 @@ exports[`Storyshots Forms/Input Inline 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -14720,6 +14731,7 @@ label + .circuit-7 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -14855,6 +14867,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -14988,6 +15001,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   background-color: #FAFBFC;
   border-style: dashed;
   box-shadow: none;
@@ -15090,6 +15104,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   text-align: right;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -15166,6 +15181,7 @@ HTMLCollection [
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -15322,6 +15338,7 @@ label + .circuit-7 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -15504,6 +15521,7 @@ label + .circuit-7 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -15639,6 +15657,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -15780,6 +15799,7 @@ label + .circuit-3 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -15899,6 +15919,7 @@ label + .circuit-3 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -16018,6 +16039,7 @@ label + .circuit-3 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -16311,6 +16333,7 @@ label + .circuit-3 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -16346,27 +16369,241 @@ label + .circuit-3 {
 }
 
 <div
-  class="circuit-5 circuit-6"
+  style="height: 20vh;"
 >
   <div
-    class="circuit-3 circuit-4"
+    class="circuit-5 circuit-6"
   >
     <div
-      class="circuit-0"
+      class="circuit-3 circuit-4"
     >
-      search.svg
+      <div
+        class="circuit-0"
+      >
+        search.svg
+      </div>
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-invalid="false"
+        autocomplete="off"
+        class="circuit-1 circuit-2"
+        id="downshift-3-input"
+        placeholder="Search by email"
+        role="combobox"
+        type="text"
+        value=""
+      />
     </div>
-    <input
-      aria-autocomplete="list"
-      aria-expanded="false"
-      aria-invalid="false"
-      autocomplete="off"
-      class="circuit-1 circuit-2"
-      id="downshift-4-input"
-      role="combobox"
-      type="text"
-      value=""
-    />
+  </div>
+</div>
+`;
+
+exports[`Storyshots Forms/Input/AutoCompleteTags Selected 1`] = `
+.circuit-5 {
+  position: relative;
+  min-width: 150px;
+}
+
+label > .circuit-5,
+label + .circuit-5 {
+  margin-top: 4px;
+}
+
+.circuit-3 {
+  color: #212933;
+  display: block;
+  position: relative;
+  margin-bottom: 16px;
+  margin-bottom: 0;
+}
+
+label > .circuit-3,
+label + .circuit-3 {
+  margin-top: 4px;
+}
+
+.circuit-0 {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  height: 40px;
+  width: 40px;
+  padding: 12px;
+  pointer-events: none;
+}
+
+.circuit-1 {
+  background-color: #FFFFFF;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #D8DDE1;
+  border-radius: 4px;
+  box-shadow: inset 0 1px 2px 0 rgba(102,113,123,0.12);
+  padding: 8px 12px;
+  -webkit-transition: border-color 200ms ease-in-out;
+  transition: border-color 200ms ease-in-out;
+  width: 100%;
+  font-size: 16px;
+  line-height: 24px;
+  margin: 0;
+  padding-left: calc( 12px + 16px + 12px );
+  padding-right: calc( 12px + 16px + 12px );
+}
+
+.circuit-1:focus,
+.circuit-1:active {
+  border: 1px solid #3388FF;
+  outline: none;
+}
+
+.circuit-1::-webkit-input-placeholder {
+  color: #9DA7B1;
+  -webkit-transition: color 200ms ease-in-out;
+  transition: color 200ms ease-in-out;
+}
+
+.circuit-1::-moz-placeholder {
+  color: #9DA7B1;
+  -webkit-transition: color 200ms ease-in-out;
+  transition: color 200ms ease-in-out;
+}
+
+.circuit-1:-ms-input-placeholder {
+  color: #9DA7B1;
+  -webkit-transition: color 200ms ease-in-out;
+  transition: color 200ms ease-in-out;
+}
+
+.circuit-1::placeholder {
+  color: #9DA7B1;
+  -webkit-transition: color 200ms ease-in-out;
+  transition: color 200ms ease-in-out;
+}
+
+.circuit-16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-top: 12px;
+}
+
+.circuit-14 {
+  border-radius: 4px;
+  font-size: 16px;
+  line-height: 24px;
+  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  padding: 4px 12px;
+  cursor: default;
+  display: inline-block;
+  margin-top: 8px;
+}
+
+.circuit-14:first-of-type: {
+  margin-top: 0;
+}
+
+.circuit-11 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  overflow: initial;
+  height: 16px;
+  width: 16px;
+  margin-left: 12px;
+  vertical-align: middle;
+}
+
+.circuit-11:focus,
+.circuit-11:active {
+  outline: none;
+}
+
+.circuit-11 > svg {
+  height: 100%;
+  width: 100%;
+}
+
+.circuit-7 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<div
+  style="height: 20vh;"
+>
+  <div
+    class="circuit-5 circuit-6"
+  >
+    <div
+      class="circuit-3 circuit-4"
+    >
+      <div
+        class="circuit-0"
+      >
+        search.svg
+      </div>
+      <input
+        aria-autocomplete="list"
+        aria-expanded="false"
+        aria-invalid="false"
+        autocomplete="off"
+        class="circuit-1 circuit-2"
+        id="downshift-4-input"
+        placeholder="Search by email"
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+  </div>
+  <div
+    class="circuit-16 circuit-17"
+    data-testid="autocomplete-tags-selected"
+  >
+    <span
+      class="circuit-13 circuit-14 circuit-15"
+    >
+      test4@sumup.com
+      <button
+        class="circuit-9 circuit-10 circuit-11 circuit-12"
+        data-testid="tag-close"
+        type="button"
+      >
+        <div
+          role="presentation"
+        >
+          close-icon.svg
+        </div>
+        <span
+          class="circuit-7 circuit-8"
+        >
+          remove
+        </span>
+      </button>
+    </span>
   </div>
 </div>
 `;
@@ -16403,6 +16640,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -16524,6 +16762,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -16615,6 +16854,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -16724,6 +16964,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -16841,6 +17082,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -16930,6 +17172,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -17024,6 +17267,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -17131,6 +17375,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -17200,6 +17445,7 @@ exports[`Storyshots Forms/Input/MaskedInput Base 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -17286,6 +17532,7 @@ exports[`Storyshots Forms/Input/RestrictedInput Base 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -17387,6 +17634,7 @@ exports[`Storyshots Forms/Input/SearchInput Base 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -17488,6 +17736,7 @@ exports[`Storyshots Forms/Input/SearchInput Clearable 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -17589,6 +17838,7 @@ exports[`Storyshots Forms/Input/SearchInput Disabled 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -18679,6 +18929,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -18770,6 +19021,7 @@ label + .circuit-2 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -18920,6 +19172,7 @@ label + .circuit-7 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -19053,6 +19306,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   background-color: #FAFBFC;
   border-style: dashed;
   box-shadow: none;
@@ -19205,6 +19459,7 @@ label + .circuit-7 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;

--- a/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
+++ b/src/components/AutoCompleteInput/__snapshots__/AutoCompleteInput.spec.js.snap
@@ -47,6 +47,7 @@ label + .circuit-3 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }

--- a/src/components/AutoCompleteTags/AutoCompleteTags.js
+++ b/src/components/AutoCompleteTags/AutoCompleteTags.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
@@ -40,49 +40,55 @@ const StyledTag = styled(Tag)(
   `
 );
 
-const AutoCompleteTags = ({
-  availableTags,
-  selectedTags,
-  onChange,
-  ...inputProps
-}) => {
-  const [selected, setSelected] = useState(selectedTags);
+class AutoCompleteTags extends Component {
+  state = {
+    selected: this.props.selectedTags
+  };
 
-  const handleAdd = tag => {
+  handleAdd = tag => {
+    const { selected } = this.state;
     const newSelected = [...selected, tag];
-    setSelected(newSelected);
-    onChange(newSelected);
+
+    this.setState({ selected: newSelected });
+    this.props.onChange(newSelected);
   };
 
-  const handleRemove = tag => {
+  handleRemove = tag => {
+    const { selected } = this.state;
     const newSelected = filter(option => option !== tag, selected);
-    setSelected(newSelected);
-    onChange(newSelected);
+
+    this.setState({ selected: newSelected });
+    this.props.onChange(newSelected);
   };
 
-  return (
-    <Fragment>
-      <AutoCompleteInput
-        clearOnSelect
-        onChange={handleAdd}
-        options={difference(availableTags, selected)}
-        {...inputProps}
-      />
-      {!isEmpty(selected) && (
-        <TagsWrapper data-testid="autocomplete-tags-selected">
-          {map(
-            tag => (
-              <StyledTag key={tag} onRemove={() => handleRemove(tag)}>
-                {tag}
-              </StyledTag>
-            ),
-            selected
-          )}
-        </TagsWrapper>
-      )}
-    </Fragment>
-  );
-};
+  render() {
+    const { availableTags, ...inputProps } = this.props;
+    const { selected } = this.state;
+
+    return (
+      <Fragment>
+        <AutoCompleteInput
+          clearOnSelect
+          options={difference(availableTags, selected)}
+          {...inputProps}
+          onChange={this.handleAdd}
+        />
+        {!isEmpty(selected) && (
+          <TagsWrapper data-testid="autocomplete-tags-selected">
+            {map(
+              tag => (
+                <StyledTag key={tag} onRemove={() => this.handleRemove(tag)}>
+                  {tag}
+                </StyledTag>
+              ),
+              selected
+            )}
+          </TagsWrapper>
+        )}
+      </Fragment>
+    );
+  }
+}
 
 AutoCompleteTags.propTypes = {
   /**

--- a/src/components/AutoCompleteTags/AutoCompleteTags.spec.js
+++ b/src/components/AutoCompleteTags/AutoCompleteTags.spec.js
@@ -14,15 +14,49 @@
  */
 
 import React from 'react';
+import { cleanup, fireEvent } from '@testing-library/react';
 
 import AutoCompleteTags from '.';
 
+const defaultProps = {
+  availableTags: [
+    'test1@sumup.com',
+    'test2@sumup.com',
+    'test3@sumup.com',
+    'test4@sumup.com'
+  ],
+  placeholder: 'Search by email',
+  selectedTags: ['test1@sumup.com'],
+  onChange: jest.fn()
+};
+
 describe('AutoCompleteTags', () => {
+  afterEach(cleanup);
   /**
    * Style tests.
    */
-  it('should render with default styles', () => {
+  it.skip('should render with default styles', () => {
     const actual = create(<AutoCompleteTags availableTags={[]} />);
     expect(actual).toMatchSnapshot();
+  });
+
+  it('should display selected tags ', () => {
+    const { getByTestId, findByText } = render(
+      <AutoCompleteTags {...defaultProps} />
+    );
+    expect(getByTestId('autocomplete-tags-selected')).not.toBeNull();
+    expect(findByText('test1@sumup.com')).not.toBeNull();
+  });
+
+  it('should handle changes in selected tags ', () => {
+    const { getByTestId, queryByTestId } = render(
+      <AutoCompleteTags {...defaultProps} />
+    );
+    const closeIcon = getByTestId('tag-close');
+
+    fireEvent.click(closeIcon);
+
+    expect(defaultProps.onChange).toHaveBeenCalledWith([]);
+    expect(queryByTestId('autocomplete-tags-selected')).toBeNull();
   });
 });

--- a/src/components/AutoCompleteTags/AutoCompleteTags.spec.js
+++ b/src/components/AutoCompleteTags/AutoCompleteTags.spec.js
@@ -44,8 +44,8 @@ describe('AutoCompleteTags', () => {
     const { getByTestId, findByText } = render(
       <AutoCompleteTags {...defaultProps} />
     );
-    expect(getByTestId('autocomplete-tags-selected')).not.toBeNull();
-    expect(findByText('test1@sumup.com')).not.toBeNull();
+    expect(getByTestId('autocomplete-tags-selected')).toBeVisible();
+    expect(findByText('test1@sumup.com')).toBeVisible();
   });
 
   it('should handle changes in selected tags ', () => {

--- a/src/components/AutoCompleteTags/AutoCompleteTags.spec.js
+++ b/src/components/AutoCompleteTags/AutoCompleteTags.spec.js
@@ -35,17 +35,17 @@ describe('AutoCompleteTags', () => {
   /**
    * Style tests.
    */
-  it.skip('should render with default styles', () => {
+  it('should render with default styles', () => {
     const actual = create(<AutoCompleteTags availableTags={[]} />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should display selected tags ', () => {
-    const { getByTestId, findByText } = render(
+    const { getByTestId, getByText } = render(
       <AutoCompleteTags {...defaultProps} />
     );
-    expect(getByTestId('autocomplete-tags-selected')).toBeVisible();
-    expect(findByText('test1@sumup.com')).toBeVisible();
+    expect(getByTestId('autocomplete-tags-selected')).not.toBeNull();
+    expect(getByText('test1@sumup.com')).toBeVisible();
   });
 
   it('should handle changes in selected tags ', () => {

--- a/src/components/AutoCompleteTags/AutoCompleteTags.story.js
+++ b/src/components/AutoCompleteTags/AutoCompleteTags.story.js
@@ -46,8 +46,27 @@ for (let i = 0; i < 10000; i += 1) {
 }
 
 export const base = () => (
-  <AutoCompleteTags
-    availableTags={randomItems}
-    onChange={action('handleChange')}
-  />
+  <div style={{ height: '20vh' }}>
+    <AutoCompleteTags
+      placeholder="Search by email"
+      availableTags={randomItems}
+      onChange={action('handleChange')}
+    />
+  </div>
+);
+
+export const selected = () => (
+  <div style={{ height: '20vh' }}>
+    <AutoCompleteTags
+      placeholder="Search by email"
+      availableTags={[
+        'test1@sumup.com',
+        'test2@sumup.com',
+        'test3@sumup.com',
+        'test4@sumup.com'
+      ]}
+      selectedTags={['test4@sumup.com']}
+      onChange={action('handleChange')}
+    />
+  </div>
 );

--- a/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
+++ b/src/components/AutoCompleteTags/__snapshots__/AutoCompleteTags.spec.js.snap
@@ -47,6 +47,7 @@ label + .circuit-3 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }

--- a/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
+++ b/src/components/CreditCardDetails/components/CardNumberInput/__snapshots__/CardNumberInput.spec.js.snap
@@ -80,6 +80,7 @@ label + .circuit-14 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -330,6 +331,7 @@ label + .circuit-14 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -546,6 +548,7 @@ HTMLCollection [
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 

--- a/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
+++ b/src/components/CurrencyInput/components/SimpleCurrencyInput/__snapshots__/SimpleCurrencyInput.spec.js.snap
@@ -26,6 +26,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -123,6 +124,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -217,6 +219,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -356,6 +359,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -449,6 +453,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -566,6 +571,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;
@@ -696,6 +702,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
   text-align: right;

--- a/src/components/Input/Input.js
+++ b/src/components/Input/Input.js
@@ -80,6 +80,7 @@ const inputBaseStyles = ({ theme }) => css`
   transition: border-color ${theme.transitions.default};
   width: 100%;
   ${textMega({ theme })};
+  margin: 0;
 
   &:focus,
   &:active {

--- a/src/components/Input/__snapshots__/Input.spec.js.snap
+++ b/src/components/Input/__snapshots__/Input.spec.js.snap
@@ -14,6 +14,7 @@ exports[`Input should prioritize disabled over error styles 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -120,6 +121,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -259,6 +261,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   background-color: #FAFBFC;
   border-style: dashed;
   box-shadow: none;
@@ -361,6 +364,7 @@ label + .circuit-6 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -505,6 +509,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -581,6 +586,7 @@ label + .circuit-2 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -667,6 +673,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   color: red;
 }
@@ -740,6 +747,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -813,6 +821,7 @@ exports[`Input should render with disabled styles when passed the disabled prop 
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -887,6 +896,7 @@ exports[`Input should render with inline styles when passed the inline prop 1`] 
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -1000,6 +1010,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -1093,6 +1104,7 @@ exports[`Input should render with no margin styles when passed the noMargin prop
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -1204,6 +1216,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   background-color: #FAFBFC;
   border-style: dashed;
   box-shadow: none;
@@ -1292,6 +1305,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   text-align: right;
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -1365,6 +1379,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 
@@ -1464,6 +1479,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
 }
 

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.js.snap
@@ -24,6 +24,7 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }
@@ -128,6 +129,7 @@ label + .circuit-3 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-left: calc( 12px + 16px + 12px );
   padding-right: calc( 12px + 16px + 12px );
 }

--- a/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.js.snap
@@ -14,6 +14,7 @@ exports[`TextArea should prioritize disabled over error styles 1`] = `
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -122,6 +123,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -263,6 +265,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   background-color: #FAFBFC;
   border-style: dashed;
   box-shadow: none;
@@ -367,6 +370,7 @@ label + .circuit-6 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -500,6 +504,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -587,6 +592,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -674,6 +680,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -749,6 +756,7 @@ exports[`TextArea should render with disabled styled when passed the disabled pr
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -825,6 +833,7 @@ exports[`TextArea should render with inline styles when passed the inline prop 1
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -940,6 +949,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -1035,6 +1045,7 @@ exports[`TextArea should render with no margin styles when passed the noMargin p
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -1148,6 +1159,7 @@ label + .circuit-4 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   background-color: #FAFBFC;
   border-style: dashed;
   box-shadow: none;
@@ -1225,6 +1237,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;
@@ -1326,6 +1339,7 @@ label + .circuit-5 {
   width: 100%;
   font-size: 16px;
   line-height: 24px;
+  margin: 0;
   padding-right: calc( 12px + 16px + 12px );
   overflow: auto;
   resize: vertical;


### PR DESCRIPTION
Addresses: https://github.com/sumup-oss/circuit-ui/issues/545

## Purpose

When I started working on adding a custom clear icon in the `SearchInput` I went through all components in the `ze-dashboard` project which depend on it. I noticed that we have a `AutoCompleteTags` in our shared components folder which uses the `SearchInput` indirectly and it contained a comment that it should be moved to CircuitUI. However, there were differences in the api of the `AutoCompleteTags` in the dashboard and the component we have here in CircuitUI. 

## Approach and changes

In order to address the aforementioned I made the following changes:

- added `selectedTags` property
- passed `inputProps` to the `AutoCompleteInput`
- fixed search input left icon alignment on Safari

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
