### PR TITLE
feat(cli): write codemod for currency utils

### DIFF
--- a/src/cli/migrate/__testfixtures__/currency-utils-1.input.js
+++ b/src/cli/migrate/__testfixtures__/currency-utils-1.input.js
@@ -1,0 +1,8 @@
+import { currencyUtils } from '@sumup/circuit-ui';
+
+const amount = '42';
+const locale = 'en-US';
+const currency = 'USD';
+
+currencyUtils.formatCurrency(amount, currency, locale);
+currencyUtils.formatAmountForLocale(amount, currency, locale);

--- a/src/cli/migrate/__testfixtures__/currency-utils-1.output.js
+++ b/src/cli/migrate/__testfixtures__/currency-utils-1.output.js
@@ -1,0 +1,8 @@
+import { formatCurrency, formatAmountForLocale } from '@sumup/intl-js';
+
+const amount = '42';
+const locale = 'en-US';
+const currency = 'USD';
+
+formatCurrency(amount, locale, currency);
+formatAmountForLocale(amount, locale, currency);

--- a/src/cli/migrate/__testfixtures__/currency-utils-2.input.js
+++ b/src/cli/migrate/__testfixtures__/currency-utils-2.input.js
@@ -1,0 +1,7 @@
+import { currencyUtils } from '@sumup/circuit-ui';
+
+const amount = '42';
+const locale = 'en-US';
+const currency = 'USD';
+
+currencyUtils.formatAmountForLocale(amount, currency, locale);

--- a/src/cli/migrate/__testfixtures__/currency-utils-2.output.js
+++ b/src/cli/migrate/__testfixtures__/currency-utils-2.output.js
@@ -1,0 +1,7 @@
+import { formatAmountForLocale } from '@sumup/intl-js';
+
+const amount = '42';
+const locale = 'en-US';
+const currency = 'USD';
+
+formatAmountForLocale(amount, locale, currency);

--- a/src/cli/migrate/__tests__/transforms.spec.js
+++ b/src/cli/migrate/__tests__/transforms.spec.js
@@ -44,3 +44,5 @@ defineTest(
   'theme-to-design-tokens-2',
 );
 defineTest(__dirname, 'theme-icon-sizes');
+defineTest(__dirname, 'currency-utils', null, 'currency-utils-1');
+defineTest(__dirname, 'currency-utils', null, 'currency-utils-2');

--- a/src/cli/migrate/currency-utils.ts
+++ b/src/cli/migrate/currency-utils.ts
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2020, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform, ASTPath, CallExpression } from 'jscodeshift';
+
+import { findImportsByPath } from './utils';
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const imports = findImportsByPath(j, root, '@sumup/circuit-ui');
+  const utilImport = imports.find((i) => i.name === 'currencyUtils');
+
+  const intlSpecifiers = [];
+
+  if (!utilImport) {
+    return;
+  }
+
+  const formatCurrency = root.find(j.CallExpression, {
+    callee: {
+      type: 'MemberExpression',
+      object: {
+        name: utilImport.local,
+      },
+      property: {
+        name: 'formatCurrency',
+      },
+    },
+  });
+
+  const formatAmountForLocale = root.find(j.CallExpression, {
+    callee: {
+      type: 'MemberExpression',
+      object: {
+        name: utilImport.local,
+      },
+      property: {
+        name: 'formatAmountForLocale',
+      },
+    },
+  });
+
+  const circuitImport = root.find(j.ImportDeclaration, {
+    source: {
+      value: '@sumup/circuit-ui',
+    },
+  });
+
+  if (formatCurrency.length) {
+    const name = 'formatCurrency';
+    const identifier = j.identifier(name);
+    const importSpecifier = j.importSpecifier(identifier);
+
+    formatCurrency.replaceWith(replaceFormatFunction(name));
+
+    intlSpecifiers.push(importSpecifier);
+  }
+
+  if (formatAmountForLocale.length) {
+    const name = 'formatAmountForLocale';
+    const identifier = j.identifier(name);
+    const importSpecifier = j.importSpecifier(identifier);
+
+    formatAmountForLocale.replaceWith(replaceFormatFunction(name));
+
+    intlSpecifiers.push(importSpecifier);
+  }
+
+  const intlImport = j.importDeclaration(
+    intlSpecifiers,
+    j.literal('@sumup/intl-js'),
+  );
+
+  if (imports.length === 1) {
+    circuitImport.replaceWith(intlImport);
+  } else {
+    circuitImport.forEach((importNodePath) => {
+      j(importNodePath)
+        .find(j.ImportSpecifier)
+        .forEach((importSpecifierNodePath) => {
+          if (importSpecifierNodePath.node.imported.name === 'currencyUtils') {
+            j(importSpecifierNodePath).remove();
+          }
+        });
+    });
+    circuitImport.insertAfter(intlImport);
+  }
+
+  return root.toSource({ quote: 'single', reuseWhitespace: false });
+};
+
+function replaceFormatFunction(callee: string) {
+  return (nodePath: ASTPath<CallExpression>) => {
+    /* eslint-disable no-param-reassign, @typescript-eslint/ban-ts-ignore */
+    // @ts-ignore
+    nodePath.value.arguments = reorderArguments(nodePath.value.arguments);
+    // @ts-ignore
+    nodePath.value.callee = callee;
+    /* eslint-enable no-param-reassign, @typescript-eslint/ban-ts-ignore */
+
+    return nodePath.node;
+  };
+}
+
+function reorderArguments(args = []) {
+  const [value, locale, currency] = args;
+
+  return [value, currency, locale];
+}
+
+export default transform;


### PR DESCRIPTION
## Purpose

This codemod cover the breaking changes related to `currencyUtils.formatCurrency` and `currencyUtils.formatAmountForLocale`.

## Approach and changes

- The `currencyUtils` methods `formatCurrency` and `formatAmountForLocale` have been moved to [@sumup/intl-js](https://github.com/sumup-oss/intl-js). Import them from there instead (🤖 _currency-utils_)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
