### PR TITLE
feat(components): update Badge design

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -114,6 +114,7 @@ The affected components are: Badge, Blockquote, Button, ButtonGroup, Card, CardF
 - The **Heading**, **SubHeading**, **Text**, and **Input** components no longer accept the `element` prop. Emotion 10 introduced the ability to change the HTML element. Use the `as` prop instead (🤖 _as-prop_)
 - The **List** component's `ordered` prop has been replaced by the `variant` enum prop (🤖 _list-variant-enum_)
 - The **List** component's default size is now `mega` to match the Text component.
+- The **Badge** component's `color` prop has been renamed to `variant` (🤖 _badge-variant-enum_)
 - The `primary` and `secondary` **Button** boolean props have been removed. Use the `variant` enum prop instead (🤖 _button-variant-enum_)
 - The `plain` **Button** prop has been removed. Use the new Anchor component or the `tertiary` Button variant instead.
 - The `flat` **Button** variant has been removed (🤖 _button-variant-enum_)

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -107,48 +107,6 @@ exports[`Storyshots Components/Badge Circular 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Badge Clickable 1`] = `
-.circuit-0 {
-  border-radius: 999999px;
-  color: #FFFFFF;
-  display: inline-block;
-  padding: 2px 8px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 700;
-  text-align: center;
-  -webkit-letter-spacing: 0.25px;
-  -moz-letter-spacing: 0.25px;
-  -ms-letter-spacing: 0.25px;
-  letter-spacing: 0.25px;
-  background-color: #D8DDE1;
-  color: #0F131A;
-  border: 0;
-  outline: 0;
-  cursor: pointer;
-}
-
-.circuit-0:hover,
-.circuit-0:active {
-  background-color: #9DA7B1;
-}
-
-.circuit-0:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0:focus::-moz-focus-inner {
-  border: 0;
-}
-
-<button
-  class="circuit-0"
->
-  Click me
-</button>
-`;
-
 exports[`Storyshots Components/Badge Colors 1`] = `
 HTMLCollection [
   .circuit-0 {

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -48,17 +48,17 @@ exports[`Storyshots Components/Badge Base 1`] = `
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #9DA7B1;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #D8DDE1;
+  color: #0F131A;
 }
 
 <div
@@ -73,17 +73,17 @@ exports[`Storyshots Components/Badge Circular 1`] = `
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #3388FF;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #D8DDE1;
+  color: #0F131A;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -112,28 +112,25 @@ exports[`Storyshots Components/Badge Clickable 1`] = `
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #3388FF;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #D8DDE1;
+  color: #0F131A;
   border: 0;
   outline: 0;
   cursor: pointer;
 }
 
-.circuit-0:hover {
-  background-color: #1760CE;
-}
-
+.circuit-0:hover,
 .circuit-0:active {
-  background-color: #003C8B;
+  background-color: #9DA7B1;
 }
 
 .circuit-0:focus {
@@ -158,17 +155,17 @@ HTMLCollection [
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #9DA7B1;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #D8DDE1;
+  color: #0F131A;
 }
 
 <div
@@ -180,17 +177,17 @@ HTMLCollection [
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
   background-color: #3388FF;
+  color: #FFFFFF;
 }
 
 <div
@@ -202,17 +199,17 @@ HTMLCollection [
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #8CC13F;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #47995A;
+  color: #FFFFFF;
 }
 
 <div
@@ -224,17 +221,17 @@ HTMLCollection [
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #D8A413;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #F6CC1B;
+  color: #0F131A;
 }
 
 <div
@@ -246,17 +243,17 @@ HTMLCollection [
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
   background-color: #DB4D4D;
+  color: #FFFFFF;
 }
 
 <div
@@ -12890,51 +12887,51 @@ exports[`Storyshots Components/Table With Component Rows 1`] = `
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #8CC13F;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #47995A;
+  color: #FFFFFF;
 }
 
 .circuit-32 {
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #D8A413;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #F6CC1B;
+  color: #0F131A;
 }
 
 .circuit-14 {
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
   background-color: #DB4D4D;
+  color: #FFFFFF;
 }
 
 .circuit-41 {

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -107,7 +107,7 @@ exports[`Storyshots Components/Badge Circular 1`] = `
 </div>
 `;
 
-exports[`Storyshots Components/Badge Colors 1`] = `
+exports[`Storyshots Components/Badge Variants 1`] = `
 HTMLCollection [
   .circuit-0 {
   border-radius: 999999px;
@@ -12819,40 +12819,6 @@ tbody .circuit-18:last-child td {
 `;
 
 exports[`Storyshots Components/Table With Component Rows 1`] = `
-.circuit-23 {
-  border-radius: 999999px;
-  color: #FFFFFF;
-  display: inline-block;
-  padding: 2px 8px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 700;
-  text-align: center;
-  -webkit-letter-spacing: 0.25px;
-  -moz-letter-spacing: 0.25px;
-  -ms-letter-spacing: 0.25px;
-  letter-spacing: 0.25px;
-  background-color: #47995A;
-  color: #FFFFFF;
-}
-
-.circuit-32 {
-  border-radius: 999999px;
-  color: #FFFFFF;
-  display: inline-block;
-  padding: 2px 8px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 700;
-  text-align: center;
-  -webkit-letter-spacing: 0.25px;
-  -moz-letter-spacing: 0.25px;
-  -ms-letter-spacing: 0.25px;
-  letter-spacing: 0.25px;
-  background-color: #F6CC1B;
-  color: #0F131A;
-}
-
 .circuit-14 {
   border-radius: 999999px;
   color: #FFFFFF;
@@ -12866,8 +12832,8 @@ exports[`Storyshots Components/Table With Component Rows 1`] = `
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #DB4D4D;
-  color: #FFFFFF;
+  background-color: #D8DDE1;
+  color: #0F131A;
 }
 
 .circuit-41 {
@@ -13097,6 +13063,7 @@ tbody .circuit-6:last-child td {
           >
             <div
               class="circuit-14"
+              color="danger"
             >
               Fruit
             </div>
@@ -13125,7 +13092,8 @@ tbody .circuit-6:last-child td {
             data-testid="table-cell"
           >
             <div
-              class="circuit-23"
+              class="circuit-14"
+              color="success"
             >
               Vegetable
             </div>
@@ -13154,7 +13122,8 @@ tbody .circuit-6:last-child td {
             data-testid="table-cell"
           >
             <div
-              class="circuit-32"
+              class="circuit-14"
+              color="warning"
             >
               Legume
             </div>

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -69,7 +69,8 @@ exports[`Storyshots Components/Badge Base 1`] = `
 `;
 
 exports[`Storyshots Components/Badge Circular 1`] = `
-.circuit-0 {
+HTMLCollection [
+  .circuit-0 {
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
@@ -96,15 +97,91 @@ exports[`Storyshots Components/Badge Circular 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  padding: 2px 4px;
   height: 24px;
   width: 24px;
 }
 
 <div
-  class="circuit-0"
->
-  42
-</div>
+    class="circuit-0"
+  >
+    1
+  </div>,
+  .circuit-0 {
+  border-radius: 999999px;
+  color: #FFFFFF;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #D8DDE1;
+  color: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 2px 4px;
+  height: 24px;
+  width: 24px;
+}
+
+<div
+    class="circuit-0"
+  >
+    42
+  </div>,
+  .circuit-0 {
+  border-radius: 999999px;
+  color: #FFFFFF;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #D8DDE1;
+  color: #0F131A;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 2px 4px;
+  height: 24px;
+  width: auto;
+}
+
+<div
+    class="circuit-0"
+  >
+    999
+  </div>,
+]
 `;
 
 exports[`Storyshots Components/Badge Variants 1`] = `

--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -144,28 +144,6 @@ HTMLCollection [
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #3388FF;
-  color: #FFFFFF;
-}
-
-<div
-    class="circuit-0"
-  >
-    Primary
-  </div>,
-  .circuit-0 {
-  border-radius: 999999px;
-  color: #FFFFFF;
-  display: inline-block;
-  padding: 2px 8px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 700;
-  text-align: center;
-  -webkit-letter-spacing: 0.25px;
-  -moz-letter-spacing: 0.25px;
-  -ms-letter-spacing: 0.25px;
-  letter-spacing: 0.25px;
   background-color: #47995A;
   color: #FFFFFF;
 }

--- a/src/cli/migrate/__testfixtures__/badge-variant-enum.input.js
+++ b/src/cli/migrate/__testfixtures__/badge-variant-enum.input.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Badge } from '@sumup/circuit-ui';
+
+const Primary = () => <Badge color="primary">primary</Badge>;
+const Neutral = () => <Badge color="neutral">neutral</Badge>;
+const Warning = () => <Badge color="warning">warning</Badge>;
+const Success = () => <Badge color="success">success</Badge>;
+const Danger = () => <Badge color="danger">danger</Badge>;
+
+const RedBadge = styled(Badge)`
+  color: red;
+`;
+
+const Styled = () => <RedBadge color="danger">Styled</RedBadge>;

--- a/src/cli/migrate/__testfixtures__/badge-variant-enum.output.js
+++ b/src/cli/migrate/__testfixtures__/badge-variant-enum.output.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Badge } from '@sumup/circuit-ui';
+
+const Primary = () => <Badge variant="primary">primary</Badge>;
+const Neutral = () => <Badge variant="neutral">neutral</Badge>;
+const Warning = () => <Badge variant="warning">warning</Badge>;
+const Success = () => <Badge variant="success">success</Badge>;
+const Danger = () => <Badge variant="danger">danger</Badge>;
+
+const RedBadge = styled(Badge)`
+  color: red;
+`;
+
+const Styled = () => <RedBadge variant="danger">Styled</RedBadge>;

--- a/src/cli/migrate/__tests__/transforms.spec.js
+++ b/src/cli/migrate/__tests__/transforms.spec.js
@@ -28,3 +28,4 @@ defineTest(__dirname, 'input-styles-prop');
 defineTest(__dirname, 'component-names-v2');
 defineTest(__dirname, 'component-static-properties');
 defineTest(__dirname, 'toggle-checked-prop');
+defineTest(__dirname, 'badge-variant-enum');

--- a/src/cli/migrate/badge-variant-enum.ts
+++ b/src/cli/migrate/badge-variant-enum.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform } from 'jscodeshift';
+
+import { renameJSXAttribute, findLocalNames } from './utils';
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const components = findLocalNames(j, root, 'Badge');
+
+  if (!components) {
+    return;
+  }
+
+  components.forEach(component => {
+    renameJSXAttribute(j, root, component, 'color', 'variant');
+  });
+
+  return root.toSource();
+};
+
+export default transform;

--- a/src/components/Badge/Badge.docs.mdx
+++ b/src/components/Badge/Badge.docs.mdx
@@ -1,5 +1,5 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import Badge from './Badge';
+import { Badge } from './Badge';
 
 # Badge
 
@@ -8,7 +8,6 @@ import Badge from './Badge';
 Badges are non-actionable elements in the UI, used to indicate the status of an object.
 
 <Story id="components-badge--base" />
-
 <Props of={Badge} />
 
 ## Best practices
@@ -22,9 +21,7 @@ Badges are non-actionable elements in the UI, used to indicate the status of an 
 - **Do** use badges to indicate the status of data rows in a table.
 - **Do** use badges to bring attention to a specific area on the screen (like a
   new feature).
-- **Do not** use badges to indicate default statuses (e.g. in the Transaction
-  History, a transaction should only include a status if it's anything other
-  than default; failed, refunded, paid out, etc.)
+- **Do not** use badges to indicate default statuses (e.g. in the Transaction History, a transaction should only include a status if it's anything other than default; failed, refunded, paid out, etc.)
 
 ## Component variations
 

--- a/src/components/Badge/Badge.docs.mdx
+++ b/src/components/Badge/Badge.docs.mdx
@@ -36,9 +36,3 @@ The badges come in a number of colors based on their semantic meaning.
 Badges that receive the `circle` prop can be used to indicate notifications.
 
 <Story id="components-badge--circular" />
-
-### Clickable badges
-
-Badges that receive the `onClick` prop can be interacted with.
-
-<Story id="components-badge--clickable" />

--- a/src/components/Badge/Badge.docs.mdx
+++ b/src/components/Badge/Badge.docs.mdx
@@ -25,11 +25,11 @@ Badges are non-actionable elements in the UI, used to indicate the status of an 
 
 ## Component variations
 
-### Semantic badges
+### Colors
 
 The badges come in a number of colors based on their semantic meaning.
 
-<Story id="components-badge--colors" />
+<Story id="components-badge--variants" />
 
 ### Circular badges
 

--- a/src/components/Badge/Badge.spec.tsx
+++ b/src/components/Badge/Badge.spec.tsx
@@ -35,26 +35,24 @@ describe('Badge', () => {
     expect(actual).toMatchSnapshot();
   });
 
-  describe('rendering color variations', () => {
-    it('should render with success colors', () => {
-      const actual = create(<Badge color={'success'} />);
-      expect(actual).toMatchSnapshot();
-    });
+  it('should render with success styles', () => {
+    const actual = create(<Badge variant="success" />);
+    expect(actual).toMatchSnapshot();
+  });
 
-    it('should render with warning colors', () => {
-      const actual = create(<Badge color={'warning'} />);
-      expect(actual).toMatchSnapshot();
-    });
+  it('should render with warning styles', () => {
+    const actual = create(<Badge variant="warning" />);
+    expect(actual).toMatchSnapshot();
+  });
 
-    it('should render with danger colors', () => {
-      const actual = create(<Badge color={'danger'} />);
-      expect(actual).toMatchSnapshot();
-    });
+  it('should render with danger styles', () => {
+    const actual = create(<Badge variant="danger" />);
+    expect(actual).toMatchSnapshot();
+  });
 
-    it('should render with primary colors', () => {
-      const actual = create(<Badge color={'primary'} />);
-      expect(actual).toMatchSnapshot();
-    });
+  it('should render with primary styles', () => {
+    const actual = create(<Badge variant="primary" />);
+    expect(actual).toMatchSnapshot();
   });
 
   it('should have hover/active styles only when the onClick handler is provided', () => {

--- a/src/components/Badge/Badge.spec.tsx
+++ b/src/components/Badge/Badge.spec.tsx
@@ -24,7 +24,7 @@ import {
   userEvent
 } from '../../util/test-utils';
 
-import Badge from '.';
+import { Badge } from './Badge';
 
 describe('Badge', () => {
   /**

--- a/src/components/Badge/Badge.story.tsx
+++ b/src/components/Badge/Badge.story.tsx
@@ -29,8 +29,8 @@ export default {
 
 const BaseBadge = (props: Partial<BadgeProps>) => (
   <Badge
-    color={select(
-      'Color',
+    variant={select(
+      'Variant',
       ['neutral', 'success', 'warning', 'danger'],
       'neutral'
     )}
@@ -41,12 +41,12 @@ const BaseBadge = (props: Partial<BadgeProps>) => (
 
 export const base = () => <BaseBadge>Badge</BaseBadge>;
 
-export const colors = () => (
+export const variants = () => (
   <Fragment>
-    <BaseBadge color="neutral">Neutral</BaseBadge>
-    <BaseBadge color="success">Success</BaseBadge>
-    <BaseBadge color="warning">Warning</BaseBadge>
-    <BaseBadge color="danger">Danger</BaseBadge>
+    <BaseBadge variant="neutral">Neutral</BaseBadge>
+    <BaseBadge variant="success">Success</BaseBadge>
+    <BaseBadge variant="warning">Warning</BaseBadge>
+    <BaseBadge variant="danger">Danger</BaseBadge>
   </Fragment>
 );
 

--- a/src/components/Badge/Badge.story.tsx
+++ b/src/components/Badge/Badge.story.tsx
@@ -31,7 +31,7 @@ const BaseBadge = (props: Partial<BadgeProps>) => (
   <Badge
     color={select(
       'Color',
-      ['neutral', 'primary', 'success', 'warning', 'danger'],
+      ['neutral', 'success', 'warning', 'danger'],
       'neutral'
     )}
     circle={boolean('Circular', false)}
@@ -44,7 +44,6 @@ export const base = () => <BaseBadge>Badge</BaseBadge>;
 export const colors = () => (
   <Fragment>
     <BaseBadge color="neutral">Neutral</BaseBadge>
-    <BaseBadge color="primary">Primary</BaseBadge>
     <BaseBadge color="success">Success</BaseBadge>
     <BaseBadge color="warning">Warning</BaseBadge>
     <BaseBadge color="danger">Danger</BaseBadge>

--- a/src/components/Badge/Badge.story.tsx
+++ b/src/components/Badge/Badge.story.tsx
@@ -15,7 +15,6 @@
 
 import React, { Fragment } from 'react';
 import { select, boolean } from '@storybook/addon-knobs';
-import { action } from '@storybook/addon-actions';
 
 import docs from './Badge.docs.mdx';
 import { Badge, BadgeProps } from './Badge';
@@ -53,7 +52,3 @@ export const colors = () => (
 );
 
 export const circular = () => <BaseBadge circle>42</BaseBadge>;
-
-export const clickable = () => (
-  <BaseBadge onClick={action('onClick')}>Click me</BaseBadge>
-);

--- a/src/components/Badge/Badge.story.tsx
+++ b/src/components/Badge/Badge.story.tsx
@@ -18,7 +18,7 @@ import { select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import docs from './Badge.docs.mdx';
-import Badge from './Badge';
+import { Badge, BadgeProps } from './Badge';
 
 export default {
   title: 'Components/Badge',
@@ -28,36 +28,32 @@ export default {
   }
 };
 
-export const base = () => (
+const BaseBadge = (props: Partial<BadgeProps>) => (
   <Badge
     color={select(
       'Color',
       ['neutral', 'primary', 'success', 'warning', 'danger'],
       'neutral'
     )}
-  >
-    Badge
-  </Badge>
+    circle={boolean('Circular', false)}
+    {...props}
+  />
 );
+
+export const base = () => <BaseBadge>Badge</BaseBadge>;
 
 export const colors = () => (
   <Fragment>
-    <Badge color={'neutral'}>Neutral</Badge>
-    <Badge color={'primary'}>Primary</Badge>
-    <Badge color={'success'}>Success</Badge>
-    <Badge color={'warning'}>Warning</Badge>
-    <Badge color={'danger'}>Danger</Badge>
+    <BaseBadge color="neutral">Neutral</BaseBadge>
+    <BaseBadge color="primary">Primary</BaseBadge>
+    <BaseBadge color="success">Success</BaseBadge>
+    <BaseBadge color="warning">Warning</BaseBadge>
+    <BaseBadge color="danger">Danger</BaseBadge>
   </Fragment>
 );
 
-export const circular = () => (
-  <Badge color={'primary'} circle={boolean('Circular', true)}>
-    42
-  </Badge>
-);
+export const circular = () => <BaseBadge circle>42</BaseBadge>;
 
 export const clickable = () => (
-  <Badge color={'primary'} onClick={action('onClick')} as="button">
-    Click me
-  </Badge>
+  <BaseBadge onClick={action('onClick')}>Click me</BaseBadge>
 );

--- a/src/components/Badge/Badge.story.tsx
+++ b/src/components/Badge/Badge.story.tsx
@@ -50,4 +50,10 @@ export const variants = () => (
   </Fragment>
 );
 
-export const circular = () => <BaseBadge circle>42</BaseBadge>;
+export const circular = () => (
+  <Fragment>
+    <BaseBadge circle>1</BaseBadge>
+    <BaseBadge circle>42</BaseBadge>
+    <BaseBadge circle>999</BaseBadge>
+  </Fragment>
+);

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -104,15 +104,23 @@ const variantStyles = ({
   `;
 };
 
-const circleStyles = ({ circle }: BadgeProps) =>
+const isDynamicWidth = (children: BadgeProps['children']) => {
+  if (typeof children === 'string') {
+    return children.length > 2;
+  }
+  return false;
+};
+
+const circleStyles = ({ circle, children }: BadgeProps) =>
   circle &&
   css`
     label: badge--circle;
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 2px 4px;
     height: 24px;
-    width: 24px;
+    width: ${isDynamicWidth(children) ? 'auto' : '24px'};
   `;
 
 const clickableStyles = ({

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -25,27 +25,28 @@ import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { focusOutline } from '../../styles/style-helpers';
-
-type OnClick = (
-  event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>
-) => void;
-type RefType = Ref<HTMLDivElement>;
+import deprecate from '../../util/deprecate';
 
 export interface BadgeProps extends HTMLProps<HTMLDivElement> {
   /**
-   * Callback for the click event.
+   * The semantic color of the badge.
    */
-  onClick?: OnClick;
-  /**
-   * Ensures text is centered and the badge looks like a circle.
-   */
-  circle?: boolean;
   color?: 'neutral' | 'primary' | 'success' | 'warning' | 'danger';
   /**
-   * The ref to the html div DOM element
+   * Use the circular badge to indicate a count of items related to an element.
    */
-  ref?: RefType;
-  as?: string;
+  circle?: boolean;
+  /**
+   * @deprecated
+   * Callback for the click event.
+   */
+  onClick?: (
+    event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>
+  ) => void;
+  /**
+   * The ref to the HTML DOM element
+   */
+  ref?: Ref<HTMLDivElement>;
 }
 
 const COLOR_MAP = {
@@ -66,8 +67,8 @@ const COLOR_MAP = {
   },
   primary: {
     text: 'white',
-    default: 'b500',
-    hover: 'b700'
+    default: 'p500',
+    hover: 'p700'
   },
   neutral: {
     text: 'bodyColor',
@@ -126,6 +127,7 @@ const clickableStyles = ({
     border: 0;
     outline: 0;
     cursor: pointer;
+    transition: background-color ${theme.transitions.default};
 
     &:hover,
     &:active {
@@ -146,8 +148,20 @@ const StyledBadge = styled('div', {
  * A badge communicates the status of an element or the count of items
  * related to an element.
  */
-export const Badge = forwardRef((props: BadgeProps, ref: BadgeProps['ref']) => (
-  <StyledBadge as={props.onClick ? 'button' : 'div'} ref={ref} {...props} />
-));
+export const Badge = forwardRef((props: BadgeProps, ref: BadgeProps['ref']) => {
+  if (props.onClick) {
+    deprecate(
+      [
+        'The `onClick` prop of the Badge component has been deprecated.',
+        'Badges are not meant to be interactive and should only',
+        'communicate the status of an element.',
+        'Use the Tag component for interactive elements instead.'
+      ].join(' ')
+    );
+  }
+
+  const as = props.onClick ? 'button' : 'div';
+  return <StyledBadge as={as} ref={ref} {...props} />;
+});
 
 Badge.displayName = 'Badge';

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -24,7 +24,7 @@ import { css } from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
-import { subHeadingKilo, focusOutline } from '../../styles/style-helpers';
+import { focusOutline } from '../../styles/style-helpers';
 
 type OnClick = (
   event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>
@@ -50,42 +50,43 @@ export interface BadgeProps extends HTMLProps<HTMLDivElement> {
 
 const COLOR_MAP = {
   success: {
-    default: 'g500',
-    hover: 'g700',
-    active: 'g900'
+    text: 'white',
+    default: 'g700',
+    hover: 'g900'
   },
   warning: {
-    default: 'y500',
-    hover: 'y700',
-    active: 'y900'
+    text: 'bodyColor',
+    default: 'y300',
+    hover: 'y500'
   },
   danger: {
+    text: 'white',
     default: 'r500',
-    hover: 'r700',
-    active: 'r900'
+    hover: 'r700'
   },
   primary: {
+    text: 'white',
     default: 'b500',
-    hover: 'b700',
-    active: 'b900'
+    hover: 'b700'
   },
   neutral: {
-    default: 'n500',
-    hover: 'n700',
-    active: 'n900'
+    text: 'bodyColor',
+    default: 'n300',
+    hover: 'n500'
   }
 } as const;
+
 const baseStyles = ({ theme }: StyleProps) => css`
   label: badge;
   border-radius: ${theme.borderRadius.pill};
   color: ${theme.colors.white};
   display: inline-block;
-  padding: 0 ${theme.spacings.byte};
-  ${subHeadingKilo({ theme })};
+  padding: 2px ${theme.spacings.byte};
+  font-size: 14px;
+  line-height: 20px;
   font-weight: ${theme.fontWeight.bold};
-  text-transform: uppercase;
-  user-select: none;
   text-align: center;
+  letter-spacing: 0.25px;
 `;
 
 const colorStyles = ({ theme, color = 'neutral' }: StyleProps & BadgeProps) => {
@@ -96,6 +97,7 @@ const colorStyles = ({ theme, color = 'neutral' }: StyleProps & BadgeProps) => {
   return css`
     label: ${`badge--${color}`};
     background-color: ${theme.colors[currentColor.default]};
+    color: ${theme.colors[currentColor.text]};
   `;
 };
 
@@ -125,12 +127,9 @@ const clickableStyles = ({
     outline: 0;
     cursor: pointer;
 
-    &:hover {
-      background-color: ${theme.colors[currentColor.hover]};
-    }
-
+    &:hover,
     &:active {
-      background-color: ${theme.colors[currentColor.active]};
+      background-color: ${theme.colors[currentColor.hover]};
     }
 
     &:focus {
@@ -139,19 +138,16 @@ const clickableStyles = ({
   `;
 };
 
-/**
- * A badge for displaying update notifications etc.
- */
 const StyledBadge = styled('div', {
   shouldForwardProp: prop => isPropValid(prop) && prop !== 'color'
 })<BadgeProps>(baseStyles, colorStyles, circleStyles, clickableStyles);
 
-/* eslint-disable react/display-name */
-const Badge = forwardRef((props: BadgeProps, ref: BadgeProps['ref']) => (
+/**
+ * A badge communicates the status of an element or the count of items
+ * related to an element.
+ */
+export const Badge = forwardRef((props: BadgeProps, ref: BadgeProps['ref']) => (
   <StyledBadge as={props.onClick ? 'button' : 'div'} ref={ref} {...props} />
 ));
 
-/**
- * @component
- */
-export default Badge;
+Badge.displayName = 'Badge';

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -160,6 +160,16 @@ export const Badge = forwardRef((props: BadgeProps, ref: BadgeProps['ref']) => {
     );
   }
 
+  if (props.color === 'primary') {
+    deprecate(
+      [
+        'The "primary" color of the Badge component has been deprecated.',
+        'It conflicts with the color of the primary Button variant.',
+        'Use the "neutral" variant instead.'
+      ].join(' ')
+    );
+  }
+
   const as = props.onClick ? 'button' : 'div';
   return <StyledBadge as={as} ref={ref} {...props} />;
 });

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -21,7 +21,6 @@ import React, {
   HTMLProps
 } from 'react';
 import { css } from '@emotion/core';
-import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { focusOutline } from '../../styles/style-helpers';
@@ -29,9 +28,9 @@ import deprecate from '../../util/deprecate';
 
 export interface BadgeProps extends HTMLProps<HTMLDivElement> {
   /**
-   * The semantic color of the badge.
+   * Choose from 4 style variants. Default: 'neutral'.
    */
-  color?: 'neutral' | 'primary' | 'success' | 'warning' | 'danger';
+  variant?: 'neutral' | 'success' | 'warning' | 'danger' | 'primary';
   /**
    * Use the circular badge to indicate a count of items related to an element.
    */
@@ -90,13 +89,16 @@ const baseStyles = ({ theme }: StyleProps) => css`
   letter-spacing: 0.25px;
 `;
 
-const colorStyles = ({ theme, color = 'neutral' }: StyleProps & BadgeProps) => {
-  const currentColor = COLOR_MAP[color];
+const variantStyles = ({
+  theme,
+  variant = 'neutral'
+}: StyleProps & BadgeProps) => {
+  const currentColor = COLOR_MAP[variant];
   if (!currentColor) {
     return null;
   }
   return css`
-    label: ${`badge--${color}`};
+    label: ${`badge--${variant}`};
     background-color: ${theme.colors[currentColor.default]};
     color: ${theme.colors[currentColor.text]};
   `;
@@ -116,9 +118,9 @@ const circleStyles = ({ circle }: BadgeProps) =>
 const clickableStyles = ({
   theme,
   onClick,
-  color = 'neutral'
+  variant = 'neutral'
 }: StyleProps & BadgeProps) => {
-  const currentColor = COLOR_MAP[color];
+  const currentColor = COLOR_MAP[variant];
   if (!onClick || !currentColor) {
     return null;
   }
@@ -140,9 +142,12 @@ const clickableStyles = ({
   `;
 };
 
-const StyledBadge = styled('div', {
-  shouldForwardProp: prop => isPropValid(prop) && prop !== 'color'
-})<BadgeProps>(baseStyles, colorStyles, circleStyles, clickableStyles);
+const StyledBadge = styled('div')<BadgeProps>(
+  baseStyles,
+  variantStyles,
+  circleStyles,
+  clickableStyles
+);
 
 /**
  * A badge communicates the status of an element or the count of items
@@ -160,7 +165,7 @@ export const Badge = forwardRef((props: BadgeProps, ref: BadgeProps['ref']) => {
     );
   }
 
-  if (props.color === 'primary') {
+  if (props.variant === 'primary') {
     deprecate(
       [
         'The "primary" color of the Badge component has been deprecated.',

--- a/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -5,17 +5,17 @@ exports[`Badge rendering color variations should render with danger colors 1`] =
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
   background-color: #DB4D4D;
+  color: #FFFFFF;
 }
 
 <div
@@ -28,17 +28,17 @@ exports[`Badge rendering color variations should render with primary colors 1`] 
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
   background-color: #3388FF;
+  color: #FFFFFF;
 }
 
 <div
@@ -51,17 +51,17 @@ exports[`Badge rendering color variations should render with success colors 1`] 
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #8CC13F;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #47995A;
+  color: #FFFFFF;
 }
 
 <div
@@ -74,17 +74,17 @@ exports[`Badge rendering color variations should render with warning colors 1`] 
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #D8A413;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #F6CC1B;
+  color: #0F131A;
 }
 
 <div
@@ -97,28 +97,25 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #9DA7B1;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #D8DDE1;
+  color: #0F131A;
   border: 0;
   outline: 0;
   cursor: pointer;
 }
 
-.circuit-0:hover {
-  background-color: #5C656F;
-}
-
+.circuit-0:hover,
 .circuit-0:active {
-  background-color: #212933;
+  background-color: #9DA7B1;
 }
 
 .circuit-0:focus {
@@ -140,17 +137,17 @@ exports[`Badge should have the correct circle styles 1`] = `
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #9DA7B1;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #D8DDE1;
+  color: #0F131A;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -177,17 +174,17 @@ exports[`Badge should render with default styles 1`] = `
   border-radius: 999999px;
   color: #FFFFFF;
   display: inline-block;
-  padding: 0 8px;
-  font-size: 12px;
+  padding: 2px 8px;
+  font-size: 14px;
   line-height: 20px;
   font-weight: 700;
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
   text-align: center;
-  background-color: #9DA7B1;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #D8DDE1;
+  color: #0F131A;
 }
 
 <div

--- a/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -111,6 +111,8 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   border: 0;
   outline: 0;
   cursor: pointer;
+  -webkit-transition: background-color 120ms ease-in-out;
+  transition: background-color 120ms ease-in-out;
 }
 
 .circuit-0:hover,

--- a/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -1,97 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Badge rendering color variations should render with danger colors 1`] = `
-.circuit-0 {
-  border-radius: 999999px;
-  color: #FFFFFF;
-  display: inline-block;
-  padding: 2px 8px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 700;
-  text-align: center;
-  -webkit-letter-spacing: 0.25px;
-  -moz-letter-spacing: 0.25px;
-  -ms-letter-spacing: 0.25px;
-  letter-spacing: 0.25px;
-  background-color: #DB4D4D;
-  color: #FFFFFF;
-}
-
-<div
-  class="circuit-0"
-/>
-`;
-
-exports[`Badge rendering color variations should render with primary colors 1`] = `
-.circuit-0 {
-  border-radius: 999999px;
-  color: #FFFFFF;
-  display: inline-block;
-  padding: 2px 8px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 700;
-  text-align: center;
-  -webkit-letter-spacing: 0.25px;
-  -moz-letter-spacing: 0.25px;
-  -ms-letter-spacing: 0.25px;
-  letter-spacing: 0.25px;
-  background-color: #3388FF;
-  color: #FFFFFF;
-}
-
-<div
-  class="circuit-0"
-/>
-`;
-
-exports[`Badge rendering color variations should render with success colors 1`] = `
-.circuit-0 {
-  border-radius: 999999px;
-  color: #FFFFFF;
-  display: inline-block;
-  padding: 2px 8px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 700;
-  text-align: center;
-  -webkit-letter-spacing: 0.25px;
-  -moz-letter-spacing: 0.25px;
-  -ms-letter-spacing: 0.25px;
-  letter-spacing: 0.25px;
-  background-color: #47995A;
-  color: #FFFFFF;
-}
-
-<div
-  class="circuit-0"
-/>
-`;
-
-exports[`Badge rendering color variations should render with warning colors 1`] = `
-.circuit-0 {
-  border-radius: 999999px;
-  color: #FFFFFF;
-  display: inline-block;
-  padding: 2px 8px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 700;
-  text-align: center;
-  -webkit-letter-spacing: 0.25px;
-  -moz-letter-spacing: 0.25px;
-  -ms-letter-spacing: 0.25px;
-  letter-spacing: 0.25px;
-  background-color: #F6CC1B;
-  color: #0F131A;
-}
-
-<div
-  class="circuit-0"
-/>
-`;
-
 exports[`Badge should have hover/active styles only when the onClick handler is provided 1`] = `
 .circuit-0 {
   border-radius: 999999px;
@@ -171,6 +79,29 @@ exports[`Badge should have the correct circle styles 1`] = `
 />
 `;
 
+exports[`Badge should render with danger styles 1`] = `
+.circuit-0 {
+  border-radius: 999999px;
+  color: #FFFFFF;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #DB4D4D;
+  color: #FFFFFF;
+}
+
+<div
+  class="circuit-0"
+/>
+`;
+
 exports[`Badge should render with default styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
@@ -186,6 +117,75 @@ exports[`Badge should render with default styles 1`] = `
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
   background-color: #D8DDE1;
+  color: #0F131A;
+}
+
+<div
+  class="circuit-0"
+/>
+`;
+
+exports[`Badge should render with primary styles 1`] = `
+.circuit-0 {
+  border-radius: 999999px;
+  color: #FFFFFF;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #3388FF;
+  color: #FFFFFF;
+}
+
+<div
+  class="circuit-0"
+/>
+`;
+
+exports[`Badge should render with success styles 1`] = `
+.circuit-0 {
+  border-radius: 999999px;
+  color: #FFFFFF;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #47995A;
+  color: #FFFFFF;
+}
+
+<div
+  class="circuit-0"
+/>
+`;
+
+exports[`Badge should render with warning styles 1`] = `
+.circuit-0 {
+  border-radius: 999999px;
+  color: #FFFFFF;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #F6CC1B;
   color: #0F131A;
 }
 

--- a/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -70,6 +70,7 @@ exports[`Badge should have the correct circle styles 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
+  padding: 2px 4px;
   height: 24px;
   width: 24px;
 }

--- a/src/components/Badge/index.ts
+++ b/src/components/Badge/index.ts
@@ -13,6 +13,6 @@
  * limitations under the License.
  */
 
-import Badge from './Badge';
+import { Badge } from './Badge';
 
 export default Badge;


### PR DESCRIPTION
## Purpose

The badges received a [design refresh on mobile](https://www.figma.com/file/aORNKPp6e3xbpkYrkfoVhW/WIP-Circuit-UI-Mobile?node-id=2168%3A5419) to make them more accessible and refine their purpose. This PR applies the same changes to the web.

## Approach and changes

- Update design of the Badge according to the new [design specs](https://www.figma.com/file/aORNKPp6e3xbpkYrkfoVhW/WIP-Circuit-UI-Mobile?node-id=2168%3A5419):

_Before_

<img width="116" alt="Screen Shot 2020-07-06 at 12 27 53" src="https://user-images.githubusercontent.com/11017722/86583792-21b01e80-bf84-11ea-8ec1-fedc189a728f.png">

_After_

<img width="115" alt="Screen Shot 2020-07-04 at 18 39 43" src="https://user-images.githubusercontent.com/11017722/86583714-06ddaa00-bf84-11ea-83d5-4c0b75137f67.png">

- Use dynamic width for long circular Badge: This prevents the content from overflowing the background:

_Before_

<img width="66" alt="Screen Shot 2020-07-06 at 12 28 43" src="https://user-images.githubusercontent.com/11017722/86583878-43a9a100-bf84-11ea-98c2-52466b7c9faf.png">

_After_

<img width="63" alt="Screen Shot 2020-07-04 at 18 50 04" src="https://user-images.githubusercontent.com/11017722/86583708-03e2b980-bf84-11ea-8697-4516b76b9eea.png">

- Deprecate the Badge's `onClick` prop: Badges are not meant to be interactive and should only communicate the status of an element. Use the Tag component instead.
- Deprecate the `primary` Badge color: It conflicts with the color of the primary Button variant. Use the "neutral" variant instead.
- Rename the Badge's `color` prop to `variant`: This makes the prop consistent with the Button and List components.

BREAKING CHANGE:
The **Badge** component's `color` prop has been renamed to `variant` (🤖 _badge-variant-enum_)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
