### PR TITLE
feat(components): add focus styles to all relevant components

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -45,9 +45,8 @@ exports[`Storyshots Components/AspectRatio Base 1`] = `
 
 exports[`Storyshots Components/Badge Base 1`] = `
 .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -72,9 +71,8 @@ exports[`Storyshots Components/Badge Base 1`] = `
 
 exports[`Storyshots Components/Badge Circular 1`] = `
 .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -111,12 +109,56 @@ exports[`Storyshots Components/Badge Circular 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Badge Clickable 1`] = `
+.circuit-0 {
+  border-radius: 999999px;
+  color: #FFFFFF;
+  display: inline-block;
+  padding: 0 8px;
+  font-size: 12px;
+  line-height: 20px;
+  font-weight: 700;
+  text-transform: uppercase;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  text-align: center;
+  background-color: #3388FF;
+  border: 0;
+  outline: 0;
+  cursor: pointer;
+}
+
+.circuit-0:hover {
+  background-color: #1760CE;
+}
+
+.circuit-0:active {
+  background-color: #003C8B;
+}
+
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+<button
+  class="circuit-0 circuit-1"
+  color="primary"
+>
+  Click me
+</button>
+`;
+
 exports[`Storyshots Components/Badge Colors 1`] = `
 HTMLCollection [
   .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -138,9 +180,8 @@ HTMLCollection [
     Neutral
   </div>,
   .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -162,9 +203,8 @@ HTMLCollection [
     Primary
   </div>,
   .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -186,9 +226,8 @@ HTMLCollection [
     Success
   </div>,
   .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -210,9 +249,8 @@ HTMLCollection [
     Warning
   </div>,
   .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -1711,15 +1749,25 @@ exports[`Storyshots Components/Calendar/CalendarTag Base 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   cursor: pointer;
+  outline: 0;
+  background: transparent;
 }
 
 .circuit-0:hover {
   background-color: #D8DDE1;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #9DA7B1;
+}
+
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
 }
 
 <div>
@@ -1744,15 +1792,25 @@ exports[`Storyshots Components/Calendar/CalendarTagTwoStep Base 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   cursor: pointer;
+  outline: 0;
+  background: transparent;
 }
 
 .circuit-0:hover {
   background-color: #D8DDE1;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #9DA7B1;
+}
+
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
 }
 
 <div>
@@ -11346,36 +11404,49 @@ exports[`Storyshots Components/Step Swiper 1`] = `
 `;
 
 exports[`Storyshots Components/Table Base 1`] = `
-.circuit-62 {
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-66 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-60 {
+.circuit-64 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-60 {
+  .circuit-64 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-58 {
+.circuit-62 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-58 {
+  .circuit-62 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-58:after {
+  .circuit-62:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -11386,16 +11457,16 @@ exports[`Storyshots Components/Table Base 1`] = `
   }
 }
 
-.circuit-18 {
+.circuit-22 {
   vertical-align: middle;
 }
 
-tbody .circuit-18:last-child th,
-tbody .circuit-18:last-child td {
+tbody .circuit-22:last-child th,
+tbody .circuit-22:last-child td {
   border-bottom: none;
 }
 
-.circuit-4 {
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -11417,7 +11488,7 @@ tbody .circuit-18:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     left: 0;
     top: auto;
     position: absolute;
@@ -11426,16 +11497,36 @@ tbody .circuit-18:last-child td {
   }
 }
 
-.circuit-4:hover {
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-4:hover > span {
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
   opacity: 1;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -11459,6 +11550,20 @@ tbody .circuit-18:last-child td {
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -11466,7 +11571,7 @@ tbody .circuit-18:last-child td {
   margin-bottom: -7px;
 }
 
-.circuit-6 {
+.circuit-8 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -11482,7 +11587,7 @@ tbody .circuit-18:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-6 {
+  .circuit-8 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -11490,7 +11595,7 @@ tbody .circuit-18:last-child td {
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -11511,16 +11616,36 @@ tbody .circuit-18:last-child td {
   user-select: none;
 }
 
-.circuit-12:hover {
+.circuit-16:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-16:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-16:focus-within,
+.circuit-16:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-12:hover > span {
+.circuit-16:focus-within > button,
+.circuit-16:hover > button {
   opacity: 1;
 }
 
-.circuit-14 {
+.circuit-18 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -11535,7 +11660,7 @@ tbody .circuit-18:last-child td {
   vertical-align: middle;
 }
 
-.circuit-16 {
+.circuit-20 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -11550,20 +11675,1029 @@ tbody .circuit-18:last-child td {
   vertical-align: middle;
 }
 
-.circuit-32 {
+.circuit-36 {
   vertical-align: middle;
   cursor: pointer;
+  position: relative;
 }
 
-tbody .circuit-32:last-child th,
-tbody .circuit-32:last-child td {
+tbody .circuit-36:last-child th,
+tbody .circuit-36:last-child td {
   border-bottom: none;
 }
 
-tbody .circuit-32:hover td,
-tbody .circuit-32:hover th {
+.circuit-36:focus::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-36:focus::after::-moz-focus-inner {
+  border: 0;
+}
+
+tbody .circuit-36:focus td,
+tbody .circuit-36:hover td,
+tbody .circuit-36:focus th,
+tbody .circuit-36:hover th {
   color: #3388FF;
   background-color: #FAFBFC;
+}
+
+.circuit-26 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+}
+
+@media (max-width:767px) {
+  .circuit-26 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-28 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+}
+
+@media (max-width:767px) {
+  .circuit-28 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-30 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.circuit-34 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: right;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+<div
+  class="circuit-66 circuit-67"
+>
+  <div
+    class="circuit-64 circuit-65"
+  >
+    <table
+      class="circuit-62 circuit-63"
+    >
+      <thead
+        class="circuit-24 circuit-25"
+      >
+        <tr
+          class="circuit-22 circuit-23"
+        >
+          <th
+            aria-sort="none"
+            class="circuit-6 circuit-7"
+            data-testid="table-header"
+            scope="col"
+          >
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
+            >
+              <svg
+                class="circuit-0"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 14l4-4 4 4"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+              <svg
+                class="circuit-0"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 10l4 4 4-4"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
+            Name
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-8 circuit-9"
+            data-testid="table-cell"
+            role="presentation"
+          >
+            Name
+          </td>
+          <th
+            aria-sort="none"
+            class="circuit-16 circuit-7"
+            data-testid="table-header"
+            scope="col"
+          >
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
+            >
+              <svg
+                class="circuit-0"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 14l4-4 4 4"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+              <svg
+                class="circuit-0"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 10l4 4 4-4"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
+            Created at
+          </th>
+          <th
+            class="circuit-18 circuit-7"
+            data-testid="table-header"
+            scope="col"
+          >
+            Permissions
+          </th>
+          <th
+            class="circuit-20 circuit-7"
+            data-testid="table-header"
+            scope="col"
+          >
+            Status
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="circuit-36 circuit-23"
+          data-selector="item-1"
+          data-testid="table-row"
+          tabindex="0"
+        >
+          <th
+            class="circuit-26 circuit-7"
+            data-testid="table-header"
+            scope="row"
+          >
+            Lorem ipsum dolor
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-28 circuit-9"
+            data-testid="table-cell"
+            role="presentation"
+          >
+            Lorem ipsum dolor
+          </td>
+          <td
+            class="circuit-30 circuit-9"
+            data-selector="item-1-cell-date-12/01/2017"
+            data-testid="table-cell"
+          >
+            12/01/2017
+          </td>
+          <td
+            class="circuit-30 circuit-9"
+            data-testid="table-cell"
+          >
+            -
+          </td>
+          <td
+            class="circuit-34 circuit-9"
+            data-testid="table-cell"
+          >
+            Disabled
+          </td>
+        </tr>
+        <tr
+          class="circuit-36 circuit-23"
+          data-testid="table-row"
+          tabindex="0"
+        >
+          <th
+            class="circuit-26 circuit-7"
+            data-testid="table-header"
+            scope="row"
+          >
+            Ipsum dolor sit amet
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-28 circuit-9"
+            data-testid="table-cell"
+            role="presentation"
+          >
+            Ipsum dolor sit amet
+          </td>
+          <td
+            class="circuit-30 circuit-9"
+            data-testid="table-cell"
+          >
+            13/01/2017
+          </td>
+          <td
+            class="circuit-30 circuit-9"
+            data-testid="table-cell"
+          >
+            Virtual Terminal
+          </td>
+          <td
+            class="circuit-34 circuit-9"
+            data-testid="table-cell"
+          >
+            Enabled
+          </td>
+        </tr>
+        <tr
+          class="circuit-36 circuit-23"
+          data-testid="table-row"
+          tabindex="0"
+        >
+          <th
+            class="circuit-26 circuit-7"
+            data-testid="table-header"
+            scope="row"
+          >
+            Dolor sit amet, consectetur adipiscing
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-28 circuit-9"
+            data-testid="table-cell"
+            role="presentation"
+          >
+            Dolor sit amet, consectetur adipiscing
+          </td>
+          <td
+            class="circuit-30 circuit-9"
+            data-testid="table-cell"
+          >
+            14/01/2017
+          </td>
+          <td
+            class="circuit-30 circuit-9"
+            data-testid="table-cell"
+          >
+            -
+          </td>
+          <td
+            class="circuit-34 circuit-9"
+            data-testid="table-cell"
+          >
+            Disabled
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/Table Custom Sort 1`] = `
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-48 {
+  position: relative;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+}
+
+.circuit-46 {
+  border-radius: 4px;
+}
+
+@media (max-width:767px) {
+  .circuit-46 {
+    height: unset;
+    margin-left: 145px;
+    overflow-x: auto;
+  }
+}
+
+.circuit-44 {
+  background-color: #FFFFFF;
+  border-collapse: separate;
+  width: 100%;
+}
+
+@media (max-width:767px) {
+  .circuit-44 {
+    margin-left: -145px;
+    width: calc(100% + 145px);
+  }
+
+  .circuit-44:after {
+    content: '';
+    background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
+    height: 100%;
+    left: 145px;
+    position: absolute;
+    top: 0;
+    width: 6px;
+  }
+}
+
+.circuit-10 {
+  vertical-align: middle;
+}
+
+tbody .circuit-10:last-child th,
+tbody .circuit-10:last-child td {
+  border-bottom: none;
+}
+
+.circuit-6 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media (max-width:767px) {
+  .circuit-6 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
+  opacity: 1;
+}
+
+.circuit-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 40px;
+  width: 20px;
+  position: absolute;
+  left: 0;
+  top: 50%;
+  opacity: 0;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+  color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0 {
+  margin-top: -7px;
+  margin-bottom: -7px;
+}
+
+.circuit-8 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+}
+
+@media (max-width:767px) {
+  .circuit-8 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-14 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+}
+
+@media (max-width:767px) {
+  .circuit-14 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-16 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+}
+
+@media (max-width:767px) {
+  .circuit-16 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+<div
+  class="circuit-48 circuit-49"
+>
+  <div
+    class="circuit-46 circuit-47"
+  >
+    <table
+      class="circuit-44 circuit-45"
+    >
+      <thead
+        class="circuit-12 circuit-13"
+      >
+        <tr
+          class="circuit-10 circuit-11"
+        >
+          <th
+            aria-sort="none"
+            class="circuit-6 circuit-7"
+            data-testid="table-header"
+            scope="col"
+          >
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
+            >
+              <svg
+                class="circuit-0"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 14l4-4 4 4"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+              <svg
+                class="circuit-0"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 10l4 4 4-4"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
+            Country
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-8 circuit-9"
+            data-testid="table-cell"
+            role="presentation"
+          >
+            Country
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="circuit-10 circuit-11"
+          data-testid="table-row"
+        >
+          <th
+            class="circuit-14 circuit-7"
+            data-testid="table-header"
+            scope="row"
+          >
+            Schweiz
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-16 circuit-9"
+            data-testid="table-cell"
+            role="presentation"
+          >
+            Schweiz
+          </td>
+        </tr>
+        <tr
+          class="circuit-10 circuit-11"
+          data-testid="table-row"
+        >
+          <th
+            class="circuit-14 circuit-7"
+            data-testid="table-header"
+            scope="row"
+          >
+            Österreich
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-16 circuit-9"
+            data-testid="table-cell"
+            role="presentation"
+          >
+            Österreich
+          </td>
+        </tr>
+        <tr
+          class="circuit-10 circuit-11"
+          data-testid="table-row"
+        >
+          <th
+            class="circuit-14 circuit-7"
+            data-testid="table-header"
+            scope="row"
+          >
+            Deutschland
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-16 circuit-9"
+            data-testid="table-cell"
+            role="presentation"
+          >
+            Deutschland
+          </td>
+        </tr>
+        <tr
+          class="circuit-10 circuit-11"
+          data-testid="table-row"
+        >
+          <th
+            class="circuit-14 circuit-7"
+            data-testid="table-header"
+            scope="row"
+          >
+            Liechtenstein
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-16 circuit-9"
+            data-testid="table-cell"
+            role="presentation"
+          >
+            Liechtenstein
+          </td>
+        </tr>
+        <tr
+          class="circuit-10 circuit-11"
+          data-testid="table-row"
+        >
+          <th
+            class="circuit-14 circuit-7"
+            data-testid="table-header"
+            scope="row"
+          >
+            Italien
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-16 circuit-9"
+            data-testid="table-cell"
+            role="presentation"
+          >
+            Italien
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Components/Table Sortable 1`] = `
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-50 {
+  position: relative;
+  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
+}
+
+.circuit-48 {
+  border-radius: 4px;
+}
+
+@media (max-width:767px) {
+  .circuit-48 {
+    height: unset;
+    margin-left: 145px;
+    overflow-x: auto;
+  }
+}
+
+.circuit-46 {
+  background-color: #FFFFFF;
+  border-collapse: separate;
+  width: 100%;
+}
+
+@media (max-width:767px) {
+  .circuit-46 {
+    margin-left: -145px;
+    width: calc(100% + 145px);
+  }
+
+  .circuit-46:after {
+    content: '';
+    background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
+    height: 100%;
+    left: 145px;
+    position: absolute;
+    top: 0;
+    width: 6px;
+  }
+}
+
+.circuit-18 {
+  vertical-align: middle;
+}
+
+tbody .circuit-18:last-child th,
+tbody .circuit-18:last-child td {
+  border-bottom: none;
+}
+
+.circuit-6 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media (max-width:767px) {
+  .circuit-6 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
+  opacity: 1;
+}
+
+.circuit-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 40px;
+  width: 20px;
+  position: absolute;
+  left: 0;
+  top: 50%;
+  opacity: 0;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: opacity 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out;
+  color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0 {
+  margin-top: -7px;
+  margin-bottom: -7px;
+}
+
+.circuit-8 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  vertical-align: middle;
+  white-space: nowrap;
+  display: none;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+}
+
+@media (max-width:767px) {
+  .circuit-8 {
+    display: table-cell;
+    min-width: 145px;
+    white-space: unset;
+    width: 145px;
+  }
+}
+
+.circuit-16 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.circuit-16:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-16:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-16:focus-within,
+.circuit-16:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-16:focus-within > button,
+.circuit-16:hover > button {
+  opacity: 1;
 }
 
 .circuit-22 {
@@ -11618,25 +12752,14 @@ tbody .circuit-32:hover th {
   white-space: nowrap;
 }
 
-.circuit-30 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: right;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-}
-
 <div
-  class="circuit-62 circuit-63"
+  class="circuit-50 circuit-51"
 >
   <div
-    class="circuit-60 circuit-61"
+    class="circuit-48 circuit-49"
   >
     <table
-      class="circuit-58 circuit-59"
+      class="circuit-46 circuit-47"
     >
       <thead
         class="circuit-20 circuit-21"
@@ -11646,51 +12769,58 @@ tbody .circuit-32:hover th {
         >
           <th
             aria-sort="none"
-            class="circuit-4 circuit-5"
-            data-testid="table-header"
-            scope="col"
-          >
-            <span
-              class="circuit-2 circuit-3"
-            >
-              <svg
-                class="circuit-0"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 14l4-4 4 4"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-              <svg
-                class="circuit-0"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 10l4 4 4-4"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-            Name
-          </th>
-          <td
-            aria-hidden="true"
             class="circuit-6 circuit-7"
+            data-testid="table-header"
+            scope="col"
+          >
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
+            >
+              <svg
+                class="circuit-0"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 14l4-4 4 4"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+              <svg
+                class="circuit-0"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 10l4 4 4-4"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
+            Name
+          </th>
+          <td
+            aria-hidden="true"
+            class="circuit-8 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
@@ -11698,12 +12828,14 @@ tbody .circuit-32:hover th {
           </td>
           <th
             aria-sort="none"
-            class="circuit-12 circuit-5"
+            class="circuit-16 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -11737,857 +12869,23 @@ tbody .circuit-32:hover th {
                   stroke-width="2"
                 />
               </svg>
-            </span>
-            Created at
-          </th>
-          <th
-            class="circuit-14 circuit-5"
-            data-testid="table-header"
-            scope="col"
-          >
-            Permissions
-          </th>
-          <th
-            class="circuit-16 circuit-5"
-            data-testid="table-header"
-            scope="col"
-          >
-            Status
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          class="circuit-32 circuit-19"
-          data-selector="item-1"
-          data-testid="table-row"
-        >
-          <th
-            class="circuit-22 circuit-5"
-            data-testid="table-header"
-            scope="row"
-          >
-            Lorem ipsum dolor
-          </th>
-          <td
-            aria-hidden="true"
-            class="circuit-24 circuit-7"
-            data-testid="table-cell"
-            role="presentation"
-          >
-            Lorem ipsum dolor
-          </td>
-          <td
-            class="circuit-26 circuit-7"
-            data-selector="item-1-cell-date-12/01/2017"
-            data-testid="table-cell"
-          >
-            12/01/2017
-          </td>
-          <td
-            class="circuit-26 circuit-7"
-            data-testid="table-cell"
-          >
-            -
-          </td>
-          <td
-            class="circuit-30 circuit-7"
-            data-testid="table-cell"
-          >
-            Disabled
-          </td>
-        </tr>
-        <tr
-          class="circuit-32 circuit-19"
-          data-testid="table-row"
-        >
-          <th
-            class="circuit-22 circuit-5"
-            data-testid="table-header"
-            scope="row"
-          >
-            Ipsum dolor sit amet
-          </th>
-          <td
-            aria-hidden="true"
-            class="circuit-24 circuit-7"
-            data-testid="table-cell"
-            role="presentation"
-          >
-            Ipsum dolor sit amet
-          </td>
-          <td
-            class="circuit-26 circuit-7"
-            data-testid="table-cell"
-          >
-            13/01/2017
-          </td>
-          <td
-            class="circuit-26 circuit-7"
-            data-testid="table-cell"
-          >
-            Virtual Terminal
-          </td>
-          <td
-            class="circuit-30 circuit-7"
-            data-testid="table-cell"
-          >
-            Enabled
-          </td>
-        </tr>
-        <tr
-          class="circuit-32 circuit-19"
-          data-testid="table-row"
-        >
-          <th
-            class="circuit-22 circuit-5"
-            data-testid="table-header"
-            scope="row"
-          >
-            Dolor sit amet, consectetur adipiscing
-          </th>
-          <td
-            aria-hidden="true"
-            class="circuit-24 circuit-7"
-            data-testid="table-cell"
-            role="presentation"
-          >
-            Dolor sit amet, consectetur adipiscing
-          </td>
-          <td
-            class="circuit-26 circuit-7"
-            data-testid="table-cell"
-          >
-            14/01/2017
-          </td>
-          <td
-            class="circuit-26 circuit-7"
-            data-testid="table-cell"
-          >
-            -
-          </td>
-          <td
-            class="circuit-30 circuit-7"
-            data-testid="table-cell"
-          >
-            Disabled
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Components/Table Custom Sort 1`] = `
-.circuit-46 {
-  position: relative;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
-}
-
-.circuit-44 {
-  border-radius: 4px;
-}
-
-@media (max-width:767px) {
-  .circuit-44 {
-    height: unset;
-    margin-left: 145px;
-    overflow-x: auto;
-  }
-}
-
-.circuit-42 {
-  background-color: #FFFFFF;
-  border-collapse: separate;
-  width: 100%;
-}
-
-@media (max-width:767px) {
-  .circuit-42 {
-    margin-left: -145px;
-    width: calc(100% + 145px);
-  }
-
-  .circuit-42:after {
-    content: '';
-    background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
-    height: 100%;
-    left: 145px;
-    position: absolute;
-    top: 0;
-    width: 6px;
-  }
-}
-
-.circuit-8 {
-  vertical-align: middle;
-}
-
-tbody .circuit-8:last-child th,
-tbody .circuit-8:last-child td {
-  border-bottom: none;
-}
-
-.circuit-4 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  white-space: nowrap;
-  color: #5C656F;
-  font-size: 13px;
-  font-weight: 700;
-  padding: 8px 24px;
-  vertical-align: middle;
-  cursor: pointer;
-  position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-@media (max-width:767px) {
-  .circuit-4 {
-    left: 0;
-    top: auto;
-    position: absolute;
-    width: 145px;
-    white-space: unset;
-  }
-}
-
-.circuit-4:hover {
-  background-color: #FAFBFC;
-  color: #3388FF;
-}
-
-.circuit-4:hover > span {
-  opacity: 1;
-}
-
-.circuit-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 40px;
-  width: 20px;
-  position: absolute;
-  left: 0;
-  top: 50%;
-  opacity: 0;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  -webkit-transition: opacity 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out;
-  color: #3388FF;
-}
-
-.circuit-0 {
-  margin-top: -7px;
-  margin-bottom: -7px;
-}
-
-.circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-  display: none;
-  font-size: 13px;
-  font-weight: 700;
-  padding: 8px 24px;
-}
-
-@media (max-width:767px) {
-  .circuit-6 {
-    display: table-cell;
-    min-width: 145px;
-    white-space: unset;
-    width: 145px;
-  }
-}
-
-.circuit-12 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  white-space: nowrap;
-}
-
-@media (max-width:767px) {
-  .circuit-12 {
-    left: 0;
-    top: auto;
-    position: absolute;
-    width: 145px;
-    white-space: unset;
-  }
-}
-
-.circuit-14 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-  display: none;
-}
-
-@media (max-width:767px) {
-  .circuit-14 {
-    display: table-cell;
-    min-width: 145px;
-    white-space: unset;
-    width: 145px;
-  }
-}
-
-<div
-  class="circuit-46 circuit-47"
->
-  <div
-    class="circuit-44 circuit-45"
-  >
-    <table
-      class="circuit-42 circuit-43"
-    >
-      <thead
-        class="circuit-10 circuit-11"
-      >
-        <tr
-          class="circuit-8 circuit-9"
-        >
-          <th
-            aria-sort="none"
-            class="circuit-4 circuit-5"
-            data-testid="table-header"
-            scope="col"
-          >
-            <span
-              class="circuit-2 circuit-3"
-            >
-              <svg
-                class="circuit-0"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                class="circuit-2 circuit-3"
               >
-                <path
-                  d="M8 14l4-4 4 4"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-              <svg
-                class="circuit-0"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 10l4 4 4-4"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-            Country
-          </th>
-          <td
-            aria-hidden="true"
-            class="circuit-6 circuit-7"
-            data-testid="table-cell"
-            role="presentation"
-          >
-            Country
-          </td>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          class="circuit-8 circuit-9"
-          data-testid="table-row"
-        >
-          <th
-            class="circuit-12 circuit-5"
-            data-testid="table-header"
-            scope="row"
-          >
-            Schweiz
-          </th>
-          <td
-            aria-hidden="true"
-            class="circuit-14 circuit-7"
-            data-testid="table-cell"
-            role="presentation"
-          >
-            Schweiz
-          </td>
-        </tr>
-        <tr
-          class="circuit-8 circuit-9"
-          data-testid="table-row"
-        >
-          <th
-            class="circuit-12 circuit-5"
-            data-testid="table-header"
-            scope="row"
-          >
-            Österreich
-          </th>
-          <td
-            aria-hidden="true"
-            class="circuit-14 circuit-7"
-            data-testid="table-cell"
-            role="presentation"
-          >
-            Österreich
-          </td>
-        </tr>
-        <tr
-          class="circuit-8 circuit-9"
-          data-testid="table-row"
-        >
-          <th
-            class="circuit-12 circuit-5"
-            data-testid="table-header"
-            scope="row"
-          >
-            Deutschland
-          </th>
-          <td
-            aria-hidden="true"
-            class="circuit-14 circuit-7"
-            data-testid="table-cell"
-            role="presentation"
-          >
-            Deutschland
-          </td>
-        </tr>
-        <tr
-          class="circuit-8 circuit-9"
-          data-testid="table-row"
-        >
-          <th
-            class="circuit-12 circuit-5"
-            data-testid="table-header"
-            scope="row"
-          >
-            Liechtenstein
-          </th>
-          <td
-            aria-hidden="true"
-            class="circuit-14 circuit-7"
-            data-testid="table-cell"
-            role="presentation"
-          >
-            Liechtenstein
-          </td>
-        </tr>
-        <tr
-          class="circuit-8 circuit-9"
-          data-testid="table-row"
-        >
-          <th
-            class="circuit-12 circuit-5"
-            data-testid="table-header"
-            scope="row"
-          >
-            Italien
-          </th>
-          <td
-            aria-hidden="true"
-            class="circuit-14 circuit-7"
-            data-testid="table-cell"
-            role="presentation"
-          >
-            Italien
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Components/Table Sortable 1`] = `
-.circuit-46 {
-  position: relative;
-  box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
-}
-
-.circuit-44 {
-  border-radius: 4px;
-}
-
-@media (max-width:767px) {
-  .circuit-44 {
-    height: unset;
-    margin-left: 145px;
-    overflow-x: auto;
-  }
-}
-
-.circuit-42 {
-  background-color: #FFFFFF;
-  border-collapse: separate;
-  width: 100%;
-}
-
-@media (max-width:767px) {
-  .circuit-42 {
-    margin-left: -145px;
-    width: calc(100% + 145px);
-  }
-
-  .circuit-42:after {
-    content: '';
-    background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
-    height: 100%;
-    left: 145px;
-    position: absolute;
-    top: 0;
-    width: 6px;
-  }
-}
-
-.circuit-14 {
-  vertical-align: middle;
-}
-
-tbody .circuit-14:last-child th,
-tbody .circuit-14:last-child td {
-  border-bottom: none;
-}
-
-.circuit-4 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  white-space: nowrap;
-  color: #5C656F;
-  font-size: 13px;
-  font-weight: 700;
-  padding: 8px 24px;
-  vertical-align: middle;
-  cursor: pointer;
-  position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-@media (max-width:767px) {
-  .circuit-4 {
-    left: 0;
-    top: auto;
-    position: absolute;
-    width: 145px;
-    white-space: unset;
-  }
-}
-
-.circuit-4:hover {
-  background-color: #FAFBFC;
-  color: #3388FF;
-}
-
-.circuit-4:hover > span {
-  opacity: 1;
-}
-
-.circuit-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 40px;
-  width: 20px;
-  position: absolute;
-  left: 0;
-  top: 50%;
-  opacity: 0;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  -webkit-transition: opacity 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out;
-  color: #3388FF;
-}
-
-.circuit-0 {
-  margin-top: -7px;
-  margin-bottom: -7px;
-}
-
-.circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-  display: none;
-  font-size: 13px;
-  font-weight: 700;
-  padding: 8px 24px;
-}
-
-@media (max-width:767px) {
-  .circuit-6 {
-    display: table-cell;
-    min-width: 145px;
-    white-space: unset;
-    width: 145px;
-  }
-}
-
-.circuit-12 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  white-space: nowrap;
-  color: #5C656F;
-  font-size: 13px;
-  font-weight: 700;
-  padding: 8px 24px;
-  vertical-align: middle;
-  cursor: pointer;
-  position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.circuit-12:hover {
-  background-color: #FAFBFC;
-  color: #3388FF;
-}
-
-.circuit-12:hover > span {
-  opacity: 1;
-}
-
-.circuit-18 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  white-space: nowrap;
-}
-
-@media (max-width:767px) {
-  .circuit-18 {
-    left: 0;
-    top: auto;
-    position: absolute;
-    width: 145px;
-    white-space: unset;
-  }
-}
-
-.circuit-20 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-  display: none;
-}
-
-@media (max-width:767px) {
-  .circuit-20 {
-    display: table-cell;
-    min-width: 145px;
-    white-space: unset;
-    width: 145px;
-  }
-}
-
-.circuit-22 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out;
-  vertical-align: middle;
-  white-space: nowrap;
-}
-
-<div
-  class="circuit-46 circuit-47"
->
-  <div
-    class="circuit-44 circuit-45"
-  >
-    <table
-      class="circuit-42 circuit-43"
-    >
-      <thead
-        class="circuit-16 circuit-17"
-      >
-        <tr
-          class="circuit-14 circuit-15"
-        >
-          <th
-            aria-sort="none"
-            class="circuit-4 circuit-5"
-            data-testid="table-header"
-            scope="col"
-          >
-            <span
-              class="circuit-2 circuit-3"
-            >
-              <svg
-                class="circuit-0"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 14l4-4 4 4"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-              <svg
-                class="circuit-0"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 10l4 4 4-4"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-            Name
-          </th>
-          <td
-            aria-hidden="true"
-            class="circuit-6 circuit-7"
-            data-testid="table-cell"
-            role="presentation"
-          >
-            Name
-          </td>
-          <th
-            aria-sort="none"
-            class="circuit-12 circuit-5"
-            data-testid="table-header"
-            scope="col"
-          >
-            <span
-              class="circuit-2 circuit-3"
-            >
-              <svg
-                class="circuit-0"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 14l4-4 4 4"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-              <svg
-                class="circuit-0"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M8 10l4 4 4-4"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
+                Sort
+              </span>
+            </button>
             Date added
           </th>
         </tr>
       </thead>
       <tbody>
         <tr
-          class="circuit-14 circuit-15"
+          class="circuit-18 circuit-19"
           data-testid="table-row"
         >
           <th
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -12595,25 +12893,25 @@ tbody .circuit-14:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-20 circuit-7"
+            class="circuit-24 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             Apple
           </td>
           <td
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
           >
             12/12/18
           </td>
         </tr>
         <tr
-          class="circuit-14 circuit-15"
+          class="circuit-18 circuit-19"
           data-testid="table-row"
         >
           <th
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -12621,25 +12919,25 @@ tbody .circuit-14:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-20 circuit-7"
+            class="circuit-24 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             Broccoli
           </td>
           <td
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
           >
             12/13/18
           </td>
         </tr>
         <tr
-          class="circuit-14 circuit-15"
+          class="circuit-18 circuit-19"
           data-testid="table-row"
         >
           <th
-            class="circuit-18 circuit-5"
+            class="circuit-22 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -12647,14 +12945,14 @@ tbody .circuit-14:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-20 circuit-7"
+            class="circuit-24 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             Chickpeas
           </td>
           <td
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
           >
             12/14/18
@@ -12668,9 +12966,8 @@ tbody .circuit-14:last-child td {
 
 exports[`Storyshots Components/Table With Component Rows 1`] = `
 .circuit-24 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -12686,9 +12983,8 @@ exports[`Storyshots Components/Table With Component Rows 1`] = `
 }
 
 .circuit-34 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -12704,9 +13000,8 @@ exports[`Storyshots Components/Table With Component Rows 1`] = `
 }
 
 .circuit-14 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -13104,7 +13399,7 @@ HTMLCollection [
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -13129,6 +13424,22 @@ HTMLCollection [
   color: #212933;
 }
 
+.circuit-0:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-0:active {
+  background-color: #EEF0F2;
+}
+
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
 .circuit-0::after {
   content: ' ';
   position: absolute;
@@ -13148,7 +13459,7 @@ HTMLCollection [
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -13169,6 +13480,22 @@ HTMLCollection [
   -ms-flex-pack: center;
   justify-content: center;
   outline: none;
+}
+
+.circuit-2:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-2:active {
+  background-color: #EEF0F2;
+}
+
+.circuit-2:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-2:focus::-moz-focus-inner {
+  border: 0;
 }
 
 <div
@@ -13297,7 +13624,7 @@ HTMLCollection [
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -13322,6 +13649,22 @@ HTMLCollection [
   color: #212933;
 }
 
+.circuit-0:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-0:active {
+  background-color: #EEF0F2;
+}
+
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
 .circuit-0::after {
   content: ' ';
   position: absolute;
@@ -13341,7 +13684,7 @@ HTMLCollection [
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -13362,6 +13705,22 @@ HTMLCollection [
   -ms-flex-pack: center;
   justify-content: center;
   outline: none;
+}
+
+.circuit-2:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-2:active {
+  background-color: #EEF0F2;
+}
+
+.circuit-2:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-2:focus::-moz-focus-inner {
+  border: 0;
 }
 
 <div
@@ -13431,7 +13790,7 @@ exports[`Storyshots Components/Tabs Links 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -13456,6 +13815,22 @@ exports[`Storyshots Components/Tabs Links 1`] = `
   color: #212933;
 }
 
+.circuit-0:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-0:active {
+  background-color: #EEF0F2;
+}
+
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
 .circuit-0::after {
   content: ' ';
   position: absolute;
@@ -13475,7 +13850,7 @@ exports[`Storyshots Components/Tabs Links 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -13496,6 +13871,22 @@ exports[`Storyshots Components/Tabs Links 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   outline: none;
+}
+
+.circuit-2:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-2:active {
+  background-color: #EEF0F2;
+}
+
+.circuit-2:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-2:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-6 {
@@ -13572,7 +13963,7 @@ exports[`Storyshots Components/Tag Base 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
 }
@@ -13597,22 +13988,32 @@ exports[`Storyshots Components/Tag Clickable 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   cursor: pointer;
+  outline: 0;
+  background: transparent;
 }
 
 .circuit-0:hover {
   background-color: #D8DDE1;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #9DA7B1;
 }
 
-<div
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+<button
   class="circuit-0 circuit-1"
 >
   Transactions
-</div>
+</button>
 `;
 
 exports[`Storyshots Components/Tag Removable 1`] = `
@@ -13669,7 +14070,7 @@ exports[`Storyshots Components/Tag Removable 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
 }
@@ -13721,11 +14122,11 @@ exports[`Storyshots Components/Tag Selected 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   background-color: #3388FF;
-  box-shadow: 0px 0px 0px 1px #3388FF;
+  border: 1px solid #3388FF;
   color: #FFFFFF;
 }
 
@@ -13749,7 +14150,7 @@ exports[`Storyshots Components/Tag With Prefix 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
 }
@@ -13794,7 +14195,7 @@ exports[`Storyshots Components/Tag With Suffix 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
 }
@@ -14171,8 +14572,11 @@ exports[`Storyshots Forms/Checkbox Base 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -14191,6 +14595,7 @@ exports[`Storyshots Forms/Checkbox Base 1`] = `
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {
@@ -14290,8 +14695,11 @@ exports[`Storyshots Forms/Checkbox Disabled 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -14310,6 +14718,7 @@ exports[`Storyshots Forms/Checkbox Disabled 1`] = `
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
@@ -14429,8 +14838,11 @@ exports[`Storyshots Forms/Checkbox Invalid 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -14449,6 +14861,7 @@ exports[`Storyshots Forms/Checkbox Invalid 1`] = `
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {
@@ -14604,8 +15017,11 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -14624,6 +15040,7 @@ HTMLCollection [
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {
@@ -14720,8 +15137,11 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -14740,6 +15160,7 @@ HTMLCollection [
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {
@@ -14836,8 +15257,11 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -14856,6 +15280,7 @@ HTMLCollection [
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {
@@ -17473,7 +17898,7 @@ label + .circuit-3 {
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   margin-top: 8px;
@@ -18911,8 +19336,11 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label::before {
@@ -18937,6 +19365,7 @@ HTMLCollection [
   color: #5C656F;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-0::before {
@@ -19004,8 +19433,11 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label::before {
@@ -19031,6 +19463,7 @@ HTMLCollection [
   color: #5C656F;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
@@ -19117,8 +19550,11 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label::before {
@@ -19143,6 +19579,7 @@ HTMLCollection [
   color: #5C656F;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-0::before {
@@ -19218,8 +19655,11 @@ exports[`Storyshots Forms/RadioButton/RadioButtonGroup Base 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label::before {
@@ -19237,6 +19677,7 @@ exports[`Storyshots Forms/RadioButton/RadioButtonGroup Base 1`] = `
   color: #5C656F;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {
@@ -19354,6 +19795,7 @@ label + .circuit-4 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -19473,6 +19915,7 @@ label + .circuit-8 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -19695,6 +20138,7 @@ label + .circuit-5 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -19846,7 +20290,11 @@ exports[`Storyshots Forms/Selector Base 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label {
@@ -19928,7 +20376,11 @@ exports[`Storyshots Forms/Selector Disabled 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label {
@@ -20019,7 +20471,11 @@ exports[`Storyshots Forms/Selector Selected 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label {
@@ -20102,7 +20558,11 @@ exports[`Storyshots Forms/Selector/SelectorGroup Base 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label {
@@ -20224,7 +20684,11 @@ exports[`Storyshots Forms/Selector/SelectorGroup Multiple 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label {
@@ -21049,10 +21513,15 @@ exports[`Storyshots Forms/Toggle Base 1`] = `
   height: 24px;
   width: 40px;
   overflow: visible;
+  cursor: pointer;
 }
 
-.circuit-4::-moz-focus-inner {
-  border-radius: 24px;
+.circuit-4:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -21088,6 +21557,7 @@ exports[`Storyshots Forms/Toggle Base 1`] = `
 .circuit-8 {
   display: block;
   margin-left: 12px;
+  cursor: pointer;
 }
 
 .circuit-6 {
@@ -21160,10 +21630,15 @@ exports[`Storyshots Forms/Toggle Reversed 1`] = `
   height: 24px;
   width: 40px;
   overflow: visible;
+  cursor: pointer;
 }
 
-.circuit-4::-moz-focus-inner {
-  border-radius: 24px;
+.circuit-4:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -21199,6 +21674,7 @@ exports[`Storyshots Forms/Toggle Reversed 1`] = `
 .circuit-8 {
   display: block;
   margin-left: 12px;
+  cursor: pointer;
 }
 
 .circuit-6 {
@@ -21311,10 +21787,15 @@ exports[`Storyshots Forms/Toggle With Explanation 1`] = `
   height: 24px;
   width: 40px;
   overflow: visible;
+  cursor: pointer;
 }
 
-.circuit-4::-moz-focus-inner {
-  border-radius: 24px;
+.circuit-4:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -21350,6 +21831,7 @@ exports[`Storyshots Forms/Toggle With Explanation 1`] = `
 .circuit-10 {
   display: block;
   margin-left: 12px;
+  cursor: pointer;
 }
 
 .circuit-6 {

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -139,6 +139,7 @@ exports[`Storyshots Components/Badge Clickable 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -1763,6 +1764,7 @@ exports[`Storyshots Components/Calendar/CalendarTag Base 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -1806,6 +1808,7 @@ exports[`Storyshots Components/Calendar/CalendarTagTwoStep Base 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -11508,6 +11511,7 @@ tbody .circuit-22:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -11627,6 +11631,7 @@ tbody .circuit-22:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -11697,6 +11702,7 @@ tbody .circuit-36:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -12147,6 +12153,7 @@ tbody .circuit-10:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -12563,6 +12570,7 @@ tbody .circuit-18:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -12682,6 +12690,7 @@ tbody .circuit-18:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -13433,6 +13442,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -13491,6 +13501,7 @@ HTMLCollection [
 }
 
 .circuit-2:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -13658,6 +13669,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -13716,6 +13728,7 @@ HTMLCollection [
 }
 
 .circuit-2:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -13824,6 +13837,7 @@ exports[`Storyshots Components/Tabs Links 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -13882,6 +13896,7 @@ exports[`Storyshots Components/Tabs Links 1`] = `
 }
 
 .circuit-2:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -14002,6 +14017,7 @@ exports[`Storyshots Components/Tag Clickable 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -14572,6 +14588,7 @@ exports[`Storyshots Forms/Checkbox Base 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -14695,6 +14712,7 @@ exports[`Storyshots Forms/Checkbox Disabled 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -14838,6 +14856,7 @@ exports[`Storyshots Forms/Checkbox Invalid 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -15017,6 +15036,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -15137,6 +15157,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -15257,6 +15278,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -19336,6 +19358,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -19433,6 +19456,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -19550,6 +19574,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -19655,6 +19680,7 @@ exports[`Storyshots Forms/RadioButton/RadioButtonGroup Base 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -20290,6 +20316,7 @@ exports[`Storyshots Forms/Selector Base 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -20376,6 +20403,7 @@ exports[`Storyshots Forms/Selector Disabled 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -20471,6 +20499,7 @@ exports[`Storyshots Forms/Selector Selected 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -20558,6 +20587,7 @@ exports[`Storyshots Forms/Selector/SelectorGroup Base 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -20684,6 +20714,7 @@ exports[`Storyshots Forms/Selector/SelectorGroup Multiple 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -21517,6 +21548,7 @@ exports[`Storyshots Forms/Toggle Base 1`] = `
 }
 
 .circuit-4:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -21634,6 +21666,7 @@ exports[`Storyshots Forms/Toggle Reversed 1`] = `
 }
 
 .circuit-4:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -21791,6 +21824,7 @@ exports[`Storyshots Forms/Toggle With Explanation 1`] = `
 }
 
 .circuit-4:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Badge/Badge.docs.mdx
+++ b/src/components/Badge/Badge.docs.mdx
@@ -39,3 +39,9 @@ The badges come in a number of colors based on their semantic meaning.
 Badges that receive the `circle` prop can be used to indicate notifications.
 
 <Story id="components-badge--circular" />
+
+### Clickable badges
+
+Badges that receive the `onClick` prop can be interacted with.
+
+<Story id="components-badge--clickable" />

--- a/src/components/Badge/Badge.js
+++ b/src/components/Badge/Badge.js
@@ -19,7 +19,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { size } from 'polished';
 
-import { subHeadingKilo } from '../../styles/style-helpers';
+import { subHeadingKilo, focusOutline } from '../../styles/style-helpers';
 import { colorNames } from '../../styles/constants';
 
 const COLOR_MAP = {
@@ -49,35 +49,10 @@ const COLOR_MAP = {
     active: 'n900'
   }
 };
-
-const colorStyles = ({ theme, color, onClick }) => {
-  const currentColor = COLOR_MAP[color];
-
-  if (!currentColor) {
-    return null;
-  }
-
-  return css`
-    label: ${`badge--${color}`};
-    background-color: ${theme.colors[currentColor.default]};
-    ${onClick &&
-      `
-      &:hover {
-        background-color: ${theme.colors[currentColor.hover]};
-      }
-
-      &:active {
-        background-color: ${theme.colors[currentColor.active]};
-      }
-    `};
-  `;
-};
-
-const baseStyles = ({ theme, onClick }) => css`
+const baseStyles = ({ theme }) => css`
   label: badge;
-  border-radius: 100px;
+  border-radius: ${theme.borderRadius.pill};
   color: ${theme.colors.white};
-  cursor: ${onClick ? 'pointer' : 'default'};
   display: inline-block;
   padding: 0 ${theme.spacings.byte};
   ${subHeadingKilo({ theme })};
@@ -86,6 +61,17 @@ const baseStyles = ({ theme, onClick }) => css`
   user-select: none;
   text-align: center;
 `;
+
+const colorStyles = ({ theme, color }) => {
+  const currentColor = COLOR_MAP[color];
+  if (!currentColor) {
+    return null;
+  }
+  return css`
+    label: ${`badge--${color}`};
+    background-color: ${theme.colors[currentColor.default]};
+  `;
+};
 
 const circleStyles = ({ circle }) =>
   circle &&
@@ -97,11 +83,37 @@ const circleStyles = ({ circle }) =>
     ${size(24)};
   `;
 
-const StyledBadge = styled('div')`
-  ${baseStyles};
-  ${colorStyles};
-  ${circleStyles};
-`;
+const clickableStyles = ({ theme, onClick, color }) => {
+  const currentColor = COLOR_MAP[color];
+  if (!onClick || !currentColor) {
+    return null;
+  }
+  return css`
+    label: badge--clickable;
+    border: 0;
+    outline: 0;
+    cursor: pointer;
+
+    &:hover {
+      background-color: ${theme.colors[currentColor.hover]};
+    }
+
+    &:active {
+      background-color: ${theme.colors[currentColor.active]};
+    }
+
+    &:focus {
+      ${focusOutline({ theme })};
+    }
+  `;
+};
+
+const StyledBadge = styled('div')(
+  baseStyles,
+  colorStyles,
+  circleStyles,
+  clickableStyles
+);
 
 /**
  * A badge for displaying update notifications etc.

--- a/src/components/Badge/Badge.spec.js
+++ b/src/components/Badge/Badge.spec.js
@@ -49,7 +49,7 @@ describe('Badge', () => {
   });
 
   it('should have hover/active styles only when the onClick handler is provided', () => {
-    const actual = create(<Badge onClick={() => {}} />);
+    const actual = create(<Badge onClick={jest.fn()} />);
     expect(actual).toMatchSnapshot();
   });
 

--- a/src/components/Badge/Badge.story.js
+++ b/src/components/Badge/Badge.story.js
@@ -15,6 +15,7 @@
 
 import React, { Fragment } from 'react';
 import { select, boolean } from '@storybook/addon-knobs/react';
+import { action } from '@storybook/addon-actions';
 import { values } from 'lodash/fp';
 
 import { colorNames } from '../../styles/constants';
@@ -48,5 +49,11 @@ export const colors = () => (
 export const circular = () => (
   <Badge color={Badge.PRIMARY} circle={boolean('Circular', true)}>
     42
+  </Badge>
+);
+
+export const clickable = () => (
+  <Badge color={Badge.PRIMARY} onClick={action('onClick')} as="button">
+    Click me
   </Badge>
 );

--- a/src/components/Badge/__snapshots__/Badge.spec.js.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.js.snap
@@ -126,6 +126,7 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Badge/__snapshots__/Badge.spec.js.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.js.snap
@@ -133,11 +133,6 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   border: 0;
 }
 
-.circuit-0:focus:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 <div
   class="circuit-0 circuit-1"
   color="neutral"

--- a/src/components/Badge/__snapshots__/Badge.spec.js.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.js.snap
@@ -2,9 +2,8 @@
 
 exports[`Badge rendering color variations should render with danger colors 1`] = `
 .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -27,9 +26,8 @@ exports[`Badge rendering color variations should render with danger colors 1`] =
 
 exports[`Badge rendering color variations should render with primary colors 1`] = `
 .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -52,9 +50,8 @@ exports[`Badge rendering color variations should render with primary colors 1`] 
 
 exports[`Badge rendering color variations should render with success colors 1`] = `
 .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -77,9 +74,8 @@ exports[`Badge rendering color variations should render with success colors 1`] 
 
 exports[`Badge rendering color variations should render with warning colors 1`] = `
 .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -102,9 +98,8 @@ exports[`Badge rendering color variations should render with warning colors 1`] 
 
 exports[`Badge should have hover/active styles only when the onClick handler is provided 1`] = `
 .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: pointer;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -117,6 +112,9 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   user-select: none;
   text-align: center;
   background-color: #9DA7B1;
+  border: 0;
+  outline: 0;
+  cursor: pointer;
 }
 
 .circuit-0:hover {
@@ -127,6 +125,14 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   background-color: #212933;
 }
 
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
 <div
   class="circuit-0 circuit-1"
   color="neutral"
@@ -135,9 +141,8 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
 
 exports[`Badge should have the correct circle styles 1`] = `
 .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;
@@ -174,9 +179,8 @@ exports[`Badge should have the correct circle styles 1`] = `
 
 exports[`Badge should render with default styles 1`] = `
 .circuit-0 {
-  border-radius: 100px;
+  border-radius: 999999px;
   color: #FFFFFF;
-  cursor: default;
   display: inline-block;
   padding: 0 8px;
   font-size: 12px;

--- a/src/components/Badge/__snapshots__/Badge.spec.js.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.js.snap
@@ -133,6 +133,11 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   border: 0;
 }
 
+.circuit-0:focus:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 <div
   class="circuit-0 circuit-1"
   color="neutral"

--- a/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -13,15 +13,25 @@ exports[`CalendarTag should render with default styles 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   cursor: pointer;
+  outline: 0;
+  background: transparent;
 }
 
 .circuit-0:hover {
   background-color: #D8DDE1;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #9DA7B1;
+}
+
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
 }
 
 <div>

--- a/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -27,6 +27,7 @@ exports[`CalendarTag should render with default styles 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -13,15 +13,25 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   cursor: pointer;
+  outline: 0;
+  background: transparent;
 }
 
 .circuit-0:hover {
   background-color: #D8DDE1;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #9DA7B1;
+}
+
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
 }
 
 <div>

--- a/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -27,6 +27,7 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/CardList/components/Item/Item.js
+++ b/src/components/CardList/components/Item/Item.js
@@ -22,7 +22,6 @@ import { setStatic } from 'recompose';
 import withKeyboardEvents from '../../../../util/withKeyboardEvents';
 import withAriaSelected from '../../../../util/withAriaSelected';
 import { sizes } from '../../../../styles/constants';
-import { shadowBorder } from '../../../../styles/style-helpers';
 
 const { KILO, MEGA, GIGA } = sizes;
 
@@ -61,7 +60,7 @@ const getBorderStyles = theme => css`
     height: 100%;
     left: 0;
     top: 0;
-    ${shadowBorder(theme.colors.b500, theme.borderWidth.mega)};
+    box-shadow: 0px 0px 0px ${theme.borderWidth.mega} ${theme.colors.b500};
     border-radius: ${theme.borderRadius.mega};
   }
 `;

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -31,6 +31,7 @@ const labelBaseStyles = ({ theme }) => css`
   display: inline-block;
   padding-left: ${theme.spacings.giga};
   position: relative;
+  cursor: pointer;
 
   &::before {
     ${size(theme.spacings.mega)};

--- a/src/components/Checkbox/Checkbox.js
+++ b/src/components/Checkbox/Checkbox.js
@@ -20,7 +20,7 @@ import styled from '@emotion/styled';
 import { hideVisually, size } from 'polished';
 import { Check } from '@sumup/icons';
 
-import { disableVisually } from '../../styles/style-helpers';
+import { disableVisually, focusOutline } from '../../styles/style-helpers';
 import { childrenPropType } from '../../util/shared-prop-types';
 import { uniqueId } from '../../util/id';
 import Tooltip from '../Tooltip';
@@ -100,8 +100,7 @@ const inputStyles = ({ theme }) => css`
   ${hideVisually()};
 
   &:focus + label::before {
-    border-width: 2px;
-    border-color: ${theme.colors.p500};
+    ${focusOutline({ theme })};
   }
 
   &:checked + label > svg {

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -30,6 +30,11 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   border: 0;
 }
 
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -197,6 +202,11 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   border: 0;
 }
 
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -319,6 +329,11 @@ exports[`Checkbox should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -438,6 +453,11 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 
 .circuit-0:focus + label::before::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label > svg {
@@ -579,6 +599,11 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 
 .circuit-0:focus + label::before::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label > svg {

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -30,11 +30,6 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   border: 0;
 }
 
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -202,11 +197,6 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   border: 0;
 }
 
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -329,11 +319,6 @@ exports[`Checkbox should render with default styles 1`] = `
   border: 0;
 }
 
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -453,11 +438,6 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 
 .circuit-0:focus + label::before::-moz-focus-inner {
   border: 0;
-}
-
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label > svg {
@@ -599,11 +579,6 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 
 .circuit-0:focus + label::before::-moz-focus-inner {
   border: 0;
-}
-
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label > svg {

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -46,6 +46,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {
@@ -213,6 +214,7 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {
@@ -335,6 +337,7 @@ exports[`Checkbox should render with default styles 1`] = `
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {
@@ -456,6 +459,7 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
@@ -597,6 +601,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   display: inline-block;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -23,8 +23,11 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -187,8 +190,11 @@ exports[`Checkbox should render with checked styles when passed the checked prop
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -306,8 +312,11 @@ exports[`Checkbox should render with default styles 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -424,8 +433,11 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -562,8 +574,11 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label > svg {

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.js.snap
@@ -23,6 +23,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -191,6 +192,7 @@ exports[`Checkbox should render with checked styles when passed the checked prop
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -314,6 +316,7 @@ exports[`Checkbox should render with default styles 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -436,6 +439,7 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -578,6 +582,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -19,7 +19,7 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { hideVisually, size } from 'polished';
 
-import { disableVisually } from '../../styles/style-helpers';
+import { disableVisually, focusOutline } from '../../styles/style-helpers';
 import { childrenPropType } from '../../util/shared-prop-types';
 import { uniqueId } from '../../util/id';
 
@@ -95,11 +95,9 @@ const labelDisabledStyles = ({ theme, disabled }) =>
 
 const inputStyles = ({ theme }) => css`
   label: radio-button__input;
-  ${hideVisually()};
 
   &:focus + label::before {
-    border-width: 2px;
-    border-color: ${theme.colors.p500};
+    ${focusOutline({ theme })}
   }
 
   &:checked + label {
@@ -114,15 +112,13 @@ const inputStyles = ({ theme }) => css`
   }
 `;
 
-const RadioButtonInput = styled('input')`
-  ${inputStyles};
-`;
+const RadioButtonInput = styled('input')(hideVisually, inputStyles);
 
-const RadioButtonLabel = styled('label')`
-  ${labelBaseStyles};
-  ${labelDisabledStyles};
-  ${labelInvalidStyles};
-`;
+const RadioButtonLabel = styled('label')(
+  labelBaseStyles,
+  labelDisabledStyles,
+  labelInvalidStyles
+);
 
 /**
  * RadioButton component for forms.

--- a/src/components/RadioButton/RadioButton.js
+++ b/src/components/RadioButton/RadioButton.js
@@ -28,6 +28,7 @@ const labelBaseStyles = ({ theme }) => css`
   color: ${theme.colors.n700};
   padding-left: ${theme.spacings.giga};
   position: relative;
+  cursor: pointer;
 
   &::before {
     box-sizing: border-box;

--- a/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
+++ b/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
@@ -16,8 +16,11 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label::before {
@@ -107,8 +110,11 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label::before {
@@ -197,8 +203,11 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label::before {
@@ -307,8 +316,11 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label::before {

--- a/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
+++ b/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
@@ -23,6 +23,11 @@ HTMLCollection [
   border: 0;
 }
 
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 .circuit-0:checked + label::before {
   border-color: #3388FF;
 }
@@ -117,6 +122,11 @@ HTMLCollection [
   border: 0;
 }
 
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 .circuit-0:checked + label::before {
   border-color: #3388FF;
 }
@@ -208,6 +218,11 @@ HTMLCollection [
 
 .circuit-0:focus + label::before::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label::before {
@@ -321,6 +336,11 @@ HTMLCollection [
 
 .circuit-0:focus + label::before::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label::before {

--- a/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
+++ b/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
@@ -45,6 +45,7 @@ HTMLCollection [
   color: #5C656F;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-0::before {
@@ -138,6 +139,7 @@ HTMLCollection [
   color: #5C656F;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-0::before {
@@ -232,6 +234,7 @@ HTMLCollection [
   color: #5C656F;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
@@ -344,6 +347,7 @@ HTMLCollection [
   color: #5C656F;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-0::before {

--- a/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
+++ b/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
@@ -23,11 +23,6 @@ HTMLCollection [
   border: 0;
 }
 
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-0:checked + label::before {
   border-color: #3388FF;
 }
@@ -122,11 +117,6 @@ HTMLCollection [
   border: 0;
 }
 
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-0:checked + label::before {
   border-color: #3388FF;
 }
@@ -218,11 +208,6 @@ HTMLCollection [
 
 .circuit-0:focus + label::before::-moz-focus-inner {
   border: 0;
-}
-
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label::before {
@@ -336,11 +321,6 @@ HTMLCollection [
 
 .circuit-0:focus + label::before::-moz-focus-inner {
   border: 0;
-}
-
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label::before {

--- a/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
+++ b/src/components/RadioButton/__snapshots__/RadioButton.spec.js.snap
@@ -16,6 +16,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -111,6 +112,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -205,6 +207,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -319,6 +322,7 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.js.snap
+++ b/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.js.snap
@@ -15,8 +15,11 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
-  border-color: #3388FF;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0:checked + label::before {

--- a/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.js.snap
+++ b/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.js.snap
@@ -15,6 +15,7 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.js.snap
+++ b/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.js.snap
@@ -22,6 +22,11 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 .circuit-0:checked + label::before {
   border-color: #3388FF;
 }

--- a/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.js.snap
+++ b/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.js.snap
@@ -22,11 +22,6 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
   border: 0;
 }
 
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-0:checked + label::before {
   border-color: #3388FF;
 }

--- a/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.js.snap
+++ b/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.js.snap
@@ -37,6 +37,7 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
   color: #5C656F;
   padding-left: 24px;
   position: relative;
+  cursor: pointer;
 }
 
 .circuit-2::before {

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -36,6 +36,7 @@ const MAX_HEIGHT = '42px';
 const selectBaseStyles = ({ theme }) => css`
   label: select;
   appearance: none;
+  cursor: pointer;
   background-color: ${theme.colors.white};
   border-width: 1px;
   border-style: solid;

--- a/src/components/Select/__snapshots__/Select.spec.js.snap
+++ b/src/components/Select/__snapshots__/Select.spec.js.snap
@@ -5,6 +5,7 @@ exports[`Select should not render with invalid styles when also passed the disab
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -157,6 +158,7 @@ label + .circuit-5 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -259,6 +261,7 @@ label + .circuit-6 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -415,6 +418,7 @@ label + .circuit-4 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -513,6 +517,7 @@ exports[`Select should render with disabled styles when passed the disabled prop
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -628,6 +633,7 @@ exports[`Select should render with inline styles when passed the inline prop 1`]
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -752,6 +758,7 @@ label + .circuit-6 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;
@@ -883,6 +890,7 @@ exports[`Select should render with no margin styles when passed the noMargin pro
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  cursor: pointer;
   background-color: #FFFFFF;
   border-width: 1px;
   border-style: solid;

--- a/src/components/Selector/Selector.js
+++ b/src/components/Selector/Selector.js
@@ -20,7 +20,11 @@ import { css } from '@emotion/core';
 import { hideVisually } from 'polished';
 
 import { childrenPropType } from '../../util/shared-prop-types';
-import { shadowSingle, shadowDouble } from '../../styles/style-helpers';
+import {
+  shadowSingle,
+  shadowDouble,
+  focusOutline
+} from '../../styles/style-helpers';
 import { uniqueId } from '../../util/id';
 
 const wrapperStyles = ({ theme }) => css`
@@ -84,10 +88,8 @@ const inputStyles = ({ theme }) => css`
   label: selector__input;
   ${hideVisually()};
 
-  &:focus + label {
-    &::before {
-      border-width: ${theme.borderWidth.mega};
-    }
+  &:focus + label::before {
+    ${focusOutline({ theme })};
   }
 
   &:checked + label {

--- a/src/components/Selector/__snapshots__/Selector.spec.js.snap
+++ b/src/components/Selector/__snapshots__/Selector.spec.js.snap
@@ -20,7 +20,16 @@ exports[`Selector should render a checked selector 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label {
@@ -104,7 +113,16 @@ exports[`Selector should render a default selector 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label {
@@ -187,7 +205,16 @@ exports[`Selector should render a disabled selector 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label {

--- a/src/components/Selector/__snapshots__/Selector.spec.js.snap
+++ b/src/components/Selector/__snapshots__/Selector.spec.js.snap
@@ -20,6 +20,7 @@ exports[`Selector should render a checked selector 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -108,6 +109,7 @@ exports[`Selector should render a default selector 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -195,6 +197,7 @@ exports[`Selector should render a disabled selector 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Selector/__snapshots__/Selector.spec.js.snap
+++ b/src/components/Selector/__snapshots__/Selector.spec.js.snap
@@ -27,11 +27,6 @@ exports[`Selector should render a checked selector 1`] = `
   border: 0;
 }
 
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-0:checked + label {
   background-color: #EDF4FC;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06), 0 4px 4px 0 rgba(12,15,20,0.06);
@@ -120,11 +115,6 @@ exports[`Selector should render a default selector 1`] = `
   border: 0;
 }
 
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-0:checked + label {
   background-color: #EDF4FC;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06), 0 4px 4px 0 rgba(12,15,20,0.06);
@@ -210,11 +200,6 @@ exports[`Selector should render a disabled selector 1`] = `
 
 .circuit-0:focus + label::before::-moz-focus-inner {
   border: 0;
-}
-
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label {

--- a/src/components/SelectorGroup/__snapshots__/SelectorGroup.spec.js.snap
+++ b/src/components/SelectorGroup/__snapshots__/SelectorGroup.spec.js.snap
@@ -20,6 +20,7 @@ exports[`SelectorGroup should render with default styles 1`] = `
 }
 
 .circuit-0:focus + label::before {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/SelectorGroup/__snapshots__/SelectorGroup.spec.js.snap
+++ b/src/components/SelectorGroup/__snapshots__/SelectorGroup.spec.js.snap
@@ -27,11 +27,6 @@ exports[`SelectorGroup should render with default styles 1`] = `
   border: 0;
 }
 
-.circuit-0:focus + label::before:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-0:checked + label {
   background-color: #EDF4FC;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 2px 2px 0 rgba(12,15,20,0.06), 0 4px 4px 0 rgba(12,15,20,0.06);

--- a/src/components/SelectorGroup/__snapshots__/SelectorGroup.spec.js.snap
+++ b/src/components/SelectorGroup/__snapshots__/SelectorGroup.spec.js.snap
@@ -20,7 +20,16 @@ exports[`SelectorGroup should render with default styles 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  border-width: 2px;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus + label::before:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0:checked + label {

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -92,6 +92,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -224,6 +225,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -615,6 +617,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -747,6 +750,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -1248,6 +1252,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -1334,6 +1339,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -1774,6 +1780,7 @@ tbody .circuit-18:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -2150,6 +2157,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -2282,6 +2290,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -2696,6 +2705,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -2828,6 +2838,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -3237,6 +3248,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -3369,6 +3381,7 @@ tbody .circuit-20:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -1,36 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table Style tests should not render a scrollable table if the rowHeaders prop is true 1`] = `
-.circuit-54 {
+.circuit-58 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-52 {
+.circuit-56 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-52 {
+  .circuit-56 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-50 {
+.circuit-54 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-50 {
+  .circuit-54 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-50:after {
+  .circuit-54:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -41,16 +41,16 @@ exports[`Table Style tests should not render a scrollable table if the rowHeader
   }
 }
 
-.circuit-16 {
+.circuit-20 {
   vertical-align: middle;
 }
 
-tbody .circuit-16:last-child th,
-tbody .circuit-16:last-child td {
+tbody .circuit-20:last-child th,
+tbody .circuit-20:last-child td {
   border-bottom: none;
 }
 
-.circuit-4 {
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -72,7 +72,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     left: 0;
     top: auto;
     position: absolute;
@@ -81,16 +81,36 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-4:hover {
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-4:hover > span {
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
   opacity: 1;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -114,6 +134,20 @@ tbody .circuit-16:last-child td {
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -121,7 +155,20 @@ tbody .circuit-16:last-child td {
   margin-bottom: -7px;
 }
 
-.circuit-6 {
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-8 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -137,7 +184,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-6 {
+  .circuit-8 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -145,7 +192,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -166,16 +213,36 @@ tbody .circuit-16:last-child td {
   user-select: none;
 }
 
-.circuit-12:hover {
+.circuit-16:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-16:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-16:focus-within,
+.circuit-16:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-12:hover > span {
+.circuit-16:focus-within > button,
+.circuit-16:hover > button {
   opacity: 1;
 }
 
-.circuit-14 {
+.circuit-18 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -190,7 +257,7 @@ tbody .circuit-16:last-child td {
   vertical-align: middle;
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -201,7 +268,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-20 {
+  .circuit-24 {
     left: 0;
     top: auto;
     position: absolute;
@@ -210,7 +277,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-22 {
+.circuit-26 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -223,7 +290,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-22 {
+  .circuit-26 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -231,7 +298,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-24 {
+.circuit-28 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -243,28 +310,30 @@ tbody .circuit-16:last-child td {
 }
 
 <div
-  class="circuit-54 circuit-55"
+  class="circuit-58 circuit-59"
 >
   <div
-    class="circuit-52 circuit-53"
+    class="circuit-56 circuit-57"
   >
     <table
-      class="circuit-50 circuit-51"
+      class="circuit-54 circuit-55"
     >
       <thead
-        class="circuit-18 circuit-19"
+        class="circuit-22 circuit-23"
       >
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
         >
           <th
             aria-sort="none"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -298,12 +367,17 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Letters
           </th>
           <td
             aria-hidden="true"
-            class="circuit-6 circuit-7"
+            class="circuit-8 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
@@ -311,12 +385,14 @@ tbody .circuit-16:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-12 circuit-5"
+            class="circuit-16 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -350,11 +426,16 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Numbers
           </th>
           <th
-            class="circuit-14 circuit-5"
+            class="circuit-18 circuit-7"
             data-testid="table-header"
             scope="col"
           >
@@ -364,11 +445,11 @@ tbody .circuit-16:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -376,31 +457,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -408,31 +489,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -440,20 +521,20 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Baz
@@ -466,33 +547,33 @@ tbody .circuit-16:last-child td {
 `;
 
 exports[`Table Style tests should render a collapsed table 1`] = `
-.circuit-54 {
+.circuit-58 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-52 {
+.circuit-56 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-52 {
+  .circuit-56 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-16 {
+.circuit-20 {
   vertical-align: middle;
 }
 
-tbody .circuit-16:last-child th,
-tbody .circuit-16:last-child td {
+tbody .circuit-20:last-child th,
+tbody .circuit-20:last-child td {
   border-bottom: none;
 }
 
-.circuit-4 {
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -514,7 +595,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     left: 0;
     top: auto;
     position: absolute;
@@ -523,16 +604,36 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-4:hover {
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-4:hover > span {
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
   opacity: 1;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -556,6 +657,20 @@ tbody .circuit-16:last-child td {
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -563,7 +678,20 @@ tbody .circuit-16:last-child td {
   margin-bottom: -7px;
 }
 
-.circuit-6 {
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-8 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -579,7 +707,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-6 {
+  .circuit-8 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -587,7 +715,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -608,16 +736,36 @@ tbody .circuit-16:last-child td {
   user-select: none;
 }
 
-.circuit-12:hover {
+.circuit-16:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-16:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-16:focus-within,
+.circuit-16:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-12:hover > span {
+.circuit-16:focus-within > button,
+.circuit-16:hover > button {
   opacity: 1;
 }
 
-.circuit-14 {
+.circuit-18 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -632,7 +780,7 @@ tbody .circuit-16:last-child td {
   vertical-align: middle;
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -643,7 +791,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-20 {
+  .circuit-24 {
     left: 0;
     top: auto;
     position: absolute;
@@ -652,7 +800,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-22 {
+.circuit-26 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -665,7 +813,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-22 {
+  .circuit-26 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -673,7 +821,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-24 {
+.circuit-28 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -684,7 +832,7 @@ tbody .circuit-16:last-child td {
   white-space: nowrap;
 }
 
-.circuit-50 {
+.circuit-54 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
@@ -692,12 +840,12 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-50 {
+  .circuit-54 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-50:after {
+  .circuit-54:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -709,28 +857,30 @@ tbody .circuit-16:last-child td {
 }
 
 <div
-  class="circuit-54 circuit-55"
+  class="circuit-58 circuit-59"
 >
   <div
-    class="circuit-52 circuit-53"
+    class="circuit-56 circuit-57"
   >
     <table
-      class="circuit-50 circuit-51"
+      class="circuit-54 circuit-55"
     >
       <thead
-        class="circuit-18 circuit-19"
+        class="circuit-22 circuit-23"
       >
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
         >
           <th
             aria-sort="none"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -764,12 +914,17 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Letters
           </th>
           <td
             aria-hidden="true"
-            class="circuit-6 circuit-7"
+            class="circuit-8 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
@@ -777,12 +932,14 @@ tbody .circuit-16:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-12 circuit-5"
+            class="circuit-16 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -816,11 +973,16 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Numbers
           </th>
           <th
-            class="circuit-14 circuit-5"
+            class="circuit-18 circuit-7"
             data-testid="table-header"
             scope="col"
           >
@@ -830,11 +992,11 @@ tbody .circuit-16:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -842,31 +1004,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -874,31 +1036,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -906,20 +1068,20 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Baz
@@ -932,36 +1094,36 @@ tbody .circuit-16:last-child td {
 `;
 
 exports[`Table Style tests should render a condensed table 1`] = `
-.circuit-54 {
+.circuit-58 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-52 {
+.circuit-56 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-52 {
+  .circuit-56 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-50 {
+.circuit-54 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-50 {
+  .circuit-54 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-50:after {
+  .circuit-54:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -972,16 +1134,16 @@ exports[`Table Style tests should render a condensed table 1`] = `
   }
 }
 
-.circuit-16 {
+.circuit-20 {
   vertical-align: middle;
 }
 
-tbody .circuit-16:last-child th,
-tbody .circuit-16:last-child td {
+tbody .circuit-20:last-child th,
+tbody .circuit-20:last-child td {
   border-bottom: none;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1005,6 +1167,20 @@ tbody .circuit-16:last-child td {
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -1012,49 +1188,17 @@ tbody .circuit-16:last-child td {
   margin-bottom: -7px;
 }
 
-.circuit-4 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
-  padding: 24px;
-  text-align: left;
-  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
-  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
   white-space: nowrap;
-  color: #5C656F;
-  font-size: 13px;
-  font-weight: 700;
-  padding: 8px 24px;
-  vertical-align: middle;
-  cursor: pointer;
-  position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  vertical-align: middle;
-  font-size: 13px;
-  line-height: 20px;
-  padding: 12px 16px;
-  padding: 8px 16px;
-}
-
-@media (max-width:767px) {
-  .circuit-4 {
-    left: 0;
-    top: auto;
-    position: absolute;
-    width: 145px;
-    white-space: unset;
-  }
-}
-
-.circuit-4:hover {
-  background-color: #FAFBFC;
-  color: #3388FF;
-}
-
-.circuit-4:hover > span {
-  opacity: 1;
+  width: 1px;
 }
 
 .circuit-6 {
@@ -1062,6 +1206,71 @@ tbody .circuit-16:last-child td {
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
   text-align: left;
+  -webkit-transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out,color 200ms ease-in-out;
+  white-space: nowrap;
+  color: #5C656F;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  font-size: 13px;
+  line-height: 20px;
+  padding: 12px 16px;
+  padding: 8px 16px;
+}
+
+@media (max-width:767px) {
+  .circuit-6 {
+    left: 0;
+    top: auto;
+    position: absolute;
+    width: 145px;
+    white-space: unset;
+  }
+}
+
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
+  background-color: #FAFBFC;
+  color: #3388FF;
+}
+
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
+  opacity: 1;
+}
+
+.circuit-8 {
+  background-color: #FFFFFF;
+  border-bottom: 1px solid #D8DDE1;
+  padding: 24px;
+  text-align: left;
   -webkit-transition: background-color 200ms ease-in-out;
   transition: background-color 200ms ease-in-out;
   vertical-align: middle;
@@ -1080,7 +1289,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-6 {
+  .circuit-8 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -1088,7 +1297,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1114,16 +1323,36 @@ tbody .circuit-16:last-child td {
   padding: 8px 16px;
 }
 
-.circuit-12:hover {
+.circuit-16:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-16:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-16:focus-within,
+.circuit-16:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-12:hover > span {
+.circuit-16:focus-within > button,
+.circuit-16:hover > button {
   opacity: 1;
 }
 
-.circuit-14 {
+.circuit-18 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1143,7 +1372,7 @@ tbody .circuit-16:last-child td {
   padding: 8px 16px;
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1158,7 +1387,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-20 {
+  .circuit-24 {
     left: 0;
     top: auto;
     position: absolute;
@@ -1167,7 +1396,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-22 {
+.circuit-26 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1186,7 +1415,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-22 {
+  .circuit-26 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -1194,7 +1423,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-24 {
+.circuit-28 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1209,28 +1438,30 @@ tbody .circuit-16:last-child td {
 }
 
 <div
-  class="circuit-54 circuit-55"
+  class="circuit-58 circuit-59"
 >
   <div
-    class="circuit-52 circuit-53"
+    class="circuit-56 circuit-57"
   >
     <table
-      class="circuit-50 circuit-51"
+      class="circuit-54 circuit-55"
     >
       <thead
-        class="circuit-18 circuit-19"
+        class="circuit-22 circuit-23"
       >
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
         >
           <th
             aria-sort="none"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -1264,12 +1495,17 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Letters
           </th>
           <td
             aria-hidden="true"
-            class="circuit-6 circuit-7"
+            class="circuit-8 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
@@ -1277,12 +1513,14 @@ tbody .circuit-16:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-12 circuit-5"
+            class="circuit-16 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -1316,11 +1554,16 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Numbers
           </th>
           <th
-            class="circuit-14 circuit-5"
+            class="circuit-18 circuit-7"
             data-testid="table-header"
             scope="col"
           >
@@ -1330,11 +1573,11 @@ tbody .circuit-16:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -1342,31 +1585,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -1374,31 +1617,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -1406,20 +1649,20 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Baz
@@ -1432,16 +1675,16 @@ tbody .circuit-16:last-child td {
 `;
 
 exports[`Table Style tests should render a scrollable table 1`] = `
-.circuit-14 {
+.circuit-18 {
   vertical-align: middle;
 }
 
-tbody .circuit-14:last-child th,
-tbody .circuit-14:last-child td {
+tbody .circuit-18:last-child th,
+tbody .circuit-18:last-child td {
   border-bottom: none;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1465,6 +1708,20 @@ tbody .circuit-14:last-child td {
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -1472,7 +1729,20 @@ tbody .circuit-14:last-child td {
   margin-bottom: -7px;
 }
 
-.circuit-4 {
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1493,16 +1763,36 @@ tbody .circuit-14:last-child td {
   user-select: none;
 }
 
-.circuit-4:hover {
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-4:hover > span {
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
   opacity: 1;
 }
 
-.circuit-12 {
+.circuit-16 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1517,7 +1807,7 @@ tbody .circuit-14:last-child td {
   vertical-align: middle;
 }
 
-.circuit-18 {
+.circuit-22 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1528,67 +1818,69 @@ tbody .circuit-14:last-child td {
   white-space: nowrap;
 }
 
-.circuit-46 {
+.circuit-50 {
   position: relative;
   height: 100%;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
 @media (max-width:767px) {
-  .circuit-46 {
+  .circuit-50 {
     height: 100%;
   }
 }
 
-.circuit-42 {
+.circuit-46 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
-.circuit-16 {
+.circuit-20 {
   -webkit-transform: translateY(px);
   -ms-transform: translateY(px);
   transform: translateY(px);
 }
 
 @media (max-width:767px) {
-  .circuit-16 {
+  .circuit-20 {
     -webkit-transform: translateY(nullpx);
     -ms-transform: translateY(nullpx);
     transform: translateY(nullpx);
   }
 }
 
-.circuit-44 {
+.circuit-48 {
   height: 0px;
   overflow-y: auto;
 }
 
 <div
-  class="circuit-46 circuit-47"
+  class="circuit-50 circuit-51"
 >
   <div
-    class="circuit-44 circuit-45"
+    class="circuit-48 circuit-49"
     height="0px"
   >
     <table
-      class="circuit-42 circuit-43"
+      class="circuit-46 circuit-47"
     >
       <thead
-        class="circuit-16 circuit-17"
+        class="circuit-20 circuit-21"
       >
         <tr
-          class="circuit-14 circuit-15"
+          class="circuit-18 circuit-19"
         >
           <th
             aria-sort="none"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -1622,17 +1914,24 @@ tbody .circuit-14:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Letters
           </th>
           <th
             aria-sort="none"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -1666,11 +1965,16 @@ tbody .circuit-14:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Numbers
           </th>
           <th
-            class="circuit-12 circuit-5"
+            class="circuit-16 circuit-7"
             data-testid="table-header"
             scope="col"
           >
@@ -1680,69 +1984,69 @@ tbody .circuit-14:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-14 circuit-15"
+          class="circuit-18 circuit-19"
           data-testid="table-row"
         >
           <td
-            class="circuit-18 circuit-19"
+            class="circuit-22 circuit-23"
             data-testid="table-cell"
           >
             b
           </td>
           <td
-            class="circuit-18 circuit-19"
+            class="circuit-22 circuit-23"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-18 circuit-19"
+            class="circuit-22 circuit-23"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-14 circuit-15"
+          class="circuit-18 circuit-19"
           data-testid="table-row"
         >
           <td
-            class="circuit-18 circuit-19"
+            class="circuit-22 circuit-23"
             data-testid="table-cell"
           >
             a
           </td>
           <td
-            class="circuit-18 circuit-19"
+            class="circuit-22 circuit-23"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-18 circuit-19"
+            class="circuit-22 circuit-23"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-14 circuit-15"
+          class="circuit-18 circuit-19"
           data-testid="table-row"
         >
           <td
-            class="circuit-18 circuit-19"
+            class="circuit-22 circuit-23"
             data-testid="table-cell"
           >
             c
           </td>
           <td
-            class="circuit-18 circuit-19"
+            class="circuit-22 circuit-23"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-18 circuit-19"
+            class="circuit-22 circuit-23"
             data-testid="table-cell"
           >
             Baz
@@ -1755,36 +2059,36 @@ tbody .circuit-14:last-child td {
 `;
 
 exports[`Table Style tests should render with default styles 1`] = `
-.circuit-54 {
+.circuit-58 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-52 {
+.circuit-56 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-52 {
+  .circuit-56 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-50 {
+.circuit-54 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-50 {
+  .circuit-54 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-50:after {
+  .circuit-54:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -1795,16 +2099,16 @@ exports[`Table Style tests should render with default styles 1`] = `
   }
 }
 
-.circuit-16 {
+.circuit-20 {
   vertical-align: middle;
 }
 
-tbody .circuit-16:last-child th,
-tbody .circuit-16:last-child td {
+tbody .circuit-20:last-child th,
+tbody .circuit-20:last-child td {
   border-bottom: none;
 }
 
-.circuit-4 {
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1826,7 +2130,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     left: 0;
     top: auto;
     position: absolute;
@@ -1835,16 +2139,36 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-4:hover {
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-4:hover > span {
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
   opacity: 1;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1868,6 +2192,20 @@ tbody .circuit-16:last-child td {
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -1875,7 +2213,20 @@ tbody .circuit-16:last-child td {
   margin-bottom: -7px;
 }
 
-.circuit-6 {
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-8 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1891,7 +2242,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-6 {
+  .circuit-8 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -1899,7 +2250,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1920,16 +2271,36 @@ tbody .circuit-16:last-child td {
   user-select: none;
 }
 
-.circuit-12:hover {
+.circuit-16:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-16:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-16:focus-within,
+.circuit-16:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-12:hover > span {
+.circuit-16:focus-within > button,
+.circuit-16:hover > button {
   opacity: 1;
 }
 
-.circuit-14 {
+.circuit-18 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1944,7 +2315,7 @@ tbody .circuit-16:last-child td {
   vertical-align: middle;
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1955,7 +2326,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-20 {
+  .circuit-24 {
     left: 0;
     top: auto;
     position: absolute;
@@ -1964,7 +2335,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-22 {
+.circuit-26 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1977,7 +2348,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-22 {
+  .circuit-26 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -1985,7 +2356,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-24 {
+.circuit-28 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -1997,28 +2368,30 @@ tbody .circuit-16:last-child td {
 }
 
 <div
-  class="circuit-54 circuit-55"
+  class="circuit-58 circuit-59"
 >
   <div
-    class="circuit-52 circuit-53"
+    class="circuit-56 circuit-57"
   >
     <table
-      class="circuit-50 circuit-51"
+      class="circuit-54 circuit-55"
     >
       <thead
-        class="circuit-18 circuit-19"
+        class="circuit-22 circuit-23"
       >
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
         >
           <th
             aria-sort="none"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -2052,12 +2425,17 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Letters
           </th>
           <td
             aria-hidden="true"
-            class="circuit-6 circuit-7"
+            class="circuit-8 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
@@ -2065,12 +2443,14 @@ tbody .circuit-16:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-12 circuit-5"
+            class="circuit-16 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -2104,11 +2484,16 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Numbers
           </th>
           <th
-            class="circuit-14 circuit-5"
+            class="circuit-18 circuit-7"
             data-testid="table-header"
             scope="col"
           >
@@ -2118,11 +2503,11 @@ tbody .circuit-16:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -2130,31 +2515,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -2162,31 +2547,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -2194,20 +2579,20 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Baz
@@ -2220,36 +2605,36 @@ tbody .circuit-16:last-child td {
 `;
 
 exports[`Table Style tests should render with rowHeader styles 1`] = `
-.circuit-54 {
+.circuit-58 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
 }
 
-.circuit-52 {
+.circuit-56 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-52 {
+  .circuit-56 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-50 {
+.circuit-54 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-50 {
+  .circuit-54 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-50:after {
+  .circuit-54:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -2260,16 +2645,16 @@ exports[`Table Style tests should render with rowHeader styles 1`] = `
   }
 }
 
-.circuit-16 {
+.circuit-20 {
   vertical-align: middle;
 }
 
-tbody .circuit-16:last-child th,
-tbody .circuit-16:last-child td {
+tbody .circuit-20:last-child th,
+tbody .circuit-20:last-child td {
   border-bottom: none;
 }
 
-.circuit-4 {
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2291,7 +2676,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     left: 0;
     top: auto;
     position: absolute;
@@ -2300,16 +2685,36 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-4:hover {
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-4:hover > span {
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
   opacity: 1;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2333,6 +2738,20 @@ tbody .circuit-16:last-child td {
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -2340,7 +2759,20 @@ tbody .circuit-16:last-child td {
   margin-bottom: -7px;
 }
 
-.circuit-6 {
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-8 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2356,7 +2788,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-6 {
+  .circuit-8 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -2364,7 +2796,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2385,16 +2817,36 @@ tbody .circuit-16:last-child td {
   user-select: none;
 }
 
-.circuit-12:hover {
+.circuit-16:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-16:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-16:focus-within,
+.circuit-16:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-12:hover > span {
+.circuit-16:focus-within > button,
+.circuit-16:hover > button {
   opacity: 1;
 }
 
-.circuit-14 {
+.circuit-18 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2409,7 +2861,7 @@ tbody .circuit-16:last-child td {
   vertical-align: middle;
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2420,7 +2872,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-20 {
+  .circuit-24 {
     left: 0;
     top: auto;
     position: absolute;
@@ -2429,7 +2881,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-22 {
+.circuit-26 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2442,7 +2894,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-22 {
+  .circuit-26 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -2450,7 +2902,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-24 {
+.circuit-28 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2462,28 +2914,30 @@ tbody .circuit-16:last-child td {
 }
 
 <div
-  class="circuit-54 circuit-55"
+  class="circuit-58 circuit-59"
 >
   <div
-    class="circuit-52 circuit-53"
+    class="circuit-56 circuit-57"
   >
     <table
-      class="circuit-50 circuit-51"
+      class="circuit-54 circuit-55"
     >
       <thead
-        class="circuit-18 circuit-19"
+        class="circuit-22 circuit-23"
       >
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
         >
           <th
             aria-sort="none"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -2517,12 +2971,17 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Letters
           </th>
           <td
             aria-hidden="true"
-            class="circuit-6 circuit-7"
+            class="circuit-8 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
@@ -2530,12 +2989,14 @@ tbody .circuit-16:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-12 circuit-5"
+            class="circuit-16 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -2569,11 +3030,16 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Numbers
           </th>
           <th
-            class="circuit-14 circuit-5"
+            class="circuit-18 circuit-7"
             data-testid="table-header"
             scope="col"
           >
@@ -2583,11 +3049,11 @@ tbody .circuit-16:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -2595,31 +3061,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -2627,31 +3093,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -2659,20 +3125,20 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Baz
@@ -2685,31 +3151,31 @@ tbody .circuit-16:last-child td {
 `;
 
 exports[`Table Style tests should render without the table shadow 1`] = `
-.circuit-52 {
+.circuit-56 {
   border-radius: 4px;
 }
 
 @media (max-width:767px) {
-  .circuit-52 {
+  .circuit-56 {
     height: unset;
     margin-left: 145px;
     overflow-x: auto;
   }
 }
 
-.circuit-50 {
+.circuit-54 {
   background-color: #FFFFFF;
   border-collapse: separate;
   width: 100%;
 }
 
 @media (max-width:767px) {
-  .circuit-50 {
+  .circuit-54 {
     margin-left: -145px;
     width: calc(100% + 145px);
   }
 
-  .circuit-50:after {
+  .circuit-54:after {
     content: '';
     background-image: linear-gradient( 90deg,rgba(0,0,0,0.12),transparent );
     height: 100%;
@@ -2720,16 +3186,16 @@ exports[`Table Style tests should render without the table shadow 1`] = `
   }
 }
 
-.circuit-16 {
+.circuit-20 {
   vertical-align: middle;
 }
 
-tbody .circuit-16:last-child th,
-tbody .circuit-16:last-child td {
+tbody .circuit-20:last-child th,
+tbody .circuit-20:last-child td {
   border-bottom: none;
 }
 
-.circuit-4 {
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2751,7 +3217,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-4 {
+  .circuit-6 {
     left: 0;
     top: auto;
     position: absolute;
@@ -2760,16 +3226,36 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-4:hover {
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-4:hover > span {
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
   opacity: 1;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2793,6 +3279,20 @@ tbody .circuit-16:last-child td {
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -2800,7 +3300,20 @@ tbody .circuit-16:last-child td {
   margin-bottom: -7px;
 }
 
-.circuit-6 {
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-8 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2816,7 +3329,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-6 {
+  .circuit-8 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -2824,7 +3337,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-12 {
+.circuit-16 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2845,16 +3358,36 @@ tbody .circuit-16:last-child td {
   user-select: none;
 }
 
-.circuit-12:hover {
+.circuit-16:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-16:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-16:focus-within,
+.circuit-16:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-12:hover > span {
+.circuit-16:focus-within > button,
+.circuit-16:hover > button {
   opacity: 1;
 }
 
-.circuit-14 {
+.circuit-18 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2869,7 +3402,7 @@ tbody .circuit-16:last-child td {
   vertical-align: middle;
 }
 
-.circuit-20 {
+.circuit-24 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2880,7 +3413,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-20 {
+  .circuit-24 {
     left: 0;
     top: auto;
     position: absolute;
@@ -2889,7 +3422,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-22 {
+.circuit-26 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2902,7 +3435,7 @@ tbody .circuit-16:last-child td {
 }
 
 @media (max-width:767px) {
-  .circuit-22 {
+  .circuit-26 {
     display: table-cell;
     min-width: 145px;
     white-space: unset;
@@ -2910,7 +3443,7 @@ tbody .circuit-16:last-child td {
   }
 }
 
-.circuit-24 {
+.circuit-28 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -2921,35 +3454,37 @@ tbody .circuit-16:last-child td {
   white-space: nowrap;
 }
 
-.circuit-54 {
+.circuit-58 {
   position: relative;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.02), 0 0 1px 0 rgba(12,15,20,0.06), 0 2px 2px 0 rgba(12,15,20,0.06);
   box-shadow: none;
 }
 
 <div
-  class="circuit-54 circuit-55"
+  class="circuit-58 circuit-59"
 >
   <div
-    class="circuit-52 circuit-53"
+    class="circuit-56 circuit-57"
   >
     <table
-      class="circuit-50 circuit-51"
+      class="circuit-54 circuit-55"
     >
       <thead
-        class="circuit-18 circuit-19"
+        class="circuit-22 circuit-23"
       >
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
         >
           <th
             aria-sort="none"
-            class="circuit-4 circuit-5"
+            class="circuit-6 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -2983,12 +3518,17 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Letters
           </th>
           <td
             aria-hidden="true"
-            class="circuit-6 circuit-7"
+            class="circuit-8 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
@@ -2996,12 +3536,14 @@ tbody .circuit-16:last-child td {
           </td>
           <th
             aria-sort="none"
-            class="circuit-12 circuit-5"
+            class="circuit-16 circuit-7"
             data-testid="table-header"
             scope="col"
           >
-            <span
-              class="circuit-2 circuit-3"
+            <button
+              class="circuit-4 circuit-5"
+              role="button"
+              title="Sort"
             >
               <svg
                 class="circuit-0"
@@ -3035,11 +3577,16 @@ tbody .circuit-16:last-child td {
                   stroke-width="2"
                 />
               </svg>
-            </span>
+              <span
+                class="circuit-2 circuit-3"
+              >
+                Sort
+              </span>
+            </button>
             Numbers
           </th>
           <th
-            class="circuit-14 circuit-5"
+            class="circuit-18 circuit-7"
             data-testid="table-header"
             scope="col"
           >
@@ -3049,11 +3596,11 @@ tbody .circuit-16:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -3061,31 +3608,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             b
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             3
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Foo
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -3093,31 +3640,31 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             a
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             1
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Bar
           </td>
         </tr>
         <tr
-          class="circuit-16 circuit-17"
+          class="circuit-20 circuit-21"
           data-testid="table-row"
         >
           <th
-            class="circuit-20 circuit-5"
+            class="circuit-24 circuit-7"
             data-testid="table-header"
             scope="row"
           >
@@ -3125,20 +3672,20 @@ tbody .circuit-16:last-child td {
           </th>
           <td
             aria-hidden="true"
-            class="circuit-22 circuit-7"
+            class="circuit-26 circuit-9"
             data-testid="table-cell"
             role="presentation"
           >
             c
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             2
           </td>
           <td
-            class="circuit-24 circuit-7"
+            class="circuit-28 circuit-9"
             data-testid="table-cell"
           >
             Baz

--- a/src/components/Table/components/SortArrow/SortArrow.js
+++ b/src/components/Table/components/SortArrow/SortArrow.js
@@ -17,6 +17,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+import { hideVisually } from 'polished';
 import { ChevronUp, ChevronDown } from '@sumup/icons';
 
 import { ASCENDING, DESCENDING } from '../../constants';
@@ -34,27 +35,45 @@ const baseStyles = ({ theme }) => css`
   transform: translateY(-50%);
   transition: opacity ${theme.transitions.default};
   color: ${theme.colors.p500};
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+
+  &:focus {
+    opacity: 1;
+
+    &::-moz-focus-inner {
+      border: 0;
+    }
+  }
 `;
 
-const Wrapper = styled.span(baseStyles);
+const Wrapper = styled.button(baseStyles);
 
-const iconStyles = theme => css`
+const iconStyles = () => css`
   margin-top: -7px;
   margin-bottom: -7px;
 `;
 
+const Label = styled('span')(hideVisually);
+
 /**
  * @private Arrow component for TableHeader sorting
  */
-const SortArrow = ({ direction = null }) => (
-  <Wrapper>
+const SortArrow = ({ label = 'Sort', direction = null, ...props }) => (
+  <Wrapper role="button" title={label} {...props}>
     {direction !== ASCENDING && <ChevronUp css={iconStyles} />}
     {direction !== DESCENDING && <ChevronDown css={iconStyles} />}
+    <Label>{label}</Label>
   </Wrapper>
 );
 
 SortArrow.propTypes = {
-  direction: PropTypes.oneOf([ASCENDING, DESCENDING])
+  direction: PropTypes.oneOf([ASCENDING, DESCENDING]),
+  label: PropTypes.string
 };
 
 export default SortArrow;

--- a/src/components/Table/components/SortArrow/SortArrow.spec.js
+++ b/src/components/Table/components/SortArrow/SortArrow.spec.js
@@ -36,6 +36,19 @@ describe('SortArrow', () => {
     });
   });
 
+  describe('Logic tests', () => {
+    it('should call the onClick callback', () => {
+      const onClick = jest.fn();
+      const { getByTestId } = render(
+        <SortArrow onClick={onClick} data-testid="sort" />
+      );
+      act(() => {
+        userEvent.click(getByTestId('sort'));
+      });
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('Accessibility tests', () => {
     it('should meet accessibility guidelines', async () => {
       const wrapper = renderToHtml(<SortArrow />);

--- a/src/components/Table/components/SortArrow/__snapshots__/SortArrow.spec.js.snap
+++ b/src/components/Table/components/SortArrow/__snapshots__/SortArrow.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
-.circuit-1 {
+.circuit-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -25,6 +25,20 @@ exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-3:focus {
+  opacity: 1;
+}
+
+.circuit-3:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -32,8 +46,23 @@ exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
   margin-bottom: -7px;
 }
 
-<span
-  class="circuit-1 circuit-2"
+.circuit-1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<button
+  class="circuit-3 circuit-4"
+  role="button"
+  title="Sort"
 >
   <svg
     class="circuit-0"
@@ -51,11 +80,16 @@ exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
       stroke-width="2"
     />
   </svg>
-</span>
+  <span
+    class="circuit-1 circuit-2"
+  >
+    Sort
+  </span>
+</button>
 `;
 
 exports[`SortArrow Style tests should render with both arrows styles 1`] = `
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -79,6 +113,20 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -86,8 +134,23 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
   margin-bottom: -7px;
 }
 
-<span
-  class="circuit-2 circuit-3"
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<button
+  class="circuit-4 circuit-5"
+  role="button"
+  title="Sort"
 >
   <svg
     class="circuit-0"
@@ -121,11 +184,16 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
       stroke-width="2"
     />
   </svg>
-</span>
+  <span
+    class="circuit-2 circuit-3"
+  >
+    Sort
+  </span>
+</button>
 `;
 
 exports[`SortArrow Style tests should render with descending arrow styles 1`] = `
-.circuit-1 {
+.circuit-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -149,6 +217,20 @@ exports[`SortArrow Style tests should render with descending arrow styles 1`] = 
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-3:focus {
+  opacity: 1;
+}
+
+.circuit-3:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -156,8 +238,23 @@ exports[`SortArrow Style tests should render with descending arrow styles 1`] = 
   margin-bottom: -7px;
 }
 
-<span
-  class="circuit-1 circuit-2"
+.circuit-1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<button
+  class="circuit-3 circuit-4"
+  role="button"
+  title="Sort"
 >
   <svg
     class="circuit-0"
@@ -175,5 +272,10 @@ exports[`SortArrow Style tests should render with descending arrow styles 1`] = 
       stroke-width="2"
     />
   </svg>
-</span>
+  <span
+    class="circuit-1 circuit-2"
+  >
+    Sort
+  </span>
+</button>
 `;

--- a/src/components/Table/components/TableBody/TableBody.js
+++ b/src/components/Table/components/TableBody/TableBody.js
@@ -16,9 +16,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
-import TableRow from '../TableRow';
-import TableHeader from '../TableHeader';
-import TableCell from '../TableCell';
 import {
   mapRowProps,
   mapCellProps,
@@ -26,6 +23,9 @@ import {
   RowPropType
 } from '../../utils';
 import { TR_KEY_PREFIX, TD_KEY_PREFIX } from '../../constants';
+import TableRow from '../TableRow';
+import TableHeader from '../TableHeader';
+import TableCell from '../TableCell';
 
 const getRowKey = index => `${TR_KEY_PREFIX}-${index}`;
 const getCellKey = (rowIndex, cellIndex) =>
@@ -39,7 +39,7 @@ const TableBody = ({ rows, condensed, rowHeaders, sortHover, onRowClick }) => (
         <TableRow
           key={getRowKey(rowIndex)}
           data-testid="table-row"
-          onClick={onRowClick && (() => onRowClick(rowIndex))}
+          onClick={onRowClick ? () => onRowClick(rowIndex) : null}
           {...props}
         >
           {cells.map((cell, cellIndex) =>

--- a/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
+++ b/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TableHead Style tests should render with default styles 1`] = `
-.circuit-10 {
+.circuit-12 {
   vertical-align: middle;
 }
 
-tbody .circuit-10:last-child th,
-tbody .circuit-10:last-child td {
+tbody .circuit-12:last-child th,
+tbody .circuit-12:last-child td {
   border-bottom: none;
 }
 
-.circuit-4 {
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -31,16 +31,36 @@ tbody .circuit-10:last-child td {
   user-select: none;
 }
 
-.circuit-4:hover {
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-4:hover > span {
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
   opacity: 1;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -64,6 +84,20 @@ tbody .circuit-10:last-child td {
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -71,7 +105,20 @@ tbody .circuit-10:last-child td {
   margin-bottom: -7px;
 }
 
-.circuit-6 {
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-8 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -87,19 +134,21 @@ tbody .circuit-10:last-child td {
 }
 
 <thead
-  class="circuit-12 circuit-13"
+  class="circuit-14 circuit-15"
 >
   <tr
-    class="circuit-10 circuit-11"
+    class="circuit-12 circuit-13"
   >
     <th
       aria-sort="none"
-      class="circuit-4 circuit-5"
+      class="circuit-6 circuit-7"
       data-testid="table-header"
       scope="col"
     >
-      <span
-        class="circuit-2 circuit-3"
+      <button
+        class="circuit-4 circuit-5"
+        role="button"
+        title="Sort"
       >
         <svg
           class="circuit-0"
@@ -133,18 +182,23 @@ tbody .circuit-10:last-child td {
             stroke-width="2"
           />
         </svg>
-      </span>
+        <span
+          class="circuit-2 circuit-3"
+        >
+          Sort
+        </span>
+      </button>
       Foo
     </th>
     <th
-      class="circuit-6 circuit-5"
+      class="circuit-8 circuit-7"
       data-testid="table-header"
       scope="col"
     >
       Bar
     </th>
     <th
-      class="circuit-6 circuit-5"
+      class="circuit-8 circuit-7"
       data-testid="table-header"
       scope="col"
     >
@@ -155,16 +209,16 @@ tbody .circuit-10:last-child td {
 `;
 
 exports[`TableHead Style tests should render with rowHeader styles 1`] = `
-.circuit-10 {
+.circuit-12 {
   vertical-align: middle;
 }
 
-tbody .circuit-10:last-child th,
-tbody .circuit-10:last-child td {
+tbody .circuit-12:last-child th,
+tbody .circuit-12:last-child td {
   border-bottom: none;
 }
 
-.circuit-4 {
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -185,16 +239,36 @@ tbody .circuit-10:last-child td {
   user-select: none;
 }
 
-.circuit-4:hover {
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-4:hover > span {
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
   opacity: 1;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -218,6 +292,20 @@ tbody .circuit-10:last-child td {
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -225,7 +313,20 @@ tbody .circuit-10:last-child td {
   margin-bottom: -7px;
 }
 
-.circuit-6 {
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-8 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -241,19 +342,21 @@ tbody .circuit-10:last-child td {
 }
 
 <thead
-  class="circuit-12 circuit-13"
+  class="circuit-14 circuit-15"
 >
   <tr
-    class="circuit-10 circuit-11"
+    class="circuit-12 circuit-13"
   >
     <th
       aria-sort="none"
-      class="circuit-4 circuit-5"
+      class="circuit-6 circuit-7"
       data-testid="table-header"
       scope="col"
     >
-      <span
-        class="circuit-2 circuit-3"
+      <button
+        class="circuit-4 circuit-5"
+        role="button"
+        title="Sort"
       >
         <svg
           class="circuit-0"
@@ -287,18 +390,23 @@ tbody .circuit-10:last-child td {
             stroke-width="2"
           />
         </svg>
-      </span>
+        <span
+          class="circuit-2 circuit-3"
+        >
+          Sort
+        </span>
+      </button>
       Foo
     </th>
     <th
-      class="circuit-6 circuit-5"
+      class="circuit-8 circuit-7"
       data-testid="table-header"
       scope="col"
     >
       Bar
     </th>
     <th
-      class="circuit-6 circuit-5"
+      class="circuit-8 circuit-7"
       data-testid="table-header"
       scope="col"
     >

--- a/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
+++ b/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
@@ -42,6 +42,7 @@ tbody .circuit-12:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -250,6 +251,7 @@ tbody .circuit-12:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Table/components/TableHeader/TableHeader.spec.js
+++ b/src/components/Table/components/TableHeader/TableHeader.spec.js
@@ -35,7 +35,15 @@ describe('TableHeader', () => {
     });
 
     it('should render with sortable styles', () => {
-      const actual = create(<TableHeader sortable>{children}</TableHeader>);
+      const sortLabel = ({ direction }) => {
+        const order = direction === 'ascending' ? 'descending' : 'ascending';
+        return `Sort by Foo in ${order} order`;
+      };
+      const actual = create(
+        <TableHeader sortable sortLabel={sortLabel}>
+          {children}
+        </TableHeader>
+      );
       expect(actual).toMatchSnapshot();
     });
 
@@ -73,7 +81,9 @@ describe('TableHeader', () => {
   describe('Accessibility tests', () => {
     it('should meet accessibility guidelines', async () => {
       const wrapper = renderToHtml(
-        <TableHeader sortable>{children}</TableHeader>
+        <TableHeader sortable sortLabel="Sort by Foo">
+          {children}
+        </TableHeader>
       );
       const actual = await axe(wrapper);
       expect(actual).toHaveNoViolations();

--- a/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
@@ -102,7 +102,7 @@ exports[`TableHeader Style tests should render with row styles 1`] = `
 `;
 
 exports[`TableHeader Style tests should render with sortable styles 1`] = `
-.circuit-4 {
+.circuit-6 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -123,16 +123,36 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   user-select: none;
 }
 
-.circuit-4:hover {
+.circuit-6:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus-within,
+.circuit-6:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-4:hover > span {
+.circuit-6:focus-within > button,
+.circuit-6:hover > button {
   opacity: 1;
 }
 
-.circuit-2 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -156,6 +176,20 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-4:focus {
+  opacity: 1;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -163,14 +197,30 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   margin-bottom: -7px;
 }
 
+.circuit-2 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 <th
+  aria-label="Sort by Foo in ascending order"
   aria-sort="none"
-  class="circuit-4 circuit-5"
+  class="circuit-6 circuit-7"
   data-testid="table-header"
   scope="col"
 >
-  <span
-    class="circuit-2 circuit-3"
+  <button
+    class="circuit-4 circuit-5"
+    role="button"
+    title="Sort by Foo in ascending order"
   >
     <svg
       class="circuit-0"
@@ -204,13 +254,18 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
         stroke-width="2"
       />
     </svg>
-  </span>
+    <span
+      class="circuit-2 circuit-3"
+    >
+      Sort by Foo in ascending order
+    </span>
+  </button>
   Foo
 </th>
 `;
 
 exports[`TableHeader Style tests sortable + sorted should render with sortable + sorted ascending styles 1`] = `
-.circuit-1 {
+.circuit-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -234,6 +289,20 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-3:focus {
+  opacity: 1;
+}
+
+.circuit-3:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -241,7 +310,20 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   margin-bottom: -7px;
 }
 
-.circuit-3 {
+.circuit-1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-5 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -262,27 +344,49 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   user-select: none;
 }
 
-.circuit-3:hover {
+.circuit-5:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-5:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-5:focus-within,
+.circuit-5:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-3:hover > span {
+.circuit-5:focus-within > button,
+.circuit-5:hover > button {
   opacity: 1;
 }
 
-.circuit-3 > span {
+.circuit-5 > button {
   opacity: 1;
 }
 
 <th
   aria-sort="ascending"
-  class="circuit-3 circuit-4"
+  class="circuit-5 circuit-6"
   data-testid="table-header"
   scope="col"
 >
-  <span
-    class="circuit-1 circuit-2"
+  <button
+    class="circuit-3 circuit-4"
+    role="button"
+    title="Sort"
   >
     <svg
       class="circuit-0"
@@ -300,13 +404,18 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
         stroke-width="2"
       />
     </svg>
-  </span>
+    <span
+      class="circuit-1 circuit-2"
+    >
+      Sort
+    </span>
+  </button>
   Foo
 </th>
 `;
 
 exports[`TableHeader Style tests sortable + sorted should render with sortable + sorted descending styles 1`] = `
-.circuit-1 {
+.circuit-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -330,6 +439,20 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   -webkit-transition: opacity 200ms ease-in-out;
   transition: opacity 200ms ease-in-out;
   color: #3388FF;
+  border: 0;
+  background: none;
+  outline: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.circuit-3:focus {
+  opacity: 1;
+}
+
+.circuit-3:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -337,7 +460,20 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   margin-bottom: -7px;
 }
 
-.circuit-3 {
+.circuit-1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-5 {
   background-color: #FFFFFF;
   border-bottom: 1px solid #D8DDE1;
   padding: 24px;
@@ -358,27 +494,49 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   user-select: none;
 }
 
-.circuit-3:hover {
+.circuit-5:focus-within::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-5:focus-within::after::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-5:focus-within,
+.circuit-5:hover {
   background-color: #FAFBFC;
   color: #3388FF;
 }
 
-.circuit-3:hover > span {
+.circuit-5:focus-within > button,
+.circuit-5:hover > button {
   opacity: 1;
 }
 
-.circuit-3 > span {
+.circuit-5 > button {
   opacity: 1;
 }
 
 <th
   aria-sort="descending"
-  class="circuit-3 circuit-4"
+  class="circuit-5 circuit-6"
   data-testid="table-header"
   scope="col"
 >
-  <span
-    class="circuit-1 circuit-2"
+  <button
+    class="circuit-3 circuit-4"
+    role="button"
+    title="Sort"
   >
     <svg
       class="circuit-0"
@@ -396,7 +554,12 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
         stroke-width="2"
       />
     </svg>
-  </span>
+    <span
+      class="circuit-1 circuit-2"
+    >
+      Sort
+    </span>
+  </button>
   Foo
 </th>
 `;

--- a/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
@@ -134,6 +134,7 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -355,6 +356,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -505,6 +507,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Table/components/TableRow/TableRow.js
+++ b/src/components/Table/components/TableRow/TableRow.js
@@ -13,8 +13,12 @@
  * limitations under the License.
  */
 
+import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+
+import { isEnter, isSpacebar } from '../../../../util/key-codes';
+import { focusOutline } from '../../../../styles/style-helpers';
 
 const baseStyles = () => css`
   label: table-row;
@@ -35,8 +39,24 @@ const clickableStyles = ({ theme, onClick }) =>
   css`
     label: table-row--clickable;
     cursor: pointer;
+    position: relative;
+
+    &:focus::after {
+      content: '';
+      display: block;
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      z-index: 1;
+      ${focusOutline({ theme })};
+    }
 
     tbody & {
+      &:focus,
       &:hover {
         td,
         th {
@@ -47,9 +67,22 @@ const clickableStyles = ({ theme, onClick }) =>
     }
   `;
 
-const TableRow = styled.tr`
-  ${baseStyles};
-  ${clickableStyles};
-`;
+const Tr = styled.tr(baseStyles, clickableStyles);
+
+const TableRow = ({ onClick, ...props }) => {
+  const handleKeyDown = event => {
+    if (isEnter(event) || isSpacebar(event)) {
+      onClick();
+    }
+  };
+  return (
+    <Tr
+      onClick={onClick}
+      onKeyDown={onClick ? handleKeyDown : null}
+      tabIndex={onClick ? '0' : undefined}
+      {...props}
+    />
+  );
+};
 
 export default TableRow;

--- a/src/components/Table/components/TableRow/TableRow.spec.js
+++ b/src/components/Table/components/TableRow/TableRow.spec.js
@@ -34,6 +34,42 @@ describe('TableHeader', () => {
     });
   });
 
+  describe('Logic tests', () => {
+    it('should call the onClick when clicked', () => {
+      const onClick = jest.fn();
+      const { getByTestId } = render(
+        <TableRow onClick={onClick} data-testid="row">
+          {children}
+        </TableRow>
+      );
+      const rowEl = getByTestId('row');
+
+      act(() => {
+        rowEl.focus();
+        fireEvent.keyDown(rowEl, { key: 'Enter', code: 'Enter' });
+      });
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call the onClick when navigating with the keyboard', () => {
+      const onClick = jest.fn();
+      const { getByTestId } = render(
+        <TableRow onClick={onClick} data-testid="row">
+          {children}
+        </TableRow>
+      );
+      const rowEl = getByTestId('row');
+
+      act(() => {
+        rowEl.focus();
+        fireEvent.keyDown(rowEl, { key: 'Enter', code: 'Enter' });
+        fireEvent.keyDown(rowEl, { key: ' ', code: 'Spacebar' });
+      });
+
+      expect(onClick).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('Accessibility tests', () => {
     it('should meet accessibility guidelines', async () => {
       const wrapper = renderToHtml(<TableRow>{children}</TableRow>);

--- a/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
+++ b/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
@@ -23,6 +23,7 @@ tbody .circuit-0:last-child td {
   bottom: 0;
   left: 0;
   z-index: 1;
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
+++ b/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
@@ -4,6 +4,7 @@ exports[`TableHeader Style tests should render with clickable styles 1`] = `
 .circuit-0 {
   vertical-align: middle;
   cursor: pointer;
+  position: relative;
 }
 
 tbody .circuit-0:last-child th,
@@ -11,7 +12,27 @@ tbody .circuit-0:last-child td {
   border-bottom: none;
 }
 
+.circuit-0:focus::after {
+  content: '';
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::after::-moz-focus-inner {
+  border: 0;
+}
+
+tbody .circuit-0:focus td,
 tbody .circuit-0:hover td,
+tbody .circuit-0:focus th,
 tbody .circuit-0:hover th {
   color: #3388FF;
   background-color: #FAFBFC;
@@ -19,6 +40,7 @@ tbody .circuit-0:hover th {
 
 <tr
   class="circuit-0 circuit-1"
+  tabindex="0"
 >
   Foo
 </tr>

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -75,6 +75,7 @@ exports[`Tabs styles should render with default styles 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -124,6 +125,7 @@ exports[`Tabs styles should render with default styles 1`] = `
 }
 
 .circuit-2:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -220,6 +222,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -269,6 +272,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
 }
 
 .circuit-2:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -43,7 +43,7 @@ exports[`Tabs styles should render with default styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -66,6 +66,14 @@ exports[`Tabs styles should render with default styles 1`] = `
   outline: none;
 }
 
+.circuit-0:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-0:active {
+  background-color: #EEF0F2;
+}
+
 .circuit-0:focus {
   box-shadow: 0 0 0 4px #AFD0FE;
 }
@@ -82,7 +90,7 @@ exports[`Tabs styles should render with default styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -105,6 +113,14 @@ exports[`Tabs styles should render with default styles 1`] = `
   outline: none;
   position: relative;
   color: #212933;
+}
+
+.circuit-2:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-2:active {
+  background-color: #EEF0F2;
 }
 
 .circuit-2:focus {
@@ -172,7 +188,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -195,6 +211,14 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   outline: none;
 }
 
+.circuit-0:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-0:active {
+  background-color: #EEF0F2;
+}
+
 .circuit-0:focus {
   box-shadow: 0 0 0 4px #AFD0FE;
 }
@@ -211,7 +235,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -234,6 +258,14 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   outline: none;
   position: relative;
   color: #212933;
+}
+
+.circuit-2:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-2:active {
+  background-color: #EEF0F2;
 }
 
 .circuit-2:focus {

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -74,11 +74,6 @@ exports[`Tabs styles should render with default styles 1`] = `
   border: 0;
 }
 
-.circuit-0:focus:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-2 {
   font-size: 16px;
   line-height: 24px;
@@ -118,11 +113,6 @@ exports[`Tabs styles should render with default styles 1`] = `
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
-}
-
-.circuit-2:focus:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
 }
 
 .circuit-2::after {
@@ -213,11 +203,6 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   border: 0;
 }
 
-.circuit-0:focus:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 .circuit-2 {
   font-size: 16px;
   line-height: 24px;
@@ -257,11 +242,6 @@ exports[`Tabs styles should render with stretched styles 1`] = `
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
-}
-
-.circuit-2:focus:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
 }
 
 .circuit-2::after {

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -66,6 +66,19 @@ exports[`Tabs styles should render with default styles 1`] = `
   outline: none;
 }
 
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 .circuit-2 {
   font-size: 16px;
   line-height: 24px;
@@ -97,6 +110,19 @@ exports[`Tabs styles should render with default styles 1`] = `
   outline: none;
   position: relative;
   color: #212933;
+}
+
+.circuit-2:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-2:focus:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-2::after {
@@ -179,6 +205,19 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   outline: none;
 }
 
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 .circuit-2 {
   font-size: 16px;
   line-height: 24px;
@@ -210,6 +249,19 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   outline: none;
   position: relative;
   color: #212933;
+}
+
+.circuit-2:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-2:focus:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-2::after {

--- a/src/components/Tabs/components/Tab/Tab.js
+++ b/src/components/Tabs/components/Tab/Tab.js
@@ -27,7 +27,7 @@ const defaultTabStyles = ({ theme }) => css`
   color: ${theme.colors.n700};
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: ${theme.colors.white};
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -37,6 +37,14 @@ const defaultTabStyles = ({ theme }) => css`
   flex-direction: column;
   justify-content: center;
   outline: none;
+
+  &:hover {
+    background-color: ${theme.colors.n100};
+  }
+
+  &:active {
+    background-color: ${theme.colors.n200};
+  }
 
   &:focus {
     ${focusOutline({ theme })};

--- a/src/components/Tabs/components/Tab/Tab.js
+++ b/src/components/Tabs/components/Tab/Tab.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
-import { textMega } from '../../../../styles/style-helpers';
+import { textMega, focusOutline } from '../../../../styles/style-helpers';
 
 const defaultTabStyles = ({ theme }) => css`
   label: tab;
@@ -29,7 +29,6 @@ const defaultTabStyles = ({ theme }) => css`
   cursor: pointer;
   background-color: transparent;
   border: none;
-
   white-space: nowrap;
   height: 100%;
   align-items: center;
@@ -38,6 +37,10 @@ const defaultTabStyles = ({ theme }) => css`
   flex-direction: column;
   justify-content: center;
   outline: none;
+
+  &:focus {
+    ${focusOutline({ theme })};
+  }
 `;
 
 const selectedTabStyles = ({ theme, selected }) =>

--- a/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
+++ b/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
@@ -41,6 +41,7 @@ exports[`Tab styles should render with default styles 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -101,6 +102,7 @@ exports[`Tab styles should render with selected styles 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
+++ b/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
@@ -32,6 +32,19 @@ exports[`Tab styles should render with default styles 1`] = `
   outline: none;
 }
 
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
 <button
   aria-selected="false"
   class="circuit-0 circuit-1"
@@ -74,6 +87,19 @@ exports[`Tab styles should render with selected styles 1`] = `
   outline: none;
   position: relative;
   color: #212933;
+}
+
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0::after {

--- a/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
+++ b/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
@@ -40,11 +40,6 @@ exports[`Tab styles should render with default styles 1`] = `
   border: 0;
 }
 
-.circuit-0:focus:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
 <button
   aria-selected="false"
   class="circuit-0 circuit-1"
@@ -95,11 +90,6 @@ exports[`Tab styles should render with selected styles 1`] = `
 
 .circuit-0:focus::-moz-focus-inner {
   border: 0;
-}
-
-.circuit-0:focus:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
 }
 
 .circuit-0::after {

--- a/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
+++ b/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
@@ -9,7 +9,7 @@ exports[`Tab styles should render with default styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -30,6 +30,14 @@ exports[`Tab styles should render with default styles 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   outline: none;
+}
+
+.circuit-0:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-0:active {
+  background-color: #EEF0F2;
 }
 
 .circuit-0:focus {
@@ -59,7 +67,7 @@ exports[`Tab styles should render with selected styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: transparent;
+  background-color: #FFFFFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -82,6 +90,14 @@ exports[`Tab styles should render with selected styles 1`] = `
   outline: none;
   position: relative;
   color: #212933;
+}
+
+.circuit-0:hover {
+  background-color: #FAFBFC;
+}
+
+.circuit-0:active {
+  background-color: #EEF0F2;
 }
 
 .circuit-0:focus {

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -22,7 +22,7 @@ import {
   eitherOrPropType,
   childrenPropType
 } from '../../util/shared-prop-types';
-import { textMega, shadowBorder } from '../../styles/style-helpers';
+import { textMega, focusOutline } from '../../styles/style-helpers';
 import CloseButton from '../CloseButton';
 
 const tagStyles = ({ theme }) => css`
@@ -31,7 +31,7 @@ const tagStyles = ({ theme }) => css`
   align-items: center;
   border-radius: ${theme.borderRadius.mega};
   ${textMega({ theme })};
-  ${shadowBorder(theme.colors.n300)};
+  border: 1px solid ${theme.colors.n300};
   padding: ${theme.spacings.bit} ${theme.spacings.kilo};
   cursor: default;
 `;
@@ -41,10 +41,16 @@ const tagClickableStyles = ({ onClick, theme }) =>
   css`
     label: tag--clickable;
     cursor: pointer;
+    outline: 0;
+    background: transparent;
 
     &:hover {
       background-color: ${theme.colors.n300};
-      ${shadowBorder(theme.colors.n300)};
+      border: 1px solid ${theme.colors.n500};
+    }
+
+    &:focus {
+      ${focusOutline({ theme })};
     }
   `;
 
@@ -53,7 +59,7 @@ const tagSelectedStyles = ({ selected, theme }) =>
   css`
     label: tag--selected;
     background-color: ${theme.colors.p500};
-    ${shadowBorder(theme.colors.p500)};
+    border: 1px solid ${theme.colors.p500};
     color: ${theme.colors.white};
   `;
 
@@ -64,16 +70,16 @@ const tagSelectedClickableStyles = ({ selected, onClick, theme }) =>
     label: tag--selected--clickable;
     &:hover {
       background-color: ${theme.colors.p500};
-      ${shadowBorder(theme.colors.p500)};
+      border: 1px solid ${theme.colors.p500};
     }
   `;
 
-const TagElement = styled('div')`
-  ${tagStyles};
-  ${tagClickableStyles};
-  ${tagSelectedStyles};
-  ${tagSelectedClickableStyles};
-`;
+const TagElement = styled('div')(
+  tagStyles,
+  tagClickableStyles,
+  tagSelectedStyles,
+  tagSelectedClickableStyles
+);
 
 const prefixStyles = ({ theme }) => css`
   label: tag__prefix;

--- a/src/components/Tag/Tag.story.js
+++ b/src/components/Tag/Tag.story.js
@@ -55,5 +55,7 @@ export const removable = () => (
 );
 
 export const clickable = () => (
-  <Tag onClick={action('Tag clicked')}>Transactions</Tag>
+  <Tag onClick={action('Tag clicked')} as="button">
+    Transactions
+  </Tag>
 );

--- a/src/components/Tag/__snapshots__/Tag.spec.js.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.js.snap
@@ -27,6 +27,7 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
 }
 
 .circuit-0:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Tag/__snapshots__/Tag.spec.js.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.js.snap
@@ -13,15 +13,25 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   cursor: pointer;
+  outline: 0;
+  background: transparent;
 }
 
 .circuit-0:hover {
   background-color: #D8DDE1;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #9DA7B1;
+}
+
+.circuit-0:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
 }
 
 <div
@@ -44,7 +54,7 @@ exports[`Tag when is default should render with default styles 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
 }
@@ -69,11 +79,11 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   background-color: #3388FF;
-  box-shadow: 0px 0px 0px 1px #3388FF;
+  border: 1px solid #3388FF;
   color: #FFFFFF;
 }
 
@@ -166,11 +176,11 @@ exports[`Tag when is selected should change the given icon color 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   background-color: #3388FF;
-  box-shadow: 0px 0px 0px 1px #3388FF;
+  border: 1px solid #3388FF;
   color: #FFFFFF;
 }
 
@@ -202,11 +212,11 @@ exports[`Tag when is selected should render with selected styles 1`] = `
   border-radius: 4px;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0px 0px 0px 1px #D8DDE1;
+  border: 1px solid #D8DDE1;
   padding: 4px 12px;
   cursor: default;
   background-color: #3388FF;
-  box-shadow: 0px 0px 0px 1px #3388FF;
+  border: 1px solid #3388FF;
   color: #FFFFFF;
 }
 

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -27,6 +27,7 @@ const textWrapperStyles = ({ theme }) => css`
   label: toggle__text-wrapper;
   display: block;
   margin-left: ${theme.spacings.kilo};
+  cursor: pointer;
 `;
 
 const ToggleTextWrapper = styled('label')(textWrapperStyles);

--- a/src/components/Toggle/Toggle.js
+++ b/src/components/Toggle/Toggle.js
@@ -29,18 +29,15 @@ const textWrapperStyles = ({ theme }) => css`
   margin-left: ${theme.spacings.kilo};
 `;
 
-const ToggleTextWrapper = styled('label')`
-  ${textWrapperStyles};
-`;
+const ToggleTextWrapper = styled('label')(textWrapperStyles);
 
 const labelStyles = css`
   label: toggle__label;
   padding-top: 2px;
 `;
 
-const ToggleLabel = styled(Text)`
-  ${labelStyles};
-`;
+const ToggleLabel = styled(Text)(labelStyles);
+
 ToggleLabel.propTypes = Text.propTypes;
 ToggleLabel.defaultProps = Text.defaultProps;
 
@@ -49,9 +46,8 @@ const explanationStyles = ({ theme }) => css`
   color: ${theme.colors.n500};
 `;
 
-const ToggleExplanation = styled(Text)`
-  ${explanationStyles};
-`;
+const ToggleExplanation = styled(Text)(explanationStyles);
+
 ToggleExplanation.propTypes = Text.propTypes;
 ToggleExplanation.defaultProps = Text.defaultProps;
 
@@ -82,11 +78,11 @@ const toggleWrapperReversedStyles = ({ theme, reversed }) =>
     }
   `;
 
-const ToggleWrapper = styled('div')`
-  ${toggleWrapperStyles}
-  ${toggleWrapperNoMarginStyles}
-  ${toggleWrapperReversedStyles};
-`;
+const ToggleWrapper = styled('div')(
+  toggleWrapperStyles,
+  toggleWrapperNoMarginStyles,
+  toggleWrapperReversedStyles
+);
 
 /**
  * A toggle component with support for labels and additional explanations.

--- a/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
@@ -33,8 +33,12 @@ exports[`Toggle should render with default styles 1`] = `
   overflow: visible;
 }
 
-.circuit-4::-moz-focus-inner {
-  border-radius: 24px;
+.circuit-4:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -165,8 +169,12 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
   overflow: visible;
 }
 
-.circuit-4::-moz-focus-inner {
-  border-radius: 24px;
+.circuit-4:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {

--- a/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
@@ -35,6 +35,7 @@ exports[`Toggle should render with default styles 1`] = `
 }
 
 .circuit-4:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -173,6 +174,7 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
 }
 
 .circuit-4:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.spec.js.snap
@@ -31,6 +31,7 @@ exports[`Toggle should render with default styles 1`] = `
   height: 24px;
   width: 40px;
   overflow: visible;
+  cursor: pointer;
 }
 
 .circuit-4:focus {
@@ -74,6 +75,7 @@ exports[`Toggle should render with default styles 1`] = `
 .circuit-10 {
   display: block;
   margin-left: 12px;
+  cursor: pointer;
 }
 
 .circuit-6 {
@@ -167,6 +169,7 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
   height: 24px;
   width: 40px;
   overflow: visible;
+  cursor: pointer;
 }
 
 .circuit-4:focus {
@@ -210,6 +213,7 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
 .circuit-10 {
   display: block;
   margin-left: 12px;
+  cursor: pointer;
 }
 
 .circuit-6 {

--- a/src/components/Toggle/components/Switch/Switch.js
+++ b/src/components/Toggle/components/Switch/Switch.js
@@ -42,6 +42,7 @@ const trackBaseStyles = ({ theme }) => css`
   transition: background-color ${ANIMATION_TIMING};
   ${size(TRACK_HEIGHT, TRACK_WIDTH)};
   overflow: visible;
+  cursor: pointer;
 
   &:focus {
     ${focusOutline({ theme })};

--- a/src/components/Toggle/components/Switch/Switch.js
+++ b/src/components/Toggle/components/Switch/Switch.js
@@ -19,6 +19,8 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { hideVisually, size } from 'polished';
 
+import { focusOutline } from '../../../../styles/style-helpers';
+
 const TRACK_WIDTH = 40;
 const TRACK_HEIGHT = 24;
 const KNOB_SIZE = 16;
@@ -41,8 +43,8 @@ const trackBaseStyles = ({ theme }) => css`
   ${size(TRACK_HEIGHT, TRACK_WIDTH)};
   overflow: visible;
 
-  &::-moz-focus-inner {
-    border-radius: ${TRACK_HEIGHT}px;
+  &:focus {
+    ${focusOutline({ theme })};
   }
 `;
 
@@ -53,9 +55,7 @@ const trackOnStyles = ({ theme, on }) =>
     background-color: ${theme.colors.p500};
   `;
 
-const SwitchTrack = styled('button')`
-  ${trackBaseStyles} ${trackOnStyles};
-`;
+const SwitchTrack = styled('button')(trackBaseStyles, trackOnStyles);
 
 const knobBaseStyles = ({ theme }) => css`
   label: toggle__switch-knob;
@@ -84,17 +84,12 @@ const knobOnStyles = ({ theme, on }) =>
 
 const labelBaseStyles = () => css`
   label: toggle__switch-label;
-  ${hideVisually()};
 `;
 
-const SwitchKnob = styled('span')`
-  ${knobBaseStyles} ${knobOnStyles};
-`;
+const SwitchKnob = styled('span')(knobBaseStyles, knobOnStyles);
 
 // Important for accessibility
-const SwitchLabel = styled('span')`
-  ${labelBaseStyles};
-`;
+const SwitchLabel = styled('span')(labelBaseStyles, hideVisually);
 
 /**
  * A simple Switch component.

--- a/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
+++ b/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
@@ -24,6 +24,7 @@ exports[`Switch should have the correct default styles 1`] = `
 }
 
 .circuit-4:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
@@ -116,6 +117,7 @@ exports[`Switch should have the correct on styles 1`] = `
 }
 
 .circuit-4:focus {
+  outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 

--- a/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
+++ b/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
@@ -20,6 +20,7 @@ exports[`Switch should have the correct default styles 1`] = `
   height: 24px;
   width: 40px;
   overflow: visible;
+  cursor: pointer;
 }
 
 .circuit-4:focus {
@@ -110,6 +111,7 @@ exports[`Switch should have the correct on styles 1`] = `
   height: 24px;
   width: 40px;
   overflow: visible;
+  cursor: pointer;
   background-color: #3388FF;
 }
 

--- a/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
+++ b/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.js.snap
@@ -22,8 +22,12 @@ exports[`Switch should have the correct default styles 1`] = `
   overflow: visible;
 }
 
-.circuit-4::-moz-focus-inner {
-  border-radius: 24px;
+.circuit-4:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {
@@ -109,8 +113,12 @@ exports[`Switch should have the correct on styles 1`] = `
   background-color: #3388FF;
 }
 
-.circuit-4::-moz-focus-inner {
-  border-radius: 24px;
+.circuit-4:focus {
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
 }
 
 .circuit-0 {

--- a/src/styles/style-helpers.spec.js
+++ b/src/styles/style-helpers.spec.js
@@ -236,6 +236,11 @@ describe('Style helpers', () => {
             &::-moz-focus-inner {
               border: 0;
             }
+
+            &:-moz-focusring {
+              color: transparent;
+              text-shadow: 0 0 0 #000;
+            }
           "
       `);
     });

--- a/src/styles/style-helpers.spec.js
+++ b/src/styles/style-helpers.spec.js
@@ -34,10 +34,10 @@ describe('Style helpers', () => {
       const { styles } = StyleHelpers.shadowSingle({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
         "
-          box-shadow: 0 0 0 1px rgba(12,15,20,0.02),
-            0 0 1px 0 rgba(12,15,20,0.06),
-            0 2px 2px 0 rgba(12,15,20,0.06);
-        "
+            box-shadow: 0 0 0 1px rgba(12,15,20,0.02),
+              0 0 1px 0 rgba(12,15,20,0.06),
+              0 2px 2px 0 rgba(12,15,20,0.06);
+          "
       `);
     });
   });
@@ -47,10 +47,10 @@ describe('Style helpers', () => {
       const { styles } = StyleHelpers.shadowDouble({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
         "
-          box-shadow: 0 0 0 1px rgba(12,15,20,0.02),
-            0 2px 2px 0 rgba(12,15,20,0.06),
-            0 4px 4px 0 rgba(12,15,20,0.06);
-        "
+            box-shadow: 0 0 0 1px rgba(12,15,20,0.02),
+              0 2px 2px 0 rgba(12,15,20,0.06),
+              0 4px 4px 0 rgba(12,15,20,0.06);
+          "
       `);
     });
   });
@@ -60,10 +60,10 @@ describe('Style helpers', () => {
       const { styles } = StyleHelpers.shadowTriple({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
         "
-          box-shadow: 0 0 0 1px rgba(12,15,20,0.02),
-            0 4px 4px 0 rgba(12,15,20,0.06),
-            0 8px 8px 0 rgba(12,15,20,0.06);
-        "
+            box-shadow: 0 0 0 1px rgba(12,15,20,0.02),
+              0 4px 4px 0 rgba(12,15,20,0.06),
+              0 8px 8px 0 rgba(12,15,20,0.06);
+          "
       `);
     });
   });
@@ -230,13 +230,13 @@ describe('Style helpers', () => {
       const { styles } = StyleHelpers.focusOutline({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
         "
-          outline: 0;
-          box-shadow: 0 0 0 4px #AFD0FE;
+            outline: 0;
+            box-shadow: 0 0 0 4px #AFD0FE;
 
-          &::-moz-focus-inner {
-            border: 0;
-          }
-        "
+            &::-moz-focus-inner {
+              border: 0;
+            }
+          "
       `);
     });
   });

--- a/src/styles/style-helpers.spec.js
+++ b/src/styles/style-helpers.spec.js
@@ -236,11 +236,6 @@ describe('Style helpers', () => {
             &::-moz-focus-inner {
               border: 0;
             }
-
-            &:-moz-focusring {
-              color: transparent;
-              text-shadow: 0 0 0 #000;
-            }
           "
       `);
     });

--- a/src/styles/style-helpers.spec.ts
+++ b/src/styles/style-helpers.spec.ts
@@ -18,17 +18,6 @@ import { light } from '@sumup/design-tokens';
 import * as StyleHelpers from './style-helpers';
 
 describe('Style helpers', () => {
-  describe('shadowBorder', () => {
-    it('should match the snapshot', () => {
-      const { styles } = StyleHelpers.shadowBorder(light.colors.black);
-      expect(styles).toMatchInlineSnapshot(`
-        "
-          box-shadow: 0px 0px 0px 1px #0F131A;
-        "
-      `);
-    });
-  });
-
   describe('shadowSingle', () => {
     it('should match the snapshot', () => {
       const { styles } = StyleHelpers.shadowSingle({ theme: light });

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -26,13 +26,6 @@ function isTheme(args: ThemeArgs): args is Theme {
 export const getTheme = (args: ThemeArgs): Theme =>
   isTheme(args) ? args : args.theme;
 
-export const shadowBorder = (
-  color: string,
-  borderSize = '1px'
-): SerializedStyles => css`
-  box-shadow: 0px 0px 0px ${borderSize} ${color};
-`;
-
 export const shadowSingle = (args: ThemeArgs): SerializedStyles => {
   const theme = getTheme(args);
   return css`

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -17,7 +17,14 @@ import { css, SerializedStyles } from '@emotion/core';
 import { transparentize } from 'polished';
 import { Theme } from '@sumup/design-tokens';
 
-import { StyleProps } from './styled';
+type ThemeArgs = Theme | { theme: Theme };
+
+function isTheme(args: ThemeArgs): args is Theme {
+  return (args as { theme: Theme }).theme === undefined;
+}
+
+export const getTheme = (args: ThemeArgs): Theme =>
+  isTheme(args) ? args : args.theme;
 
 export const shadowBorder = (
   color: string,
@@ -26,29 +33,39 @@ export const shadowBorder = (
   box-shadow: 0px 0px 0px ${borderSize} ${color};
 `;
 
-export const shadowSingle = ({ theme }: StyleProps): SerializedStyles => css`
-  box-shadow: 0 0 0 1px ${transparentize(0.98, theme.colors.shadow)},
-    0 0 1px 0 ${transparentize(0.94, theme.colors.shadow)},
-    0 2px 2px 0 ${transparentize(0.94, theme.colors.shadow)};
-`;
+export const shadowSingle = (args: ThemeArgs): SerializedStyles => {
+  const theme = getTheme(args);
+  return css`
+    box-shadow: 0 0 0 1px ${transparentize(0.98, theme.colors.shadow)},
+      0 0 1px 0 ${transparentize(0.94, theme.colors.shadow)},
+      0 2px 2px 0 ${transparentize(0.94, theme.colors.shadow)};
+  `;
+};
 
-export const shadowDouble = ({ theme }: StyleProps): SerializedStyles => css`
-  box-shadow: 0 0 0 1px ${transparentize(0.98, theme.colors.shadow)},
-    0 2px 2px 0 ${transparentize(0.94, theme.colors.shadow)},
-    0 4px 4px 0 ${transparentize(0.94, theme.colors.shadow)};
-`;
+export const shadowDouble = (args: ThemeArgs): SerializedStyles => {
+  const theme = getTheme(args);
+  return css`
+    box-shadow: 0 0 0 1px ${transparentize(0.98, theme.colors.shadow)},
+      0 2px 2px 0 ${transparentize(0.94, theme.colors.shadow)},
+      0 4px 4px 0 ${transparentize(0.94, theme.colors.shadow)};
+  `;
+};
 
-export const shadowTriple = ({ theme }: StyleProps): SerializedStyles => css`
-  box-shadow: 0 0 0 1px ${transparentize(0.98, theme.colors.shadow)},
-    0 4px 4px 0 ${transparentize(0.94, theme.colors.shadow)},
-    0 8px 8px 0 ${transparentize(0.94, theme.colors.shadow)};
-`;
+export const shadowTriple = (args: ThemeArgs): SerializedStyles => {
+  const theme = getTheme(args);
+  return css`
+    box-shadow: 0 0 0 1px ${transparentize(0.98, theme.colors.shadow)},
+      0 4px 4px 0 ${transparentize(0.94, theme.colors.shadow)},
+      0 8px 8px 0 ${transparentize(0.94, theme.colors.shadow)};
+  `;
+};
 
 function createTypeHelper<T extends 'headings' | 'subHeadings' | 'text'>(
   type: T,
   size: keyof Theme['typography'][T]
 ) {
-  return ({ theme }: StyleProps): SerializedStyles => {
+  return (args: ThemeArgs): SerializedStyles => {
+    const theme = getTheme(args);
     const { fontSize, lineHeight } = (theme.typography[type][
       size
     ] as unknown) as {
@@ -90,14 +107,17 @@ export const disableVisually = (): SerializedStyles => css`
 /**
  * Visually communicates to the user that an element is focused.
  */
-export const focusOutline = ({ theme }: StyleProps): SerializedStyles => css`
-  outline: 0;
-  box-shadow: 0 0 0 4px ${theme.colors.p300};
+export const focusOutline = (args: ThemeArgs): SerializedStyles => {
+  const theme = getTheme(args);
+  return css`
+    outline: 0;
+    box-shadow: 0 0 0 4px ${theme.colors.p300};
 
-  &::-moz-focus-inner {
-    border: 0;
-  }
-`;
+    &::-moz-focus-inner {
+      border: 0;
+    }
+  `;
+};
 
 /**
  * A CSS hack to force an element to self-clear its floated children.

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -116,11 +116,6 @@ export const focusOutline = (args: ThemeArgs): SerializedStyles => {
     &::-moz-focus-inner {
       border: 0;
     }
-
-    &:-moz-focusring {
-      color: transparent;
-      text-shadow: 0 0 0 #000;
-    }
   `;
 };
 

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -116,6 +116,11 @@ export const focusOutline = (args: ThemeArgs): SerializedStyles => {
     &::-moz-focus-inner {
       border: 0;
     }
+
+    &:-moz-focusring {
+      color: transparent;
+      text-shadow: 0 0 0 #000;
+    }
   `;
 };
 

--- a/src/util/key-codes.js
+++ b/src/util/key-codes.js
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-// event.keyCode has been deprecated and replaced by event.key,
-// however not all browsers implement it yet.
+// `event.keyCode` has been deprecated and replaced by `event.key`,
+// however, not all browsers implement it yet.
 
 export const isEnter = event =>
   'key' in event ? event.key === 'Enter' : event.keyCode === 13;


### PR DESCRIPTION
Closes #410.

## Purpose

The goal of this PR is to improve accessibility for users who prefer to navigate using their keyboard or a screen reader. Initially, I focused on the focus styles (pun intended), but there were some other low-hanging fruits that I tackled as well.

_I want to thank @larimaza for doing the initial investigation and testing in #410._

## Approach and changes

- make style helpers work with Emotion's `css` prop (they now accept the plain theme or wrapped in an object — `theme` and `{ theme }`)
- add focus outline to style helpers
- add focus styles to Badge, Checkbox, RadioButton, Selector, Table, Tabs, Tag, and Toggle components
- switch the cursor to `pointer` on hover for Checkbox, RadioButton, Select, Tabs, and Toggle components
- make Table component keyboard and screen reader accessible

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
