### PR TITLE
fix(cli): rename formatAmountForLocale to format for currency-utils

### DIFF
--- a/src/cli/migrate/__testfixtures__/currency-utils-1.output.js
+++ b/src/cli/migrate/__testfixtures__/currency-utils-1.output.js
@@ -1,8 +1,8 @@
-import { formatCurrency, formatAmountForLocale } from '@sumup/intl';
+import { formatCurrency, format } from '@sumup/intl';
 
 const amount = '42';
 const locale = 'en-US';
 const currency = 'USD';
 
 formatCurrency(amount, locale, currency);
-formatAmountForLocale(amount, locale, currency);
+format(amount, locale, currency);

--- a/src/cli/migrate/__testfixtures__/currency-utils-2.output.js
+++ b/src/cli/migrate/__testfixtures__/currency-utils-2.output.js
@@ -1,7 +1,7 @@
-import { formatAmountForLocale } from '@sumup/intl';
+import { format } from '@sumup/intl';
 
 const amount = '42';
 const locale = 'en-US';
 const currency = 'USD';
 
-formatAmountForLocale(amount, locale, currency);
+format(amount, locale, currency);

--- a/src/cli/migrate/currency-utils.ts
+++ b/src/cli/migrate/currency-utils.ts
@@ -71,7 +71,7 @@ const transform: Transform = (file, api) => {
   }
 
   if (formatAmountForLocale.length) {
-    const name = 'formatAmountForLocale';
+    const name = 'format';
     const identifier = j.identifier(name);
     const importSpecifier = j.importSpecifier(identifier);
 


### PR DESCRIPTION
## Purpose

`currencyUtils.formatAmountForLocale` should be renamed to `format`

## Approach and changes

Rename the function name in the `currency-utils` codemod

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
