### PR TITLE
fix(components): remove Input focus outline

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -10767,6 +10767,7 @@ label + .circuit-6 {
 .circuit-5 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -15607,6 +15608,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -15722,6 +15724,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -15833,6 +15836,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -15934,6 +15938,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -16066,6 +16071,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -16241,6 +16247,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -16355,6 +16362,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -16468,6 +16476,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -16609,6 +16618,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -16765,6 +16775,7 @@ label + .circuit-3 {
 .circuit-2 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -16902,6 +16913,7 @@ label + .circuit-3 {
 .circuit-2 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -17035,6 +17047,7 @@ label + .circuit-3 {
 .circuit-2 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -17173,6 +17186,7 @@ label + .circuit-3 {
 .circuit-2 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -17306,6 +17320,7 @@ label + .circuit-3 {
 .circuit-2 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -17427,6 +17442,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -17533,6 +17549,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -17644,6 +17661,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -19594,6 +19612,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -19685,6 +19704,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -19791,6 +19811,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -19879,6 +19900,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -20036,6 +20058,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -20143,6 +20166,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;

--- a/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -36,6 +36,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -144,6 +145,7 @@ label + .circuit-2 {
 .circuit-1 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -28,6 +28,7 @@ import { uniqueId } from '../../util/id';
 import Label from '../Label';
 import ValidationHint from '../ValidationHint';
 import { ReturnType } from '../../types/return-type';
+import deprecate from '../../util/deprecate';
 
 export interface InputProps extends Omit<HTMLProps<HTMLInputElement>, 'label'> {
   /**
@@ -286,6 +287,17 @@ function InputComponent(
   }: InputProps,
   ref: InputProps['ref']
 ): ReturnType {
+  if (!label) {
+    deprecate(
+      [
+        'The label is now built into the input component.',
+        'Use the `label` prop to pass in the label content and',
+        'remove the Label component from your code.',
+        'The label will become required in the next major version.'
+      ].join(' ')
+    );
+  }
+
   const id = customId || uniqueId('input_');
 
   const prefix = RenderPrefix && <RenderPrefix css={prefixStyles} />;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -136,6 +136,7 @@ const inputBaseStyles = ({ theme }: StyleProps) => css`
   label: input;
   background-color: ${theme.colors.white};
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(${theme.spacings.byte} + 1px) ${theme.spacings.kilo};
   transition: box-shadow ${theme.transitions.default},

--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -23,6 +23,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -110,6 +111,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -226,6 +228,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -331,6 +334,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -418,6 +422,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -505,6 +510,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -588,6 +594,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -674,6 +681,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -753,6 +761,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -845,6 +854,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -938,6 +948,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -1027,6 +1038,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -1112,6 +1124,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -1196,6 +1209,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -1279,6 +1293,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
@@ -23,6 +23,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -126,6 +127,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -313,7 +313,7 @@ function SelectComponent(
         'The label is now built into the Select component.',
         'Use the `label` prop to pass in the label content and',
         'remove the Label component from your code.',
-        'The label will become required in the next major version'
+        'The label will become required in the next major version.'
       ].join(' ')
     );
   }

--- a/src/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
@@ -23,6 +23,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -109,6 +110,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -224,6 +226,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -328,6 +331,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -414,6 +418,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -500,6 +505,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -585,6 +591,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -663,6 +670,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -754,6 +762,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -846,6 +855,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -934,6 +944,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -1018,6 +1029,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
@@ -1100,6 +1112,7 @@ label + .circuit-1 {
 .circuit-0 {
   background-color: #FFFFFF;
   border: none;
+  outline: 0;
   border-radius: 8px;
   padding: calc(8px + 1px) 12px;
   -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;


### PR DESCRIPTION
## Purpose

I noticed some issues related to the Input component as I was working on related stuff. 

## Approach and changes

- remove default focus outline on Firefox

_Before_

<img width="295" alt="Screen Shot 2020-07-07 at 10 45 06" src="https://user-images.githubusercontent.com/11017722/86764357-44a40680-c048-11ea-9ae0-b57574f9ace1.png">

_After_

<img width="297" alt="Screen Shot 2020-07-07 at 10 45 13" src="https://user-images.githubusercontent.com/11017722/86764386-4968ba80-c048-11ea-85f2-79a35b21f56a.png">

- add deprecation notice for missing Input label 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
