### PR TITLE
feat(components): add optional suffix to the Tag component

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -1758,13 +1758,20 @@ exports[`Storyshots Components/Button/LoadingButton Success 1`] = `
 
 exports[`Storyshots Components/Calendar/CalendarTag Base 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
   cursor: pointer;
 }
 
@@ -1776,23 +1783,30 @@ exports[`Storyshots Components/Calendar/CalendarTag Base 1`] = `
 <div
   class="circuit-2 circuit-3"
 >
-  <span
+  <div
     class="circuit-0 circuit-1"
   >
     Dates
-  </span>
+  </div>
 </div>
 `;
 
 exports[`Storyshots Components/Calendar/CalendarTagTwoStep Base 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
   cursor: pointer;
 }
 
@@ -1804,11 +1818,11 @@ exports[`Storyshots Components/Calendar/CalendarTagTwoStep Base 1`] = `
 <div
   class="circuit-2 circuit-3"
 >
-  <span
+  <div
     class="circuit-0 circuit-1"
   >
     Dates
-  </span>
+  </div>
 </div>
 `;
 
@@ -5190,6 +5204,29 @@ HTMLCollection [
   width: 1px;
 }
 
+.circuit-5 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  overflow: initial;
+  height: 16px;
+  width: 16px;
+}
+
+.circuit-5:focus,
+.circuit-5:active {
+  outline: none;
+}
+
+.circuit-5 > svg {
+  height: 100%;
+  width: 100%;
+}
+
 .circuit-11 {
   background-color: #FFFFFF;
   border-radius: 4px;
@@ -5257,29 +5294,6 @@ HTMLCollection [
     font-size: 16px;
     line-height: 24px;
   }
-}
-
-.circuit-5 {
-  padding: 0;
-  margin: 0;
-  display: inline-block;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  fill: #0F131A;
-  overflow: initial;
-  height: 16px;
-  width: 16px;
-}
-
-.circuit-5:focus,
-.circuit-5:active {
-  outline: none;
-}
-
-.circuit-5 > svg {
-  height: 100%;
-  width: 100%;
 }
 
 <div
@@ -7627,6 +7641,29 @@ exports[`Storyshots Components/Modal/Embedded With Title And Close Button 1`] = 
   width: 1px;
 }
 
+.circuit-5 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  overflow: initial;
+  height: 16px;
+  width: 16px;
+}
+
+.circuit-5:focus,
+.circuit-5:active {
+  outline: none;
+}
+
+.circuit-5 > svg {
+  height: 100%;
+  width: 100%;
+}
+
 .circuit-7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7656,29 +7693,6 @@ exports[`Storyshots Components/Modal/Embedded With Title And Close Button 1`] = 
     font-size: 17px;
     line-height: 24px;
   }
-}
-
-.circuit-5 {
-  padding: 0;
-  margin: 0;
-  display: inline-block;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  fill: #0F131A;
-  overflow: initial;
-  height: 16px;
-  width: 16px;
-}
-
-.circuit-5:focus,
-.circuit-5:active {
-  outline: none;
-}
-
-.circuit-5 > svg {
-  height: 100%;
-  width: 100%;
 }
 
 .circuit-9 {
@@ -11344,31 +11358,45 @@ exports[`Storyshots Components/Tabs Links 1`] = `
 
 exports[`Storyshots Components/Tag Base 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
 }
 
-<span
+<div
   class="circuit-0 circuit-1"
 >
   Transactions
-</span>
+</div>
 `;
 
 exports[`Storyshots Components/Tag Clickable 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
   cursor: pointer;
 }
 
@@ -11377,11 +11405,11 @@ exports[`Storyshots Components/Tag Clickable 1`] = `
   box-shadow: 0px 0px 0px 1px #D8DDE1;
 }
 
-<span
+<div
   class="circuit-0 circuit-1"
 >
   Transactions
-</span>
+</div>
 `;
 
 exports[`Storyshots Components/Tag Removable 1`] = `
@@ -11400,7 +11428,7 @@ exports[`Storyshots Components/Tag Removable 1`] = `
   width: 1px;
 }
 
-.circuit-4 {
+.circuit-3 {
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -11411,105 +11439,159 @@ exports[`Storyshots Components/Tag Removable 1`] = `
   overflow: initial;
   height: 16px;
   width: 16px;
-  margin-left: 12px;
-  vertical-align: middle;
 }
 
-.circuit-4:focus,
-.circuit-4:active {
+.circuit-3:focus,
+.circuit-3:active {
   outline: none;
 }
 
-.circuit-4 > svg {
+.circuit-3 > svg {
   height: 100%;
   width: 100%;
 }
 
-.circuit-6 {
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
-}
-
-<span
-  class="circuit-6 circuit-7"
->
-  Transactions
-  <button
-    class="circuit-2 circuit-3 circuit-4 circuit-5"
-    data-testid="tag-close"
-    type="button"
-  >
-    <div
-      role="presentation"
-    >
-      close-icon.svg
-    </div>
-    <span
-      class="circuit-0 circuit-1"
-    >
-      Remove
-    </span>
-  </button>
-</span>
-`;
-
-exports[`Storyshots Components/Tag Selected 1`] = `
-.circuit-0 {
-  border-radius: 4px;
-  font-size: 16px;
-  line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
-  padding: 4px 12px;
-  cursor: default;
-  display: inline-block;
   background-color: #3388FF;
   box-shadow: 0px 0px 0px 1px #3388FF;
   color: #FFFFFF;
 }
 
-<span
+.circuit-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  margin-left: 8px;
+}
+
+.circuit-5 > svg,
+.circuit-5 svg {
+  fill: #FFFFFF;
+}
+
+<div
+  class="circuit-7 circuit-8"
+>
+  Transactions
+  <div
+    class="circuit-5 circuit-6"
+  >
+    <button
+      class="circuit-2 circuit-3 circuit-4"
+      data-testid="tag-close"
+      type="button"
+    >
+      <div
+        role="presentation"
+      >
+        close-icon.svg
+      </div>
+      <span
+        class="circuit-0 circuit-1"
+      >
+        Remove
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/Tag Selected 1`] = `
+.circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 4px;
+  font-size: 16px;
+  line-height: 24px;
+  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  padding: 4px 12px;
+  cursor: default;
+  background-color: #3388FF;
+  box-shadow: 0px 0px 0px 1px #3388FF;
+  color: #FFFFFF;
+}
+
+<div
   class="circuit-0 circuit-1"
 >
   Transactions
-</span>
+</div>
 `;
 
-exports[`Storyshots Components/Tag With Left Icon 1`] = `
+exports[`Storyshots Components/Tag With Prefix 1`] = `
 .circuit-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
+  background-color: #3388FF;
+  box-shadow: 0px 0px 0px 1px #3388FF;
+  color: #FFFFFF;
 }
 
 .circuit-0 {
-  margin-right: 4px;
-  display: inline-block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   width: 16px;
   height: 16px;
-  vertical-align: middle;
+  margin-right: 8px;
 }
 
-.circuit-0 > svg {
-  vertical-align: top;
+.circuit-0 > svg,
+.circuit-0 svg {
+  fill: #FFFFFF;
 }
 
-<span
+<div
   class="circuit-2 circuit-3"
 >
-  <span
+  <div
     class="circuit-0 circuit-1"
   >
     <svg
-      fill="#000000"
       height="16"
       viewBox="0 0 24 24"
       width="16"
@@ -11523,45 +11605,51 @@ exports[`Storyshots Components/Tag With Left Icon 1`] = `
         d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
       />
     </svg>
-  </span>
+  </div>
   Transactions
-</span>
+</div>
 `;
 
-exports[`Storyshots Components/Tag With Right Icon 1`] = `
+exports[`Storyshots Components/Tag With Suffix 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  margin-left: 8px;
+}
+
 .circuit-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
 }
 
-.circuit-0 {
-  margin-right: 4px;
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  vertical-align: middle;
-  margin-right: 0;
-  margin-left: 4px;
-}
-
-.circuit-0 > svg {
-  vertical-align: top;
-}
-
-<span
+<div
   class="circuit-2 circuit-3"
 >
   Transactions
-  <span
+  <div
     class="circuit-0 circuit-1"
   >
     <svg
-      fill="#000000"
       height="16"
       viewBox="0 0 24 24"
       width="16"
@@ -11575,8 +11663,8 @@ exports[`Storyshots Components/Tag With Right Icon 1`] = `
         d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
       />
     </svg>
-  </span>
-</span>
+  </div>
+</div>
 `;
 
 exports[`Storyshots Components/Tooltip Base 1`] = `
@@ -16548,7 +16636,7 @@ label + .circuit-3 {
   width: 1px;
 }
 
-.circuit-16 {
+.circuit-17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16563,22 +16651,43 @@ label + .circuit-3 {
   margin-top: 12px;
 }
 
-.circuit-14 {
+.circuit-15 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
   margin-top: 8px;
 }
 
-.circuit-14:first-of-type: {
+.circuit-15:first-of-type: {
   margin-top: 0;
 }
 
-.circuit-11 {
+.circuit-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  margin-left: 8px;
+}
+
+.circuit-10 {
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -16589,16 +16698,14 @@ label + .circuit-3 {
   overflow: initial;
   height: 16px;
   width: 16px;
-  margin-left: 12px;
-  vertical-align: middle;
 }
 
-.circuit-11:focus,
-.circuit-11:active {
+.circuit-10:focus,
+.circuit-10:active {
   outline: none;
 }
 
-.circuit-11 > svg {
+.circuit-10 > svg {
   height: 100%;
   width: 100%;
 }
@@ -16632,30 +16739,34 @@ label + .circuit-3 {
     </div>
   </div>
   <div
-    class="circuit-16 circuit-17"
+    class="circuit-17 circuit-18"
     data-testid="autocomplete-tags-selected"
   >
-    <span
-      class="circuit-13 circuit-14 circuit-15"
+    <div
+      class="circuit-14 circuit-15 circuit-16"
     >
       test4@sumup.com
-      <button
-        class="circuit-9 circuit-10 circuit-11 circuit-12"
-        data-testid="tag-close"
-        type="button"
+      <div
+        class="circuit-12 circuit-13"
       >
-        <div
-          role="presentation"
+        <button
+          class="circuit-9 circuit-10 circuit-11"
+          data-testid="tag-close"
+          type="button"
         >
-          close-icon.svg
-        </div>
-        <span
-          class="circuit-7 circuit-8"
-        >
-          remove
-        </span>
-      </button>
-    </span>
+          <div
+            role="presentation"
+          >
+            close-icon.svg
+          </div>
+          <span
+            class="circuit-7 circuit-8"
+          >
+            remove
+          </span>
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -11428,6 +11428,20 @@ exports[`Storyshots Components/Tag Removable 1`] = `
   width: 1px;
 }
 
+.circuit-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  margin-left: 8px;
+}
+
 .circuit-3 {
   padding: 0;
   margin: 0;
@@ -11466,28 +11480,6 @@ exports[`Storyshots Components/Tag Removable 1`] = `
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  background-color: #3388FF;
-  box-shadow: 0px 0px 0px 1px #3388FF;
-  color: #FFFFFF;
-}
-
-.circuit-5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 16px;
-  height: 16px;
-  margin-left: 8px;
-}
-
-.circuit-5 > svg,
-.circuit-5 svg {
-  fill: #FFFFFF;
 }
 
 <div
@@ -11545,7 +11537,7 @@ exports[`Storyshots Components/Tag Selected 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Tag With Prefix 1`] = `
+exports[`Storyshots Components/Tag With Icon 1`] = `
 .circuit-2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -11561,9 +11553,6 @@ exports[`Storyshots Components/Tag With Prefix 1`] = `
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  background-color: #3388FF;
-  box-shadow: 0px 0px 0px 1px #3388FF;
-  color: #FFFFFF;
 }
 
 .circuit-0 {
@@ -11580,9 +11569,62 @@ exports[`Storyshots Components/Tag With Prefix 1`] = `
   margin-right: 8px;
 }
 
-.circuit-0 > svg,
-.circuit-0 svg {
-  fill: #FFFFFF;
+<div
+  class="circuit-2 circuit-3"
+>
+  <div
+    class="circuit-0 circuit-1"
+  >
+    <svg
+      fill="#000000"
+      height="16"
+      viewBox="0 0 24 24"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M0 0h24v24H0z"
+        fill="none"
+      />
+      <path
+        d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+      />
+    </svg>
+  </div>
+  Transactions
+</div>
+`;
+
+exports[`Storyshots Components/Tag With Prefix 1`] = `
+.circuit-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 4px;
+  font-size: 16px;
+  line-height: 24px;
+  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  padding: 4px 12px;
+  cursor: default;
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
 }
 
 <div
@@ -11592,6 +11634,7 @@ exports[`Storyshots Components/Tag With Prefix 1`] = `
     class="circuit-0 circuit-1"
   >
     <svg
+      fill="#000000"
       height="16"
       viewBox="0 0 24 24"
       width="16"
@@ -11650,6 +11693,7 @@ exports[`Storyshots Components/Tag With Suffix 1`] = `
     class="circuit-0 circuit-1"
   >
     <svg
+      fill="#000000"
       height="16"
       viewBox="0 0 24 24"
       width="16"

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -5204,29 +5204,6 @@ HTMLCollection [
   width: 1px;
 }
 
-.circuit-5 {
-  padding: 0;
-  margin: 0;
-  display: inline-block;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  fill: #0F131A;
-  overflow: initial;
-  height: 16px;
-  width: 16px;
-}
-
-.circuit-5:focus,
-.circuit-5:active {
-  outline: none;
-}
-
-.circuit-5 > svg {
-  height: 100%;
-  width: 100%;
-}
-
 .circuit-11 {
   background-color: #FFFFFF;
   border-radius: 4px;
@@ -5294,6 +5271,29 @@ HTMLCollection [
     font-size: 16px;
     line-height: 24px;
   }
+}
+
+.circuit-5 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  overflow: initial;
+  height: 16px;
+  width: 16px;
+}
+
+.circuit-5:focus,
+.circuit-5:active {
+  outline: none;
+}
+
+.circuit-5 > svg {
+  height: 100%;
+  width: 100%;
 }
 
 <div
@@ -7641,29 +7641,6 @@ exports[`Storyshots Components/Modal/Embedded With Title And Close Button 1`] = 
   width: 1px;
 }
 
-.circuit-5 {
-  padding: 0;
-  margin: 0;
-  display: inline-block;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  fill: #0F131A;
-  overflow: initial;
-  height: 16px;
-  width: 16px;
-}
-
-.circuit-5:focus,
-.circuit-5:active {
-  outline: none;
-}
-
-.circuit-5 > svg {
-  height: 100%;
-  width: 100%;
-}
-
 .circuit-7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -7693,6 +7670,29 @@ exports[`Storyshots Components/Modal/Embedded With Title And Close Button 1`] = 
     font-size: 17px;
     line-height: 24px;
   }
+}
+
+.circuit-5 {
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  fill: #0F131A;
+  overflow: initial;
+  height: 16px;
+  width: 16px;
+}
+
+.circuit-5:focus,
+.circuit-5:active {
+  outline: none;
+}
+
+.circuit-5 > svg {
+  height: 100%;
+  width: 100%;
 }
 
 .circuit-9 {
@@ -11428,7 +11428,7 @@ exports[`Storyshots Components/Tag Removable 1`] = `
   width: 1px;
 }
 
-.circuit-3 {
+.circuit-4 {
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -11439,19 +11439,20 @@ exports[`Storyshots Components/Tag Removable 1`] = `
   overflow: initial;
   height: 16px;
   width: 16px;
+  margin-left: 8px;
 }
 
-.circuit-3:focus,
-.circuit-3:active {
+.circuit-4:focus,
+.circuit-4:active {
   outline: none;
 }
 
-.circuit-3 > svg {
+.circuit-4 > svg {
   height: 100%;
   width: 100%;
 }
 
-.circuit-5 {
+.circuit-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11469,11 +11470,11 @@ exports[`Storyshots Components/Tag Removable 1`] = `
 }
 
 <div
-  class="circuit-5 circuit-6"
+  class="circuit-6 circuit-7"
 >
   Transactions
   <button
-    class="circuit-2 circuit-3 circuit-4"
+    class="circuit-2 circuit-3 circuit-4 circuit-5"
     data-testid="tag-close"
     type="button"
   >
@@ -11512,6 +11513,10 @@ exports[`Storyshots Components/Tag Selected 1`] = `
   color: #FFFFFF;
 }
 
+.circuit-0 > svg {
+  fill: #FFFFFF;
+}
+
 <div
   class="circuit-0 circuit-1"
 >
@@ -11535,44 +11540,41 @@ exports[`Storyshots Components/Tag With Icon 1`] = `
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
+  background-color: #3388FF;
+  box-shadow: 0px 0px 0px 1px #3388FF;
+  color: #FFFFFF;
+}
+
+.circuit-2 > svg {
+  fill: #FFFFFF;
 }
 
 .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  margin-right: 4px;
+  display: inline-block;
   width: 16px;
   height: 16px;
-  margin-right: 8px;
+  vertical-align: middle;
+}
+
+.circuit-0 > svg {
+  vertical-align: top;
+}
+
+.circuit-0 > svg {
+  fill: #FFFFFF;
 }
 
 <div
   class="circuit-2 circuit-3"
 >
-  <div
+  <span
     class="circuit-0 circuit-1"
   >
-    <svg
-      fill="#000000"
-      height="16"
-      viewBox="0 0 24 24"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
-      />
-    </svg>
-  </div>
+    <div>
+      icon-tick.svg
+    </div>
+  </span>
   Transactions
 </div>
 `;
@@ -11596,41 +11598,21 @@ exports[`Storyshots Components/Tag With Prefix 1`] = `
 }
 
 .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 16px;
-  height: 16px;
   margin-right: 8px;
+}
+
+.circuit-0: svg {
+  fill: #FFFFFF;
 }
 
 <div
   class="circuit-1 circuit-2"
 >
-  <span
+  <div
     class="circuit-0"
   >
-    <svg
-      fill="#000000"
-      height="16"
-      viewBox="0 0 24 24"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
-      />
-    </svg>
-  </span>
+    icon-tick.svg
+  </div>
   Transactions
 </div>
 `;
@@ -11654,42 +11636,22 @@ exports[`Storyshots Components/Tag With Suffix 1`] = `
 }
 
 .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 16px;
-  height: 16px;
   margin-left: 8px;
+}
+
+.circuit-0: svg {
+  fill: #FFFFFF;
 }
 
 <div
   class="circuit-1 circuit-2"
 >
   Transactions
-  <span
+  <div
     class="circuit-0"
   >
-    <svg
-      fill="#000000"
-      height="16"
-      viewBox="0 0 24 24"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M0 0h24v24H0z"
-        fill="none"
-      />
-      <path
-        d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
-      />
-    </svg>
-  </span>
+    icon-tick.svg
+  </div>
 </div>
 `;
 
@@ -16662,7 +16624,7 @@ label + .circuit-3 {
   width: 1px;
 }
 
-.circuit-15 {
+.circuit-16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16677,7 +16639,7 @@ label + .circuit-3 {
   margin-top: 12px;
 }
 
-.circuit-13 {
+.circuit-14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -16695,11 +16657,11 @@ label + .circuit-3 {
   margin-top: 8px;
 }
 
-.circuit-13:first-of-type: {
+.circuit-14:first-of-type: {
   margin-top: 0;
 }
 
-.circuit-10 {
+.circuit-11 {
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -16710,14 +16672,15 @@ label + .circuit-3 {
   overflow: initial;
   height: 16px;
   width: 16px;
+  margin-left: 8px;
 }
 
-.circuit-10:focus,
-.circuit-10:active {
+.circuit-11:focus,
+.circuit-11:active {
   outline: none;
 }
 
-.circuit-10 > svg {
+.circuit-11 > svg {
   height: 100%;
   width: 100%;
 }
@@ -16751,15 +16714,15 @@ label + .circuit-3 {
     </div>
   </div>
   <div
-    class="circuit-15 circuit-16"
+    class="circuit-16 circuit-17"
     data-testid="autocomplete-tags-selected"
   >
     <div
-      class="circuit-12 circuit-13 circuit-14"
+      class="circuit-13 circuit-14 circuit-15"
     >
       test4@sumup.com
       <button
-        class="circuit-9 circuit-10 circuit-11"
+        class="circuit-9 circuit-10 circuit-11 circuit-12"
         data-testid="tag-close"
         type="button"
       >

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -11428,20 +11428,6 @@ exports[`Storyshots Components/Tag Removable 1`] = `
   width: 1px;
 }
 
-.circuit-5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 16px;
-  height: 16px;
-  margin-left: 8px;
-}
-
 .circuit-3 {
   padding: 0;
   margin: 0;
@@ -11465,7 +11451,7 @@ exports[`Storyshots Components/Tag Removable 1`] = `
   width: 100%;
 }
 
-.circuit-7 {
+.circuit-5 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11483,29 +11469,25 @@ exports[`Storyshots Components/Tag Removable 1`] = `
 }
 
 <div
-  class="circuit-7 circuit-8"
+  class="circuit-5 circuit-6"
 >
   Transactions
-  <div
-    class="circuit-5 circuit-6"
+  <button
+    class="circuit-2 circuit-3 circuit-4"
+    data-testid="tag-close"
+    type="button"
   >
-    <button
-      class="circuit-2 circuit-3 circuit-4"
-      data-testid="tag-close"
-      type="button"
+    <div
+      role="presentation"
     >
-      <div
-        role="presentation"
-      >
-        close-icon.svg
-      </div>
-      <span
-        class="circuit-0 circuit-1"
-      >
-        Remove
-      </span>
-    </button>
-  </div>
+      close-icon.svg
+    </div>
+    <span
+      class="circuit-0 circuit-1"
+    >
+      Remove
+    </span>
+  </button>
 </div>
 `;
 
@@ -11596,7 +11578,7 @@ exports[`Storyshots Components/Tag With Icon 1`] = `
 `;
 
 exports[`Storyshots Components/Tag With Prefix 1`] = `
-.circuit-2 {
+.circuit-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11628,10 +11610,10 @@ exports[`Storyshots Components/Tag With Prefix 1`] = `
 }
 
 <div
-  class="circuit-2 circuit-3"
+  class="circuit-1 circuit-2"
 >
-  <div
-    class="circuit-0 circuit-1"
+  <span
+    class="circuit-0"
   >
     <svg
       fill="#000000"
@@ -11648,27 +11630,13 @@ exports[`Storyshots Components/Tag With Prefix 1`] = `
         d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
       />
     </svg>
-  </div>
+  </span>
   Transactions
 </div>
 `;
 
 exports[`Storyshots Components/Tag With Suffix 1`] = `
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 16px;
-  height: 16px;
-  margin-left: 8px;
-}
-
-.circuit-2 {
+.circuit-1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11685,12 +11653,26 @@ exports[`Storyshots Components/Tag With Suffix 1`] = `
   cursor: default;
 }
 
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  margin-left: 8px;
+}
+
 <div
-  class="circuit-2 circuit-3"
+  class="circuit-1 circuit-2"
 >
   Transactions
-  <div
-    class="circuit-0 circuit-1"
+  <span
+    class="circuit-0"
   >
     <svg
       fill="#000000"
@@ -11707,7 +11689,7 @@ exports[`Storyshots Components/Tag With Suffix 1`] = `
         d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
       />
     </svg>
-  </div>
+  </span>
 </div>
 `;
 
@@ -16680,7 +16662,7 @@ label + .circuit-3 {
   width: 1px;
 }
 
-.circuit-17 {
+.circuit-15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -16695,7 +16677,7 @@ label + .circuit-3 {
   margin-top: 12px;
 }
 
-.circuit-15 {
+.circuit-13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -16713,22 +16695,8 @@ label + .circuit-3 {
   margin-top: 8px;
 }
 
-.circuit-15:first-of-type: {
+.circuit-13:first-of-type: {
   margin-top: 0;
-}
-
-.circuit-12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 16px;
-  height: 16px;
-  margin-left: 8px;
 }
 
 .circuit-10 {
@@ -16783,33 +16751,29 @@ label + .circuit-3 {
     </div>
   </div>
   <div
-    class="circuit-17 circuit-18"
+    class="circuit-15 circuit-16"
     data-testid="autocomplete-tags-selected"
   >
     <div
-      class="circuit-14 circuit-15 circuit-16"
+      class="circuit-12 circuit-13 circuit-14"
     >
       test4@sumup.com
-      <div
-        class="circuit-12 circuit-13"
+      <button
+        class="circuit-9 circuit-10 circuit-11"
+        data-testid="tag-close"
+        type="button"
       >
-        <button
-          class="circuit-9 circuit-10 circuit-11"
-          data-testid="tag-close"
-          type="button"
+        <div
+          role="presentation"
         >
-          <div
-            role="presentation"
-          >
-            close-icon.svg
-          </div>
-          <span
-            class="circuit-7 circuit-8"
-          >
-            remove
-          </span>
-        </button>
-      </div>
+          close-icon.svg
+        </div>
+        <span
+          class="circuit-7 circuit-8"
+        >
+          remove
+        </span>
+      </button>
     </div>
   </div>
 </div>

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -11479,7 +11479,7 @@ exports[`Storyshots Components/Tag Selected 1`] = `
 </span>
 `;
 
-exports[`Storyshots Components/Tag With Icon 1`] = `
+exports[`Storyshots Components/Tag With Left Icon 1`] = `
 .circuit-2 {
   border-radius: 4px;
   font-size: 16px;
@@ -11525,6 +11525,57 @@ exports[`Storyshots Components/Tag With Icon 1`] = `
     </svg>
   </span>
   Transactions
+</span>
+`;
+
+exports[`Storyshots Components/Tag With Right Icon 1`] = `
+.circuit-2 {
+  border-radius: 4px;
+  font-size: 16px;
+  line-height: 24px;
+  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  padding: 4px 12px;
+  cursor: default;
+  display: inline-block;
+}
+
+.circuit-0 {
+  margin-right: 4px;
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
+  margin-right: 0;
+  margin-left: 4px;
+}
+
+.circuit-0 > svg {
+  vertical-align: top;
+}
+
+<span
+  class="circuit-2 circuit-3"
+>
+  Transactions
+  <span
+    class="circuit-0 circuit-1"
+  >
+    <svg
+      fill="#000000"
+      height="16"
+      viewBox="0 0 24 24"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M0 0h24v24H0z"
+        fill="none"
+      />
+      <path
+        d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+      />
+    </svg>
+  </span>
 </span>
 `;
 

--- a/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -2,13 +2,20 @@
 
 exports[`CalendarTag should render with default styles 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
   cursor: pointer;
 }
 
@@ -20,10 +27,10 @@ exports[`CalendarTag should render with default styles 1`] = `
 <div
   class="circuit-2 circuit-3"
 >
-  <span
+  <div
     class="circuit-0 circuit-1"
   >
     Dates
-  </span>
+  </div>
 </div>
 `;

--- a/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -2,13 +2,20 @@
 
 exports[`CalendarTagTwoStep should render with default styles 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
   cursor: pointer;
 }
 
@@ -20,10 +27,10 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
 <div
   class="circuit-2 circuit-3"
 >
-  <span
+  <div
     class="circuit-0 circuit-1"
   >
     Dates
-  </span>
+  </div>
 </div>
 `;

--- a/src/components/Tag/Tag.docs.mdx
+++ b/src/components/Tag/Tag.docs.mdx
@@ -33,11 +33,15 @@ example: transaction history for a given day or week.
 
 <Story id="components-tag--selected" />
 
-### With left icon
+### With icon
+
+<Story id="components-tag--with-icon" />
+
+### With prefix 
 
 <Story id="components-tag--with-prefix" />
 
-### With right icon
+### With suffix 
 
 <Story id="components-tag--with-suffix" />
 

--- a/src/components/Tag/Tag.docs.mdx
+++ b/src/components/Tag/Tag.docs.mdx
@@ -33,9 +33,13 @@ example: transaction history for a given day or week.
 
 <Story id="components-tag--selected" />
 
-### With icon
+### With left icon
 
-<Story id="components-tag--with-icon" />
+<Story id="components-tag--with-left-icon" />
+
+### With right icon
+
+<Story id="components-tag--with-right-icon" />
 
 ### Clickable
 

--- a/src/components/Tag/Tag.docs.mdx
+++ b/src/components/Tag/Tag.docs.mdx
@@ -35,11 +35,11 @@ example: transaction history for a given day or week.
 
 ### With left icon
 
-<Story id="components-tag--with-left-icon" />
+<Story id="components-tag--with-prefix" />
 
 ### With right icon
 
-<Story id="components-tag--with-right-icon" />
+<Story id="components-tag--with-suffix" />
 
 ### Clickable
 

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -177,7 +177,7 @@ Tag.propTypes = {
   /**
    * An optional  tag's right icon.
    */
-  rightIcon: eitherOrPropType('icon', 'onRemove', PropTypes.element),
+  rightIcon: eitherOrPropType('rightIcon', 'onRemove', PropTypes.element),
   /**
    * Renders a close button inside the tag and calls the provided function
    * when the button is clicked.

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -102,6 +102,14 @@ const iconStyles = ({ theme }) => css`
   }
 `;
 
+const rightIconStyles = ({ right, theme }) =>
+  right &&
+  css`
+    label: tag__icon--right;
+    margin-right: 0;
+    margin-left: ${theme.spacings.bit};
+  `;
+
 const iconSelectedStyles = ({ selected, theme }) =>
   selected &&
   css`
@@ -114,6 +122,7 @@ const iconSelectedStyles = ({ selected, theme }) =>
 
 const IconContainer = styled('span')`
   ${iconStyles};
+  ${rightIconStyles}
   ${iconSelectedStyles};
 `;
 const TagElement = styled('span')`
@@ -129,6 +138,7 @@ const TagElement = styled('span')`
 const Tag = ({
   children,
   icon,
+  rightIcon,
   onRemove,
   labelRemoveButton,
   selected,
@@ -139,6 +149,11 @@ const Tag = ({
       <IconContainer {...{ selected }}>{icon}</IconContainer>
     )}
     {children}
+    {!onRemove && rightIcon && (
+      <IconContainer right {...{ selected }}>
+        {rightIcon}
+      </IconContainer>
+    )}
     {onRemove && (
       <CloseButton
         onClick={onRemove}
@@ -159,6 +174,10 @@ Tag.propTypes = {
    * An optional  tag's icon.
    */
   icon: eitherOrPropType('icon', 'onRemove', PropTypes.element),
+  /**
+   * An optional  tag's right icon.
+   */
+  rightIcon: eitherOrPropType('icon', 'onRemove', PropTypes.element),
   /**
    * Renders a close button inside the tag and calls the provided function
    * when the button is clicked.

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -175,7 +175,8 @@ Tag.propTypes = {
    * An optional  tag's icon.
    */
   icon: deprecatedPropType(
-    eitherOrPropType('icon', 'onRemove', PropTypes.element)
+    eitherOrPropType('icon', 'onRemove', PropTypes.element),
+    'The icon prop has been deprecated in favour of the renderPrefix prop.'
   ),
   /**
    * Render prop that should render a left-aligned icon or element.

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -56,6 +56,10 @@ const tagSelectedStyles = ({ selected, theme }) =>
     background-color: ${theme.colors.p500};
     ${shadowBorder(theme.colors.p500)};
     color: ${theme.colors.white};
+
+    > svg {
+      fill: ${theme.colors.white};
+    }
   `;
 
 const tagSelectedClickableStyles = ({ selected, onClick, theme }) =>
@@ -69,60 +73,82 @@ const tagSelectedClickableStyles = ({ selected, onClick, theme }) =>
     }
   `;
 
+const TagElement = styled('div')`
+  ${tagStyles};
+  ${tagClickableStyles};
+  ${tagSelectedStyles};
+  ${tagSelectedClickableStyles};
+`;
+
+const prefixStyles = ({ theme, selected }) => css`
+  label: tag__prefix;
+  margin-right: ${theme.spacings.byte};
+  ${selected}: {
+    label: tag__prefix--selected;
+    svg {
+      fill: ${theme.colors.white};
+    }
+  }
+`;
+
+const suffixStyles = ({ theme, selected }) => css`
+  label: tag__suffix;
+  margin-left: ${theme.spacings.byte};
+  ${selected}: {
+    label: tag__suffix--selected;
+    svg {
+      fill: ${theme.colors.white};
+    }
+  }
+`;
+
+const closeButtonStyles = ({ theme }) => css`
+  label: tag__close-btn;
+  margin-left: ${theme.spacings.byte};
+`;
+
+const selectedCloseButtonStyles = ({ theme, selected }) =>
+  selected &&
+  css`
+    label: tag__close-btn--selected;
+    svg {
+      fill: ${theme.colors.white};
+    }
+  `;
+
+const StyledCloseButton = styled(CloseButton)`
+  ${closeButtonStyles};
+  ${selectedCloseButtonStyles};
+`;
+
+/* 
+  The IconContainer and its styles are left as they are for backwards compatibility.
+  They should be deleted in v2.0 when we remove the icon prop.
+*/
 const iconStyles = ({ theme }) => css`
   label: tag__icon;
-  display: flex;
-  align-items: center;
+  margin-right: ${theme.spacings.bit};
+  display: inline-block;
   width: ${theme.spacings.mega};
   height: ${theme.spacings.mega};
+  vertical-align: middle;
+  > svg {
+    vertical-align: top;
+  }
 `;
 
 const iconSelectedStyles = ({ selected, theme }) =>
   selected &&
   css`
     label: tag__icon--selected;
-
     > svg {
       fill: ${theme.colors.white};
     }
   `;
 
-const prefixIconStyles = ({ theme, hasPrefix }) =>
-  hasPrefix &&
-  css`
-    label: tag__icon--prefix;
-    margin-right: ${theme.spacings.byte};
-  `;
-
-const suffixIconStyles = ({ theme }) =>
-  css`
-    label: tag__icon--suffix;
-    margin-left: ${theme.spacings.byte};
-  `;
-
-const prefixStyles = ({ theme, selected }) => css`
-  ${iconStyles({ theme })}
-  ${iconSelectedStyles({ theme, selected })}
-  ${prefixIconStyles({ theme, hasPrefix: true })}
-`;
-
-const suffixStyles = ({ theme, selected }) => css`
-  ${iconStyles({ theme })}
-  ${iconSelectedStyles({ theme, selected })}
-  ${suffixIconStyles({ theme })}
-`;
-
-const IconContainer = styled('div')`
+const IconContainer = styled('span')`
   ${iconStyles};
   ${iconSelectedStyles};
-  ${prefixIconStyles};
-`;
-
-const TagElement = styled('div')`
-  ${tagStyles};
-  ${tagClickableStyles};
-  ${tagSelectedStyles};
-  ${tagSelectedClickableStyles};
 `;
 
 /**
@@ -131,41 +157,40 @@ const TagElement = styled('div')`
 const Tag = ({
   children,
   icon,
-  renderPrefix: RenderPrefix,
-  renderSuffix: RenderSuffix,
+  prefix: Prefix,
+  suffix: Suffix,
   onRemove,
   labelRemoveButton,
   selected,
   ...props
 }) => {
-  const prefix = RenderPrefix && (
-    <RenderPrefix css={theme => prefixStyles({ theme, selected })} />
+  const prefixElement = Prefix && (
+    <Prefix css={theme => prefixStyles({ theme, selected })} />
   );
-  const suffix = RenderSuffix && (
-    <RenderSuffix css={theme => suffixStyles({ theme, selected })} />
+  const suffixElement = Suffix && (
+    <Suffix css={theme => suffixStyles({ theme, selected })} />
   );
 
   return (
     <TagElement {...{ selected, ...props }}>
       {!onRemove && icon && (
-        <IconContainer hasPrefix {...{ selected }}>
-          {icon}
-        </IconContainer>
+        <IconContainer {...{ selected }}>{icon}</IconContainer>
       )}
 
-      {!icon && !onRemove && prefix}
+      {!icon && !onRemove && prefixElement}
 
       {children}
 
       {onRemove && (
-        <CloseButton
+        <StyledCloseButton
+          selected={selected}
           label={labelRemoveButton}
           data-testid="tag-close"
           onClick={onRemove}
         />
       )}
 
-      {!onRemove && suffix}
+      {!onRemove && !icon && suffixElement}
     </TagElement>
   );
 };
@@ -181,16 +206,16 @@ Tag.propTypes = {
    */
   icon: deprecatedPropType(
     eitherOrPropType('icon', 'onRemove', PropTypes.element),
-    'The icon prop has been deprecated in favour of the renderPrefix prop.'
+    'The icon prop has been deprecated in favour of the prefix prop.'
   ),
   /**
    * Render prop that should render a left-aligned icon or element.
    */
-  renderPrefix: eitherOrPropType('renderPrefix', 'onRemove', PropTypes.func),
+  prefix: eitherOrPropType('prefix', 'onRemove', PropTypes.func),
   /**
    * Render prop that should render a right-aligned icon or element.
    */
-  renderSuffix: eitherOrPropType('renderSuffix', 'onRemove', PropTypes.func),
+  suffix: eitherOrPropType('suffix', 'onRemove', PropTypes.func),
   /**
    * Renders a close button inside the tag and calls the provided function
    * when the button is clicked.
@@ -210,8 +235,8 @@ Tag.propTypes = {
 Tag.defaultProps = {
   children: null,
   icon: null,
-  renderPrefix: null,
-  renderSuffix: null,
+  prefix: null,
+  suffix: null,
   onRemove: null,
   selected: false,
   labelRemoveButton: 'remove'

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -82,8 +82,7 @@ const iconSelectedStyles = ({ selected, theme }) =>
   css`
     label: tag__icon--selected;
 
-    > svg,
-    svg {
+    > svg {
       fill: ${theme.colors.white};
     }
   `;
@@ -95,18 +94,28 @@ const prefixIconStyles = ({ theme, hasPrefix }) =>
     margin-right: ${theme.spacings.byte};
   `;
 
-const suffixIconStyles = ({ theme, hasSuffix }) =>
-  hasSuffix &&
+const suffixIconStyles = ({ theme }) =>
   css`
     label: tag__icon--suffix;
     margin-left: ${theme.spacings.byte};
   `;
 
+const prefixStyles = ({ theme, selected }) => css`
+  ${iconStyles({ theme })}
+  ${iconSelectedStyles({ theme, selected })}
+  ${prefixIconStyles({ theme, hasPrefix: true })}
+`;
+
+const suffixStyles = ({ theme, selected }) => css`
+  ${iconStyles({ theme })}
+  ${iconSelectedStyles({ theme, selected })}
+  ${suffixIconStyles({ theme })}
+`;
+
 const IconContainer = styled('div')`
   ${iconStyles};
   ${iconSelectedStyles};
   ${prefixIconStyles};
-  ${suffixIconStyles};
 `;
 
 const TagElement = styled('div')`
@@ -129,8 +138,12 @@ const Tag = ({
   selected,
   ...props
 }) => {
-  const prefix = RenderPrefix && <RenderPrefix />;
-  const suffix = RenderSuffix && <RenderSuffix />;
+  const prefix = RenderPrefix && (
+    <RenderPrefix css={theme => prefixStyles({ theme, selected })} />
+  );
+  const suffix = RenderSuffix && (
+    <RenderSuffix css={theme => suffixStyles({ theme, selected })} />
+  );
 
   return (
     <TagElement {...{ selected, ...props }}>
@@ -140,27 +153,19 @@ const Tag = ({
         </IconContainer>
       )}
 
-      {!icon && prefix && !onRemove && (
-        <IconContainer hasPrefix {...{ selected }}>
-          {prefix}
-        </IconContainer>
-      )}
+      {!icon && !onRemove && prefix}
 
       {children}
 
-      {(onRemove || suffix) && (
-        <IconContainer hasSuffix {...{ selected }}>
-          {onRemove ? (
-            <CloseButton
-              label={labelRemoveButton}
-              data-testid="tag-close"
-              onClick={onRemove}
-            />
-          ) : (
-            suffix
-          )}
-        </IconContainer>
+      {onRemove && (
+        <CloseButton
+          label={labelRemoveButton}
+          data-testid="tag-close"
+          onClick={onRemove}
+        />
       )}
+
+      {!onRemove && suffix}
     </TagElement>
   );
 };
@@ -181,11 +186,11 @@ Tag.propTypes = {
   /**
    * Render prop that should render a left-aligned icon or element.
    */
-  renderPrefix: eitherOrPropType('renderPrefix', 'onRemove', PropTypes.element),
+  renderPrefix: eitherOrPropType('renderPrefix', 'onRemove', PropTypes.func),
   /**
    * Render prop that should render a right-aligned icon or element.
    */
-  renderSuffix: eitherOrPropType('renderSuffix', 'onRemove', PropTypes.element),
+  renderSuffix: eitherOrPropType('renderSuffix', 'onRemove', PropTypes.func),
   /**
    * Renders a close button inside the tag and calls the provided function
    * when the button is clicked.

--- a/src/components/Tag/Tag.spec.js
+++ b/src/components/Tag/Tag.spec.js
@@ -143,7 +143,7 @@ describe('Tag', () => {
       renderPrefix: () => <DummyIcon data-testid="tag-icon" />
     };
 
-    it('should render with a suffix', () => {
+    it('should render with a prefix', () => {
       const { getByTestId } = render(<Tag {...props}>SomeTest</Tag>);
       expect(getByTestId('tag-icon')).not.toBeNull();
     });

--- a/src/components/Tag/Tag.spec.js
+++ b/src/components/Tag/Tag.spec.js
@@ -106,7 +106,7 @@ describe('Tag', () => {
     });
   });
 
-  describe('when it has s left icon', () => {
+  describe('when it has a left icon', () => {
     const props = {
       icon: <DummyIcon data-testid="tag-icon" />
     };

--- a/src/components/Tag/Tag.spec.js
+++ b/src/components/Tag/Tag.spec.js
@@ -16,14 +16,9 @@
 import React from 'react';
 
 import Tag from '.';
+import { ReactComponent as DummyIcon } from './icon-tick.svg';
 
 describe('Tag', () => {
-  const DummyIcon = props => (
-    <svg {...props} fill="#000000" xmlns="http://www.w3.org/2000/svg">
-      <path />
-    </svg>
-  );
-
   /**
    * Style tests.
    */
@@ -137,10 +132,10 @@ describe('Tag', () => {
     });
   });
 
-  describe('when it has a prefix render prop', () => {
+  describe('when a prefix prop is passed', () => {
     const props = {
       // eslint-disable-next-line
-      renderPrefix: () => <DummyIcon data-testid="tag-icon" />
+      prefix: ({ className }) => <DummyIcon className={className} data-testid="tag-icon" />
     };
 
     it('should render with a prefix', () => {
@@ -159,7 +154,7 @@ describe('Tag', () => {
       expect(queryByTestId('tag-close')).not.toBeNull();
     });
 
-    it('should warn when both the renderPrefix and onRemove prop are passed', () => {
+    it('should warn when both the prefix and onRemove prop are passed', () => {
       jest.spyOn(console, 'error');
       const onRemove = jest.fn();
 
@@ -169,10 +164,10 @@ describe('Tag', () => {
     });
   });
 
-  describe('when it has a suffix render prop', () => {
+  describe('when a suffix prop is passed', () => {
     const props = {
       // eslint-disable-next-line
-      renderSuffix: () => <DummyIcon data-testid="tag-icon" />
+      suffix: ({ className }) => <DummyIcon className={className} data-testid="tag-icon" />
     };
 
     it('should render with a suffix', () => {
@@ -191,7 +186,7 @@ describe('Tag', () => {
       expect(queryByTestId('tag-close')).not.toBeNull();
     });
 
-    it('should warn when both the renderSuffix and onRemove prop are passed', () => {
+    it('should warn when both the suffix and onRemove prop are passed', () => {
       jest.spyOn(console, 'error');
       const onRemove = jest.fn();
 

--- a/src/components/Tag/Tag.spec.js
+++ b/src/components/Tag/Tag.spec.js
@@ -106,9 +106,40 @@ describe('Tag', () => {
     });
   });
 
-  describe('when has icon', () => {
+  describe('when it has s left icon', () => {
     const props = {
       icon: <DummyIcon data-testid="tag-icon" />
+    };
+
+    it('should render with icon', () => {
+      const { getByTestId } = render(<Tag {...props}>SomeTest</Tag>);
+      expect(getByTestId('tag-icon')).not.toBeNull();
+    });
+
+    it('gives priority to close button when a removable', () => {
+      const onRemove = jest.fn();
+
+      const { queryByTestId } = render(
+        <Tag {...{ onRemove, props }}>SomeTest</Tag>
+      );
+
+      expect(queryByTestId('tag-icon')).toBeNull();
+      expect(queryByTestId('tag-close')).not.toBeNull();
+    });
+
+    it('should warn when both the icon and onRemove prop are passed', () => {
+      jest.spyOn(console, 'error');
+      const onRemove = jest.fn();
+
+      render(<Tag {...{ onRemove, ...props }}>SomeTest</Tag>);
+
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('when it has a right icon', () => {
+    const props = {
+      rightIcon: <DummyIcon data-testid="tag-icon" />
     };
 
     it('should render with icon', () => {

--- a/src/components/Tag/Tag.spec.js
+++ b/src/components/Tag/Tag.spec.js
@@ -106,7 +106,7 @@ describe('Tag', () => {
     });
   });
 
-  describe('when it has a left icon', () => {
+  describe('when it has an icon', () => {
     const props = {
       icon: <DummyIcon data-testid="tag-icon" />
     };
@@ -137,17 +137,18 @@ describe('Tag', () => {
     });
   });
 
-  describe('when it has a right icon', () => {
+  describe('when it has a prefix render prop', () => {
     const props = {
-      rightIcon: <DummyIcon data-testid="tag-icon" />
+      // eslint-disable-next-line
+      renderPrefix: () => <DummyIcon data-testid="tag-icon" />
     };
 
-    it('should render with icon', () => {
+    it('should render with a suffix', () => {
       const { getByTestId } = render(<Tag {...props}>SomeTest</Tag>);
       expect(getByTestId('tag-icon')).not.toBeNull();
     });
 
-    it('gives priority to close button when a removable', () => {
+    it(`gives priority to close button when it's removable`, () => {
       const onRemove = jest.fn();
 
       const { queryByTestId } = render(
@@ -158,7 +159,39 @@ describe('Tag', () => {
       expect(queryByTestId('tag-close')).not.toBeNull();
     });
 
-    it('should warn when both the icon and onRemove prop are passed', () => {
+    it('should warn when both the renderPrefix and onRemove prop are passed', () => {
+      jest.spyOn(console, 'error');
+      const onRemove = jest.fn();
+
+      render(<Tag {...{ onRemove, ...props }}>SomeTest</Tag>);
+
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('when it has a suffix render prop', () => {
+    const props = {
+      // eslint-disable-next-line
+      renderSuffix: () => <DummyIcon data-testid="tag-icon" />
+    };
+
+    it('should render with a suffix', () => {
+      const { getByTestId } = render(<Tag {...props}>SomeTest</Tag>);
+      expect(getByTestId('tag-icon')).not.toBeNull();
+    });
+
+    it(`gives priority to close button when it's removable`, () => {
+      const onRemove = jest.fn();
+
+      const { queryByTestId } = render(
+        <Tag {...{ onRemove, props }}>SomeTest</Tag>
+      );
+
+      expect(queryByTestId('tag-icon')).toBeNull();
+      expect(queryByTestId('tag-close')).not.toBeNull();
+    });
+
+    it('should warn when both the renderSuffix and onRemove prop are passed', () => {
       jest.spyOn(console, 'error');
       const onRemove = jest.fn();
 

--- a/src/components/Tag/Tag.story.js
+++ b/src/components/Tag/Tag.story.js
@@ -55,11 +55,9 @@ export const base = () => (
 
 export const selected = () => <Tag selected>Transactions</Tag>;
 
-export const withPrefix = () => (
-  <Tag selected renderPrefix={Icon}>
-    Transactions
-  </Tag>
-);
+export const withIcon = () => <Tag icon={<Icon />}>Transactions</Tag>;
+
+export const withPrefix = () => <Tag renderPrefix={Icon}>Transactions</Tag>;
 
 export const withSuffix = () => (
   <Tag renderSuffix={() => <Icon />}>Transactions</Tag>

--- a/src/components/Tag/Tag.story.js
+++ b/src/components/Tag/Tag.story.js
@@ -19,19 +19,7 @@ import { boolean } from '@storybook/addon-knobs/react';
 
 import docs from './Tag.docs.mdx';
 import Tag from './Tag';
-
-const Icon = () => (
-  <svg
-    fill="#000000"
-    height="16"
-    viewBox="0 0 24 24"
-    width="16"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path d="M0 0h24v24H0z" fill="none" />
-    <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
-  </svg>
-);
+import { ReactComponent as Icon } from './icon-tick.svg';
 
 export default {
   title: 'Components/Tag',
@@ -55,31 +43,15 @@ export const base = () => (
 
 export const selected = () => <Tag selected>Transactions</Tag>;
 
-export const withIcon = () => <Tag icon={<Icon />}>Transactions</Tag>;
-
-export const withPrefix = () => (
-  <Tag
-    renderPrefix={({ className }) => (
-      <span className={className}>
-        <Icon />
-      </span>
-    )}
-  >
+export const withIcon = () => (
+  <Tag selected icon={<Icon />}>
     Transactions
   </Tag>
 );
 
-export const withSuffix = () => (
-  <Tag
-    renderSuffix={({ className }) => (
-      <span className={className}>
-        <Icon />
-      </span>
-    )}
-  >
-    Transactions
-  </Tag>
-);
+export const withPrefix = () => <Tag prefix={Icon}>Transactions</Tag>;
+
+export const withSuffix = () => <Tag suffix={Icon}>Transactions</Tag>;
 
 export const removable = () => (
   <Tag onRemove={action('Tag removed')} labelRemoveButton="Remove">

--- a/src/components/Tag/Tag.story.js
+++ b/src/components/Tag/Tag.story.js
@@ -57,10 +57,28 @@ export const selected = () => <Tag selected>Transactions</Tag>;
 
 export const withIcon = () => <Tag icon={<Icon />}>Transactions</Tag>;
 
-export const withPrefix = () => <Tag renderPrefix={Icon}>Transactions</Tag>;
+export const withPrefix = () => (
+  <Tag
+    renderPrefix={({ className }) => (
+      <span className={className}>
+        <Icon />
+      </span>
+    )}
+  >
+    Transactions
+  </Tag>
+);
 
 export const withSuffix = () => (
-  <Tag renderSuffix={() => <Icon />}>Transactions</Tag>
+  <Tag
+    renderSuffix={({ className }) => (
+      <span className={className}>
+        <Icon />
+      </span>
+    )}
+  >
+    Transactions
+  </Tag>
 );
 
 export const removable = () => (

--- a/src/components/Tag/Tag.story.js
+++ b/src/components/Tag/Tag.story.js
@@ -55,9 +55,15 @@ export const base = () => (
 
 export const selected = () => <Tag selected>Transactions</Tag>;
 
-export const withLeftIcon = () => <Tag icon={<Icon />}>Transactions</Tag>;
+export const withPrefix = () => (
+  <Tag selected renderPrefix={Icon}>
+    Transactions
+  </Tag>
+);
 
-export const withRightIcon = () => <Tag rightIcon={<Icon />}>Transactions</Tag>;
+export const withSuffix = () => (
+  <Tag renderSuffix={() => <Icon />}>Transactions</Tag>
+);
 
 export const removable = () => (
   <Tag onRemove={action('Tag removed')} labelRemoveButton="Remove">

--- a/src/components/Tag/Tag.story.js
+++ b/src/components/Tag/Tag.story.js
@@ -55,7 +55,9 @@ export const base = () => (
 
 export const selected = () => <Tag selected>Transactions</Tag>;
 
-export const withIcon = () => <Tag icon={<Icon />}>Transactions</Tag>;
+export const withLeftIcon = () => <Tag icon={<Icon />}>Transactions</Tag>;
+
+export const withRightIcon = () => <Tag rightIcon={<Icon />}>Transactions</Tag>;
 
 export const removable = () => (
   <Tag onRemove={action('Tag removed')} labelRemoveButton="Remove">

--- a/src/components/Tag/__snapshots__/Tag.spec.js.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.js.snap
@@ -2,13 +2,20 @@
 
 exports[`Tag when is clickable should render with clickable styles 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
   cursor: pointer;
 }
 
@@ -17,46 +24,79 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
   box-shadow: 0px 0px 0px 1px #D8DDE1;
 }
 
-<span
+<div
   class="circuit-0 circuit-1"
 >
   SomeTest
-</span>
+</div>
 `;
 
 exports[`Tag when is default should render with default styles 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
 }
 
-<span
+<div
   class="circuit-0 circuit-1"
 >
   SomeTest
-</span>
+</div>
 `;
 
 exports[`Tag when is selected should change the close icon color 1`] = `
-.circuit-6 {
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
   background-color: #3388FF;
   box-shadow: 0px 0px 0px 1px #3388FF;
   color: #FFFFFF;
 }
 
-.circuit-4 {
+.circuit-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+  margin-left: 8px;
+}
+
+.circuit-5 > svg,
+.circuit-5 svg {
+  fill: #FFFFFF;
+}
+
+.circuit-3 {
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -67,23 +107,16 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   overflow: initial;
   height: 16px;
   width: 16px;
-  margin-left: 12px;
-  vertical-align: middle;
 }
 
-.circuit-4:focus,
-.circuit-4:active {
+.circuit-3:focus,
+.circuit-3:active {
   outline: none;
 }
 
-.circuit-4 > svg {
+.circuit-3 > svg {
   height: 100%;
   width: 100%;
-}
-
-.circuit-4 > svg {
-  fill: #FFFFFF;
-  vertical-align: inherit;
 }
 
 .circuit-0 {
@@ -101,63 +134,77 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   width: 1px;
 }
 
-<span
-  class="circuit-6 circuit-7"
+<div
+  class="circuit-7 circuit-8"
 >
   SomeTest
-  <button
-    class="circuit-2 circuit-3 circuit-4 circuit-5"
-    data-testid="tag-close"
-    type="button"
+  <div
+    class="circuit-5 circuit-6"
   >
-    <div
-      role="presentation"
+    <button
+      class="circuit-2 circuit-3 circuit-4"
+      data-testid="tag-close"
+      type="button"
     >
-      close-icon.svg
-    </div>
-    <span
-      class="circuit-0 circuit-1"
-    >
-      remove
-    </span>
-  </button>
-</span>
+      <div
+        role="presentation"
+      >
+        close-icon.svg
+      </div>
+      <span
+        class="circuit-0 circuit-1"
+      >
+        remove
+      </span>
+    </button>
+  </div>
+</div>
 `;
 
 exports[`Tag when is selected should change the given icon color 1`] = `
 .circuit-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
   background-color: #3388FF;
   box-shadow: 0px 0px 0px 1px #3388FF;
   color: #FFFFFF;
 }
 
 .circuit-0 {
-  margin-right: 4px;
-  display: inline-block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   width: 16px;
   height: 16px;
-  vertical-align: middle;
+  margin-right: 8px;
 }
 
-.circuit-0 > svg {
-  vertical-align: top;
-}
-
-.circuit-0 > svg {
+.circuit-0 > svg,
+.circuit-0 svg {
   fill: #FFFFFF;
 }
 
-<span
+<div
   class="circuit-2 circuit-3"
 >
-  <span
+  <div
     class="circuit-0 circuit-1"
   >
     <svg
@@ -166,28 +213,35 @@ exports[`Tag when is selected should change the given icon color 1`] = `
     >
       <path />
     </svg>
-  </span>
+  </div>
   SomeTest
-</span>
+</div>
 `;
 
 exports[`Tag when is selected should render with selected styles 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
   box-shadow: 0px 0px 0px 1px #D8DDE1;
   padding: 4px 12px;
   cursor: default;
-  display: inline-block;
   background-color: #3388FF;
   box-shadow: 0px 0px 0px 1px #3388FF;
   color: #FFFFFF;
 }
 
-<span
+<div
   class="circuit-0 circuit-1"
 >
   SomeTest
-</span>
+</div>
 `;

--- a/src/components/Tag/__snapshots__/Tag.spec.js.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.js.snap
@@ -57,7 +57,7 @@ exports[`Tag when is default should render with default styles 1`] = `
 `;
 
 exports[`Tag when is selected should change the close icon color 1`] = `
-.circuit-7 {
+.circuit-5 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -75,25 +75,6 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   background-color: #3388FF;
   box-shadow: 0px 0px 0px 1px #3388FF;
   color: #FFFFFF;
-}
-
-.circuit-5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 16px;
-  height: 16px;
-  margin-left: 8px;
-}
-
-.circuit-5 > svg,
-.circuit-5 svg {
-  fill: #FFFFFF;
 }
 
 .circuit-3 {
@@ -135,29 +116,25 @@ exports[`Tag when is selected should change the close icon color 1`] = `
 }
 
 <div
-  class="circuit-7 circuit-8"
+  class="circuit-5 circuit-6"
 >
   SomeTest
-  <div
-    class="circuit-5 circuit-6"
+  <button
+    class="circuit-2 circuit-3 circuit-4"
+    data-testid="tag-close"
+    type="button"
   >
-    <button
-      class="circuit-2 circuit-3 circuit-4"
-      data-testid="tag-close"
-      type="button"
+    <div
+      role="presentation"
     >
-      <div
-        role="presentation"
-      >
-        close-icon.svg
-      </div>
-      <span
-        class="circuit-0 circuit-1"
-      >
-        remove
-      </span>
-    </button>
-  </div>
+      close-icon.svg
+    </div>
+    <span
+      class="circuit-0 circuit-1"
+    >
+      remove
+    </span>
+  </button>
 </div>
 `;
 
@@ -196,8 +173,7 @@ exports[`Tag when is selected should change the given icon color 1`] = `
   margin-right: 8px;
 }
 
-.circuit-0 > svg,
-.circuit-0 svg {
+.circuit-0 > svg {
   fill: #FFFFFF;
 }
 

--- a/src/components/Tag/__snapshots__/Tag.spec.js.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.js.snap
@@ -57,7 +57,7 @@ exports[`Tag when is default should render with default styles 1`] = `
 `;
 
 exports[`Tag when is selected should change the close icon color 1`] = `
-.circuit-5 {
+.circuit-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -77,7 +77,11 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   color: #FFFFFF;
 }
 
-.circuit-3 {
+.circuit-6 > svg {
+  fill: #FFFFFF;
+}
+
+.circuit-4 {
   padding: 0;
   margin: 0;
   display: inline-block;
@@ -88,16 +92,21 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   overflow: initial;
   height: 16px;
   width: 16px;
+  margin-left: 8px;
 }
 
-.circuit-3:focus,
-.circuit-3:active {
+.circuit-4:focus,
+.circuit-4:active {
   outline: none;
 }
 
-.circuit-3 > svg {
+.circuit-4 > svg {
   height: 100%;
   width: 100%;
+}
+
+.circuit-4 svg {
+  fill: #FFFFFF;
 }
 
 .circuit-0 {
@@ -116,11 +125,11 @@ exports[`Tag when is selected should change the close icon color 1`] = `
 }
 
 <div
-  class="circuit-5 circuit-6"
+  class="circuit-6 circuit-7"
 >
   SomeTest
   <button
-    class="circuit-2 circuit-3 circuit-4"
+    class="circuit-2 circuit-3 circuit-4 circuit-5"
     data-testid="tag-close"
     type="button"
   >
@@ -159,18 +168,20 @@ exports[`Tag when is selected should change the given icon color 1`] = `
   color: #FFFFFF;
 }
 
+.circuit-2 > svg {
+  fill: #FFFFFF;
+}
+
 .circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  margin-right: 4px;
+  display: inline-block;
   width: 16px;
   height: 16px;
-  margin-right: 8px;
+  vertical-align: middle;
+}
+
+.circuit-0 > svg {
+  vertical-align: top;
 }
 
 .circuit-0 > svg {
@@ -180,16 +191,13 @@ exports[`Tag when is selected should change the given icon color 1`] = `
 <div
   class="circuit-2 circuit-3"
 >
-  <div
+  <span
     class="circuit-0 circuit-1"
   >
-    <svg
-      fill="#000000"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path />
-    </svg>
-  </div>
+    <div>
+      icon-tick.svg
+    </div>
+  </span>
   SomeTest
 </div>
 `;
@@ -213,6 +221,10 @@ exports[`Tag when is selected should render with selected styles 1`] = `
   background-color: #3388FF;
   box-shadow: 0px 0px 0px 1px #3388FF;
   color: #FFFFFF;
+}
+
+.circuit-0 > svg {
+  fill: #FFFFFF;
 }
 
 <div

--- a/src/components/Tag/icon-tick.svg
+++ b/src/components/Tag/icon-tick.svg
@@ -1,0 +1,10 @@
+ <svg
+    fill="#000000"
+    height="16"
+    viewBox="0 0 24 24"
+    width="16"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M0 0h24v24H0z" fill="none" />
+    <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+</svg>


### PR DESCRIPTION
## Purpose

The PR adds a prefix and suffix support to the `Tag` component. The designers have this case in the components they use in Figma and that's why we have decided to introduce the change in Circuit UI as well.

## Approach and changes

An optional `prefix` and `suffix` props could be now passed to the `Tag` component which always gives precedence to the clear icon (it isn't displayed in case the `onRemove` prop is passed). A new story is added to our storybook and the unit and snapshot tests are updated as well.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
