### PR TITLE
feat(configs): move @sumup/collector to peer dependencies

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -57,13 +57,13 @@ yarn add react react-dom @emotion/core @emotion/styled emotion-theming
 npm install --save react-dom @emotion/core @emotion/styled emotion-theming
 ```
 
-In Circuit UI v2 some functionality has been extracted into separate packages for easier maintenance. The themes have been moved to [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens), the icons are available from [@sumup/icons](https://www.npmjs.com/package/@sumup/icons), and the number & currency utils have been completely rewritten in [@sumup/intl](https://www.npmjs.com/package/@sumup/intl). These packages are marked as required peer dependencies. To install them, run the following command in your terminal:
+In Circuit UI v2 some functionality has been extracted into separate packages for easier maintenance. The themes have been moved to [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens), the icons are available from [@sumup/icons](https://www.npmjs.com/package/@sumup/icons), and the number & currency utils have been completely rewritten in [@sumup/intl](https://www.npmjs.com/package/@sumup/intl). The new [@sumup/collector](https://www.npmjs.com/package/@sumup/collector) package is used for event tracking. These packages are marked as required peer dependencies. To install them, run the following command in your terminal:
 
 ```sh
 # With yarn
-yarn add @sumup/design-tokens @sumup/icons @sumup/intl
+yarn add @sumup/collector @sumup/design-tokens @sumup/icons @sumup/intl
 # With npm
-npm install --save @sumup/design-tokens @sumup/icons @sumup/intl
+npm install --save @sumup/collector @sumup/design-tokens @sumup/icons @sumup/intl
 ```
 
 Refer to the individual packages for documentation on how to use them.

--- a/docs/introduction/getting-started.story.mdx
+++ b/docs/introduction/getting-started.story.mdx
@@ -43,13 +43,13 @@ yarn add @sumup/circuit-ui
 npm install @sumup/circuit-ui
 ```
 
-Circuit UI relies on some mandatory peer dependencies, namely [@sumup/icons](https://www.npmjs.com/package/@sumup/icons), [React](https://reactjs.org/), and [Emotion](https://emotion.sh/). You should install them with the following command:
+Circuit UI relies on some mandatory peer dependencies, namely [@sumup/collector](https://www.npmjs.com/package/@sumup/collector), [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens), [@sumup/icons](https://www.npmjs.com/package/@sumup/icons), [@sumup/intl](https://www.npmjs.com/package/@sumup/intl), [React](https://reactjs.org/), and [Emotion](https://emotion.sh/). You should install them with the following command:
 
 ```bash
 # With yarn:
-yarn add @sumup/design-tokens @sumup/icons react react-dom @emotion/core @emotion/styled emotion-theming
+yarn add @sumup/collector @sumup/design-tokens @sumup/icons react react-dom @emotion/core @emotion/styled emotion-theming
 # With npm:
-npm install @sumup/design-tokens @sumup/icons react react-dom @emotion/core @emotion/styled emotion-theming
+npm install --save @sumup/collector @sumup/design-tokens @sumup/icons react react-dom @emotion/core @emotion/styled emotion-theming
 ```
 
 ### Configuring the theme
@@ -66,7 +66,7 @@ import { Button } from '@sumup/circuit-ui';
 
 const App = () => (
   <ThemeProvider theme={light}>
-    <Button primary>Click me</Button>
+    <Button variant="primary">Click me</Button>
   </ThemeProvider>
 );
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "homepage": "https://github.com/sumup-oss/circuit-ui#readme",
   "dependencies": {
-    "@sumup/collector": "^1.0.0-alpha.1",
     "cross-spawn": "^7.0.3",
     "jscodeshift": "^0.9.0",
     "lodash": "^4.17.11",
@@ -96,6 +95,7 @@
     "@storybook/preset-typescript": "^3.0.0",
     "@storybook/react": "^5.2.0",
     "@storybook/source-loader": "^5.2.4",
+    "@sumup/collector": "^1.0.0-alpha.1",
     "@sumup/design-tokens": "^1.0.0",
     "@sumup/foundry": "^3.0.0",
     "@sumup/icons": "^1.0.0",
@@ -162,6 +162,7 @@
     "@emotion/is-prop-valid": "0.8.x",
     "@emotion/styled": "10.x",
     "@emotion/stylis": "0.8.x",
+    "@sumup/collector": "1.x",
     "@sumup/design-tokens": "1.x",
     "@sumup/icons": "1.x",
     "@sumup/intl": "1.x",


### PR DESCRIPTION
## Purpose

Like the other @sumup packages, Collector should be a peer dependency to enable upgrades independently of Circuit UI.

## Approach and changes

- move Collector to peer dependencies

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
