### PR TITLE
feat(cli): add prop codemods

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,8 @@ module.exports = require('@sumup/foundry/eslint')(
         rules: {
           'import/no-unresolved': 'off',
           'notice/notice': 'off',
-          '@typescript-eslint/no-unused-vars': 'off'
+          '@typescript-eslint/no-unused-vars': 'off',
+          'prettier/prettier': 'off'
         }
       },
       {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,14 @@ module.exports = require('@sumup/foundry/eslint')(
           'notice/notice': 'off',
           '@typescript-eslint/no-unused-vars': 'off'
         }
+      },
+      {
+        files: ['src/cli/migrate/*.ts'],
+        rules: {
+          // jscodeshift expect no return value for files
+          // that should not be transformed.
+          'consistent-return': 'off'
+        }
       }
     ]
   }

--- a/src/cli/migrate/__testfixtures__/as-prop.input.js
+++ b/src/cli/migrate/__testfixtures__/as-prop.input.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Heading, SubHeading, Text, Input } from '@sumup/circuit-ui';
+
+const BaseHeading = () => <Heading element="h1" />;
+
+const RedHeading = styled(Heading)`
+  color: red;
+`;
+
+const StyledHeading = () => <RedHeading element="h1" />;
+
+const BaseSubHeading = () => <SubHeading element="h1" />;
+
+const RedSubHeading = styled(SubHeading)`
+  color: red;
+`;
+
+const StyledSubHeading = () => <RedSubHeading element="h1" />;
+
+const BaseText = () => <Text element="h1" />;
+
+const RedText = styled(Text)`
+  color: red;
+`;
+
+const StyledText = () => <RedText element="h1" />;
+
+const BaseInput = () => <Input element="h1" />;
+
+const RedInput = styled(Input)`
+  color: red;
+`;
+
+const StyledInput = () => <RedInput element="h1" />;

--- a/src/cli/migrate/__testfixtures__/as-prop.output.js
+++ b/src/cli/migrate/__testfixtures__/as-prop.output.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Heading, SubHeading, Text, Input } from '@sumup/circuit-ui';
+
+const BaseHeading = () => <Heading as="h1" />;
+
+const RedHeading = styled(Heading)`
+  color: red;
+`;
+
+const StyledHeading = () => <RedHeading as="h1" />;
+
+const BaseSubHeading = () => <SubHeading as="h1" />;
+
+const RedSubHeading = styled(SubHeading)`
+  color: red;
+`;
+
+const StyledSubHeading = () => <RedSubHeading as="h1" />;
+
+const BaseText = () => <Text as="h1" />;
+
+const RedText = styled(Text)`
+  color: red;
+`;
+
+const StyledText = () => <RedText as="h1" />;
+
+const BaseInput = () => <Input as="h1" />;
+
+const RedInput = styled(Input)`
+  color: red;
+`;
+
+const StyledInput = () => <RedInput as="h1" />;

--- a/src/cli/migrate/__testfixtures__/exit-animations.input.js
+++ b/src/cli/migrate/__testfixtures__/exit-animations.input.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { LoadingButton } from '@sumup/circuit-ui';
+
+const BaseLoadingButton = () => (
+  <LoadingButton
+    exitAnimation={LoadingButton.ERROR}
+    onAnimationComplete={console.log}
+    exitAnimationDuration={300}
+  />
+);
+
+const RedLoadingButton = styled(LoadingButton)`
+  color: red;
+`;
+
+const StyledLoadingButton = () => (
+  <RedLoadingButton
+    exitAnimation={LoadingButton.ERROR}
+    onAnimationComplete={console.log}
+    exitAnimationDuration={300}
+  />
+);

--- a/src/cli/migrate/__testfixtures__/exit-animations.output.js
+++ b/src/cli/migrate/__testfixtures__/exit-animations.output.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { LoadingButton } from '@sumup/circuit-ui';
+
+const BaseLoadingButton = () => (
+  <LoadingButton />
+);
+
+const RedLoadingButton = styled(LoadingButton)`
+  color: red;
+`;
+
+const StyledLoadingButton = () => (
+  <RedLoadingButton />
+);

--- a/src/cli/migrate/__testfixtures__/input-deepref-prop.input.js
+++ b/src/cli/migrate/__testfixtures__/input-deepref-prop.input.js
@@ -1,0 +1,17 @@
+import React, { useRef } from 'react';
+import styled from '@emotion/styled';
+import { Input } from '@sumup/circuit-ui';
+
+const Form = () => {
+  const ref = useRef(null);
+  return <Input deepRef={ref} />;
+};
+
+const RedInput = styled(Input)`
+  color: red;
+`;
+
+const RedForm = () => {
+  const ref = useRef(null);
+  return <RedInput deepRef={ref} />;
+};

--- a/src/cli/migrate/__testfixtures__/input-deepref-prop.output.js
+++ b/src/cli/migrate/__testfixtures__/input-deepref-prop.output.js
@@ -1,0 +1,17 @@
+import React, { useRef } from 'react';
+import styled from '@emotion/styled';
+import { Input } from '@sumup/circuit-ui';
+
+const Form = () => {
+  const ref = useRef(null);
+  return <Input ref={ref} />;
+};
+
+const RedInput = styled(Input)`
+  color: red;
+`;
+
+const RedForm = () => {
+  const ref = useRef(null);
+  return <RedInput ref={ref} />;
+};

--- a/src/cli/migrate/__testfixtures__/list-variant-enum.input.js
+++ b/src/cli/migrate/__testfixtures__/list-variant-enum.input.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { List, Text } from '@sumup/circuit-ui';
+
+const Ordered = () => <List ordered>primary</List>;
+
+const Unordered = () => <List unordered>Secondary</List>;
+
+const RedList = styled(List)`
+  color: red;
+`;
+
+const BlueList = styled(List)`
+  color: blue;
+`;
+
+const BlueText = styled(Text)`
+  color: blue;
+`;
+
+const Styled = () => (
+  <>
+    <RedList ordered>Ordered red</RedList>
+    <BlueList unordered>Unordered blue</BlueList>
+    <Text ordered>Text</Text>
+    <BlueText unordered>Text blue</BlueText>
+  </>
+);

--- a/src/cli/migrate/__testfixtures__/list-variant-enum.output.js
+++ b/src/cli/migrate/__testfixtures__/list-variant-enum.output.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { List, Text } from '@sumup/circuit-ui';
+
+const Ordered = () => <List variant="ordered">primary</List>;
+
+const Unordered = () => <List variant="unordered">Secondary</List>;
+
+const RedList = styled(List)`
+  color: red;
+`;
+
+const BlueList = styled(List)`
+  color: blue;
+`;
+
+const BlueText = styled(Text)`
+  color: blue;
+`;
+
+const Styled = () => (
+  <>
+    <RedList variant="ordered">Ordered red</RedList>
+    <BlueList variant="unordered">Unordered blue</BlueList>
+    <Text ordered>Text</Text>
+    <BlueText unordered>Text blue</BlueText>
+  </>
+);

--- a/src/cli/migrate/__testfixtures__/onchange-prop.input.js
+++ b/src/cli/migrate/__testfixtures__/onchange-prop.input.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { RadioButton, Switch } from '@sumup/circuit-ui';
+
+const BaseRadioButton = () => <RadioButton onToggle={console.log} checked />;
+
+const RedRadioButton = styled(RadioButton)`
+  color: red;
+`;
+
+const StyledRadioButton = () => (
+  <RedRadioButton onToggle={console.log} checked />
+);
+
+const BaseSwitch = () => <Switch onToggle={console.log} checked />;
+
+const RedSwitch = styled(Switch)`
+  color: red;
+`;
+
+const StyledSwitch = () => <RedSwitch onToggle={console.log} checked />;

--- a/src/cli/migrate/__testfixtures__/onchange-prop.output.js
+++ b/src/cli/migrate/__testfixtures__/onchange-prop.output.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { RadioButton, Switch } from '@sumup/circuit-ui';
+
+const BaseRadioButton = () => <RadioButton onChange={console.log} checked />;
+
+const RedRadioButton = styled(RadioButton)`
+  color: red;
+`;
+
+const StyledRadioButton = () => (
+  <RedRadioButton onChange={console.log} checked />
+);
+
+const BaseSwitch = () => <Switch onChange={console.log} checked />;
+
+const RedSwitch = styled(Switch)`
+  color: red;
+`;
+
+const StyledSwitch = () => <RedSwitch onChange={console.log} checked />;

--- a/src/cli/migrate/__testfixtures__/selector-props.input.js
+++ b/src/cli/migrate/__testfixtures__/selector-props.input.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Selector } from '@sumup/circuit-ui';
+
+const BaseSelector = () => <Selector onClick={console.log} selected />;
+
+const RedSelector = styled(Selector)`
+  color: red;
+`;
+
+const StyledSelector = () => <RedSelector onClick={console.log} selected />;

--- a/src/cli/migrate/__testfixtures__/selector-props.output.js
+++ b/src/cli/migrate/__testfixtures__/selector-props.output.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Selector } from '@sumup/circuit-ui';
+
+const BaseSelector = () => <Selector onChange={console.log} checked />;
+
+const RedSelector = styled(Selector)`
+  color: red;
+`;
+
+const StyledSelector = () => <RedSelector onChange={console.log} checked />;

--- a/src/cli/migrate/__tests__/transforms.spec.js
+++ b/src/cli/migrate/__tests__/transforms.spec.js
@@ -18,3 +18,4 @@ import { defineTest } from 'jscodeshift/dist/testUtils';
 jest.autoMockOff();
 
 defineTest(__dirname, 'button-variant-enum');
+defineTest(__dirname, 'list-variant-enum');

--- a/src/cli/migrate/__tests__/transforms.spec.js
+++ b/src/cli/migrate/__tests__/transforms.spec.js
@@ -20,3 +20,4 @@ jest.autoMockOff();
 defineTest(__dirname, 'button-variant-enum');
 defineTest(__dirname, 'list-variant-enum');
 defineTest(__dirname, 'onchange-prop');
+defineTest(__dirname, 'as-prop');

--- a/src/cli/migrate/__tests__/transforms.spec.js
+++ b/src/cli/migrate/__tests__/transforms.spec.js
@@ -19,3 +19,4 @@ jest.autoMockOff();
 
 defineTest(__dirname, 'button-variant-enum');
 defineTest(__dirname, 'list-variant-enum');
+defineTest(__dirname, 'onchange-prop');

--- a/src/cli/migrate/__tests__/transforms.spec.js
+++ b/src/cli/migrate/__tests__/transforms.spec.js
@@ -22,3 +22,4 @@ defineTest(__dirname, 'list-variant-enum');
 defineTest(__dirname, 'onchange-prop');
 defineTest(__dirname, 'as-prop');
 defineTest(__dirname, 'selector-props');
+defineTest(__dirname, 'exit-animations');

--- a/src/cli/migrate/as-prop.ts
+++ b/src/cli/migrate/as-prop.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform, JSCodeshift, Collection } from 'jscodeshift';
+
+import { renameJSXAttribute, findLocalNames } from './utils';
+
+function transformFactory(
+  j: JSCodeshift,
+  root: Collection,
+  componentName: string
+): void {
+  const components = findLocalNames(j, root, componentName);
+
+  if (!components) {
+    return;
+  }
+
+  components.forEach(component => {
+    renameJSXAttribute(j, root, component, 'element', 'as');
+  });
+}
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  ['Heading', 'SubHeading', 'Text', 'Input'].forEach(componentName => {
+    transformFactory(j, root, componentName);
+  });
+
+  return root.toSource();
+};
+
+export default transform;

--- a/src/cli/migrate/button-variant-enum.ts
+++ b/src/cli/migrate/button-variant-enum.ts
@@ -15,26 +15,18 @@
 
 import { Transform, JSCodeshift, Collection } from 'jscodeshift';
 
-import { findImportsByPath, findStyledComponentNames } from './utils';
+import { findLocalNames } from './utils';
 
 function transformFactory(
   j: JSCodeshift,
   root: Collection,
   buttonName: string
 ): void {
-  const imports = findImportsByPath(j, root, '@sumup/circuit-ui');
+  const components = findLocalNames(j, root, buttonName);
 
-  const buttonImport = imports.find(i => i.name === buttonName);
-
-  if (!buttonImport) {
+  if (!components) {
     return;
   }
-
-  const localName = buttonImport.local;
-
-  const styledButtons = findStyledComponentNames(j, root, localName);
-
-  const components = [localName, ...styledButtons];
 
   components.forEach(component => {
     // Change variants from boolean to enum prop

--- a/src/cli/migrate/exit-animations.ts
+++ b/src/cli/migrate/exit-animations.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform } from 'jscodeshift';
+
+import { findLocalNames } from './utils';
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const components = findLocalNames(j, root, 'LoadingButton');
+
+  if (!components) {
+    return;
+  }
+
+  components.forEach(component => {
+    ['exitAnimation', 'exitAnimationDuration', 'onAnimationComplete'].forEach(
+      prop => {
+        root
+          .findJSXElements(component)
+          .find(j.JSXAttribute, {
+            name: {
+              type: 'JSXIdentifier',
+              name: prop
+            }
+          })
+          .remove();
+      }
+    );
+  });
+
+  return root.toSource();
+};
+
+export default transform;

--- a/src/cli/migrate/input-deepref-prop.ts
+++ b/src/cli/migrate/input-deepref-prop.ts
@@ -13,14 +13,25 @@
  * limitations under the License.
  */
 
-import { defineTest } from 'jscodeshift/dist/testUtils';
+import { Transform } from 'jscodeshift';
 
-jest.autoMockOff();
+import { renameJSXAttribute, findLocalNames } from './utils';
 
-defineTest(__dirname, 'button-variant-enum');
-defineTest(__dirname, 'list-variant-enum');
-defineTest(__dirname, 'onchange-prop');
-defineTest(__dirname, 'as-prop');
-defineTest(__dirname, 'selector-props');
-defineTest(__dirname, 'exit-animations');
-defineTest(__dirname, 'input-deepref-prop');
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const components = findLocalNames(j, root, 'Input');
+
+  if (!components) {
+    return;
+  }
+
+  components.forEach(component => {
+    renameJSXAttribute(j, root, component, 'deepRef', 'ref');
+  });
+
+  return root.toSource();
+};
+
+export default transform;

--- a/src/cli/migrate/list-variant-enum.ts
+++ b/src/cli/migrate/list-variant-enum.ts
@@ -15,25 +15,17 @@
 
 import { Transform } from 'jscodeshift';
 
-import { findImportsByPath, findStyledComponentNames } from './utils';
+import { findLocalNames } from './utils';
 
 const transform: Transform = (file, api) => {
   const j = api.jscodeshift;
   const root = j(file.source);
 
-  const imports = findImportsByPath(j, root, '@sumup/circuit-ui');
+  const components = findLocalNames(j, root, 'List');
 
-  const listImport = imports.find(i => i.name === 'List');
-
-  if (!listImport) {
-    return;
+  if (!components) {
+    return null;
   }
-
-  const localName = listImport.local;
-
-  const styledList = findStyledComponentNames(j, root, localName);
-
-  const components = [localName, ...styledList];
 
   components.forEach(component => {
     // Change variants from boolean to enum prop

--- a/src/cli/migrate/list-variant-enum.ts
+++ b/src/cli/migrate/list-variant-enum.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform } from 'jscodeshift';
+
+import { findImportsByPath, findStyledComponentNames } from './utils';
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const imports = findImportsByPath(j, root, '@sumup/circuit-ui');
+
+  const listImport = imports.find(i => i.name === 'List');
+
+  if (!listImport) {
+    return;
+  }
+
+  const localName = listImport.local;
+
+  const styledList = findStyledComponentNames(j, root, localName);
+
+  const components = [localName, ...styledList];
+
+  components.forEach(component => {
+    // Change variants from boolean to enum prop
+    ['ordered', 'unordered'].forEach(variant => {
+      root
+        .findJSXElements(component)
+        .find(j.JSXAttribute, {
+          name: {
+            type: 'JSXIdentifier',
+            name: variant
+          }
+        })
+        .replaceWith(() =>
+          j.jsxAttribute(j.jsxIdentifier('variant'), j.stringLiteral(variant))
+        );
+    });
+  });
+
+  return root.toSource();
+};
+
+export default transform;

--- a/src/cli/migrate/onchange-prop.ts
+++ b/src/cli/migrate/onchange-prop.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform, JSCodeshift, Collection } from 'jscodeshift';
+
+import { renameJSXAttribute, findLocalNames } from './utils';
+
+function transformFactory(
+  j: JSCodeshift,
+  root: Collection,
+  componentName: string
+): void {
+  const components = findLocalNames(j, root, componentName);
+
+  if (!components) {
+    return;
+  }
+
+  components.forEach(component => {
+    renameJSXAttribute(j, root, component, 'onToggle', 'onChange');
+  });
+}
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  transformFactory(j, root, 'RadioButton');
+  transformFactory(j, root, 'Switch');
+
+  return root.toSource();
+};
+
+export default transform;

--- a/src/cli/migrate/selector-props.ts
+++ b/src/cli/migrate/selector-props.ts
@@ -13,12 +13,26 @@
  * limitations under the License.
  */
 
-import { defineTest } from 'jscodeshift/dist/testUtils';
+import { Transform } from 'jscodeshift';
 
-jest.autoMockOff();
+import { renameJSXAttribute, findLocalNames } from './utils';
 
-defineTest(__dirname, 'button-variant-enum');
-defineTest(__dirname, 'list-variant-enum');
-defineTest(__dirname, 'onchange-prop');
-defineTest(__dirname, 'as-prop');
-defineTest(__dirname, 'selector-props');
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const components = findLocalNames(j, root, 'Selector');
+
+  if (!components) {
+    return;
+  }
+
+  components.forEach(component => {
+    renameJSXAttribute(j, root, component, 'onClick', 'onChange');
+    renameJSXAttribute(j, root, component, 'selected', 'checked');
+  });
+
+  return root.toSource();
+};
+
+export default transform;

--- a/src/cli/migrate/utils/index.ts
+++ b/src/cli/migrate/utils/index.ts
@@ -113,3 +113,22 @@ export function findLocalNames(
   return [localName, ...styledButtons];
 }
 
+export function renameJSXAttribute(
+  j: JSCodeshift,
+  root: Collection,
+  componentName: string,
+  fromName: string,
+  toName: string
+): void {
+  root
+    .findJSXElements(componentName)
+    .find(j.JSXAttribute, {
+      name: {
+        type: 'JSXIdentifier',
+        name: fromName
+      }
+    })
+    .replaceWith(nodePath =>
+      j.jsxAttribute(j.jsxIdentifier(toName), nodePath.node.value)
+    );
+}

--- a/src/cli/migrate/utils/index.ts
+++ b/src/cli/migrate/utils/index.ts
@@ -92,3 +92,24 @@ export function findStyledComponentNames(
 
   return styledComponents;
 }
+
+export function findLocalNames(
+  j: JSCodeshift,
+  root: Collection,
+  componentName: string
+): string[] | null {
+  const imports = findImportsByPath(j, root, '@sumup/circuit-ui');
+
+  const buttonImport = imports.find(i => i.name === componentName);
+
+  if (!buttonImport) {
+    return null;
+  }
+
+  const localName = buttonImport.local;
+
+  const styledButtons = findStyledComponentNames(j, root, localName);
+
+  return [localName, ...styledButtons];
+}
+


### PR DESCRIPTION
Follow-up to #596. 

## Purpose

Circuit UI v2 comes with a lot of breaking changes — most small and component-specific, but together they add up to a lot of manual work for the users. We can automate these changes with _codemods_, small scripts that modify the source code automatically.

**This PR focuses on prop related codemods.** Other codemods will come in follow-up PRs.

## Approach and changes

- add codemod to change List boolean props to enum prop
- add codemod to rename `onChange` props for RadioButton and Switch
- add codemod to rename `as` prop for Heading, SubHeading, Text, and Input
- add codemod to rename `onChange` and `checked` props for Selector
- add codemod to remove exit animations from LoadingButton
- add codemod to rename `ref` prop for Input

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
