### PR TITLE
fix(cli): rename intl-js import to intl for currency-utils codemod

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -138,7 +138,7 @@ The affected components are: Badge, Blockquote, Button, ButtonGroup, Card, CardF
 (_in writing_)
 
 - The `currencyAmountUtils` have been removed. There is not replacement, we suggest you copy the [old implementation](https://github.com/sumup-oss/circuit-ui/blob/b3d89f43ac54ef1f7c0c2ff6f4edce92e2bd937d/src/components/CurrencyInput/CurrencyInputService.js) to your application.
-- The `currencyUtils` have been removed. Use [@sumup/intl](https://www.npmjs.com/package/@sumup/intl) instead (🤖 _TODO_)
+- The `currencyUtils` have been removed. Use [@sumup/intl](https://www.npmjs.com/package/@sumup/intl) instead (🤖 _currency-utils_)
 - The `textTera` style helper has been removed. Use the `textGiga` style helper instead.
 - The `shadowGround` and `shadowBorder` style helpers have been removed. Use the [`box-shadow`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow) CSS property instead.
 - The unit style helpers (`addUnit`, `subtractUnit`, `multiplyUnit`, `divideUnit` ) have been removed. Use the CSS [`calc`](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) function instead.

--- a/src/cli/migrate/__testfixtures__/currency-utils-1.output.js
+++ b/src/cli/migrate/__testfixtures__/currency-utils-1.output.js
@@ -1,4 +1,4 @@
-import { formatCurrency, formatAmountForLocale } from '@sumup/intl-js';
+import { formatCurrency, formatAmountForLocale } from '@sumup/intl';
 
 const amount = '42';
 const locale = 'en-US';

--- a/src/cli/migrate/__testfixtures__/currency-utils-2.output.js
+++ b/src/cli/migrate/__testfixtures__/currency-utils-2.output.js
@@ -1,4 +1,4 @@
-import { formatAmountForLocale } from '@sumup/intl-js';
+import { formatAmountForLocale } from '@sumup/intl';
 
 const amount = '42';
 const locale = 'en-US';

--- a/src/cli/migrate/currency-utils.ts
+++ b/src/cli/migrate/currency-utils.ts
@@ -82,7 +82,7 @@ const transform: Transform = (file, api) => {
 
   const intlImport = j.importDeclaration(
     intlSpecifiers,
-    j.literal('@sumup/intl-js'),
+    j.literal('@sumup/intl'),
   );
 
   if (imports.length === 1) {


### PR DESCRIPTION
## Purpose

The initial version of the `currency-utils` codemod is pointing to a non-existing `intl-js` package

## Approach and changes

- Rename `intl-js` to `intl`
- Add `currency-utils` to `MIGRATIONS.md`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
