### PR TITLE
fix(components): show focus outline around TableRow

### DIFF
--- a/src/__snapshots__/storyshots.spec.js.snap
+++ b/src/__snapshots__/storyshots.spec.js.snap
@@ -9973,22 +9973,16 @@ tbody .circuit-36:last-child td {
   border-bottom: none;
 }
 
-.circuit-36:focus::after {
-  content: '';
-  display: block;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+.circuit-36:focus {
   z-index: 1;
+  -webkit-transform: translate(0,0);
+  -ms-transform: translate(0,0);
+  transform: translate(0,0);
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-36:focus::after::-moz-focus-inner {
+.circuit-36:focus::-moz-focus-inner {
   border: 0;
 }
 

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -245,6 +245,7 @@ class Table extends Component {
       condensed,
       scrollable,
       onRowClick,
+      onSortBy,
       ...props
     } = this.props;
     const {

--- a/src/components/Table/components/TableRow/TableRow.js
+++ b/src/components/Table/components/TableRow/TableRow.js
@@ -34,6 +34,9 @@ const baseStyles = () => css`
   }
 `;
 
+// Chrome doesn't respect position: relative; on table elements
+// so the transform property is used to create a separate stacking context
+// which is needed to show the focus outline above the other table rows.
 const clickableStyles = ({ theme, onClick }) =>
   onClick &&
   css`
@@ -41,17 +44,9 @@ const clickableStyles = ({ theme, onClick }) =>
     cursor: pointer;
     position: relative;
 
-    &:focus::after {
-      content: '';
-      display: block;
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
+    &:focus {
       z-index: 1;
+      transform: translate(0, 0);
       ${focusOutline({ theme })};
     }
 

--- a/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
+++ b/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
@@ -12,22 +12,16 @@ tbody .circuit-0:last-child td {
   border-bottom: none;
 }
 
-.circuit-0:focus::after {
-  content: '';
-  display: block;
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+.circuit-0:focus {
   z-index: 1;
+  -webkit-transform: translate(0,0);
+  -ms-transform: translate(0,0);
+  transform: translate(0,0);
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:focus::after::-moz-focus-inner {
+.circuit-0:focus::-moz-focus-inner {
   border: 0;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2852,9 +2852,9 @@
   integrity sha512-NkWjLKU1tnFcgBe6beRDS0LE9E4Kwb/d8Mb2SV+dv3tSb52r/SYOvPS2/NPpVCuOblqxf27Fwswo0XPPEEyyEg==
 
 "@sumup/intl@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@sumup/intl/-/intl-1.0.1.tgz#3288c3cc834b15ae03990927216014bac5b0b068"
-  integrity sha512-nJXeAyiHPPaC8VvJEFgiJWI+jHQoB4K3cA6IX2nNirXWNTuOGVZagmGgyE4JWm7BS3aoSVeijCmcjJu40cAwNg==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@sumup/intl/-/intl-1.0.2.tgz#465df828552f4cb7ad427e77e5d800302ed699c1"
+  integrity sha512-oXGr2VSccJG2+ydHH29H49LpFsH8vBmrlsr5w6Cw4NMHYf/i9ZYS3w2b9cKpB/2xXNt+qhOzOpaQlm+6D3vWjw==
   dependencies:
     intl-format-cache "^4.2.27"
 


### PR DESCRIPTION
Fixes #646.

## Approach and changes

Chrome doesn't respect `position: relative;` on table elements so the `transform` property is used to create a separate stacking context which is needed to show the focus outline around the table row.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
