### PR TITLE
fix(configs): restore IE11 compatibility

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -16,21 +16,24 @@ module.exports = {
     '@storybook/addon-a11y',
     '@storybook/addon-viewport',
   ],
-  webpack: (config) => {
-    config.module.rules = config.module.rules.map((rule) => {
-      // We want to override the rule for `.js` files only.
-      if (
-        rule.test &&
-        rule.test instanceof RegExp &&
-        ['.js', '.ts', '.tsx'].some((extension) => rule.test.test(extension))
-      ) {
-        return {
-          ...rule,
-          exclude: /node_modules\/(?!(@sumup|acorn-jsx)\/).*/,
-        };
-      }
-      return rule;
-    });
-    return config;
-  },
+  webpackFinal: transpileModules,
+  managerWebpack: transpileModules,
 };
+
+function transpileModules(config) {
+  config.module.rules = config.module.rules.map((rule) => {
+    // We want to override the rule for `.js` files only.
+    if (
+      rule.test &&
+      rule.test instanceof RegExp &&
+      ['.js', '.ts', '.tsx'].some((extension) => rule.test.test(extension))
+    ) {
+      return {
+        ...rule,
+        exclude: /node_modules\/(?!(@sumup|acorn-jsx)\/).*/,
+      };
+    }
+    return rule;
+  });
+  return config;
+}

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -20,9 +20,10 @@ module.exports = {
   managerWebpack: transpileModules,
 };
 
+// Transpile all node_modules under the @sumup/* namespace.
 function transpileModules(config) {
   config.module.rules = config.module.rules.map((rule) => {
-    // We want to override the rule for `.js` files only.
+    // Modify all rules that apply to story files.
     if (
       rule.test &&
       rule.test instanceof RegExp &&

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -19,7 +19,11 @@ module.exports = {
   webpack: (config) => {
     config.module.rules = config.module.rules.map((rule) => {
       // We want to override the rule for `.js` files only.
-      if (rule.test && rule.test instanceof RegExp && rule.test.test('.js')) {
+      if (
+        rule.test &&
+        rule.test instanceof RegExp &&
+        ['.js', '.ts', '.tsx'].some((extension) => rule.test.test(extension))
+      ) {
         return {
           ...rule,
           exclude: /node_modules\/(?!(@sumup|acorn-jsx)\/).*/,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "create:component": "foundry run plop component",
     "static-styles": "cross-env BABEL_ENV=static babel-node --extensions '.js,.ts,.tsx' ./scripts/static-styles/cli.js",
     "build:docs": "yarn build:storybook && yarn build:stylesheets",
-    "prebuild:storybook": "yarn test:output",
     "build:storybook": "build-storybook -c .storybook -o public -s .storybook/public",
     "build:stylesheets": "mkdir -p public/static && yarn static-styles --global --filePath=./public/static/circuit-ui-v1.css",
     "lint": "foundry run eslint . --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
## Purpose

Storybook fails to load under IE11.

## Approach and changes

- transpile all node_modules under the `@sumup/*` namespace
- transpile the Storybook manager code as well, since `@sumup/design-tokens` is used to theme the Storybook UI
- (unrelated) remove the prebuild step for Storybook as it's no longer needed since #621, this reduces the build and deploy times by 2-3 minutes

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
