### PR TITLE
feat(utils): add Colombia number and currency formats

### DIFF
--- a/src/util/currency.js
+++ b/src/util/currency.js
@@ -105,6 +105,10 @@ export const CURRENCY_FORMATS = {
   HRK: {
     'hr-HR': { prependSymbol: false, fractionalPrecision: 2, addSpace: true },
     default: { prependSymbol: false, fractionalPrecision: 2, addSpace: true }
+  },
+  COP: {
+    default: { prependSymbol: true, fractionalPrecision: 2, addSpace: false },
+    'es-CO': { prependSymbol: true, fractionalPrecision: 2, addSpace: false }
   }
 };
 
@@ -124,7 +128,8 @@ export const CURRENCY_SYMBOLS = {
   HUF: 'Ft',
   NOK: 'kr',
   RON: 'Lei',
-  HRK: 'kn'
+  HRK: 'kn',
+  COP: '$'
 };
 
 function prependSymbol(amount, symbol, addSpace) {

--- a/src/util/currency.spec.js
+++ b/src/util/currency.spec.js
@@ -216,6 +216,11 @@ describe('currency', () => {
       testCurrency(inputs, 'CLP', 'es-CL', outputs);
     });
 
+    it('should localize COP', () => {
+      const outputs = ['$11,23', '$1.000,00', '$0,98'];
+      testCurrency(inputs, 'COP', 'es-CO', outputs);
+    });
+
     it('should localize BGN', () => {
       const outputs = ['11,23\xA0лв.', '1\xA0000,00\xA0лв.', '0,98\xA0лв.'];
       testCurrency(inputs, 'BGN', 'bg-BG', outputs);

--- a/src/util/numbers.js
+++ b/src/util/numbers.js
@@ -30,6 +30,7 @@ export const NUMBER_SEPARATORS = {
   'en-MT': { decimal: '.', thousand: ',' },
   'en-US': { decimal: '.', thousand: ',' },
   'es-CL': { decimal: ',', thousand: '.' },
+  'es-CO': { decimal: ',', thousand: '.' },
   'es-ES': { decimal: ',', thousand: '.' },
   'et-EE': { decimal: '.', thousand: '\xA0' },
   'fi-FI': { decimal: ',', thousand: '\xA0' },

--- a/src/util/numbers.spec.js
+++ b/src/util/numbers.spec.js
@@ -120,7 +120,8 @@ describe('numbers', () => {
       'ru-RU': '1\xA0000,00',
       'sl-SI': '1.000,00',
       'sk-SK': '1\xA0000,00',
-      'sv-SE': '1\xA0000,00'
+      'sv-SE': '1\xA0000,00',
+      'es-CO': '1.000,00'
     };
     locales.forEach(locale => {
       it(`should localize ${number} to ${


### PR DESCRIPTION
## Purpose

We need to support colombian currency and number formats.

Formats are taken from:
https://www.freeformatter.com/colombia-standards-code-snippets.html

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
