### PR TITLE
feat(components): add Anchor component

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -236,109 +236,6 @@ HTMLCollection [
 ]
 `;
 
-exports[`Storyshots Components/Blockquote Base 1`] = `
-.circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 13px;
-  line-height: 20px;
-  font-style: italic;
-  padding-left: 12px;
-  border-left: 2px solid #3388FF;
-}
-
-@media (min-width:480px) {
-  .circuit-0 {
-    font-size: 13px;
-    line-height: 20px;
-  }
-}
-
-<blockquote
-  class="circuit-0 circuit-1"
->
-  
-Lorem ipsum dolor amet echo park activated charcoal banjo deep
-crucifix pinterest yr af tumeric literally. Tbh four loko tattooed
-kickstarter artisan. Lumbersexual tote bag selfies truffaut, tofu vape
-tbh adaptogen green juice lo-fi kombucha.
-
-</blockquote>
-`;
-
-exports[`Storyshots Components/Blockquote Size 1`] = `
-HTMLCollection [
-  .circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 13px;
-  line-height: 20px;
-  font-style: italic;
-  padding-left: 12px;
-  border-left: 2px solid #3388FF;
-}
-
-@media (min-width:480px) {
-  .circuit-0 {
-    font-size: 13px;
-    line-height: 20px;
-  }
-}
-
-<blockquote
-    class="circuit-0 circuit-1"
-  >
-    Kilo - The ability to accept credit card payments that are EMV-compliant is essentially an insurance policy against fraud and an impressively economical one at that.
-  </blockquote>,
-  .circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  font-style: italic;
-  padding-left: 12px;
-  border-left: 2px solid #3388FF;
-}
-
-@media (min-width:480px) {
-  .circuit-0 {
-    font-size: 16px;
-    line-height: 24px;
-  }
-}
-
-<blockquote
-    class="circuit-0 circuit-1"
-  >
-    Mega - The ability to accept credit card payments that are EMV-compliant is essentially an insurance policy against fraud and an impressively economical one at that.
-  </blockquote>,
-  .circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  font-style: italic;
-  padding-left: 12px;
-  border-left: 2px solid #3388FF;
-  padding-left: 16px;
-  border-left: 3px solid #3388FF;
-}
-
-@media (min-width:480px) {
-  .circuit-0 {
-    font-size: 18px;
-    line-height: 28px;
-  }
-}
-
-<blockquote
-    class="circuit-0 circuit-1"
-  >
-    Giga - The ability to accept credit card payments that are EMV-compliant is essentially an insurance policy against fraud and an impressively economical one at that.
-  </blockquote>,
-]
-`;
-
 exports[`Storyshots Components/Button Base 1`] = `
 .circuit-0 {
   background-color: #FAFBFC;
@@ -7222,195 +7119,6 @@ exports[`Storyshots Components/Image Base 1`] = `
   class="circuit-0 circuit-1"
   src="https://source.unsplash.com/random"
 />
-`;
-
-exports[`Storyshots Components/List Base 1`] = `
-.circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  padding-left: 12px;
-  font-size: 13px;
-  line-height: 20px;
-}
-
-.circuit-0 li {
-  margin-bottom: 12px;
-  margin-left: 4px;
-}
-
-.circuit-0 ul,
-.circuit-0 ol {
-  margin-left: 4px;
-}
-
-<ul
-  class="circuit-0 circuit-1"
->
-  <li>
-    This is a list
-  </li>
-  <li>
-    A very fine list
-  </li>
-</ul>
-`;
-
-exports[`Storyshots Components/List Nested 1`] = `
-.circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  padding-left: 12px;
-  font-size: 13px;
-  line-height: 20px;
-}
-
-.circuit-0 li {
-  margin-bottom: 12px;
-  margin-left: 4px;
-}
-
-.circuit-0 ul,
-.circuit-0 ol {
-  margin-left: 4px;
-}
-
-<ul
-  class="circuit-0 circuit-1"
->
-  <li>
-    This is a list
-  </li>
-  <li>
-    A very fine list
-  </li>
-  <ul
-    class="circuit-0 circuit-1"
-  >
-    <li>
-      Sometimes a nested list
-    </li>
-  </ul>
-</ul>
-`;
-
-exports[`Storyshots Components/List Ordered 1`] = `
-.circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  padding-left: 12px;
-  font-size: 13px;
-  line-height: 20px;
-}
-
-.circuit-0 li {
-  margin-bottom: 12px;
-  margin-left: 4px;
-}
-
-.circuit-0 ul,
-.circuit-0 ol {
-  margin-left: 4px;
-}
-
-<ol
-  class="circuit-0 circuit-1"
->
-  <li>
-    This is a list
-  </li>
-  <li>
-    A very fine list
-  </li>
-</ol>
-`;
-
-exports[`Storyshots Components/List Size 1`] = `
-HTMLCollection [
-  .circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  padding-left: 12px;
-  font-size: 13px;
-  line-height: 20px;
-}
-
-.circuit-0 li {
-  margin-bottom: 12px;
-  margin-left: 4px;
-}
-
-.circuit-0 ul,
-.circuit-0 ol {
-  margin-left: 4px;
-}
-
-<ul
-    class="circuit-0 circuit-1"
-  >
-    <li>
-      This is a list
-    </li>
-    <li>
-      A very fine list
-    </li>
-  </ul>,
-  .circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  padding-left: 12px;
-  font-size: 16px;
-  line-height: 24px;
-}
-
-.circuit-0 li {
-  margin-bottom: 8px;
-  margin-left: 12px;
-}
-
-.circuit-0 ul,
-.circuit-0 ol {
-  margin-left: 12px;
-}
-
-<ul
-    class="circuit-0 circuit-1"
-  >
-    <li>
-      This is a list
-    </li>
-    <li>
-      A very fine list
-    </li>
-  </ul>,
-  .circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  padding-left: 16px;
-  font-size: 18px;
-  line-height: 28px;
-}
-
-.circuit-0 li {
-  margin-bottom: 12px;
-  margin-left: 12px;
-}
-
-.circuit-0 ul,
-.circuit-0 ol {
-  margin-left: 12px;
-}
-
-<ul
-    class="circuit-0 circuit-1"
-  >
-    <li>
-      This is a list
-    </li>
-    <li>
-      A very fine list
-    </li>
-  </ul>,
-]
 `;
 
 exports[`Storyshots Components/Modal Base 1`] = `
@@ -24599,6 +24307,109 @@ exports[`Storyshots Typography/Anchor As Link 1`] = `
 </a>
 `;
 
+exports[`Storyshots Typography/Blockquote Base 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 13px;
+  line-height: 20px;
+  font-style: italic;
+  padding-left: 12px;
+  border-left: 2px solid #3388FF;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 13px;
+    line-height: 20px;
+  }
+}
+
+<blockquote
+  class="circuit-0 circuit-1"
+>
+  
+Lorem ipsum dolor amet echo park activated charcoal banjo deep
+crucifix pinterest yr af tumeric literally. Tbh four loko tattooed
+kickstarter artisan. Lumbersexual tote bag selfies truffaut, tofu vape
+tbh adaptogen green juice lo-fi kombucha.
+
+</blockquote>
+`;
+
+exports[`Storyshots Typography/Blockquote Size 1`] = `
+HTMLCollection [
+  .circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 13px;
+  line-height: 20px;
+  font-style: italic;
+  padding-left: 12px;
+  border-left: 2px solid #3388FF;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 13px;
+    line-height: 20px;
+  }
+}
+
+<blockquote
+    class="circuit-0 circuit-1"
+  >
+    Kilo - The ability to accept credit card payments that are EMV-compliant is essentially an insurance policy against fraud and an impressively economical one at that.
+  </blockquote>,
+  .circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  font-style: italic;
+  padding-left: 12px;
+  border-left: 2px solid #3388FF;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 16px;
+    line-height: 24px;
+  }
+}
+
+<blockquote
+    class="circuit-0 circuit-1"
+  >
+    Mega - The ability to accept credit card payments that are EMV-compliant is essentially an insurance policy against fraud and an impressively economical one at that.
+  </blockquote>,
+  .circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  font-style: italic;
+  padding-left: 12px;
+  border-left: 2px solid #3388FF;
+  padding-left: 16px;
+  border-left: 3px solid #3388FF;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 18px;
+    line-height: 28px;
+  }
+}
+
+<blockquote
+    class="circuit-0 circuit-1"
+  >
+    Giga - The ability to accept credit card payments that are EMV-compliant is essentially an insurance policy against fraud and an impressively economical one at that.
+  </blockquote>,
+]
+`;
+
 exports[`Storyshots Typography/Heading Base 1`] = `
 .circuit-0 {
   font-weight: 700;
@@ -24770,6 +24581,195 @@ HTMLCollection [
     kilo
      heading
   </h2>,
+]
+`;
+
+exports[`Storyshots Typography/List Base 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  padding-left: 12px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.circuit-0 li {
+  margin-bottom: 12px;
+  margin-left: 4px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-left: 4px;
+}
+
+<ul
+  class="circuit-0 circuit-1"
+>
+  <li>
+    This is a list
+  </li>
+  <li>
+    A very fine list
+  </li>
+</ul>
+`;
+
+exports[`Storyshots Typography/List Nested 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  padding-left: 12px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.circuit-0 li {
+  margin-bottom: 12px;
+  margin-left: 4px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-left: 4px;
+}
+
+<ul
+  class="circuit-0 circuit-1"
+>
+  <li>
+    This is a list
+  </li>
+  <li>
+    A very fine list
+  </li>
+  <ul
+    class="circuit-0 circuit-1"
+  >
+    <li>
+      Sometimes a nested list
+    </li>
+  </ul>
+</ul>
+`;
+
+exports[`Storyshots Typography/List Ordered 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  padding-left: 12px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.circuit-0 li {
+  margin-bottom: 12px;
+  margin-left: 4px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-left: 4px;
+}
+
+<ol
+  class="circuit-0 circuit-1"
+>
+  <li>
+    This is a list
+  </li>
+  <li>
+    A very fine list
+  </li>
+</ol>
+`;
+
+exports[`Storyshots Typography/List Size 1`] = `
+HTMLCollection [
+  .circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  padding-left: 12px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.circuit-0 li {
+  margin-bottom: 12px;
+  margin-left: 4px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-left: 4px;
+}
+
+<ul
+    class="circuit-0 circuit-1"
+  >
+    <li>
+      This is a list
+    </li>
+    <li>
+      A very fine list
+    </li>
+  </ul>,
+  .circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  padding-left: 12px;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.circuit-0 li {
+  margin-bottom: 8px;
+  margin-left: 12px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-left: 12px;
+}
+
+<ul
+    class="circuit-0 circuit-1"
+  >
+    <li>
+      This is a list
+    </li>
+    <li>
+      A very fine list
+    </li>
+  </ul>,
+  .circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  padding-left: 16px;
+  font-size: 18px;
+  line-height: 28px;
+}
+
+.circuit-0 li {
+  margin-bottom: 12px;
+  margin-left: 12px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-left: 12px;
+}
+
+<ul
+    class="circuit-0 circuit-1"
+  >
+    <li>
+      This is a list
+    </li>
+    <li>
+      A very fine list
+    </li>
+  </ul>,
 ]
 `;
 

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -24478,6 +24478,127 @@ HTMLCollection [
 ]
 `;
 
+exports[`Storyshots Typography/Anchor As Button 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  display: inline-block;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-text-decoration-skip-ink: auto;
+  text-decoration-skip-ink: auto;
+  border: 0;
+  outline: none;
+  background: none;
+  padding: 0;
+  margin-top: 0;
+  margin-left: 0;
+  margin-right: 0;
+  color: #1760CE;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 16px;
+    line-height: 24px;
+  }
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  color: #003C8B;
+  cursor: pointer;
+}
+
+.circuit-0:visited {
+  color: #8928A2;
+}
+
+.circuit-0:visited:hover,
+.circuit-0:visited:active {
+  color: #5F1D6B;
+}
+
+.circuit-0:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-radius: 5px;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+<button
+  class="circuit-0"
+>
+  Say hello
+</button>
+`;
+
+exports[`Storyshots Typography/Anchor As Link 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  display: inline-block;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-text-decoration-skip-ink: auto;
+  text-decoration-skip-ink: auto;
+  border: 0;
+  outline: none;
+  background: none;
+  padding: 0;
+  margin-top: 0;
+  margin-left: 0;
+  margin-right: 0;
+  color: #1760CE;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 16px;
+    line-height: 24px;
+  }
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  color: #003C8B;
+  cursor: pointer;
+}
+
+.circuit-0:visited {
+  color: #8928A2;
+}
+
+.circuit-0:visited:hover,
+.circuit-0:visited:active {
+  color: #5F1D6B;
+}
+
+.circuit-0:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-radius: 5px;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+<a
+  class="circuit-0"
+  href="https://opensource.sumup.com"
+>
+  View SumUp's OSS projects
+</a>
+`;
+
 exports[`Storyshots Typography/Heading Base 1`] = `
 .circuit-0 {
   font-weight: 700;

--- a/src/components/Anchor/Anchor.docs.mdx
+++ b/src/components/Anchor/Anchor.docs.mdx
@@ -1,0 +1,21 @@
+import { Status, Props, Story } from '../../../.storybook/components';
+import Anchor from '.';
+
+# Anchor
+
+<Status.Stable />
+
+Anchor is used to display a link or button that visually looks like a hyperlink.
+
+<Story id="typography-anchor--as-link" />
+<Props of={Anchor} />
+
+## Usage guidelines
+
+- **Do** use the `mega` size as the default for body text
+- **Do** open the link in the same window unless it leads to an external source.
+- **Do not** use in combination with the button component, use the tertiary button variant instead
+
+### As button
+
+<Story id="typography-anchor--as-button" />

--- a/src/components/Anchor/Anchor.spec.tsx
+++ b/src/components/Anchor/Anchor.spec.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import {
+  create,
+  render,
+  renderToHtml,
+  axe,
+  RenderFn,
+  act,
+  userEvent
+} from '../../util/test-utils';
+
+import { Anchor, AnchorProps } from './Anchor';
+
+describe('Anchor', () => {
+  function renderAnchor(renderFn: RenderFn, props: AnchorProps) {
+    return renderFn(<Anchor {...props} />);
+  }
+
+  const baseProps = { children: 'Anchor' };
+
+  describe('styles', () => {
+    it('should render as a `span` when neither href nor onClick is passed', () => {
+      const actual = renderAnchor(create, baseProps);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render as an `a` when an href (and onClick) is passed', () => {
+      const props = {
+        ...baseProps,
+        href: 'https://sumup.com',
+        onClick: jest.fn()
+      };
+      const actual = renderAnchor(create, props);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render as a `button` when an onClick is passed', () => {
+      const props = { ...baseProps, onClick: jest.fn() };
+      const actual = renderAnchor(create, props);
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
+  describe('business logic', () => {
+    it('should call the onClick handler when rendered as a link', () => {
+      const props = {
+        ...baseProps,
+        href: 'https://sumup.com',
+        onClick: jest.fn(event => event.preventDefault()),
+        'data-testid': 'anchor'
+      };
+      const { getByTestId } = renderAnchor(render, props);
+
+      act(() => {
+        userEvent.click(getByTestId('anchor'));
+      });
+
+      expect(props.onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call the onClick handler when rendered as a button', () => {
+      const props = {
+        ...baseProps,
+        onClick: jest.fn(),
+        'data-testid': 'anchor'
+      };
+      const { getByTestId } = renderAnchor(render, props);
+
+      act(() => {
+        userEvent.click(getByTestId('anchor'));
+      });
+
+      expect(props.onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const props = {
+        ...baseProps,
+        href: 'https://sumup.com',
+        onClick: jest.fn()
+      };
+      const wrapper = renderAnchor(renderToHtml, props);
+      const actual = await axe(wrapper);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/src/components/Anchor/Anchor.story.tsx
+++ b/src/components/Anchor/Anchor.story.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { FunctionComponent } from 'react';
+
+import Anchor from '.';
+import docs from './Anchor.docs.mdx';
+
+export default {
+  title: 'Typography/Anchor',
+  component: Anchor,
+  parameters: {
+    docs: { page: docs },
+    jest: ['Anchor']
+  }
+};
+
+export const AsLink: FunctionComponent = () => (
+  <Anchor href="https://opensource.sumup.com">
+    {`View SumUp's OSS projects`}
+  </Anchor>
+);
+
+export const AsButton: FunctionComponent = () => (
+  <Anchor onClick={() => alert('Hello')}>Say hello</Anchor>
+);

--- a/src/components/Anchor/Anchor.tsx
+++ b/src/components/Anchor/Anchor.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { HTMLProps, ReactNode, ReactElement } from 'react';
+import { css } from '@emotion/core';
+
+import styled, { StyleProps } from '../../styles/styled';
+import { focusOutline } from '../../styles/style-helpers';
+import Text from '../Text';
+import { TextProps } from '../Text/Text';
+import { useComponents } from '../ComponentsContext';
+
+interface BaseProps extends TextProps {
+  children: ReactNode;
+}
+
+type LinkElProps = Omit<HTMLProps<HTMLAnchorElement>, 'size'>;
+type ButtonElProps = Omit<HTMLProps<HTMLButtonElement>, 'size'>;
+
+export type AnchorProps = BaseProps & LinkElProps & ButtonElProps;
+
+type ReturnType = ReactElement<any, any> | null;
+
+const baseStyles = ({ theme }: StyleProps) => css`
+  display: inline-block;
+  text-decoration: underline;
+  text-decoration-skip-ink: auto;
+  border: 0;
+  outline: none;
+  background: none;
+  padding: 0;
+  margin-top: 0;
+  margin-left: 0;
+  margin-right: 0;
+  color: ${theme.colors.p700};
+
+  &:hover,
+  &:active {
+    color: ${theme.colors.p900};
+    cursor: pointer;
+  }
+
+  &:visited {
+    color: ${theme.colors.v700};
+
+    &:hover,
+    &:active {
+      color: ${theme.colors.v900};
+    }
+  }
+
+  &:focus {
+    ${focusOutline({ theme })};
+    border-radius: ${theme.borderRadius.giga};
+  }
+`;
+
+const BaseAnchor = styled(Text)<AnchorProps>(baseStyles);
+
+/**
+ * The Anchor is used to display a link or button that visually looks like
+ * a hyperlink. Based on the Text component, so it also supports its props.
+ */
+export function Anchor(props: BaseProps & LinkElProps): ReturnType;
+export function Anchor(props: BaseProps & ButtonElProps): ReturnType;
+export function Anchor(props: AnchorProps): ReturnType {
+  const { Link } = useComponents();
+  const AnchorLink = BaseAnchor.withComponent(Link);
+
+  if (!props.href && !props.onClick) {
+    return <Text as="span" {...props} />;
+  }
+
+  if (props.href) {
+    return <AnchorLink {...props} />;
+  }
+
+  return <BaseAnchor as="button" {...props} />;
+}

--- a/src/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
+++ b/src/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
@@ -1,0 +1,144 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Anchor styles should render as a \`button\` when an onClick is passed 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  display: inline-block;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-text-decoration-skip-ink: auto;
+  text-decoration-skip-ink: auto;
+  border: 0;
+  outline: none;
+  background: none;
+  padding: 0;
+  margin-top: 0;
+  margin-left: 0;
+  margin-right: 0;
+  color: #1760CE;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 16px;
+    line-height: 24px;
+  }
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  color: #003C8B;
+  cursor: pointer;
+}
+
+.circuit-0:visited {
+  color: #8928A2;
+}
+
+.circuit-0:visited:hover,
+.circuit-0:visited:active {
+  color: #5F1D6B;
+}
+
+.circuit-0:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-radius: 5px;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+<button
+  class="circuit-0"
+>
+  Anchor
+</button>
+`;
+
+exports[`Anchor styles should render as a \`span\` when neither href nor onClick is passed 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 16px;
+    line-height: 24px;
+  }
+}
+
+<span
+  class="circuit-0"
+>
+  Anchor
+</span>
+`;
+
+exports[`Anchor styles should render as an \`a\` when an href (and onClick) is passed 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  display: inline-block;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+  -webkit-text-decoration-skip-ink: auto;
+  text-decoration-skip-ink: auto;
+  border: 0;
+  outline: none;
+  background: none;
+  padding: 0;
+  margin-top: 0;
+  margin-left: 0;
+  margin-right: 0;
+  color: #1760CE;
+}
+
+@media (min-width:480px) {
+  .circuit-0 {
+    font-size: 16px;
+    line-height: 24px;
+  }
+}
+
+.circuit-0:hover,
+.circuit-0:active {
+  color: #003C8B;
+  cursor: pointer;
+}
+
+.circuit-0:visited {
+  color: #8928A2;
+}
+
+.circuit-0:visited:hover,
+.circuit-0:visited:active {
+  color: #5F1D6B;
+}
+
+.circuit-0:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-radius: 5px;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+<a
+  class="circuit-0"
+  href="https://sumup.com"
+>
+  Anchor
+</a>
+`;

--- a/src/components/Anchor/index.ts
+++ b/src/components/Anchor/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Anchor } from './Anchor';
+
+export default Anchor;

--- a/src/components/Blockquote/Blockquote.story.js
+++ b/src/components/Blockquote/Blockquote.story.js
@@ -29,7 +29,7 @@ tbh adaptogen green juice lo-fi kombucha.
 const sizes = [Blockquote.KILO, Blockquote.MEGA, Blockquote.GIGA];
 
 export default {
-  title: 'Components/Blockquote',
+  title: 'Typography/Blockquote',
   component: Blockquote,
   parameters: {
     docs: { page: docs },

--- a/src/components/List/List.story.js
+++ b/src/components/List/List.story.js
@@ -22,7 +22,7 @@ import List from './List';
 const sizes = [List.KILO, List.MEGA, List.GIGA];
 
 export default {
-  title: 'Components/List',
+  title: 'Typography/List',
   component: List,
   parameters: {
     docs: { page: docs },

--- a/src/index.js
+++ b/src/index.js
@@ -29,10 +29,10 @@ const currencyAmountUtils = {
 
 // Typography
 export { default as Heading } from './components/Heading';
-export { default as List } from './components/List';
-
 export { default as SubHeading } from './components/SubHeading';
 export { default as Text } from './components/Text';
+export { default as Anchor } from './components/Anchor';
+export { default as List } from './components/List';
 export { default as Blockquote } from './components/Blockquote';
 
 // Forms

--- a/src/styles/style-helpers.spec.js
+++ b/src/styles/style-helpers.spec.js
@@ -230,6 +230,7 @@ describe('Style helpers', () => {
       const { styles } = StyleHelpers.focusOutline({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
         "
+          outline: 0;
           box-shadow: 0 0 0 4px #AFD0FE;
 
           &::-moz-focus-inner {

--- a/src/styles/style-helpers.spec.js
+++ b/src/styles/style-helpers.spec.js
@@ -211,4 +211,50 @@ describe('Style helpers', () => {
       `);
     });
   });
+
+  describe('disableVisually', () => {
+    it('should match the snapshot', () => {
+      const { styles } = StyleHelpers.disableVisually();
+      expect(styles).toMatchInlineSnapshot(`
+        "
+          opacity: 0.5;
+          pointer-events: none;
+          box-shadow: none;
+        "
+      `);
+    });
+  });
+
+  describe('focusOutline', () => {
+    it('should match the snapshot', () => {
+      const { styles } = StyleHelpers.focusOutline({ theme: light });
+      expect(styles).toMatchInlineSnapshot(`
+        "
+          box-shadow: 0 0 0 4px #AFD0FE;
+
+          &::-moz-focus-inner {
+            border: 0;
+          }
+        "
+      `);
+    });
+  });
+
+  describe('clearfix', () => {
+    it('should match the snapshot', () => {
+      const { styles } = StyleHelpers.clearfix();
+      expect(styles).toMatchInlineSnapshot(`
+        "
+          &::before,
+          &::after {
+            content: ' ';
+            display: table;
+          }
+          &::after {
+            clear: both;
+          }
+        "
+      `);
+    });
+  });
 });

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -91,6 +91,7 @@ export const disableVisually = (): SerializedStyles => css`
  * Visually communicates to the user that an element is focused.
  */
 export const focusOutline = ({ theme }: StyleProps): SerializedStyles => css`
+  outline: 0;
   box-shadow: 0 0 0 4px ${theme.colors.p300};
 
   &::-moz-focus-inner {

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -17,9 +17,7 @@ import { css, SerializedStyles } from '@emotion/core';
 import { transparentize } from 'polished';
 import { Theme } from '@sumup/design-tokens';
 
-interface StyleArgs {
-  theme: Theme;
-}
+import { StyleProps } from './styled';
 
 export const shadowBorder = (
   color: string,
@@ -28,19 +26,19 @@ export const shadowBorder = (
   box-shadow: 0px 0px 0px ${borderSize} ${color};
 `;
 
-export const shadowSingle = ({ theme }: StyleArgs): SerializedStyles => css`
+export const shadowSingle = ({ theme }: StyleProps): SerializedStyles => css`
   box-shadow: 0 0 0 1px ${transparentize(0.98, theme.colors.shadow)},
     0 0 1px 0 ${transparentize(0.94, theme.colors.shadow)},
     0 2px 2px 0 ${transparentize(0.94, theme.colors.shadow)};
 `;
 
-export const shadowDouble = ({ theme }: StyleArgs): SerializedStyles => css`
+export const shadowDouble = ({ theme }: StyleProps): SerializedStyles => css`
   box-shadow: 0 0 0 1px ${transparentize(0.98, theme.colors.shadow)},
     0 2px 2px 0 ${transparentize(0.94, theme.colors.shadow)},
     0 4px 4px 0 ${transparentize(0.94, theme.colors.shadow)};
 `;
 
-export const shadowTriple = ({ theme }: StyleArgs): SerializedStyles => css`
+export const shadowTriple = ({ theme }: StyleProps): SerializedStyles => css`
   box-shadow: 0 0 0 1px ${transparentize(0.98, theme.colors.shadow)},
     0 4px 4px 0 ${transparentize(0.94, theme.colors.shadow)},
     0 8px 8px 0 ${transparentize(0.94, theme.colors.shadow)};
@@ -50,7 +48,7 @@ function createTypeHelper<T extends 'headings' | 'subHeadings' | 'text'>(
   type: T,
   size: keyof Theme['typography'][T]
 ) {
-  return ({ theme }: StyleArgs): SerializedStyles => {
+  return ({ theme }: StyleProps): SerializedStyles => {
     const { fontSize, lineHeight } = (theme.typography[type][
       size
     ] as unknown) as {
@@ -80,13 +78,24 @@ export const textMega = createTypeHelper('text', 'mega');
 export const textGiga = createTypeHelper('text', 'giga');
 
 /**
- * Visually communicate to the user that an element is disabled
+ * Visually communicates to the user that an element is disabled
  * and prevent user interactions.
  */
 export const disableVisually = (): SerializedStyles => css`
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+`;
+
+/**
+ * Visually communicates to the user that an element is focused.
+ */
+export const focusOutline = ({ theme }: StyleProps): SerializedStyles => css`
+  box-shadow: 0 0 0 4px ${theme.colors.p300};
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
 `;
 
 /**


### PR DESCRIPTION
Relates to #582.

## Purpose

The Anchor component should be used for textual links or buttons, usually inline in long-form text. It is the successor of the `plain` Button variant.

## Approach and changes

👀 [Live preview](https://circuit-ui-git-feature-component-anchor.sumup-oss.now.sh/?path=/story/typography-anchor--as-link)

- add Anchor component with the same colors as the [`tertiary` Button](https://www.figma.com/file/aORNKPp6e3xbpkYrkfoVhW/WIP-Circuit-UI-Mobile?node-id=456%3A0) variant

_Default_

<img width="135" alt="Screenshot 2020-05-03 12 09 46" src="https://user-images.githubusercontent.com/11017722/80911516-1992f300-8d37-11ea-8c7e-d5b673292d1a.png">

_Hovered_

<img width="136" alt="Screenshot 2020-05-03 12 10 30" src="https://user-images.githubusercontent.com/11017722/80911523-20216a80-8d37-11ea-92cc-45551ea48ecb.png">

_Focused_

<img width="152" alt="Screenshot 2020-05-03 12 09 52" src="https://user-images.githubusercontent.com/11017722/80911531-27e10f00-8d37-11ea-943e-6221f5b90af4.png">

_Visited_

<img width="143" alt="Screenshot 2020-05-03 12 10 15" src="https://user-images.githubusercontent.com/11017722/80911536-2d3e5980-8d37-11ea-9419-fcdbea095a0f.png">

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
