### PR TITLE
refactor(components): remove React.FC

### DIFF
--- a/src/components/Anchor/Anchor.story.tsx
+++ b/src/components/Anchor/Anchor.story.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
 import Anchor from '.';
 import docs from './Anchor.docs.mdx';
@@ -26,12 +26,12 @@ export default {
   }
 };
 
-export const AsLink: FunctionComponent = () => (
+export const AsLink = () => (
   <Anchor href="https://opensource.sumup.com">
     {`View SumUp's OSS projects`}
   </Anchor>
 );
 
-export const AsButton: FunctionComponent = () => (
+export const AsButton = () => (
   <Anchor onClick={() => alert('Hello')}>Say hello</Anchor>
 );

--- a/src/components/Badge/Badge.story.tsx
+++ b/src/components/Badge/Badge.story.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React, { FunctionComponent, Fragment } from 'react';
+import React, { Fragment } from 'react';
 import { select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
@@ -28,7 +28,7 @@ export default {
   }
 };
 
-export const base: FunctionComponent = () => (
+export const base = () => (
   <Badge
     color={select(
       'Color',
@@ -40,7 +40,7 @@ export const base: FunctionComponent = () => (
   </Badge>
 );
 
-export const colors: FunctionComponent = () => (
+export const colors = () => (
   <Fragment>
     <Badge color={'neutral'}>Neutral</Badge>
     <Badge color={'primary'}>Primary</Badge>
@@ -50,13 +50,13 @@ export const colors: FunctionComponent = () => (
   </Fragment>
 );
 
-export const circular: FunctionComponent = () => (
+export const circular = () => (
   <Badge color={'primary'} circle={boolean('Circular', true)}>
     42
   </Badge>
 );
 
-export const clickable: FunctionComponent = () => (
+export const clickable = () => (
   <Badge color={'primary'} onClick={action('onClick')} as="button">
     Click me
   </Badge>

--- a/src/components/Hamburger/Hamburger.tsx
+++ b/src/components/Hamburger/Hamburger.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React, { FC, HTMLProps } from 'react';
+import React, { HTMLProps } from 'react';
 import { css } from '@emotion/core';
 
 import styled, { StyleProps } from '../../styles/styled';
@@ -126,7 +126,7 @@ const Layers = styled('span')<{ isActive?: boolean }>(
 /**
  * A hamburger button for menus. Morphs into a close icon when active.
  */
-export const Hamburger: FC<HamburgerProps> = ({
+export const Hamburger = ({
   isActive,
   labelActive = 'Close menu',
   labelInActive = 'Open menu',

--- a/src/components/ValidationHint/ValidationHint.tsx
+++ b/src/components/ValidationHint/ValidationHint.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React, { FC, HTMLProps } from 'react';
+import React, { HTMLProps } from 'react';
 import { css } from '@emotion/core';
 import { CircleCheckmark, CircleWarning, CircleCross } from '@sumup/icons';
 import { Theme } from '@sumup/design-tokens';
@@ -83,10 +83,10 @@ const getIcon = (state: ValidationHintProps) => {
 /**
  * @private
  */
-export const ValidationHint: FC<ValidationHintProps> = ({
+export const ValidationHint = ({
   validationHint,
   ...props
-}) => {
+}: ValidationHintProps) => {
   if (!validationHint) {
     return null;
   }


### PR DESCRIPTION
Addresses https://github.com/sumup-oss/circuit-ui/pull/615#discussion_r442273911.

## Purpose

> React.FC is unnecessary: it provides next to no benefits and has a few downsides. (See below.) I see a lot of beginners to TS+React using it, however, and I think that it's usage in this template is a contributing factor to that, as the prominence of this template makes it a de facto source of "best practice".

From https://github.com/facebook/create-react-app/pull/8177

## Approach and changes

- remove all unnecessary uses of React.FC and React.FunctionComponent

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
