### PR TITLE
docs: add migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -13,7 +13,7 @@
 
 ## 🤖 Codemods
 
-Some of the changes in this guide can be automated with _codemods_, small scripts that modify the source code automatically. Changes that can be codemodded are marked with a robot emoji (🤖) and the name of the transform (e.g. _button-props_). The codemods are built with [jscodeshift](https://github.com/facebook/jscodeshift) and can be run through the Circuit UI CLI. Here is an overview of all available options (you can view this help menu by running `yarn circuit-ui migrate --help`):
+Some of the changes in this guide can be automated with _codemods_, small scripts that modify your app's source code automatically. Changes that can be codemodded are marked with a robot emoji (🤖) and the name of the transform (e.g. _button-variant-enum_). The codemods are built with [jscodeshift](https://github.com/facebook/jscodeshift) and can be run through the CLI that ships with Circuit UI. Here is an overview of all available options (you can view this help menu by running `yarn circuit-ui migrate --help`):
 
 ```sh
 yarn circuit-ui migrate
@@ -21,8 +21,6 @@ yarn circuit-ui migrate
 Automatically transforms your source code to Circuit UI's latest APIs
 
 Options:
-  --help           Show help                                           [boolean]
-  --version        Show version number                                 [boolean]
   --transform, -t  The transform to be applied to the source code
                                    [string] [required] [choices: "button-props"]
   --language, -l   The programming language of the files to be transformed
@@ -99,21 +97,21 @@ React [`ref`s](https://reactjs.org/docs/refs-and-the-dom.html) allow you to acce
 ### Changed components
 
 - The **GlobalStyles** component no longer accepts a `custom` prop. Use Emotion's [Global](https://emotion.sh/docs/globals) component instead.
-- 🤖 The **RadioButton** and **Switch** components no longer accept the `onToggle` prop. Use the `onChange` prop instead.
+- The **RadioButton** and **Switch** components no longer accept the `onToggle` prop. Use the `onChange` prop instead (🤖 _onchange-prop_)
 - The **Input** and **Textarea** components no longer accept `*ClassName` props. Emotion 10 uses style objects instead of class names. Use the `*Styles` props instead.
-- 🤖 The **Heading**, **SubHeading**, **Text**, and **Input** components no longer accept the `element` prop. Emotion 10 introduced the ability to change the HTML element. Use the `as` prop instead.
-- 🤖 The **Selector** component no longer accepts the `onClick` and `selected` props. Use the `onChange` and `checked` props instead. The `value` and `name` have been added as required props.
+- The **Heading**, **SubHeading**, **Text**, and **Input** components no longer accept the `element` prop. Emotion 10 introduced the ability to change the HTML element. Use the `as` prop instead (🤖 _as-prop_)
+- The **Selector** component no longer accepts the `onClick` and `selected` props. Use the `onChange` and `checked` props instead (🤖 _selector-props_). The `value` and `name` have been added as required props.
 - The **RadioButtonGroup** component's `label` property inside the `options` prop has been renamed to `children`.
 - The **Hamburger** component's `light` prop has been removed. Set the color through CSS instead.
-- The **LoadingButton**'s exit animations have been removed. An action's success or error result should be communicated outside the button.
-- 🤖 The `flat` **Button** variant has been removed (🤖 _button props_)
+- The `primary` and `secondary` **Button** boolean props have been removed. Use the `variant` enum prop instead (🤖 _button-variant-enum_)
 - The `plain` **Button** prop has been removed. Use the new Anchor component or the `tertiary` Button variant instead.
+- The `flat` **Button** variant has been removed (🤖 _button-variant-enum_)
+- The **LoadingButton**'s exit animations have been removed. An action's success or error result should be communicated outside the button (🤖 _exit-animations_)
 - The **Button** component doesn't have static properties anymore ...
-- The `primary` and `secondary` **Button** boolean props have been removed. Use the `variant` enum prop instead (🤖 _button props_)
 - combine label with form input components
-- 🤖 The **List** component's `ordered` prop has been replaced by the `variant` enum prop.
+- The **List** component's `ordered` prop has been replaced by the `variant` enum prop (🤖 _list-variant-enum_)
 - The **List** component's default size is now `mega` to match the Text component.
-- 🤖 The Heading component doesn't export sizes anymore. Instead of writing `size={Heading.GIGA}`, write `size="giga"`. Button, Text ...
+- 🤖 The **Heading** component doesn't export sizes anymore. Instead of writing `size={Heading.GIGA}`, write `size="giga"`. Button, Text ...
 
 ### Utilities
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,7 +10,7 @@
   - [Renamed components](#renamed-components)
   - [Changed components](#changed-components)
   - [Utilities](#utilities)
-  - [Changes to the theme](#changes-to-the-theme)
+  - [Theme changes](#theme-changes)
 
 ## 🤖 Codemods
 
@@ -130,31 +130,26 @@ The affected components are: Badge, Blockquote, Button, ButtonGroup, Card, CardF
 - The **Input** and **Textarea** components no longer accept `*ClassName` props. Emotion 10 uses style objects instead of class names. Use the `*Styles` props instead.
 - The **Selector** component no longer accepts the `onClick` and `selected` props. Use the `onChange` and `checked` props instead (🤖 _selector-props_). The `value` and `name` have been added as required props.
 - The **RadioButtonGroup** component's `label` property inside the `options` prop has been renamed to `children`.
+- The **IconButton** component's dimensions and style have changed. It is now consistent with the Button component.
+- The **Hamburger** component's default size has been increased to match the IconButton component.
 - The **Hamburger** component's `light` prop has been removed. Set the color through CSS instead.
+- The **Spinner** component's `dark` prop has been removed. Set the color through CSS instead.
 - (_in writing_) combine label with form input components
 
 ### Utilities
 
 (_in writing_)
 
-- The `currencyUtils` and `currencyAmountUtils` have been removed. Use [@sumup/intl](https://www.npmjs.com/package/@sumup/intl) instead.
-- The `shadowGround` and `textTera` style helpers have been removed.
-- The `shadowBorder` style helper has been removed. Use the [`box-shadow`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow) CSS property instead.
-- The unit style helpers have been removed. Use the CSS [`calc`](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) function instead.
+- The `currencyAmountUtils` have been removed. There is not replacement, we suggest you copy the [old implementation](https://github.com/sumup-oss/circuit-ui/blob/b3d89f43ac54ef1f7c0c2ff6f4edce92e2bd937d/src/components/CurrencyInput/CurrencyInputService.js) to your application.
+- The `currencyUtils` have been removed. Use [@sumup/intl](https://www.npmjs.com/package/@sumup/intl) instead (🤖 _TODO_)
+- The `textTera` style helper has been removed. Use the `textGiga` style helper instead.
+- The `shadowGround` and `shadowBorder` style helpers have been removed. Use the [`box-shadow`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow) CSS property instead.
+- The unit style helpers (`addUnit`, `subtractUnit`, `multiplyUnit`, `divideUnit` ) have been removed. Use the CSS [`calc`](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) function instead.
 
-### Changes to the theme
-
-(_in writing_)
-
-- 🤖? The themes have been moved to [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens). Import them from there instead.
-- 🤖 The `iconSizes.byte` theme value has been removed. Use `iconSizes.kilo` instead.
-- 🤖 The `grid.afterTera` theme value has been renamed to `grid.tera`.
-
----
-
-## New features
+### Theme changes
 
 (_in writing_)
 
-components: Carousel and Step components (#482)
-components: add Anchor component (#583)
+- The themes have been moved to [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens). Import them from there instead (🤖 _TODO_)
+- The `iconSizes.byte` theme value has been removed. Use `iconSizes.kilo` instead (🤖 _TODO_)
+- The `grid.afterTera` theme value has been renamed to `grid.tera` (🤖 _TODO_)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,10 +1,11 @@
 # Migration
 
-- [Codemods](#-codemods)
+- [🤖 Codemods](#-codemods)
 - [From v1.x to v2](#from-v1.x-to-v2)
   - [Library format](#library-format)
   - [Peer dependencies](#peer-dependencies)
   - [Forward custom props and refs](#forward-custom-props-and-refs)
+  - [Component static properties](#component-static-properties)
   - [Removed components](#removed-components)
   - [Renamed components](#renamed-components)
   - [Changed components](#changed-components)
@@ -22,7 +23,7 @@ Automatically transforms your source code to Circuit UI's latest APIs
 
 Options:
   --transform, -t  The transform to be applied to the source code
-                                   [string] [required] [choices: "button-props"]
+                            [string] [required] [choices: "button-variant-enum"]
   --language, -l   The programming language of the files to be transformed
                        [string] [required] [choices: "TypeScript", "JavaScript"]
   --path, -p       A path to the folder that contains the files to be
@@ -35,7 +36,7 @@ You can only run one codemod at a time and we encourage you to apply the transfo
 
 ### Library format
 
-Circuit UI is now compiled with TypeScript instead of Babel (#563, #597). ES and CJS versions are available as before, though this is not something you need to worry about since most bundlers pick the best format that they support automatically based on the `main` and `module` entries in `package.json`.
+Circuit UI is now compiled with TypeScript instead of Babel ([#563](https://github.com/sumup-oss/circuit-ui/pull/563), [#597](https://github.com/sumup-oss/circuit-ui/pull/593)). ES and CJS versions are available as before, though this is not something you need to worry about since most bundlers pick the best format that they support automatically based on the `main` and `module` entries in `package.json`.
 
 Note, however, that some modern JavaScript syntax and language features are no longer pretranspiled. Tools such as [react-scripts v2+](https://github.com/facebook/create-react-app/tree/master/packages/react-scripts) and [Next.js](https://github.com/vercel/next.js) include `node_modules` in their transpilation process so Circuit UI works with them out of the box. If you have a custom build process, you should make sure that Circuit UI is transpiled like the rest of your source code.
 
@@ -45,7 +46,7 @@ We recommend testing your application in your oldest supported browsers to verif
 
 Circuit UI v1 included React and Emotion dependencies as direct dependencies. This could cause these dependencies to be bundled twice if your application specified a different version of React or Emotion.
 
-Circuit UI v2 moves these dependencies to peer dependencies, so Circuit UI will use whatever version your application specifies (#485). The minimum version of React has been bumped to 16.8+ to support hooks.
+Circuit UI v2 moves these dependencies to peer dependencies, so Circuit UI will use whatever version your application specifies ([#485](https://github.com/sumup-oss/circuit-ui/pull/485)). The minimum version of React has been bumped to v16.8+ to support hooks.
 
 If you haven't installed them already, you can do so by running the following command in your terminal:
 
@@ -56,7 +57,7 @@ yarn add react react-dom @emotion/core @emotion/styled emotion-theming
 npm install --save react-dom @emotion/core @emotion/styled emotion-theming
 ```
 
-In Circuit UI v2 some functionality has been extracted into separate packages for easier maintenance. The themes have been moved to [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens), the icons are available from [@sumup/icons](https://www.npmjs.com/package/@sumup/icons), and the number & currency utils have been completely rewritten in [@sumup/intl](https://www.npmjs.com/package/@sumup/intl). These packages are also marked as required peer dependencies. To install them, run the following command in your terminal:
+In Circuit UI v2 some functionality has been extracted into separate packages for easier maintenance. The themes have been moved to [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens), the icons are available from [@sumup/icons](https://www.npmjs.com/package/@sumup/icons), and the number & currency utils have been completely rewritten in [@sumup/intl](https://www.npmjs.com/package/@sumup/intl). These packages are marked as required peer dependencies. To install them, run the following command in your terminal:
 
 ```sh
 # With yarn
@@ -69,11 +70,32 @@ Refer to the individual packages for documentation on how to use them.
 
 ### Forward custom props and refs
 
-Any additional props that are passed to a component are now spread on their outermost child element (#553). This is useful for test ids, data attributes, and custom styles using Emotion's `styled` function or `css` prop.
+Any additional props that are passed to a component are now spread on their outermost child element ([#553](https://github.com/sumup-oss/circuit-ui/pull/553)). This is useful for test ids, data attributes, and custom styles using Emotion's `styled` function or `css` prop.
 
-React [`ref`s](https://reactjs.org/docs/refs-and-the-dom.html) allow you to access the underlying DOM node of a component. All Circuit UI components now forward `ref`s to the underlying DOM node (for single node components such as a Button) or to the main interactive DOM node (for composite components such as an Input) (#592).
+React [`ref`s](https://reactjs.org/docs/refs-and-the-dom.html) allow you to access the underlying DOM node of a component. All Circuit UI components now forward `ref`s to the underlying DOM node (for single node components such as a Button) or to the main interactive DOM node (for composite components such as an Input) ([#592](https://github.com/sumup-oss/circuit-ui/pull/592)).
 
-⚠️ _The ability to pass custom styles and `ref`s is meant as an escape hatch. We strongly recommend to avoid using them as we cannot guarantee that they will be compatible with future changes. Please open an issue or PR to suggest the improvement in Circuit UI instead._
+⚠️ _The ability to pass custom styles and `ref`s is meant as an escape hatch. We strongly recommend to avoid using them as we cannot guarantee that they will be compatible with future changes. Please consider opening an issue or PR to suggest the improvement in Circuit UI instead._
+
+### Component static properties
+
+Many components expose their configuration values as static properties. The `Text` component, for example, exposes its size options as `Text.KILO`, `Text.MEGA`, and `Text.GIGA`. The purpose of these static properties was to autocomplete the options and prevent typos.
+
+Since Circuit UI is being migrated to TypeScript, the static properties are no longer necessary. VS Code can suggest and autocomplete the options based on the TypeScript types. TypeScript will warn you at build time if you use an unsupported or mistyped value. Furthermore, removing the static properties reduces the bundle size slightly.
+
+Thus, the static properties have been removed from all components. Here's how you can pass a value to a component now:
+
+```diff
+import { Text } from '@sumup/circuit-ui';
+
+const Hello = () => (
+-  <Text size={Text.KILO}>Hello</Text>
++  <Text size="kilo">Hello</Text>
+);
+```
+
+The affected components are: Badge, Blockquote, Button, ButtonGroup, Card, CardFooter, CardList.Item, Heading, InlineMessage, Input, List, MessageIcon, ModalFooter, NotificationIcon, Popover, ProgressBar, SubHeading, TableHeader, TableCell, Text, TextArea, and Tooltip.
+
+(🤖 _component-static-properties_)
 
 ### Removed components
 
@@ -82,45 +104,47 @@ React [`ref`s](https://reactjs.org/docs/refs-and-the-dom.html) allow you to acce
 - The **CardSchemes** and **PaymentMethodIcon** components have been removed. Use [@sumup/icons](https://www.npmjs.com/package/@sumup/icons) instead.
 - The **AutoCompleteInput** and **AutoCompleteTags** components have been removed. You can build them yourself using the SearchInput, Card, and Tag components.
 - The **MaskedInput** and **RestrictedInput** components have been removed. Use [react-text-mask](https://www.npmjs.com/package/react-text-mask) or a similar package directly instead.
-- The **Markdown** component has been removed. Use [markdown-to-jsx](https://www.npmjs.com/package/markdown-to-jsx) or a similar package directly instead.
+- The **Markdown** component has been removed. Use [markdown-to-jsx](https://www.npmjs.com/package/markdown-to-jsx) or a similar package instead.
 - The **State** component has been removed. Use React's [useState](https://reactjs.org/docs/hooks-reference.html#usestate) hook instead.
 - The **Picture** component has been removed. Use the native HTML `picture` element instead.
 
 ### Renamed components
 
-- 🤖 The **ListView** component has been renamed to **CardList**.
-- 🤖 The **SvgButton** component has been renamed to **IconButton**.
-- 🤖 The **Message** component has been renamed to **Notification**.
-- 🤖 The **InlineNotification** component has been renamed to **InlineMessage**.
-- 🤖 The **GlobalStyles** component has been renamed to **BaseStyles**.
+- The **ListView** component has been renamed to **CardList** (🤖 _component-names-v2_)
+- The **SvgButton** component has been renamed to **IconButton** (🤖 _component-names-v2_)
+- The **Message** component has been renamed to **Notification** (🤖 _component-names-v2_)
+- The **InlineNotification** component has been renamed to **InlineMessage** (🤖 _component-names-v2_)
+- The **GlobalStyles** component has been renamed to **BaseStyles** (🤖 _component-names-v2_)
 
 ### Changed components
 
 - The **GlobalStyles** component no longer accepts a `custom` prop. Use Emotion's [Global](https://emotion.sh/docs/globals) component instead.
-- The **RadioButton** and **Switch** components no longer accept the `onToggle` prop. Use the `onChange` prop instead (🤖 _onchange-prop_)
-- The **Input** and **Textarea** components no longer accept `*ClassName` props. Emotion 10 uses style objects instead of class names. Use the `*Styles` props instead.
 - The **Heading**, **SubHeading**, **Text**, and **Input** components no longer accept the `element` prop. Emotion 10 introduced the ability to change the HTML element. Use the `as` prop instead (🤖 _as-prop_)
-- The **Selector** component no longer accepts the `onClick` and `selected` props. Use the `onChange` and `checked` props instead (🤖 _selector-props_). The `value` and `name` have been added as required props.
-- The **RadioButtonGroup** component's `label` property inside the `options` prop has been renamed to `children`.
-- The **Hamburger** component's `light` prop has been removed. Set the color through CSS instead.
+- The **List** component's `ordered` prop has been replaced by the `variant` enum prop (🤖 _list-variant-enum_)
+- The **List** component's default size is now `mega` to match the Text component.
 - The `primary` and `secondary` **Button** boolean props have been removed. Use the `variant` enum prop instead (🤖 _button-variant-enum_)
 - The `plain` **Button** prop has been removed. Use the new Anchor component or the `tertiary` Button variant instead.
 - The `flat` **Button** variant has been removed (🤖 _button-variant-enum_)
 - The **LoadingButton**'s exit animations have been removed. An action's success or error result should be communicated outside the button (🤖 _exit-animations_)
-- The **Button** component doesn't have static properties anymore ...
-- combine label with form input components
-- The **List** component's `ordered` prop has been replaced by the `variant` enum prop (🤖 _list-variant-enum_)
-- The **List** component's default size is now `mega` to match the Text component.
-- 🤖 The **Heading** component doesn't export sizes anymore. Instead of writing `size={Heading.GIGA}`, write `size="giga"`. Button, Text ...
+- The **RadioButton** and **Switch** components no longer accept the `onToggle` prop. Use the `onChange` prop instead (🤖 _onchange-prop_)
+- The **Input** and **Textarea** components no longer accept `*ClassName` props. Emotion 10 uses style objects instead of class names. Use the `*Styles` props instead.
+- The **Selector** component no longer accepts the `onClick` and `selected` props. Use the `onChange` and `checked` props instead (🤖 _selector-props_). The `value` and `name` have been added as required props.
+- The **RadioButtonGroup** component's `label` property inside the `options` prop has been renamed to `children`.
+- The **Hamburger** component's `light` prop has been removed. Set the color through CSS instead.
+- (_in writing_) combine label with form input components
 
 ### Utilities
 
-- The currencyUtils and currencyAmountUtils have been removed. Use [@sumup/intl](https://www.npmjs.com/package/@sumup/intl) instead.
+(_in writing_)
+
+- The `currencyUtils` and `currencyAmountUtils` have been removed. Use [@sumup/intl](https://www.npmjs.com/package/@sumup/intl) instead.
 - The `shadowGround` and `textTera` style helpers have been removed.
 - The `shadowBorder` style helper has been removed. Use the [`box-shadow`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow) CSS property instead.
 - The unit style helpers have been removed. Use the CSS [`calc`](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) function instead.
 
 ### Changes to the theme
+
+(_in writing_)
 
 - 🤖? The themes have been moved to [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens). Import them from there instead.
 - 🤖 The `iconSizes.byte` theme value has been removed. Use `iconSizes.kilo` instead.
@@ -129,6 +153,8 @@ React [`ref`s](https://reactjs.org/docs/refs-and-the-dom.html) allow you to acce
 ---
 
 ## New features
+
+(_in writing_)
 
 components: Carousel and Step components (#482)
 components: add Anchor component (#583)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,136 @@
+# Migration
+
+- [Codemods](#-codemods)
+- [From v1.x to v2](#from-v1.x-to-v2)
+  - [Library format](#library-format)
+  - [Peer dependencies](#peer-dependencies)
+  - [Forward custom props and refs](#forward-custom-props-and-refs)
+  - [Removed components](#removed-components)
+  - [Renamed components](#renamed-components)
+  - [Changed components](#changed-components)
+  - [Utilities](#utilities)
+  - [Changes to the theme](#changes-to-the-theme)
+
+## 🤖 Codemods
+
+Some of the changes in this guide can be automated with _codemods_, small scripts that modify the source code automatically. Changes that can be codemodded are marked with a robot emoji (🤖) and the name of the transform (e.g. _button-props_). The codemods are built with [jscodeshift](https://github.com/facebook/jscodeshift) and can be run through the Circuit UI CLI. Here is an overview of all available options (you can view this help menu by running `yarn circuit-ui migrate --help`):
+
+```sh
+yarn circuit-ui migrate
+
+Automatically transforms your source code to Circuit UI's latest APIs
+
+Options:
+  --help           Show help                                           [boolean]
+  --version        Show version number                                 [boolean]
+  --transform, -t  The transform to be applied to the source code
+                                   [string] [required] [choices: "button-props"]
+  --language, -l   The programming language of the files to be transformed
+                       [string] [required] [choices: "TypeScript", "JavaScript"]
+  --path, -p       A path to the folder that contains the files to be
+                   transformed                           [string] [default: "."]
+```
+
+You can only run one codemod at a time and we encourage you to apply the transforms incrementally and review the changes before continuing. The codemods don't cover all edge cases, so further manual changes might be necessary.
+
+## From v1.x to v2
+
+### Library format
+
+Circuit UI is now compiled with TypeScript instead of Babel (#563, #597). ES and CJS versions are available as before, though this is not something you need to worry about since most bundlers pick the best format that they support automatically based on the `main` and `module` entries in `package.json`.
+
+Note, however, that some modern JavaScript syntax and language features are no longer pretranspiled. Tools such as [react-scripts v2+](https://github.com/facebook/create-react-app/tree/master/packages/react-scripts) and [Next.js](https://github.com/vercel/next.js) include `node_modules` in their transpilation process so Circuit UI works with them out of the box. If you have a custom build process, you should make sure that Circuit UI is transpiled like the rest of your source code.
+
+We recommend testing your application in your oldest supported browsers to verify that it still works.
+
+### Peer dependencies
+
+Circuit UI v1 included React and Emotion dependencies as direct dependencies. This could cause these dependencies to be bundled twice if your application specified a different version of React or Emotion.
+
+Circuit UI v2 moves these dependencies to peer dependencies, so Circuit UI will use whatever version your application specifies (#485). The minimum version of React has been bumped to 16.8+ to support hooks.
+
+If you haven't installed them already, you can do so by running the following command in your terminal:
+
+```sh
+# With yarn
+yarn add react react-dom @emotion/core @emotion/styled emotion-theming
+# With npm
+npm install --save react-dom @emotion/core @emotion/styled emotion-theming
+```
+
+In Circuit UI v2 some functionality has been extracted into separate packages for easier maintenance. The themes have been moved to [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens), the icons are available from [@sumup/icons](https://www.npmjs.com/package/@sumup/icons), and the number & currency utils have been completely rewritten in [@sumup/intl](https://www.npmjs.com/package/@sumup/intl). These packages are also marked as required peer dependencies. To install them, run the following command in your terminal:
+
+```sh
+# With yarn
+yarn add @sumup/design-tokens @sumup/icons @sumup/intl
+# With npm
+npm install --save @sumup/design-tokens @sumup/icons @sumup/intl
+```
+
+Refer to the individual packages for documentation on how to use them.
+
+### Forward custom props and refs
+
+Any additional props that are passed to a component are now spread on their outermost child element (#553). This is useful for test ids, data attributes, and custom styles using Emotion's `styled` function or `css` prop.
+
+React [`ref`s](https://reactjs.org/docs/refs-and-the-dom.html) allow you to access the underlying DOM node of a component. All Circuit UI components now forward `ref`s to the underlying DOM node (for single node components such as a Button) or to the main interactive DOM node (for composite components such as an Input) (#592).
+
+⚠️ _The ability to pass custom styles and `ref`s is meant as an escape hatch. We strongly recommend to avoid using them as we cannot guarantee that they will be compatible with future changes. Please open an issue or PR to suggest the improvement in Circuit UI instead._
+
+### Removed components
+
+- The **SideNav** component has been removed. Use the Sidebar component instead.
+- The **CreditCardDetails**, **CardNumberInput**, **NameOnCardInput**, **SecurityCodeInput**, **ExpiryDateInput**, and the credit card utils have been removed. Use [SumUp's card widget](https://developer.sumup.com/docs/widgets-card-v2) instead.
+- The **CardSchemes** and **PaymentMethodIcon** components have been removed. Use [@sumup/icons](https://www.npmjs.com/package/@sumup/icons) instead.
+- The **AutoCompleteInput** and **AutoCompleteTags** components have been removed. You can build them yourself using the SearchInput, Card, and Tag components.
+- The **MaskedInput** and **RestrictedInput** components have been removed. Use [react-text-mask](https://www.npmjs.com/package/react-text-mask) or a similar package directly instead.
+- The **Markdown** component has been removed. Use [markdown-to-jsx](https://www.npmjs.com/package/markdown-to-jsx) or a similar package directly instead.
+- The **State** component has been removed. Use React's [useState](https://reactjs.org/docs/hooks-reference.html#usestate) hook instead.
+- The **Picture** component has been removed. Use the native HTML `picture` element instead.
+
+### Renamed components
+
+- 🤖 The **ListView** component has been renamed to **CardList**.
+- 🤖 The **SvgButton** component has been renamed to **IconButton**.
+- 🤖 The **Message** component has been renamed to **Notification**.
+- 🤖 The **InlineNotification** component has been renamed to **InlineMessage**.
+- 🤖 The **GlobalStyles** component has been renamed to **BaseStyles**.
+
+### Changed components
+
+- The **GlobalStyles** component no longer accepts a `custom` prop. Use Emotion's [Global](https://emotion.sh/docs/globals) component instead.
+- 🤖 The **RadioButton** and **Switch** components no longer accept the `onToggle` prop. Use the `onChange` prop instead.
+- The **Input** and **Textarea** components no longer accept `*ClassName` props. Emotion 10 uses style objects instead of class names. Use the `*Styles` props instead.
+- 🤖 The **Heading**, **SubHeading**, **Text**, and **Input** components no longer accept the `element` prop. Emotion 10 introduced the ability to change the HTML element. Use the `as` prop instead.
+- 🤖 The **Selector** component no longer accepts the `onClick` and `selected` props. Use the `onChange` and `checked` props instead. The `value` and `name` have been added as required props.
+- The **RadioButtonGroup** component's `label` property inside the `options` prop has been renamed to `children`.
+- The **Hamburger** component's `light` prop has been removed. Set the color through CSS instead.
+- The **LoadingButton**'s exit animations have been removed. An action's success or error result should be communicated outside the button.
+- 🤖 The `flat` **Button** variant has been removed (🤖 _button props_)
+- The `plain` **Button** prop has been removed. Use the new Anchor component or the `tertiary` Button variant instead.
+- The **Button** component doesn't have static properties anymore ...
+- The `primary` and `secondary` **Button** boolean props have been removed. Use the `variant` enum prop instead (🤖 _button props_)
+- combine label with form input components
+- 🤖 The **List** component's `ordered` prop has been replaced by the `variant` enum prop.
+- The **List** component's default size is now `mega` to match the Text component.
+- 🤖 The Heading component doesn't export sizes anymore. Instead of writing `size={Heading.GIGA}`, write `size="giga"`. Button, Text ...
+
+### Utilities
+
+- The currencyUtils and currencyAmountUtils have been removed. Use [@sumup/intl](https://www.npmjs.com/package/@sumup/intl) instead.
+- The `shadowGround` and `textTera` style helpers have been removed.
+- The `shadowBorder` style helper has been removed. Use the [`box-shadow`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow) CSS property instead.
+- The unit style helpers have been removed. Use the CSS [`calc`](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) function instead.
+
+### Changes to the theme
+
+- 🤖? The themes have been moved to [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens). Import them from there instead.
+- 🤖 The `iconSizes.byte` theme value has been removed. Use `iconSizes.kilo` instead.
+- 🤖 The `grid.afterTera` theme value has been renamed to `grid.tera`.
+
+---
+
+## New features
+
+components: Carousel and Step components (#482)
+components: add Anchor component (#583)

--- a/README.md
+++ b/README.md
@@ -8,94 +8,20 @@
 
 </div>
 
-## Table of Contents <!-- omit in toc -->
-
-- [Getting started](#getting-started)
-- [Installation](#installation)
-- [Development](#development)
-- [Deployment](#deployment)
-- [Linting and formatting](#linting-and-formatting)
-- [Testing](#testing)
-- [Utils](#utils)
-- [Creating components](#creating-components)
-- [Code of conduct](#code-of-conduct)
-  - [Maintainers](#maintainers)
-- [Contributing](#contributing)
-- [About SumUp](#about-sumup)
-
-## Getting started
+## Quick start
 
 Here are a few helpful links for getting started with Circuit UI:
 
-- [Getting started](http://circuit.sumup.com/#/getting-started/developers) - Install and configure Circuit for your React app
-- [Styles](http://circuit.sumup.com/#/styles/colors) - Learn about our foundations such as colors, spacing, and typography.
-- [Guidelines](http://circuit.sumup.com/#/guidelines/content) - Use the design system in a compliant way.
-- [Components](http://circuit.sumup.com/#/components/badge) - Explore the available UI components.
+- [Documentation](https://circuit.sumup.com/) - Learn how to use Circuit UI and view the components in Storybook.
+- [Getting started](https://circuit.sumup.com/?path=/docs/introduction-getting-started--page) - Set up a new app with Circuit UI or add it to an existing project.
+- [Design Principles](https://circuit.sumup.com/?path=/docs/introduction-design-principles--page) - Discover the guiding principles behind Circuit UI's design.
+- [Theming](https://circuit.sumup.com/?path=/docs/advanced-theme--page) - Learn about our foundations such as colors, spacing, and typography.
+- [Contribute](https://circuit.sumup.com/?path=/docs/introduction-contributing--page) - File a bug report, suggest a change, or open a pull request.
 
-## Installation
+## Related projects
 
-```
-yarn add @sumup/circuit-ui
-```
-
-## Development
-
-```
-yarn && yarn start
-```
-
-## Deployment
-
-```
-yarn deploy
-```
-
-## Linting and formatting
-
-```
-yarn lint
-
-yarn lint:fix
-```
-
-## Testing
-
-```
-yarn test
-```
-
-```javascript
-import React from 'react';
-import Button from '.';
-
-describe('Button', () => {
-  it('should not render if there is no click handler, label, or children', () => {
-    const button = create(<Button />);
-    expect(button).toMatchSnapshot();
-  });
-  it('should take the body text as a child', () => {
-    const output = mount(<Button onClick={() => {}}>Hello World</Button>);
-    expect(output.text()).toContain('Hello World');
-  });
-});
-```
-
-## Utils
-
-Besides the component library, we also export some utilities which you
-might need in order to use the components. The three main ones:
-
-- `numbersUtils` - a module for dealing with number localization.
-- `currencyUtils` - a module for formatting currency amounts.
-- `styleHelpers` - a module containing helpers for writing styles.
-
-## Creating components
-
-This project uses [@sumup/foundry](https://www.npmjs.com/package/@sumup/foundry) and the provided `plop` command to generate new React components. The functionality is exposed as the `create-component` npm script from package.json.
-
-To create a new component, run `yarn create-component` inside the project. You'll see a CLI that guides you through the process.
-
-After the CLI has finished, all files will have been created in the location you specified.
+- **[create-sumup-react-app](https://github.com/sumup/create-sumup-react-app)** — bootstrap a new React app with [create-react-app](https://create-react-app.dev/), Circuit UI, and [Foundry](https://github.com/sumup-oss/foundry)
+- **[create-sumup-next-app](https://github.com/sumup/create-sumup-next-app)** — bootstrap a fresh [Next.js](https://nextjs.org/) app with Circuit UI and [Foundry](https://github.com/sumup-oss/foundry)
 
 ## Code of conduct
 

--- a/docs/introduction/welcome.story.mdx
+++ b/docs/introduction/welcome.story.mdx
@@ -67,7 +67,12 @@ Circuit UI follows semantic versioning. In short, this means we use patch versio
 
 - **[create-sumup-react-app](https://github.com/sumup/create-sumup-react-app)** — bootstrap a new React app with [create-react-app](https://create-react-app.dev/), Circuit UI, Prettier, and Jest
 - **[create-sumup-next-app](https://github.com/sumup/create-sumup-next-app)** — bootstrap a fresh [Next.js](https://nextjs.org/) app with SumUp's standard frontend toolchain
-- **[circuit-deck](https://github.com/sumup/circuit-deck)** — create presentations with [mdx-deck](https://github.com/jxnblk/mdx-deck) and Circuit UI
+
+## Code of conduct
+
+We want to foster an inclusive and friendly community around our Open Source efforts. Like all SumUp Open Source projects, this project follows the Contributor Covenant Code of Conduct. Please, [read it and follow it](Introduction/Code-of-Conduct).
+
+If you feel another member of the community violated our CoC or you are experiencing problems participating in our community because of another individual's behavior, please get in touch with our maintainers. We will enforce the CoC.
 
 ## About SumUp
 


### PR DESCRIPTION
## Purpose

The migration guide documents all the changes that users need to make in their application — manually or using a codemod — when they upgrade from Circuit UI v1 to v2.

## Approach and changes

- add [MIGRATION.md](https://github.com/sumup-oss/circuit-ui/blob/fdc87245e87b79be51b6ae22df412ff9cff1fb52/MIGRATION.md)
- simplify [README.md](https://github.com/sumup-oss/circuit-ui/blob/3c3a2f05cd705838ef430ff99784b67c7b90d77d/README.md)

_The migration guide is far from finished. Particularly the sections on the utilities and theme changes need additional details. We will add those before the stable release._

## Definition of done

* [x] Reviewers assigned
