### PR TITLE
fix(components): update clearfix to improve accessibility

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -19806,11 +19806,8 @@ exports[`Storyshots Layout/Grid/Grid Responsive Columns 1`] = `
 
 .circuit-8::before,
 .circuit-8::after {
-  content: '.';
-  display: block;
-  height: 0;
-  width: 0;
-  overflow: hidden;
+  content: ' ';
+  display: table;
 }
 
 .circuit-8::after {
@@ -20064,11 +20061,8 @@ exports[`Storyshots Layout/Grid/Grid Responsive Skipping 1`] = `
 
 .circuit-6::before,
 .circuit-6::after {
-  content: '.';
-  display: block;
-  height: 0;
-  width: 0;
-  overflow: hidden;
+  content: ' ';
+  display: table;
 }
 
 .circuit-6::after {
@@ -20434,11 +20428,8 @@ exports[`Storyshots Layout/Grid/Grid Skipping Columns 1`] = `
 
 .circuit-6::before,
 .circuit-6::after {
-  content: '.';
-  display: block;
-  height: 0;
-  width: 0;
-  overflow: hidden;
+  content: ' ';
+  display: table;
 }
 
 .circuit-6::after {
@@ -20783,11 +20774,8 @@ exports[`Storyshots Layout/Grid/Grid Static Columns 1`] = `
 
 .circuit-12::before,
 .circuit-12::after {
-  content: '.';
-  display: block;
-  height: 0;
-  width: 0;
-  overflow: hidden;
+  content: ' ';
+  display: table;
 }
 
 .circuit-12::after {
@@ -21241,11 +21229,8 @@ exports[`Storyshots Layout/Grid/Row Base 1`] = `
 
 .circuit-6::before,
 .circuit-6::after {
-  content: '.';
-  display: block;
-  height: 0;
-  width: 0;
-  overflow: hidden;
+  content: ' ';
+  display: table;
 }
 
 .circuit-6::after {
@@ -21402,11 +21387,8 @@ exports[`Storyshots Layout/InlineElements Three Inline Elements 1`] = `
 
   .circuit-6::before,
   .circuit-6::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-6::after {
@@ -21512,11 +21494,8 @@ exports[`Storyshots Layout/InlineElements Three Inline Elements Inline On Mobile
 
   .circuit-6::before,
   .circuit-6::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-6::after {
@@ -21566,11 +21545,8 @@ exports[`Storyshots Layout/InlineElements Three Inline Elements Inline On Mobile
 
   .circuit-6::before,
   .circuit-6::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-6::after {
@@ -21649,11 +21625,8 @@ exports[`Storyshots Layout/InlineElements Two Inline Elements 1`] = `
 
   .circuit-4::before,
   .circuit-4::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-4::after {
@@ -21768,11 +21741,8 @@ exports[`Storyshots Layout/InlineElements Two Inline Elements With Ratios 1`] = 
 
   .circuit-4::before,
   .circuit-4::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-4::after {
@@ -21895,11 +21865,8 @@ exports[`Storyshots Layout/InlineElements Two Inline Elements With Ratios Inline
 
   .circuit-4::before,
   .circuit-4::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-4::after {
@@ -21965,11 +21932,8 @@ exports[`Storyshots Layout/InlineElements Two Inline Elements With Ratios Inline
 
   .circuit-4::before,
   .circuit-4::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-4::after {

--- a/src/components/CreditCardDetails/__snapshots__/CreditCardDetails.spec.js.snap
+++ b/src/components/CreditCardDetails/__snapshots__/CreditCardDetails.spec.js.snap
@@ -30,11 +30,8 @@ exports[`CreditCardDetails should render with default styles 1`] = `
 
   .circuit-0::before,
   .circuit-0::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-0::after {
@@ -84,11 +81,8 @@ exports[`CreditCardDetails should render with default styles 1`] = `
 
   .circuit-0::before,
   .circuit-0::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-0::after {

--- a/src/components/InlineElements/__snapshots__/InlineElements.spec.js.snap
+++ b/src/components/InlineElements/__snapshots__/InlineElements.spec.js.snap
@@ -26,11 +26,8 @@ exports[`InlineElements should render with default styles 1`] = `
 
   .circuit-0::before,
   .circuit-0::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-0::after {
@@ -102,11 +99,8 @@ exports[`InlineElements should render with inlineMobile styles 1`] = `
 
   .circuit-0::before,
   .circuit-0::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-0::after {
@@ -156,11 +150,8 @@ exports[`InlineElements should render with inlineMobile styles 1`] = `
 
   .circuit-0::before,
   .circuit-0::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-0::after {
@@ -217,11 +208,8 @@ exports[`InlineElements should render with ratio styles 1`] = `
 
   .circuit-0::before,
   .circuit-0::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-0::after {
@@ -287,11 +275,8 @@ exports[`InlineElements should render with ratio styles 1`] = `
 
   .circuit-0::before,
   .circuit-0::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   .circuit-0::after {

--- a/src/components/Row/__snapshots__/Row.spec.js.snap
+++ b/src/components/Row/__snapshots__/Row.spec.js.snap
@@ -7,11 +7,8 @@ exports[`Row should render with default styles 1`] = `
 
 .circuit-0::before,
 .circuit-0::after {
-  content: '.';
-  display: block;
-  height: 0;
-  width: 0;
-  overflow: hidden;
+  content: ' ';
+  display: table;
 }
 
 .circuit-0::after {

--- a/src/styles/style-helpers.js
+++ b/src/styles/style-helpers.js
@@ -149,13 +149,19 @@ export const createMediaQueries = mapValues(mediaExpression => {
 });
 
 export const clearfix = css`
+  /*
+ * For modern browsers
+ * 1. The space content is one way to avoid an Opera bug when the
+ *  contenteditable attribute is included anywhere else in the document.
+ *  Otherwise it causes space to appear at the top and bottom of elements
+ *  that are clearfixed.
+ * 2. The use of table rather than "block" is only necessary if using
+ * ":before" to contain the top-margins of child elements.
+ */
   &::before,
   &::after {
-    content: '.';
-    display: block;
-    height: 0;
-    width: 0;
-    overflow: hidden;
+    content: ' '; /* 1 */
+    display: table; /* 2 */
   }
   &::after {
     clear: both;


### PR DESCRIPTION
Addresses #564 
## Purpose

Improve Row accessibility for screen readers.

## Approach and changes
Updated the current clearfix implementation: from "clearfix reloaded" to "micro clearfix". 
Source: https://css-tricks.com/clearfix-a-lesson-in-web-development-evolution/

## Before
![before](https://user-images.githubusercontent.com/53574544/78983124-3cf9c200-7b2c-11ea-847d-5a484a08c98e.gif)

## After
![after](https://user-images.githubusercontent.com/53574544/78992371-c10b7400-7b43-11ea-8174-bca8f7f790db.gif)



## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
