### PR TITLE
feat(docs): replace Storybook knobs with controls

### DIFF
--- a/.storybook/components/Stack.tsx
+++ b/.storybook/components/Stack.tsx
@@ -13,33 +13,18 @@
  * limitations under the License.
  */
 
-import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 
-const baseStyles = ({ theme }) => css`
-  label: sidebar-header;
+const Stack = styled.div<{}>`
   display: flex;
-  align-self: flex-start;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  justify-content: flex-start;
-  min-height: 64px;
-  width: 100%;
-  padding: ${theme.spacings.mega};
-  background-color: ${theme.colors.bodyColor};
-  color: ${theme.colors.n100};
+  gap: 1rem;
+
+  @media screen and (min-width: 600px) {
+    flex-direction: row;
+  }
 `;
 
-const Header = styled('header')(baseStyles);
-
-Header.propTypes = {
-  /**
-   * The children component passed to the Sidebar Header.
-   */
-  children: PropTypes.node,
-};
-
-/**
- * @component
- */
-export default Header;
+export default Stack;

--- a/.storybook/components/index.js
+++ b/.storybook/components/index.js
@@ -13,9 +13,17 @@
  * limitations under the License.
  */
 
+import {
+  ArgsTable as Props,
+  PRIMARY_STORY,
+} from '@storybook/addon-docs/blocks';
+
+Props.defaultProps = { ...Props.defaultProps, story: PRIMARY_STORY };
+
+export { Props };
+
 export {
   Meta,
-  ArgsTable as Props,
   IconGallery,
   IconItem,
   Typeset,

--- a/.storybook/components/index.js
+++ b/.storybook/components/index.js
@@ -37,3 +37,4 @@ export { default as Intro } from './Intro';
 export { default as Teaser } from './Teaser';
 export { default as Link } from './Link';
 export { default as Image } from './Image';
+export { default as Stack } from './Stack';

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -11,7 +11,6 @@ module.exports = {
     '@storybook/addon-docs/',
     '@storybook/addon-storysource',
     '@storybook/addon-controls',
-    '@storybook/addon-knobs',
     '@storybook/addon-actions',
     '@storybook/addon-a11y',
     '@storybook/addon-links',

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "@storybook/addon-actions": "^6.0.10",
     "@storybook/addon-controls": "^6.0.10",
     "@storybook/addon-docs": "^6.0.10",
-    "@storybook/addon-knobs": "^6.0.10",
     "@storybook/addon-links": "^6.0.10",
     "@storybook/addon-storysource": "^6.0.10",
     "@storybook/addon-viewport": "^6.0.10",

--- a/src/components/Anchor/Anchor.docs.mdx
+++ b/src/components/Anchor/Anchor.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import Anchor from '.';
 
 # Anchor
 
@@ -8,7 +7,7 @@ import Anchor from '.';
 Anchor is used to display a link or button that visually looks like a hyperlink.
 
 <Story id="typography-anchor--as-link" />
-<Props of={Anchor} />
+<Props />
 
 ## Usage guidelines
 

--- a/src/components/Anchor/Anchor.stories.tsx
+++ b/src/components/Anchor/Anchor.stories.tsx
@@ -15,9 +15,8 @@
 
 import React from 'react';
 
+import { Anchor, AnchorProps } from './Anchor';
 import docs from './Anchor.docs.mdx';
-
-import Anchor from '.';
 
 export default {
   title: 'Typography/Anchor',
@@ -25,14 +24,22 @@ export default {
   parameters: {
     docs: { page: docs },
   },
+  argTypes: {
+    href: { control: 'text' },
+    children: { control: 'text' },
+  },
 };
 
-export const AsLink = () => (
-  <Anchor href="https://opensource.sumup.com">
-    {`View SumUp's OSS projects`}
-  </Anchor>
-);
+export const AsLink = (args: AnchorProps) => <Anchor {...args} />;
 
-export const AsButton = () => (
-  <Anchor onClick={() => alert('Hello')}>Say hello</Anchor>
-);
+AsLink.args = {
+  href: 'https://opensource.sumup.com',
+  children: `View SumUp's OSS projects`,
+};
+
+export const AsButton = (args: AnchorProps) => <Anchor {...args} />;
+
+AsButton.args = {
+  onClick: () => alert('Hello'),
+  children: `Say hello`,
+};

--- a/src/components/AspectRatio/AspectRatio.js
+++ b/src/components/AspectRatio/AspectRatio.js
@@ -91,7 +91,6 @@ AspectRatio.displayName = 'AspectRatio';
 AspectRatio.propTypes = {
   children: childrenPropType,
   aspectRatio: PropTypes.number,
-  className: PropTypes.string,
 };
 
 export default AspectRatio;

--- a/src/components/AspectRatio/AspectRatio.stories.js
+++ b/src/components/AspectRatio/AspectRatio.stories.js
@@ -14,7 +14,6 @@
  */
 
 import React from 'react';
-import { number } from '@storybook/addon-knobs';
 import styled from '@emotion/styled';
 
 import AspectRatio from './AspectRatio';
@@ -28,10 +27,14 @@ export default {
   component: AspectRatio,
 };
 
-export const base = () => (
+export const Base = (args) => (
   <div style={{ width: '50vw' }}>
-    <AspectRatio aspectRatio={number('Aspect ratio', 1.5)}>
+    <AspectRatio {...args}>
       <Background />
     </AspectRatio>
   </div>
 );
+
+Base.args = {
+  aspectRatio: 1.5,
+};

--- a/src/components/Badge/Badge.docs.mdx
+++ b/src/components/Badge/Badge.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Badge } from './Badge';
 
 # Badge
 
@@ -8,7 +7,7 @@ import { Badge } from './Badge';
 Badges are non-actionable elements in the UI, used to indicate the status of an object.
 
 <Story id="components-badge--base" />
-<Props of={Badge} />
+<Props />
 
 ## Best practices
 

--- a/src/components/Badge/Badge.docs.mdx
+++ b/src/components/Badge/Badge.docs.mdx
@@ -25,9 +25,9 @@ Badges are non-actionable elements in the UI, used to indicate the status of an 
 
 ## Component variations
 
-### Colors
+### Variants
 
-The badges come in a number of colors based on their semantic meaning.
+The badges come in a number of variants based on their semantic meaning.
 
 <Story id="components-badge--variants" />
 

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -13,11 +13,12 @@
  * limitations under the License.
  */
 
-import React, { Fragment } from 'react';
-import { select, boolean } from '@storybook/addon-knobs';
+import React from 'react';
 
-import docs from './Badge.docs.mdx';
+import { Stack } from '../../../.storybook/components';
+
 import { Badge, BadgeProps } from './Badge';
+import docs from './Badge.docs.mdx';
 
 export default {
   title: 'Components/Badge',
@@ -27,33 +28,39 @@ export default {
   },
 };
 
-const BaseBadge = (props: Partial<BadgeProps>) => (
-  <Badge
-    variant={select(
-      'Variant',
-      ['neutral', 'success', 'warning', 'danger'],
-      'neutral',
-    )}
-    circle={boolean('Circular', false)}
-    {...props}
-  />
+export const Base = (args: BadgeProps) => <Badge {...args} />;
+
+Base.args = {
+  children: 'Badge',
+};
+
+export const Variants = (args: BadgeProps) => (
+  <Stack>
+    <Badge {...args} variant="neutral">
+      Neutral
+    </Badge>
+    <Badge {...args} variant="success">
+      Success
+    </Badge>
+    <Badge {...args} variant="warning">
+      Warning
+    </Badge>
+    <Badge {...args} variant="danger">
+      Danger
+    </Badge>
+  </Stack>
 );
 
-export const base = () => <BaseBadge>Badge</BaseBadge>;
-
-export const variants = () => (
-  <Fragment>
-    <BaseBadge variant="neutral">Neutral</BaseBadge>
-    <BaseBadge variant="success">Success</BaseBadge>
-    <BaseBadge variant="warning">Warning</BaseBadge>
-    <BaseBadge variant="danger">Danger</BaseBadge>
-  </Fragment>
-);
-
-export const circular = () => (
-  <Fragment>
-    <BaseBadge circle>1</BaseBadge>
-    <BaseBadge circle>42</BaseBadge>
-    <BaseBadge circle>999</BaseBadge>
-  </Fragment>
+export const Circular = (args: BadgeProps) => (
+  <Stack>
+    <Badge {...args} circle>
+      1
+    </Badge>
+    <Badge {...args} circle>
+      42
+    </Badge>
+    <Badge {...args} circle>
+      999
+    </Badge>
+  </Stack>
 );

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -111,7 +111,7 @@ const isDynamicWidth = (children: BadgeProps['children']) => {
   return false;
 };
 
-const circleStyles = ({ circle, children }: BadgeProps) =>
+const circleStyles = ({ circle = false, children }: BadgeProps) =>
   circle &&
   css`
     label: badge--circle;

--- a/src/components/Blockquote/Blockquote.docs.mdx
+++ b/src/components/Blockquote/Blockquote.docs.mdx
@@ -25,4 +25,4 @@ For instance, we should use a blockquote to highlight a quote from a user that w
 You can customize the size of the blockquote using the `size` property.
 We reccomend always sticking to mega in most cases, since it fits well with the Circuit's default body text size.
 
-<Story id="typography-blockquote--size" />
+<Story id="typography-blockquote--sizes" />

--- a/src/components/Blockquote/Blockquote.docs.mdx
+++ b/src/components/Blockquote/Blockquote.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Blockquote } from './Blockquote';
 
 # Blockquote
 
@@ -8,7 +7,7 @@ import { Blockquote } from './Blockquote';
 Blockquotes are a way of styling specific text with indention, normally used for demonstrating and highlighting textual information that comes from an external source.
 
 <Story id="typography-blockquote--base" />
-<Props of={Blockquote} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Blockquote/Blockquote.stories.tsx
+++ b/src/components/Blockquote/Blockquote.stories.tsx
@@ -14,14 +14,9 @@
  */
 
 import React, { Fragment } from 'react';
-import { select, text } from '@storybook/addon-knobs';
 
+import { Blockquote, BlockquoteProps } from './Blockquote';
 import docs from './Blockquote.docs.mdx';
-import { Blockquote } from './Blockquote';
-
-const defaultQuote = `The ability to accept credit card payments that are EMV-compliant is essentially an insurance policy against fraud and an impressively economical one at that.`;
-
-const sizes = ['kilo', 'mega', 'giga'] as const;
 
 export default {
   title: 'Typography/Blockquote',
@@ -31,16 +26,22 @@ export default {
   },
 };
 
-export const base = () => (
-  <Blockquote size={select('Size', sizes, sizes[1])}>
-    {text('Quote', defaultQuote)}
-  </Blockquote>
-);
+export const Base = (args: BlockquoteProps) => <Blockquote {...args} />;
 
-export const size = () => (
+Base.args = {
+  children: `The ability to accept credit card payments that are EMV-compliant is essentially an insurance policy against fraud and an impressively economical one at that.`,
+};
+
+export const Sizes = (args: BlockquoteProps) => (
   <Fragment>
-    <Blockquote size="kilo">Kilo - {text('Quote', defaultQuote)}</Blockquote>
-    <Blockquote size="mega">Mega - {text('Quote', defaultQuote)}</Blockquote>
-    <Blockquote size="giga">Giga - {text('Quote', defaultQuote)}</Blockquote>
+    <Base {...args} size="kilo">
+      Kilo
+    </Base>
+    <Base {...args} size="mega">
+      Mega
+    </Base>
+    <Base {...args} size="giga">
+      Giga
+    </Base>
   </Fragment>
 );

--- a/src/components/Button/Button.docs.mdx
+++ b/src/components/Button/Button.docs.mdx
@@ -1,8 +1,6 @@
 import { Status, Props, Story } from '../../../.storybook/components';
 
 import Button from '.';
-import ButtonGroup from '../ButtonGroup';
-import LoadingButton from '../LoadingButton';
 
 # Button
 
@@ -10,7 +8,7 @@ import LoadingButton from '../LoadingButton';
 
 A button allows us to highlight actions in the product and make them easily perceived and achievable through just one click.
 
-<Story id="components-button--primary" />
+<Story id="components-button--base" />
 <Props of={Button} />
 
 ## When to use it
@@ -35,23 +33,15 @@ Use buttons when users need to either navigate through a product or perform a sp
 
 ## Component variations
 
-### Primary
+### Variants
+
+<Story id="components-button--variants" />
 
 The **primary button** should be used for the most important actions. There should always be just one primary button visible at a time on the screen.
 
-<Story id="components-button--primary" />
-
-### Secondary
-
 The **secondary button** should be used for secondary actions to compliment a primary action, or when multiple actions of equal importance are required.
 
-<Story id="components-button--secondary" />
-
-### Tertiary
-
 The **tertiary button** should be used for supportive actions, and can be paired with the primary or the secondary button.
-
-<Story id="components-button--tertiary" />
 
 ### Sizes
 
@@ -68,7 +58,6 @@ Used when users have two opposite actions to be taken in a certain step of a flo
 with a primary button for the expected action and a secondary button on its left.
 
 <Story id="components-button-buttongroup--base" />
-<Props of={ButtonGroup} />
 
 - **Do** use the same verb tenses for both actions
 
@@ -77,4 +66,3 @@ with a primary button for the expected action and a secondary button on its left
 When the button's action is inputting/saving information or it takes more than 3 seconds to take the user to the next step/page, you can indicate a loading state with `LoadingButton`.
 
 <Story id="components-button-loadingbutton--base" />
-<Props of={LoadingButton} />

--- a/src/components/Button/Button.docs.mdx
+++ b/src/components/Button/Button.docs.mdx
@@ -1,7 +1,5 @@
 import { Status, Props, Story } from '../../../.storybook/components';
 
-import Button from '.';
-
 # Button
 
 <Status.Stable />
@@ -9,7 +7,7 @@ import Button from '.';
 A button allows us to highlight actions in the product and make them easily perceived and achievable through just one click.
 
 <Story id="components-button--base" />
-<Props of={Button} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -14,70 +14,77 @@
  */
 
 import React from 'react';
-import { select, boolean, text, object } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { ThumbUp } from '@sumup/icons';
 
-import docs from './Button.docs.mdx';
+import { Stack } from '../../../.storybook/components';
+import ButtonGroup from '../ButtonGroup';
+import LoadingButton from '../LoadingButton';
+import IconButton from '../IconButton';
+import CloseButton from '../CloseButton';
 
-import Button from '.';
+import { Button, ButtonProps } from './Button';
+import docs from './Button.docs.mdx';
 
 export default {
   title: 'Components/Button',
   component: Button,
+  subcomponents: { LoadingButton, IconButton, CloseButton, ButtonGroup },
   parameters: {
     docs: { page: docs },
   },
+  argTypes: {
+    children: { control: 'text' },
+  },
 };
 
-export const Primary = () => (
-  <Button
-    variant={select('Variant', ['primary', 'secondary', 'tertiary'], 'primary')}
-    size={select('Size', ['kilo', 'mega'], 'mega')}
-    href={boolean('Link', false) ? '#' : undefined}
-    target={boolean('Link', false) ? '_blank' : undefined}
-    stretch={boolean('Stretched', false)}
-    disabled={boolean('Disabled', false)}
-  >
-    {text('Button Label', 'Button')}
-  </Button>
+export const Base = (args: ButtonProps) => <Button {...args} />;
+
+Base.args = {
+  onClick: () => alert('Hello'),
+  children: `Say hello`,
+};
+
+export const Variants = (args: ButtonProps) => (
+  <Stack>
+    <Button {...args} variant="primary">
+      Primary
+    </Button>
+    <Button {...args} variant="secondary">
+      Secondary
+    </Button>
+    <Button {...args} variant="tertiary">
+      Tertiary
+    </Button>
+  </Stack>
 );
 
-export const Secondary = () => (
-  <Button variant="secondary">
-    {text('Button Label', 'Secondary Button')}
-  </Button>
+export const Sizes = (args: ButtonProps) => (
+  <Stack>
+    <Button {...args} size="kilo">
+      Kilo
+    </Button>
+    <Button {...args} size="mega">
+      Mega
+    </Button>
+  </Stack>
 );
 
-export const Tertiary = () => (
-  <Button variant="tertiary">{text('Button Label', 'Tertiary Button')}</Button>
-);
-
-export const Sizes = () => (
-  <>
-    <Button size="kilo">Button kilo</Button>
-    <Button size="mega">Button mega</Button>
-  </>
-);
-
-export const WithIcon = () => (
-  <Button
-    icon={ThumbUp}
-    variant={select('Variant', ['primary', 'secondary', 'tertiary'], 'primary')}
-    size={select('Size', ['kilo', 'mega'], 'mega')}
-  >
+export const WithIcon = (args: ButtonProps) => (
+  <Button {...args} icon={ThumbUp}>
     Like
   </Button>
 );
 
-export const Tracking = () => (
+export const Tracking = (args: ButtonProps) => (
   <Button
+    {...args}
     onClick={action('Button Click')}
     tracking={{
-      label: text('Tracking Label', 'trackingId'),
-      customParameters: object('Custom Parameters', { custom1: 'data' }),
+      label: 'track-button',
+      customParameters: { key: 'value' },
     }}
   >
-    {'Click'}
+    Track me
   </Button>
 );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -39,39 +39,40 @@ import { useComponents } from '../ComponentsContext';
 import useClickHandler from '../../hooks/use-click-handler';
 
 export interface BaseProps {
-  children: ReactNode;
+  'children': ReactNode;
   /**
    * Choose from 3 style variants. Default: 'primary'.
    */
-  variant?: 'primary' | 'secondary' | 'tertiary';
+  'variant'?: 'primary' | 'secondary' | 'tertiary';
   /**
-   * Choose from 3 sizes. Default: 'mega'.
+   * Choose from 2 sizes. Default: 'mega'.
    */
-  size?: 'kilo' | 'mega';
+  'size'?: 'kilo' | 'mega';
   /**
    * Visually and functionally disable the button.
    */
-  disabled?: boolean;
+  'disabled'?: boolean;
   /**
    * Stretch the button across the full width of its parent.
    */
-  stretch?: boolean;
+  'stretch'?: boolean;
   /**
    * Display an icon in addition to the text to help to identify the action.
    */
-  icon?: FC<SVGProps<SVGSVGElement>>;
-  /**
-   * Additional data that is dispatched with the tracking event.
-   */
-  tracking?: TrackingProps;
-  /**
-   The ref to the html dom element, it can be an anchor or a button
-   */
-  ref?: Ref<HTMLButtonElement & HTMLAnchorElement>;
+  'icon'?: FC<SVGProps<SVGSVGElement>>;
   /**
    * The HTML button type
    */
-  type?: 'button' | 'submit' | 'reset' | undefined;
+  'type'?: 'button' | 'submit' | 'reset' | undefined;
+  /**
+   * Additional data that is dispatched with the tracking event.
+   */
+  'tracking'?: TrackingProps;
+  /**
+   The ref to the html dom element, it can be an anchor or a button
+   */
+  'ref'?: Ref<HTMLButtonElement & HTMLAnchorElement>;
+  'data-testid'?: string;
 }
 
 type LinkElProps = Omit<HTMLProps<HTMLAnchorElement>, 'size'>;

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -14,22 +14,18 @@
  */
 
 import React from 'react';
-import { select, boolean } from '@storybook/addon-knobs';
 
 import Button from '../Button';
 
-import { ButtonGroup } from './ButtonGroup';
+import { ButtonGroup, ButtonGroupProps } from './ButtonGroup';
 
 export default {
   title: 'Components/Button/ButtonGroup',
   component: ButtonGroup,
 };
 
-export const base = () => (
-  <ButtonGroup
-    align={select('Align', ['left', 'center', 'right'], 'right')}
-    inlineMobile={boolean('Display inline on mobile', false)}
-  >
+export const Base = (args: ButtonGroupProps) => (
+  <ButtonGroup {...args}>
     <Button variant="secondary">Cancel</Button>
     <Button variant="primary">Confirm</Button>
   </ButtonGroup>

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -89,7 +89,7 @@ const alignmentStyles = ({ align = 'right' }: ButtonGroupProps) => {
 
 const inlineMobileStyles = ({
   theme,
-  inlineMobile,
+  inlineMobile = false,
 }: StyleProps & ButtonGroupProps) =>
   inlineMobile &&
   css`

--- a/src/components/Calendar/RangePicker.stories.js
+++ b/src/components/Calendar/RangePicker.stories.js
@@ -20,28 +20,29 @@ import RangePicker from './RangePicker';
 export default {
   title: 'Forms/Calendar/RangePicker',
   component: RangePicker,
+  argTypes: {
+    showClearDates: { control: 'boolean' },
+  },
 };
 
-const RangePickerWithState = (props) => {
+export const Base = (args) => {
   const [{ startDate, endDate }, setRange] = useState({});
   const [focusedInput, setFocusedInput] = useState(null);
 
   return (
     <RangePicker
-      {...props}
+      {...args}
       startDate={startDate}
       endDate={endDate}
       onDatesChange={setRange}
       focusedInput={focusedInput}
       onFocusChange={setFocusedInput}
+      startDateId="your_unique_start_date_id"
+      endDateId="your_unique_end_date_id"
     />
   );
 };
 
-export const base = () => (
-  <RangePickerWithState
-    startDateId="your_unique_start_date_id"
-    endDateId="your_unique_end_date_id"
-    showClearDates
-  />
-);
+Base.args = {
+  showClearDates: true,
+};

--- a/src/components/Calendar/SingleDayPicker.stories.js
+++ b/src/components/Calendar/SingleDayPicker.stories.js
@@ -22,13 +22,13 @@ export default {
   component: SingleDayPicker,
 };
 
-const SingleDayPickerWithState = (props) => {
+export const Base = (args) => {
   const [date, setDate] = useState(null);
   const [focusedInput, setFocusedInput] = useState(null);
 
   return (
     <SingleDayPicker
-      {...props}
+      {...args}
       date={date}
       onDateChange={setDate}
       focused={focusedInput}
@@ -36,5 +36,3 @@ const SingleDayPickerWithState = (props) => {
     />
   );
 };
-
-export const base = () => <SingleDayPickerWithState />;

--- a/src/components/CalendarTag/CalendarTag.stories.js
+++ b/src/components/CalendarTag/CalendarTag.stories.js
@@ -15,7 +15,6 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { text } from '@storybook/addon-knobs';
 
 import CalendarTag from './CalendarTag';
 
@@ -24,9 +23,6 @@ export default {
   component: CalendarTag,
 };
 
-export const base = () => (
-  <CalendarTag
-    onDatesRangeChange={action('onDatesRangeChange')}
-    tracking={{ label: text('Tracking Label', 'trackingId') }}
-  />
+export const Base = (args) => (
+  <CalendarTag {...args} onDatesRangeChange={action('onDatesRangeChange')} />
 );

--- a/src/components/CalendarTagTwoStep/CalendarTagTwoStep.stories.js
+++ b/src/components/CalendarTagTwoStep/CalendarTagTwoStep.stories.js
@@ -15,7 +15,6 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { text } from '@storybook/addon-knobs';
 
 import CalendarTagTwoStep from './CalendarTagTwoStep';
 
@@ -24,9 +23,9 @@ export default {
   component: CalendarTagTwoStep,
 };
 
-export const base = () => (
+export const Base = (args) => (
   <CalendarTagTwoStep
+    {...args}
     onDatesRangeChange={action('onDatesRangeChange')}
-    tracking={{ label: text('Tracking Label', 'trackingId') }}
   />
 );

--- a/src/components/Card/Card.docs.mdx
+++ b/src/components/Card/Card.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import Card from './Card';
 
 # Card
 
@@ -10,7 +9,7 @@ users. They group related information and make our product easy to scan and unde
 
 <Story id="components-card--base" />
 
-<Props of={Card} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Card/Card.stories.js
+++ b/src/components/Card/Card.stories.js
@@ -15,10 +15,11 @@
 
 /** @jsx jsx */
 import { Fragment } from 'react';
-import { text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { css, jsx } from '@emotion/core';
 
+import { Stack } from '../../../.storybook/components';
+import CardList from '../CardList';
 import Heading from '../Heading';
 import Text from '../Text';
 import ButtonGroup from '../ButtonGroup';
@@ -31,23 +32,31 @@ import Card, { CardHeader, CardFooter } from '.';
 export default {
   title: 'Components/Card',
   component: Card,
+  subcomponents: { CardList },
   parameters: {
     docs: { page: docs },
   },
 };
 
-const cardStyles = (theme) => css`
-  width: 500px;
+const cardStyles = () => css`
+  width: 400px;
+  min-height: 120px;
+  max-width: 90vw;
+  max-height: 90vh;
+  margin-bottom: 1rem;
+`;
+
+const squareStyles = () => css`
+  width: 150px;
   min-height: 150px;
   max-width: 90vw;
   max-height: 90vh;
-  margin-bottom: ${theme.spacings.mega};
 `;
 
 const contentStyles = (theme) => css`
-  background: ${theme.colors.n200};
+  background: ${theme.colors.n300};
   width: 100%;
-  height: 100%;
+  height: 118px;
 `;
 
 const Header = () => (
@@ -60,28 +69,28 @@ const Content = () => (
   <Text noMargin>This is some text showing in my card</Text>
 );
 
-export const base = () => <Card css={cardStyles} />;
+export const Base = () => <Card css={cardStyles} />;
 
-export const shadows = () => (
-  <Fragment>
-    <Card shadow={'single'} css={cardStyles} />
-    <Card shadow={'double'} css={cardStyles} />
-    <Card shadow={'triple'} css={cardStyles} />
-  </Fragment>
+export const Shadows = () => (
+  <Stack>
+    <Card shadow={'single'} css={squareStyles} />
+    <Card shadow={'double'} css={squareStyles} />
+    <Card shadow={'triple'} css={squareStyles} />
+  </Stack>
 );
 
-export const spacings = () => (
-  <Fragment>
-    <Card spacing={'mega'} css={cardStyles}>
+export const Spacings = () => (
+  <Stack>
+    <Card spacing={'mega'} css={squareStyles}>
       <div css={contentStyles} />
     </Card>
-    <Card spacing={'giga'} css={cardStyles}>
+    <Card spacing={'giga'} css={squareStyles}>
       <div css={contentStyles} />
     </Card>
-  </Fragment>
+  </Stack>
 );
 
-export const withHeader = () => (
+export const WithHeader = () => (
   <Fragment>
     <Card css={cardStyles}>
       <CardHeader>
@@ -93,9 +102,7 @@ export const withHeader = () => (
     <Card css={cardStyles}>
       <CardHeader
         onClose={action('CloseButton clicked')}
-        tracking={{
-          label: text('Tracking Label', 'trackingId'),
-        }}
+        tracking={{ label: 'trackingId' }}
       >
         <Header />
       </CardHeader>
@@ -104,7 +111,7 @@ export const withHeader = () => (
   </Fragment>
 );
 
-export const withFooter = () => (
+export const WithFooter = () => (
   <Fragment>
     <Card css={cardStyles}>
       <Content />

--- a/src/components/CardList/CardList.docs.mdx
+++ b/src/components/CardList/CardList.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import CardList from '.';
 
 # CardList
 
@@ -9,4 +8,4 @@ You can create a list of cards using `CardList`. You should use it when showing 
 
 <Story id="components-card-cardlist--base" />
 
-<Props of={CardList} />
+<Props />

--- a/src/components/CardList/CardList.stories.js
+++ b/src/components/CardList/CardList.stories.js
@@ -13,39 +13,12 @@
  * limitations under the License.
  */
 
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { range } from 'lodash/fp';
-import * as knobs from '@storybook/addon-knobs';
 
 import docs from './CardList.docs.mdx';
 
 import CardList from '.';
-
-class CardListStory extends Component {
-  state = { selected: 0 };
-
-  handleClick = (selected) => () => this.setState({ selected });
-
-  render() {
-    const { selected } = this.state;
-    const padding = knobs.select('padding', ['kilo', 'mega', 'giga'], 'giga');
-
-    return (
-      <CardList>
-        {range(1, 6).map((i) => (
-          <CardList.Item
-            key={i}
-            selected={selected === i}
-            onClick={this.handleClick(i)}
-            padding={padding}
-          >
-            Item #{i}
-          </CardList.Item>
-        ))}
-      </CardList>
-    );
-  }
-}
 
 export default {
   title: 'Components/Card/CardList',
@@ -55,4 +28,22 @@ export default {
   },
 };
 
-export const base = () => <CardListStory />;
+export const Base = (args) => {
+  const [selected, setSelected] = useState(0);
+
+  const handleClick = (index) => () => setSelected(index);
+
+  return (
+    <CardList {...args}>
+      {range(1, 6).map((i) => (
+        <CardList.Item
+          key={i}
+          selected={selected === i}
+          onClick={handleClick(i)}
+        >
+          Item #{i}
+        </CardList.Item>
+      ))}
+    </CardList>
+  );
+};

--- a/src/components/Carousel/Carousel.docs.mdx
+++ b/src/components/Carousel/Carousel.docs.mdx
@@ -1,10 +1,10 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import Carousel from './Carousel';
 
 # Carousel
 
 <Status.Stable />
-<Props of={Carousel} />
+
+<Props />
 
 ## Component variations
 

--- a/src/components/Carousel/Carousel.stories.js
+++ b/src/components/Carousel/Carousel.stories.js
@@ -16,7 +16,6 @@
 /* eslint-disable react/prop-types */
 
 import React, { useState } from 'react';
-import { object, number, boolean } from '@storybook/addon-knobs';
 
 import Container from './components/Container';
 import Slides from './components/Slides';
@@ -25,9 +24,9 @@ import SlideImage from './components/SlideImage';
 import Controls from './components/Controls';
 import { ButtonList, NextButton, PrevButton } from './components/Buttons';
 import Status from './components/Status';
-import { ASPECT_RATIO, ANIMATION_DURATION, SLIDE_DURATION } from './constants';
 import Carousel from './Carousel';
 import docs from './Carousel.docs.mdx';
+import { ASPECT_RATIO, ANIMATION_DURATION, SLIDE_DURATION } from './constants';
 import { SLIDES } from './__fixtures__';
 
 export default {
@@ -38,61 +37,54 @@ export default {
   },
 };
 
-const CustomCarousel = ({ slides }) => {
-  const total = slides.length;
+export const Stateful = (args) => (
+  <div style={{ width: '50vw' }}>
+    <Carousel {...args} />
+  </div>
+);
+
+Stateful.args = {
+  slides: SLIDES,
+  slideDuration: SLIDE_DURATION,
+  animationDuration: ANIMATION_DURATION,
+  aspectRatio: ASPECT_RATIO,
+  cycle: true,
+  autoPlay: true,
+  hideControls: false,
+};
+
+export const Composed = () => {
+  const total = SLIDES.length;
   const [step, setStep] = useState(0);
   const goBack = () => setStep(step === 0 ? total - 1 : step - 1);
   const goForward = () => setStep(step === total - 1 ? 0 : step + 1);
 
   return (
-    <Container>
-      <Slides>
-        {slides.map(({ image }, index) => (
-          <Slide
-            key={index}
-            index={index}
-            step={step}
-            style={{
-              opacity: step === index ? 1 : 0,
-              transition: 'opacity .3s ease-in',
-            }}
-          >
-            <SlideImage
-              src={image.src}
-              alt={image.alt}
-              aspectRatio={number('Aspect ratio', 2.5)}
-            />
-          </Slide>
-        ))}
-      </Slides>
-      <Controls>
-        <ButtonList>
-          <PrevButton onClick={goBack} />
-          <Status style={{ marginLeft: 8 }} step={step} total={total} />
-          <NextButton onClick={goForward} />
-        </ButtonList>
-      </Controls>
-    </Container>
+    <div style={{ width: '50vw' }}>
+      <Container>
+        <Slides>
+          {SLIDES.map(({ image }, index) => (
+            <Slide
+              key={index}
+              index={index}
+              step={step}
+              style={{
+                opacity: step === index ? 1 : 0,
+                transition: 'opacity .3s ease-in',
+              }}
+            >
+              <SlideImage src={image.src} alt={image.alt} aspectRatio={2.5} />
+            </Slide>
+          ))}
+        </Slides>
+        <Controls>
+          <ButtonList>
+            <PrevButton onClick={goBack} />
+            <Status style={{ marginLeft: 8 }} step={step} total={total} />
+            <NextButton onClick={goForward} />
+          </ButtonList>
+        </Controls>
+      </Container>
+    </div>
   );
 };
-
-export const stateful = () => (
-  <div style={{ width: '50vw' }}>
-    <Carousel
-      slides={object('Slides', SLIDES)}
-      slideDuration={number('Slide duration', SLIDE_DURATION)}
-      animationDuration={number('Animation duration', ANIMATION_DURATION)}
-      aspectRatio={number('Aspect ratio', ASPECT_RATIO)}
-      cycle={boolean('Cycle', true)}
-      swipe={boolean('Swipe', true)}
-      autoPlay={boolean('Auto play', true)}
-      hideControls={boolean('Hide controls', false)}
-    />
-  </div>
-);
-
-export const composed = () => (
-  <div style={{ width: '50vw' }}>
-    <CustomCarousel slides={object('Slides', SLIDES)} />
-  </div>
-);

--- a/src/components/Carousel/components/Buttons/Buttons.stories.js
+++ b/src/components/Carousel/components/Buttons/Buttons.stories.js
@@ -25,7 +25,7 @@ export default {
   component: Buttons,
 };
 
-export const allButtons = () => (
+export const AllButtons = () => (
   <ButtonList>
     <PlayButton onClick={action('on play click')} />
     <PlayButton paused onClick={action('on pause click')} />

--- a/src/components/Carousel/components/Slide/Slide.stories.js
+++ b/src/components/Carousel/components/Slide/Slide.stories.js
@@ -22,6 +22,11 @@ import Image from '../../../Image';
 
 import Slide from './Slide';
 
+export default {
+  title: 'Components/Carousel/Slide',
+  component: Slide,
+};
+
 const headingStyles = css`
   color: #fff;
   width: 66%;
@@ -32,30 +37,21 @@ const headingStyles = css`
 `;
 const StyledHeading = styled(Heading)(headingStyles);
 
-export default {
-  title: 'Components/Carousel/Slide',
-  component: Slide,
-};
-
-export const onlyImage = () => (
-  <div style={{ width: '600px', maxWidth: '90vw' }}>
-    <Slide>
-      <Image
-        src="https://source.unsplash.com/TpHmEoVSmfQ/1600x900"
-        alt="Aerial photo of turbulent turquoise ocean waves"
-      />
-    </Slide>
-  </div>
+export const OnlyImage = (args) => (
+  <Slide {...args}>
+    <Image
+      src="https://source.unsplash.com/TpHmEoVSmfQ/1600x900"
+      alt="Aerial photo of turbulent turquoise ocean waves"
+    />
+  </Slide>
 );
 
-export const textAndImage = () => (
-  <div style={{ width: '600px', maxWidth: '90vw' }}>
-    <Slide>
-      <Image
-        src="https://source.unsplash.com/TpHmEoVSmfQ/1600x900"
-        alt="Aerial photo of turbulent turquoise ocean waves"
-      />
-      <StyledHeading size="exa">Get The SumUp Card Reader Today!</StyledHeading>
-    </Slide>
-  </div>
+export const TextAndImage = (args) => (
+  <Slide {...args}>
+    <Image
+      src="https://source.unsplash.com/TpHmEoVSmfQ/1600x900"
+      alt="Aerial photo of turbulent turquoise ocean waves"
+    />
+    <StyledHeading size="exa">Get The SumUp Card Reader Today!</StyledHeading>
+  </Slide>
 );

--- a/src/components/Carousel/components/Status/Status.stories.js
+++ b/src/components/Carousel/components/Status/Status.stories.js
@@ -14,7 +14,6 @@
  */
 
 import React from 'react';
-import { number } from '@storybook/addon-knobs';
 
 import Status from './Status';
 
@@ -23,6 +22,9 @@ export default {
   component: Status,
 };
 
-export const base = () => (
-  <Status step={number('Current index', 0)} total={number('Total slides', 3)} />
-);
+export const Base = (args) => <Status {...args} />;
+
+Base.args = {
+  step: 0,
+  total: 3,
+};

--- a/src/components/Checkbox/Checkbox.docs.mdx
+++ b/src/components/Checkbox/Checkbox.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Checkbox } from './Checkbox';
 
 # Checkbox
 
@@ -10,7 +9,7 @@ The users can select from zero, one, or multiple options. In other words, each c
 of all other checkboxes in the list, and checking one box doesn’t uncheck the others.
 
 <Story id="forms-checkbox--base" />
-<Props of={Checkbox} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -15,7 +15,6 @@
 
 import React, { useState, ChangeEvent } from 'react';
 import { action } from '@storybook/addon-actions';
-import { text } from '@storybook/addon-knobs';
 
 import { Checkbox, CheckboxProps } from './Checkbox';
 import docs from './Checkbox.docs.mdx';
@@ -25,6 +24,11 @@ export default {
   component: Checkbox,
   parameters: {
     docs: { page: docs },
+  },
+  argTypes: {
+    name: { control: 'text' },
+    value: { control: 'text' },
+    disabled: { control: 'boolean' },
   },
 };
 
@@ -39,25 +43,21 @@ const CheckboxWithState = ({
     setChecked((prev) => !prev);
   };
   return (
-    <Checkbox
-      {...props}
-      checked={checked}
-      onChange={handleChange}
-      tracking={{ label: text('Tracking Label', 'trackingId') }}
-    >
+    <Checkbox {...props} checked={checked} onChange={handleChange}>
       {children || (checked ? 'Checked' : 'Unchecked')}
     </Checkbox>
   );
 };
 
-export const base = () => <CheckboxWithState name="base" value="true" />;
+export const Base = (args: CheckboxProps) => <CheckboxWithState {...args} />;
 
-const InvalidCheckboxWithState = ({
-  checked: initial = false,
-  children,
-  ...props
-}: CheckboxProps) => {
-  const [checked, setChecked] = useState(initial);
+Base.args = {
+  name: 'base',
+  value: 'true',
+};
+
+export const Invalid = (args: CheckboxProps) => {
+  const [checked, setChecked] = useState(false);
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     action('Checkbox clicked')(event);
     setChecked((prev) => !prev);
@@ -65,37 +65,42 @@ const InvalidCheckboxWithState = ({
   const invalid = !checked;
   return (
     <Checkbox
-      {...props}
+      {...args}
       checked={checked}
       onChange={handleChange}
-      tracking={{ label: text('Tracking Label', 'trackingId') }}
-      validationHint={
-        invalid ? text('Validation hint', 'This field is required.') : undefined
-      }
+      validationHint={invalid ? args.validationHint : undefined}
       invalid={invalid}
     >
-      {children || (checked ? 'Checked' : 'Unchecked')}
+      {checked ? 'Checked' : 'Unchecked'}
     </Checkbox>
   );
 };
 
-export const invalid = () => (
-  <InvalidCheckboxWithState name="invalid" value="invalid" />
+Invalid.args = {
+  name: 'invalid',
+  value: 'true',
+  validationHint: 'This field is required.',
+};
+
+export const Disabled = (args: CheckboxProps) => (
+  <CheckboxWithState {...args} />
 );
 
-export const disabled = () => (
-  <CheckboxWithState name="disabled" value="disabled" disabled />
-);
+Disabled.args = {
+  name: 'disabled',
+  value: 'true',
+  disabled: true,
+};
 
-export const multiple = () => (
+export const Multiple = (args: CheckboxProps) => (
   <>
-    <CheckboxWithState value="apples" name="fruits">
+    <CheckboxWithState {...args} value="apples" name="fruits">
       Apples
     </CheckboxWithState>
-    <CheckboxWithState value="bananas" name="fruits">
+    <CheckboxWithState {...args} value="bananas" name="fruits">
       Bananas
     </CheckboxWithState>
-    <CheckboxWithState value="oranges" name="fruits">
+    <CheckboxWithState {...args} value="oranges" name="fruits">
       Oranges
     </CheckboxWithState>
   </>

--- a/src/components/CloseButton/CloseButton.stories.tsx
+++ b/src/components/CloseButton/CloseButton.stories.tsx
@@ -14,9 +14,8 @@
  */
 
 import React from 'react';
-import { text } from '@storybook/addon-knobs';
 
-import { CloseButton } from './CloseButton';
+import { CloseButton, CloseButtonProps } from './CloseButton';
 
 export default {
   title: 'Components/Button/CloseButton',
@@ -25,4 +24,8 @@ export default {
   },
 };
 
-export const base = () => <CloseButton label={text('Label', 'Close')} />;
+export const Base = (args: CloseButtonProps) => <CloseButton {...args} />;
+
+Base.args = {
+  label: 'Close',
+};

--- a/src/components/Col/Col.js
+++ b/src/components/Col/Col.js
@@ -20,7 +20,7 @@ import isPropValid from '@emotion/is-prop-valid';
 
 import { getSpanStyles, getSkipStyles, getBreakPointStyles } from './utils';
 
-const baseStyles = ({ theme, skip, span }) => css`
+const baseStyles = ({ theme, skip = '0', span = '0' }) => css`
   label: col;
 
   box-sizing: border-box;
@@ -62,11 +62,6 @@ Col.propTypes = {
    * span of 6 columns.
    */
   span: sizingProp,
-};
-
-Col.defaultProps = {
-  skip: '0',
-  span: '0',
 };
 
 /**

--- a/src/components/Col/Col.stories.js
+++ b/src/components/Col/Col.stories.js
@@ -21,32 +21,47 @@ import docs from '../Grid/Grid.docs.mdx';
 
 import Col from './Col';
 
+const colControl = {
+  control: {
+    type: 'range',
+    min: 0,
+    max: 12,
+    step: 1,
+  },
+};
+
 export default {
   title: 'Layout/Grid/Col',
   component: Col,
   parameters: {
+    layout: 'fullscreen',
     docs: { page: docs },
+  },
+  argTypes: {
+    span: colControl,
+    skip: colControl,
   },
 };
 
 const StyledCol = styled(Col)(
   ({ theme }) => css`
-    background-color: ${theme.colors.b500};
-    color: ${theme.colors.white};
-    font-size: 14px;
+    background-color: ${theme.colors.n300};
+    text-align: center;
+    font-size: 16px;
     font-weight: bold;
-    line-height: 20px;
-    height: 40px;
-    padding: 10px;
+    line-height: 24px;
+    height: 48px;
+    padding: 12px;
   `,
 );
 
-StyledCol.defaultProps = {
-  skip: '0',
-};
-
-export const col = () => (
-  <div style={{ width: '100vw' }}>
-    <StyledCol span="12">Column</StyledCol>
-  </div>
+export const Base = (args) => (
+  <StyledCol span={args.span.toString()} skip={args.skip.toString()}>
+    Column
+  </StyledCol>
 );
+
+Base.args = {
+  span: '12',
+  skip: 0,
+};

--- a/src/components/CurrencyInput/CurrencyInput.docs.mdx
+++ b/src/components/CurrencyInput/CurrencyInput.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { CurrencyInput } from './CurrencyInput';
 
 # CurrencyInput
 
@@ -8,7 +7,7 @@ import { CurrencyInput } from './CurrencyInput';
 The CurrencyInput component indicates to the user that a number should be entered in a given currency.
 
 <Story id="forms-input-currencyinput--base" />
-<Props of={CurrencyInput} />
+<Props />
 
 ⚠️ The CurrencyInput uses `@sumup/intl` to format the currency value. It wraps the [ECMAScript Internationalization API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) which is [supported by all modern browsers](https://caniuse.com/#search=NumberFormat) but not IE11. If you need to support older browsers, you need to include [a polyfill for the `Intl.NumberFormat` API](https://formatjs.io/docs/polyfills/intl-numberformat).
 

--- a/src/components/CurrencyInput/CurrencyInput.stories.tsx
+++ b/src/components/CurrencyInput/CurrencyInput.stories.tsx
@@ -14,9 +14,9 @@
  */
 
 /** @jsx jsx */
-import { Fragment } from 'react';
 import { css, jsx } from '@emotion/core';
-import { boolean, text } from '@storybook/addon-knobs';
+
+import { Stack } from '../../../.storybook/components';
 
 import docs from './CurrencyInput.docs.mdx';
 import { CurrencyInput, CurrencyInputProps } from './CurrencyInput';
@@ -29,59 +29,62 @@ export default {
   },
 };
 
-const BaseCurrencyInput = (props: Partial<CurrencyInputProps>) => (
-  <CurrencyInput
-    currency="EUR"
-    validationHint={text('Validation hint', 'Excluding VAT')}
-    invalid={boolean('Invalid', false)}
-    showValid={boolean('Show valid', false)}
-    hasWarning={boolean('Has warning', false)}
-    css={css`
-      max-width: 250px;
-    `}
-    {...props}
-  />
+const storyStyles = css`
+  max-width: 250px;
+`;
+
+const baseArgs = {
+  label: 'Amount (de-DE, EUR)',
+  placeholder: 123.45,
+  validationHint: 'Excluding VAT',
+  currency: 'EUR',
+  locale: 'de-DE',
+};
+
+export const Base = (args: CurrencyInputProps) => (
+  <CurrencyInput {...args} css={storyStyles} />
 );
 
-export const base = () => (
-  <BaseCurrencyInput
-    label="Amount (de-DE, EUR)"
-    placeholder={123.45}
-    locale="de-DE"
-    currency="EUR"
-  />
-);
+Base.args = baseArgs;
 
-export const currencies = () => (
-  <Fragment>
-    <BaseCurrencyInput
+export const Currencies = (args: CurrencyInputProps) => (
+  <Stack>
+    <CurrencyInput
+      {...args}
       label="Amount (pt-BR, BRL)"
       placeholder={1234.5}
       currency="BRL"
       locale="pt-BR"
     />
-    <BaseCurrencyInput
+    <CurrencyInput
+      {...args}
       label="Amount (pt-BR, EUR)"
       placeholder={1234.5}
       currency="EUR"
       locale="pt-BR"
     />
-  </Fragment>
+  </Stack>
 );
 
-export const locales = () => (
-  <Fragment>
-    <BaseCurrencyInput
+Currencies.args = baseArgs;
+
+export const Locales = (args: CurrencyInputProps) => (
+  <Stack>
+    <CurrencyInput
+      {...args}
       label="Amount (de-DE, EUR)"
       placeholder={1234.5}
       currency="EUR"
       locale="de-DE"
     />
-    <BaseCurrencyInput
+    <CurrencyInput
+      {...args}
       label="Amount (en-IE, EUR)"
       placeholder={1234.5}
       currency="EUR"
       locale="en-IE"
     />
-  </Fragment>
+  </Stack>
 );
+
+Locales.args = baseArgs;

--- a/src/components/Grid/Grid.stories.js
+++ b/src/components/Grid/Grid.stories.js
@@ -26,146 +26,125 @@ export default {
   title: 'Layout/Grid/Grid',
   component: Grid,
   parameters: {
+    layout: 'fullscreen',
+    controls: { hideNoControlsWarning: true },
     docs: { page: docs },
   },
 };
 
 const StyledCol = styled(Col)`
-  color: ${(p) => p.theme.colors.white};
-  font-size: 14px;
+  font-size: 16px;
   font-weight: bold;
-  line-height: 20px;
-  height: 40px;
-  padding: 10px;
+  line-height: 24px;
+  height: 48px;
+  padding: 12px;
   &:nth-of-type(n) {
-    background-color: ${(p) => p.theme.colors.b500};
+    background-color: ${(p) => p.theme.colors.n300};
   }
 
   &:nth-of-type(2n) {
-    background-color: ${(p) => p.theme.colors.b300};
+    background-color: ${(p) => p.theme.colors.n100};
   }
 `;
 
-StyledCol.defaultProps = {
-  skip: '0',
-};
-
 const StyledRow = styled(Row)`
-  border: 2px solid ${(p) => p.theme.colors.y100};
+  border: 1px solid magenta;
   margin-bottom: 8px;
 `;
 
-export const staticColumns = () => (
-  <div style={{ width: '100vw' }}>
-    <Grid>
-      <StyledRow>
-        <StyledCol span="2">Col 2</StyledCol>
-        <StyledCol span="2">Col 2</StyledCol>
-        <StyledCol span="2">Col 2</StyledCol>
-        <StyledCol span="2">Col 2</StyledCol>
-        <StyledCol span="2">Col 2</StyledCol>
-        <StyledCol span="2">Col 2</StyledCol>
-      </StyledRow>
+export const StaticColumns = () => (
+  <Grid>
+    <StyledRow>
+      <StyledCol span="2">Col 2</StyledCol>
+      <StyledCol span="2">Col 2</StyledCol>
+      <StyledCol span="2">Col 2</StyledCol>
+      <StyledCol span="2">Col 2</StyledCol>
+      <StyledCol span="2">Col 2</StyledCol>
+      <StyledCol span="2">Col 2</StyledCol>
+    </StyledRow>
 
-      <StyledRow>
-        <StyledCol span="3">Col 3</StyledCol>
-        <StyledCol span="3">Col 3</StyledCol>
-        <StyledCol span="3">Col 3</StyledCol>
-        <StyledCol span="3">Col 3</StyledCol>
-      </StyledRow>
+    <StyledRow>
+      <StyledCol span="3">Col 3</StyledCol>
+      <StyledCol span="3">Col 3</StyledCol>
+      <StyledCol span="3">Col 3</StyledCol>
+      <StyledCol span="3">Col 3</StyledCol>
+    </StyledRow>
 
-      <StyledRow>
-        <StyledCol span="4">Col 4</StyledCol>
-        <StyledCol span="4">Col 4</StyledCol>
-        <StyledCol span="4">Col 4</StyledCol>
-      </StyledRow>
+    <StyledRow>
+      <StyledCol span="4">Col 4</StyledCol>
+      <StyledCol span="4">Col 4</StyledCol>
+      <StyledCol span="4">Col 4</StyledCol>
+    </StyledRow>
 
-      <StyledRow>
-        <StyledCol span="4">Col 4</StyledCol>
-        <StyledCol span="2">Col 2</StyledCol>
-        <StyledCol span="2">Col 2</StyledCol>
-        <StyledCol span="1">1</StyledCol>
-        <StyledCol span="3">Col 4</StyledCol>
-      </StyledRow>
+    <StyledRow>
+      <StyledCol span="4">Col 4</StyledCol>
+      <StyledCol span="2">Col 2</StyledCol>
+      <StyledCol span="2">Col 2</StyledCol>
+      <StyledCol span="1">Col 1</StyledCol>
+      <StyledCol span="3">Col 4</StyledCol>
+    </StyledRow>
 
-      <StyledRow>
-        <StyledCol span="6">Col 6</StyledCol>
-        <StyledCol span="6">Col 6</StyledCol>
-      </StyledRow>
-    </Grid>
-  </div>
+    <StyledRow>
+      <StyledCol span="6">Col 6</StyledCol>
+      <StyledCol span="6">Col 6</StyledCol>
+    </StyledRow>
+  </Grid>
 );
 
-export const responsiveColumns = () => (
-  <div style={{ width: '100vw' }}>
-    <Grid>
-      <StyledRow>
-        <StyledCol span={{ default: 12, mega: 3, kilo: 6 }}>
-          resize me
-        </StyledCol>
-        <StyledCol span={{ default: 12, mega: 3, kilo: 6 }}>
-          resize me
-        </StyledCol>
-        <StyledCol span={{ default: 12, mega: 3, kilo: 6 }}>
-          resize me
-        </StyledCol>
-        <StyledCol span={{ default: 12, mega: 3, kilo: 6 }}>
-          resize me
-        </StyledCol>
-      </StyledRow>
+export const ResponsiveColumns = () => (
+  <Grid>
+    <StyledRow>
+      <StyledCol span={{ default: 12, mega: 3, kilo: 6 }}>resize me</StyledCol>
+      <StyledCol span={{ default: 12, mega: 3, kilo: 6 }}>resize me</StyledCol>
+      <StyledCol span={{ default: 12, mega: 3, kilo: 6 }}>resize me</StyledCol>
+      <StyledCol span={{ default: 12, mega: 3, kilo: 6 }}>resize me</StyledCol>
+    </StyledRow>
 
-      <StyledRow>
-        <StyledCol span={{ default: 12, mega: 3, kilo: 6 }}>
-          resize me
-        </StyledCol>
-        <StyledCol span="6">half</StyledCol>
-      </StyledRow>
-    </Grid>
-  </div>
+    <StyledRow>
+      <StyledCol span={{ default: 12, mega: 3, kilo: 6 }}>resize me</StyledCol>
+      <StyledCol span="6">half</StyledCol>
+    </StyledRow>
+  </Grid>
 );
 
-export const skippingColumns = () => (
-  <div style={{ width: '100vw' }}>
-    <Grid>
-      <StyledRow>
-        <StyledCol span="3">Col 3</StyledCol>
-        <StyledCol span="3">Col 3</StyledCol>
-        <StyledCol span="3" skip="3">
-          Col 3
-        </StyledCol>
-      </StyledRow>
+export const SkippingColumns = () => (
+  <Grid>
+    <StyledRow>
+      <StyledCol span="3">Col 3</StyledCol>
+      <StyledCol span="3">Col 3</StyledCol>
+      <StyledCol span="3" skip="3">
+        Col 3
+      </StyledCol>
+    </StyledRow>
 
-      <StyledRow>
-        <StyledCol span="6" skip="6">
-          First column
-        </StyledCol>
-        <StyledCol span="6" skip="-6">
-          Second Column
-        </StyledCol>
-      </StyledRow>
-    </Grid>
-  </div>
+    <StyledRow>
+      <StyledCol span="6" skip="6">
+        First column
+      </StyledCol>
+      <StyledCol span="6" skip="-6">
+        Second Column
+      </StyledCol>
+    </StyledRow>
+  </Grid>
 );
 
-export const responsiveSkipping = () => (
-  <div style={{ width: '100vw' }}>
-    <Grid>
-      <StyledRow>
-        <StyledCol span="3">Col 3</StyledCol>
-        <StyledCol span="3">Col 3</StyledCol>
-        <StyledCol span="3" skip={{ default: 0, untilKilo: 3 }}>
-          skip mobile
-        </StyledCol>
-      </StyledRow>
+export const ResponsiveSkipping = () => (
+  <Grid>
+    <StyledRow>
+      <StyledCol span="3">Col 3</StyledCol>
+      <StyledCol span="3">Col 3</StyledCol>
+      <StyledCol span="3" skip={{ default: 0, untilKilo: 3 }}>
+        skip mobile
+      </StyledCol>
+    </StyledRow>
 
-      <StyledRow>
-        <StyledCol span="6" skip={{ default: 6, untilKilo: 0 }}>
-          first column
-        </StyledCol>
-        <StyledCol span="6" skip={{ default: -6, untilKilo: 0 }}>
-          second column
-        </StyledCol>
-      </StyledRow>
-    </Grid>
-  </div>
+    <StyledRow>
+      <StyledCol span="6" skip={{ default: 6, untilKilo: 0 }}>
+        first column
+      </StyledCol>
+      <StyledCol span="6" skip={{ default: -6, untilKilo: 0 }}>
+        second column
+      </StyledCol>
+    </StyledRow>
+  </Grid>
 );

--- a/src/components/Hamburger/Hamburger.stories.tsx
+++ b/src/components/Hamburger/Hamburger.stories.tsx
@@ -14,7 +14,6 @@
  */
 
 import React, { useState } from 'react';
-import { text } from '@storybook/addon-knobs';
 
 import { Hamburger, HamburgerProps } from './Hamburger';
 
@@ -23,20 +22,15 @@ export default {
   component: Hamburger,
 };
 
-const HamburgerWithState = (props: HamburgerProps) => {
+export const Base = (args: HamburgerProps) => {
   const [active, setActive] = useState(false);
   const handleClick = () => {
     setActive((prev) => !prev);
   };
-  return <Hamburger isActive={active} onClick={handleClick} {...props} />;
+  return <Hamburger isActive={active} onClick={handleClick} {...args} />;
 };
 
-export const Base = () => (
-  <HamburgerWithState
-    labelActive={text('Label active', 'Close menu')}
-    labelInActive={text('Label inactive', 'Open menu')}
-    tracking={{
-      label: text('Tracking Label', 'trackingId'),
-    }}
-  />
-);
+Base.args = {
+  labelActive: 'Close menu',
+  labelInActive: 'Open menu',
+};

--- a/src/components/Hamburger/Hamburger.tsx
+++ b/src/components/Hamburger/Hamburger.tsx
@@ -23,24 +23,23 @@ import { IconButton, IconButtonProps } from '../IconButton/IconButton';
 export type HamburgerRef = HTMLButtonElement;
 
 export interface HamburgerProps
-  extends Omit<IconButtonProps, 'ref' | 'children' | 'label'> {
+  extends Omit<IconButtonProps, 'ref' | 'children' | 'label' | 'type'> {
   /**
    * When active, the Hamburger transform into a close button.
    */
-  'isActive'?: boolean;
+  isActive?: boolean;
   /**
    * Label for the 'active' state. Important for accessibility.
    */
-  'labelActive': string;
+  labelActive: string;
   /**
    * Label for the 'inactive' state. Important for accessibility.
    */
-  'labelInActive': string;
-  'data-testid'?: string;
+  labelInActive: string;
   /**
    * Additional data that is dispatched with the tracking event.
    */
-  'tracking'?: TrackingProps;
+  tracking?: TrackingProps;
 }
 
 const LAYER_HEIGHT = '2px';
@@ -142,6 +141,7 @@ export const Hamburger = ({
     label={isActive ? labelActive : labelInActive}
     {...props}
     tracking={{ component: 'hamburger', ...tracking }}
+    type="button"
   >
     <Box>
       <Layers isActive={isActive} />

--- a/src/components/Hamburger/__snapshots__/Hamburger.spec.tsx.snap
+++ b/src/components/Hamburger/__snapshots__/Hamburger.spec.tsx.snap
@@ -159,6 +159,7 @@ exports[`Hamburger should render with active styles when passed the isActive pro
 <button
   class="circuit-3"
   title="Close menu"
+  type="button"
 >
   <span
     class="circuit-1"
@@ -310,6 +311,7 @@ exports[`Hamburger should render with default styles 1`] = `
 <button
   class="circuit-3"
   title="Open menu"
+  type="button"
 >
   <span
     class="circuit-1"

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -65,11 +65,6 @@ Header.propTypes = {
   children: PropTypes.node,
 };
 
-Header.defaultProps = {
-  title: '',
-  children: '',
-};
-
 /**
  * @component
  */

--- a/src/components/Header/Header.stories.js
+++ b/src/components/Header/Header.stories.js
@@ -14,7 +14,6 @@
  */
 
 import React from 'react';
-import { boolean } from '@storybook/addon-knobs';
 
 import Hamburger from '../Hamburger';
 
@@ -25,8 +24,13 @@ export default {
   component: Header,
 };
 
-export const base = () => (
-  <Header title="Title" mobileOnly={boolean('mobileOnly')}>
+export const Base = (args) => (
+  <Header {...args}>
     <Hamburger size="kilo" />
   </Header>
 );
+
+Base.args = {
+  title: 'Title',
+  mobileOnly: false,
+};

--- a/src/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Header/__snapshots__/Header.spec.js.snap
@@ -36,7 +36,6 @@ exports[`Header styles should render and match snapshot for mobileOnly styles 1`
 <div
   class="circuit-2 circuit-3"
 >
-  
   <h1
     class="circuit-0 circuit-1"
   >
@@ -75,7 +74,6 @@ exports[`Header styles should render with default styles 1`] = `
 <div
   class="circuit-2 circuit-3"
 >
-  
   <h1
     class="circuit-0 circuit-1"
   >

--- a/src/components/Heading/Heading.docs.mdx
+++ b/src/components/Heading/Heading.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Heading } from './Heading';
 
 # Heading
 
@@ -8,7 +7,7 @@ import { Heading } from './Heading';
 Headings are used for titling major sections of the interface. They help better organize the information for our users providing useful labels for each possible section.
 
 <Story id="typography-heading--base" />
-<Props of={Heading} />
+<Props />
 
 ## Usage guidelines
 

--- a/src/components/Heading/Heading.docs.mdx
+++ b/src/components/Heading/Heading.docs.mdx
@@ -5,17 +5,16 @@ import { Heading } from './Heading';
 
 <Status.Stable />
 
-Headings are used for titling major sections of the interface. They help better organize the information
-for our users providing useful labels for each possible section.
-
-## Usage guidelines
-
-- **Do** position the heading above the content
-- **Do** use the `Mega` size for titling cards and `Giga` for pages
+Headings are used for titling major sections of the interface. They help better organize the information for our users providing useful labels for each possible section.
 
 <Story id="typography-heading--base" />
 <Props of={Heading} />
 
+## Usage guidelines
+
+- **Do** position the heading above the content
+- **Do** use the `mega` size for titling cards and `giga` for pages
+
 ### Sizes
 
-<Story id="typography-heading--size" />
+<Story id="typography-heading--sizes" />

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -14,13 +14,9 @@
  */
 
 import React from 'react';
-import { select, boolean, text } from '@storybook/addon-knobs';
 
-import { Heading } from './Heading';
+import { Heading, HeadingProps } from './Heading';
 import docs from './Heading.docs.mdx';
-
-const elements = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
-const sizes = ['zetta', 'exa', 'peta', 'tera', 'giga', 'mega', 'kilo'] as const;
 
 export default {
   title: 'Typography/Heading',
@@ -30,19 +26,15 @@ export default {
   },
 };
 
-export const base = () => (
-  <Heading
-    as={select('Element', elements, elements[0])}
-    size={select('Size', sizes, sizes[0])}
-    noMargin={boolean('No margin', false)}
-  >
-    {text('Text', 'This is a heading')}
-  </Heading>
+export const Base = (args: HeadingProps) => (
+  <Heading {...args}>This is a heading</Heading>
 );
 
-export const size = () =>
+const sizes = ['zetta', 'exa', 'peta', 'tera', 'giga', 'mega', 'kilo'] as const;
+
+export const Sizes = (args: HeadingProps) =>
   sizes.map((s) => (
-    <Heading key={s} size={s}>
+    <Heading key={s} {...args} size={s}>
       This is a {s} heading
     </Heading>
   ));

--- a/src/components/Hr/Hr.docs.mdx
+++ b/src/components/Hr/Hr.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Hr } from './Hr';
 
 # HR
 
@@ -8,7 +7,7 @@ import { Hr } from './Hr';
 HR provides a visual line that separates content into sections
 
 <Story id="components-hr--base" />
-<Props of={Hr} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Hr/Hr.stories.tsx
+++ b/src/components/Hr/Hr.stories.tsx
@@ -22,8 +22,10 @@ export default {
   title: 'Components/Hr',
   component: Hr,
   parameters: {
+    layout: 'fullscreen',
+    controls: { hideNoControlsWarning: true },
     docs: { page: docs },
   },
 };
 
-export const base = () => <Hr />;
+export const Base = () => <Hr />;

--- a/src/components/IconButton/IconButton.stories.tsx
+++ b/src/components/IconButton/IconButton.stories.tsx
@@ -14,12 +14,11 @@
  */
 
 import React from 'react';
-import { select, boolean, text } from '@storybook/addon-knobs';
 import { Download } from '@sumup/icons';
 
 import docs from '../Button/Button.docs.mdx';
 
-import { IconButton } from './IconButton';
+import { IconButton, IconButtonProps } from './IconButton';
 
 export default {
   title: 'Components/Button/IconButton',
@@ -29,14 +28,9 @@ export default {
   },
 };
 
-export const Base = () => (
-  <IconButton
-    label={text('Label', 'Download')}
-    variant={select('Variant', ['primary', 'secondary', 'tertiary'], 'primary')}
-    size={select('Size', ['kilo', 'mega'], 'mega')}
-    stretch={boolean('Stretched', false)}
-    disabled={boolean('Disabled', false)}
-  >
-    <Download />
-  </IconButton>
-);
+export const Base = (args: IconButtonProps) => <IconButton {...args} />;
+
+Base.args = {
+  children: <Download />,
+  label: 'Download',
+};

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -22,7 +22,7 @@ import { hideVisually } from '../../styles/style-helpers';
 import styled from '../../styles/styled';
 import { Button, ButtonProps } from '../Button/Button';
 
-export interface IconButtonProps extends ButtonProps {
+export interface IconButtonProps extends Omit<ButtonProps, 'icon' | 'stretch'> {
   /**
    * A single icon element.
    */

--- a/src/components/Image/Image.docs.mdx
+++ b/src/components/Image/Image.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Image } from './Image';
 
 # Image
 
@@ -7,7 +6,7 @@ import { Image } from './Image';
 
 <Story id="components-image--base" />
 
-<Props of={Image} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 
 import docs from './Image.docs.mdx';
-import { Image } from './Image';
+import { Image, ImageProps } from './Image';
 
 export default {
   title: 'Components/Image',
@@ -24,11 +24,15 @@ export default {
   parameters: {
     docs: { page: docs },
   },
+  argTypes: {
+    src: { control: 'text' },
+    alt: { control: 'text' },
+  },
 };
 
-export const base = () => (
-  <Image
-    src="https://source.unsplash.com/QU-zhliIV8Q/1600x900"
-    alt="Aerial photo of turbulent blue-turquoise ocean waves"
-  />
-);
+export const Base = (args: ImageProps) => <Image {...args} />;
+
+Base.args = {
+  src: 'https://source.unsplash.com/QU-zhliIV8Q/1600x900',
+  alt: 'Aerial photo of turbulent blue-turquoise ocean waves',
+};

--- a/src/components/InlineElements/InlineElements.js
+++ b/src/components/InlineElements/InlineElements.js
@@ -46,7 +46,7 @@ const fallbackBaseStyles = ({ children, theme }) => {
   `;
 };
 
-const baseStyles = ({ theme, ratios, children }) => {
+const baseStyles = ({ theme, ratios = [], children }) => {
   const flexGrows =
     ratios.length &&
     Children.map(
@@ -162,11 +162,6 @@ InlineElements.propTypes = {
    * used with.
    */
   ratios: PropTypes.arrayOf(PropTypes.number),
-};
-
-InlineElements.defaultProps = {
-  inlineMobile: false,
-  ratios: [],
 };
 
 /**

--- a/src/components/InlineElements/InlineElements.stories.js
+++ b/src/components/InlineElements/InlineElements.stories.js
@@ -13,79 +13,77 @@
  * limitations under the License.
  */
 
-import React from 'react';
+/** @jsx jsx */
 import styled from '@emotion/styled';
+import { jsx, css } from '@emotion/core';
 
 import InlineElements from './InlineElements';
-
-const Box = styled('div')`
-  height: 42px;
-
-  &:nth-of-type(n) {
-    background-color: yellow;
-  }
-
-  &:nth-of-type(2n) {
-    background-color: red;
-  }
-`;
-
-const Container = styled('div')({
-  width: '95vw',
-  maxWidth: '600px',
-  margin: '0 auto',
-  border: '1px solid green',
-  padding: '12px',
-});
 
 export default {
   title: 'Layout/InlineElements',
   component: InlineElements,
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
 };
 
-export const twoInlineElements = () => (
-  <Container>
-    <InlineElements>
-      <Box />
-      <Box />
-    </InlineElements>
-  </Container>
+const Box = styled('div')`
+  text-align: center;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 24px;
+  height: 48px;
+  padding: 12px;
+
+  &:nth-of-type(n) {
+    background-color: ${(p) => p.theme.colors.n300};
+  }
+
+  &:nth-of-type(2n) {
+    background-color: ${(p) => p.theme.colors.n100};
+  }
+`;
+
+const inlineElementsStyles = css`
+  width: 95vw;
+  max-width: 600px;
+  margin: 0 auto;
+  border: 1px solid magenta;
+`;
+
+export const TwoInlineElements = () => (
+  <InlineElements css={inlineElementsStyles}>
+    <Box />
+    <Box />
+  </InlineElements>
 );
 
-export const threeInlineElements = () => (
-  <Container>
-    <InlineElements>
-      <Box />
-      <Box />
-      <Box />
-    </InlineElements>
-  </Container>
+export const ThreeInlineElements = () => (
+  <InlineElements css={inlineElementsStyles}>
+    <Box />
+    <Box />
+    <Box />
+  </InlineElements>
 );
 
-export const threeInlineElementsInlineOnMobile = () => (
-  <Container>
-    <InlineElements inlineMobile>
-      <Box />
-      <Box />
-      <Box />
-    </InlineElements>
-  </Container>
+export const ThreeInlineElementsInlineOnMobile = () => (
+  <InlineElements css={inlineElementsStyles} inlineMobile>
+    <Box />
+    <Box />
+    <Box />
+  </InlineElements>
 );
 
-export const twoInlineElementsWithRatios = () => (
-  <Container>
-    <InlineElements ratios={[2, 1]}>
-      <Box>2x</Box>
-      <Box>1x</Box>
-    </InlineElements>
-  </Container>
+export const TwoInlineElementsWithRatios = () => (
+  <InlineElements css={inlineElementsStyles} ratios={[2, 1]}>
+    <Box>2x</Box>
+    <Box>1x</Box>
+  </InlineElements>
 );
 
-export const twoInlineElementsWithRatiosInlineOnMobile = () => (
-  <Container>
-    <InlineElements ratios={[3, 1]} inlineMobile>
-      <Box>2x</Box>
-      <Box>1x</Box>
-    </InlineElements>
-  </Container>
+export const TwoInlineElementsWithRatiosInlineOnMobile = () => (
+  <InlineElements css={inlineElementsStyles} ratios={[2, 1]} inlineMobile>
+    <Box>2x</Box>
+    <Box>1x</Box>
+  </InlineElements>
 );

--- a/src/components/InlineMessage/InlineMessage.docs.mdx
+++ b/src/components/InlineMessage/InlineMessage.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { InlineMessage } from './InlineMessage';
 
 # InlineMessage
 
@@ -8,7 +7,7 @@ import { InlineMessage } from './InlineMessage';
 Inline message is a component that provides a short contextual message about an action taken by a user within the same card structure that they are in.
 
 <Story id="forms-inlinemessage--base" />
-<Props of={InlineMessage} />
+<Props />
 
 ## When to use it
 

--- a/src/components/InlineMessage/InlineMessage.stories.tsx
+++ b/src/components/InlineMessage/InlineMessage.stories.tsx
@@ -15,10 +15,11 @@
 
 import React from 'react';
 
+import { Stack } from '../../../.storybook/components';
 import UntypedCard from '../Card';
 
 import docs from './InlineMessage.docs.mdx';
-import { InlineMessage } from './InlineMessage';
+import { InlineMessage, InlineMessageProps } from './InlineMessage';
 
 // FIXME: Remove once the Card component has been migrated to TypeScript.
 const Card = UntypedCard as any;
@@ -31,41 +32,43 @@ export default {
   },
 };
 
-export const base = () => (
-  <Card>
-    <InlineMessage variant="warning">
-      Something might go terribly wrong.
-    </InlineMessage>
+export const Base = (args: InlineMessageProps) => (
+  <Card spacing={args.size}>
+    <InlineMessage {...args}>Something might go terribly wrong.</InlineMessage>
   </Card>
 );
 
-export const variants = () => (
-  <Card>
-    <InlineMessage variant="success">
+Base.args = {
+  variant: 'warning',
+};
+
+export const Variants = (args: InlineMessageProps) => (
+  <Card spacing={args.size}>
+    <InlineMessage {...args} variant="success">
       Something has gone wonderfully right.
     </InlineMessage>
 
-    <InlineMessage variant="warning">
+    <InlineMessage {...args} variant="warning">
       Something might go sideways.
     </InlineMessage>
 
-    <InlineMessage variant="danger">
+    <InlineMessage {...args} variant="danger">
       Something has gone terribly wrong.
     </InlineMessage>
   </Card>
 );
 
-export const sizes = () => (
-  <>
+export const Sizes = (args: InlineMessageProps) => (
+  <Stack>
     <Card spacing="mega">
-      <InlineMessage variant="success" size="mega">
+      <InlineMessage {...args} variant="success" size="mega">
         Something has gone wonderfully right with a smaller card.
       </InlineMessage>
     </Card>
     <Card>
-      <InlineMessage variant="success" size="giga">
+      <InlineMessage {...args} variant="success" size="giga">
         Something has gone wonderfully right with a larger card.
       </InlineMessage>
     </Card>
-  </>
+  </Stack>
 );

--- a/src/components/Input/Input.docs.mdx
+++ b/src/components/Input/Input.docs.mdx
@@ -37,18 +37,6 @@ field should only be open for editing again if a CTA is clicked.
 
 <Story id="forms-input--disabled" />
 
-### Optional
-
-We should always strive for not asking optional information from our users. We
-recommend using optional inputs only if you feel that information is not
-critical and the user could benefit from having it input (such as `cellphone`
-in the context of a delivery address).
-
-Remember to always mark the input as optional on the label and never on the
-placeholder.
-
-<Story id="forms-input--optional" />
-
 ### Invalid
 
 When you have a validation logic behind information that is required in

--- a/src/components/Input/Input.docs.mdx
+++ b/src/components/Input/Input.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Input } from './Input';
 
 # Input
 
@@ -9,7 +8,7 @@ A text field is an input field for inserting short text and numbers. It has
 multiple functions and supports multiple character types/formats.
 
 <Story id="forms-input--base" />
-<Props of={Input} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -14,9 +14,10 @@
  */
 
 /** @jsx jsx */
-import { useState, ChangeEvent } from 'react';
 import { css, jsx } from '@emotion/core';
-import { boolean, text } from '@storybook/addon-knobs';
+
+import SearchInput from '../SearchInput';
+import CurrencyInput from '../CurrencyInput';
 
 import docs from './Input.docs.mdx';
 import { Input, InputProps } from './Input';
@@ -24,83 +25,113 @@ import { Input, InputProps } from './Input';
 export default {
   title: 'Forms/Input',
   component: Input,
+  subcomponents: { SearchInput, CurrencyInput },
   parameters: {
     docs: { page: docs },
   },
+  argTypes: {
+    placeholder: { control: 'text' },
+    disabled: { control: 'boolean' },
+  },
 };
 
-const BaseInput = ({
-  value: initialValue = '',
-  ...props
-}: Partial<InputProps>) => {
-  const [value, setValue] = useState(initialValue);
+const inputStyles = css`
+  max-width: 250px;
+`;
 
-  // The readOnly attribute is treated as truthy even if the value is falsy
-  const readOnly = boolean('Readonly', false);
-
-  if (readOnly) {
-    // eslint-disable-next-line no-param-reassign
-    props.readOnly = true;
-  }
-
-  return (
-    <Input
-      value={value}
-      label={text('Label', 'First name')}
-      placeholder={text('Placeholder', 'Jane')}
-      validationHint={text('Validation hint', 'Maximum 100 characters')}
-      invalid={boolean('Invalid', false)}
-      showValid={boolean('Show valid', false)}
-      hasWarning={boolean('Has warning', false)}
-      readOnly={boolean('Readonly', false)}
-      onChange={(event: ChangeEvent<HTMLInputElement>) => {
-        setValue(event.target.value);
-      }}
-      css={css`
-        max-width: 250px;
-      `}
-      {...props}
-    />
-  );
+const baseArgs = {
+  label: 'First name',
+  placeholder: 'Jane',
+  validationHint: 'Maximum 100 characters',
 };
 
-export const base = () => <BaseInput />;
+export const Base = (args: InputProps) => <Input {...args} css={inputStyles} />;
 
-export const valid = () => (
-  <BaseInput
-    label="Username"
-    validationHint="Yay! That username is available."
-    showValid
-  />
+Base.args = baseArgs;
+
+export const Valid = (args: InputProps) => (
+  <Input {...args} css={inputStyles} />
 );
 
-export const invalid = () => (
-  <BaseInput validationHint="This field is required." invalid />
+Valid.args = {
+  label: 'Username',
+  placeholder: 'jane123',
+  validationHint: 'Yay! That username is available.',
+  showValid: true,
+};
+
+export const Invalid = (args: InputProps) => (
+  <Input {...args} css={inputStyles} />
 );
 
-export const warning = () => (
-  <BaseInput validationHint="This does not look right." hasWarning />
+Invalid.args = {
+  ...baseArgs,
+  validationHint: 'This field is required.',
+  invalid: true,
+};
+
+export const Warning = (args: InputProps) => (
+  <Input {...args} css={inputStyles} />
 );
 
-export const readonly = () => <BaseInput readOnly value="Copy me" />;
+Warning.args = {
+  ...baseArgs,
+  validationHint: 'This does not look right.',
+  hasWarning: true,
+};
 
-export const disabled = () => <BaseInput value="Some value" disabled />;
+export const Readonly = (args: InputProps) => (
+  <Input {...args} css={inputStyles} />
+);
 
-export const rightAligned = () => <BaseInput textAlign="right" />;
+Readonly.args = {
+  ...baseArgs,
+  label: 'API token',
+  value: 'a3b2c1',
+  validationHint: 'Select and copy me',
+  readOnly: true,
+};
 
-export const inline = () => (
+export const Disabled = (args: InputProps) => (
+  <Input {...args} css={inputStyles} />
+);
+
+Disabled.args = {
+  ...baseArgs,
+  value: "You can't edit me",
+  disabled: true,
+};
+
+export const RightAligned = (args: InputProps) => (
+  <Input {...args} css={inputStyles} />
+);
+
+RightAligned.args = {
+  ...baseArgs,
+  textAlign: 'right',
+};
+
+export const Inline = (args: InputProps) => (
   <div>
-    <BaseInput placeholder="First name" inline />
-    <BaseInput placeholder="Last name" inline />
+    <Input {...args} label="First name" placeholder="Jane" />
+    <Input {...args} label="Last name" placeholder="Doe" />
   </div>
 );
 
-export const hiddenLabel = () => (
-  <BaseInput
-    hideLabel
-    label="Email"
-    placeholder="Email"
-    type="email"
-    validationHint=""
-  />
+Inline.args = {
+  ...baseArgs,
+  inline: true,
+};
+
+export const HiddenLabel = (args: InputProps) => (
+  <Input {...args} css={inputStyles} />
 );
+
+HiddenLabel.args = {
+  ...baseArgs,
+  label: 'Email',
+  placeholder: 'Email',
+  type: 'email',
+  validationHint: '',
+  hideLabel: true,
+};

--- a/src/components/Label/Label.docs.mdx
+++ b/src/components/Label/Label.docs.mdx
@@ -1,7 +1,5 @@
 import { Status, Props, Story } from '../../../.storybook/components';
 
-import { Label } from './Label';
-
 # Label
 
 <Status.Stable />
@@ -12,7 +10,7 @@ what is the purpose of the input but also helps directly with making forms
 more accessible.
 
 <Story id="forms-label--base" />
-<Props of={Label} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -15,7 +15,7 @@
 
 import React from 'react';
 
-import { Label } from './Label';
+import { Label, LabelProps } from './Label';
 import docs from './Label.docs.mdx';
 
 export default {
@@ -26,10 +26,8 @@ export default {
   },
 };
 
-export const base = () => <Label htmlFor="some-id">An input label</Label>;
-
-export const visuallyHidden = () => (
-  <Label htmlFor="some-id" visuallyHidden>
-    Only visible for screen readers
+export const Base = (args: LabelProps) => (
+  <Label {...args} htmlFor="some-id">
+    An input label
   </Label>
 );

--- a/src/components/List/List.docs.mdx
+++ b/src/components/List/List.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { List } from './List';
 
 # List
 
@@ -8,7 +7,7 @@ import { List } from './List';
 At its core, the list component allows you to easily display a related content grouped together and organized vertically. They should be used to present simple pieces of information. For more complex sets of data, consider using a Data Table.
 
 <Story id="components-list--base" />
-<Props of={List} />
+<Props />
 
 ## When to use it
 

--- a/src/components/List/List.docs.mdx
+++ b/src/components/List/List.docs.mdx
@@ -31,13 +31,13 @@ Use an ordered list to imply sequence and order. Ordered lists are commonly used
 
 Use an unordered list to present content of equal status or value.
 
-<Story id="components-list--variant" />
+<Story id="components-list--variants" />
 
 ### Sizes
 
 The size of the list should be the same as the surrounding content.
 
-<Story id="components-list--size" />
+<Story id="components-list--sizes" />
 
 ### Nested
 

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -14,10 +14,9 @@
  */
 
 import React from 'react';
-import { boolean, select } from '@storybook/addon-knobs';
 
 import docs from './List.docs.mdx';
-import { List } from './List';
+import { List, ListProps } from './List';
 
 export default {
   title: 'Typography/List',
@@ -27,9 +26,6 @@ export default {
   },
 };
 
-const sizes: ['kilo', 'mega', 'giga'] = ['kilo', 'mega', 'giga'];
-const variants: ['unordered', 'ordered'] = ['unordered', 'ordered'];
-
 const ListItems = () => (
   <>
     <li>This is a list</li>
@@ -37,33 +33,34 @@ const ListItems = () => (
   </>
 );
 
-export const Base = () => (
-  <List
-    size={select('Size', sizes, 'mega')}
-    variant={boolean('Ordered', false) ? 'ordered' : 'unordered'}
-  >
+export const Base = (args: ListProps) => (
+  <List {...args}>
     <ListItems />
   </List>
 );
 
-export const Variant = () =>
+const variants = ['unordered', 'ordered'] as const;
+
+export const Variants = (args: ListProps) =>
   variants.map((variant) => (
-    <List key={variant} variant={variant}>
+    <List key={variant} {...args} variant={variant}>
       <ListItems />
     </List>
   ));
 
-export const Size = () =>
+const sizes = ['kilo', 'mega', 'giga'] as const;
+
+export const Sizes = (args: ListProps) =>
   sizes.map((size) => (
-    <List key={size} size={size}>
+    <List key={size} {...args} size={size}>
       <ListItems />
     </List>
   ));
 
-export const Nested = () => (
-  <List>
+export const Nested = (args: ListProps) => (
+  <List {...args}>
     <ListItems />
-    <List>
+    <List {...args}>
       <li>Sometimes a nested list</li>
     </List>
   </List>

--- a/src/components/LoadingButton/LoadingButton.stories.tsx
+++ b/src/components/LoadingButton/LoadingButton.stories.tsx
@@ -14,7 +14,6 @@
  */
 
 import React, { useState } from 'react';
-import { select } from '@storybook/addon-knobs';
 
 import docs from '../Button/Button.docs.mdx';
 
@@ -28,7 +27,7 @@ export default {
   },
 };
 
-const StatefulLoadingButton = (props: Partial<LoadingButtonProps>) => {
+export const Base = (args: LoadingButtonProps) => {
   const [loading, setLoading] = useState(false);
 
   const handleClick = () => {
@@ -39,21 +38,8 @@ const StatefulLoadingButton = (props: Partial<LoadingButtonProps>) => {
   };
 
   return (
-    <LoadingButton
-      isLoading={loading}
-      loadingLabel="Loading"
-      onClick={handleClick}
-      variant={select(
-        'Variant',
-        ['primary', 'secondary', 'tertiary'],
-        'primary',
-      )}
-      size={select('Size', ['kilo', 'mega'], 'mega')}
-      {...props}
-    >
+    <LoadingButton isLoading={loading} onClick={handleClick} {...args}>
       Things take time
     </LoadingButton>
   );
 };
-
-export const Base = () => <StatefulLoadingButton />;

--- a/src/components/Modal/Modal.embed.stories.tsx
+++ b/src/components/Modal/Modal.embed.stories.tsx
@@ -22,36 +22,43 @@ import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
 import Text from '../Text';
 
-import { ModalWrapper, ModalHeader, ModalFooter } from './components';
+import { ModalHeader, ModalFooter } from './components';
+import {
+  ModalWrapper,
+  ModalWrapperProps,
+} from './components/ModalWrapper/ModalWrapper';
 
 export default {
   title: 'Components/Modal/Embedded',
+  component: ModalWrapper,
 };
 
-export const base = () => <ModalWrapper>Hello World!</ModalWrapper>;
+export const Base = (args: ModalWrapperProps) => (
+  <ModalWrapper {...args}>Hello World!</ModalWrapper>
+);
 
-export const withTitle = () => (
-  <ModalWrapper>
+export const WithTitle = (args: ModalWrapperProps) => (
+  <ModalWrapper {...args}>
     <ModalHeader title="A title" />
     <Text>Hello world!</Text>
   </ModalWrapper>
 );
 
-export const withoutCloseButton = () => (
-  <ModalWrapper>
+export const WithoutCloseButton = (args: ModalWrapperProps) => (
+  <ModalWrapper {...args}>
     <Text>Some text in the modal body.</Text>
   </ModalWrapper>
 );
 
-export const withTitleAndCloseButton = () => (
-  <ModalWrapper>
+export const WithTitleAndCloseButton = (args: ModalWrapperProps) => (
+  <ModalWrapper {...args}>
     <ModalHeader title="A modal" onClose={action('onClose')} />
     <Text>Some text in the modal body.</Text>
   </ModalWrapper>
 );
 
-export const withFooter = () => (
-  <ModalWrapper>
+export const WithFooter = (args: ModalWrapperProps) => (
+  <ModalWrapper {...args}>
     <ModalHeader title="A modal" />
     <Text>Some text in the modal body.</Text>
     <ModalFooter>
@@ -67,7 +74,7 @@ export const withFooter = () => (
   </ModalWrapper>
 );
 
-export const withCustomStyles = () => {
+export const WithCustomStyles = (args: ModalWrapperProps) => {
   const Container = styled('div')`
     display: flex;
     justify-content: stretch;
@@ -93,7 +100,8 @@ export const withCustomStyles = () => {
   `;
 
   return (
-    <div
+    <ModalWrapper
+      {...args}
       css={css`
         width: 100%;
         padding: 0;
@@ -106,6 +114,6 @@ export const withCustomStyles = () => {
         </LeftColumn>
         <RightColumn />
       </Container>
-    </div>
+    </ModalWrapper>
   );
 };

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -17,7 +17,6 @@
 import { MouseEvent, KeyboardEvent } from 'react';
 import styled from '@emotion/styled';
 import { css, jsx } from '@emotion/core';
-import { text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import Button from '../Button';
@@ -61,17 +60,12 @@ const defaultModal = {
   onClose: () => {},
 };
 
-export const base = () => (
-  <PageWithModal
-    {...defaultModal}
-    tracking={{
-      label: text('Tracking Label', 'trackingId'),
-    }}
-  />
+export const Base = (args: ModalProps) => (
+  <PageWithModal {...args} {...defaultModal} />
 );
 
-export const withHeader = () => (
-  <PageWithModal {...defaultModal}>
+export const WithHeader = (args: ModalProps) => (
+  <PageWithModal {...args} {...defaultModal}>
     {() => (
       <ModalWrapper>
         <ModalHeader title="A modal" />
@@ -81,8 +75,8 @@ export const withHeader = () => (
   </PageWithModal>
 );
 
-export const withoutCloseButton = () => (
-  <PageWithModal {...defaultModal}>
+export const WithoutCloseButton = (args: ModalProps) => (
+  <PageWithModal {...args} {...defaultModal}>
     {() => (
       <ModalWrapper>
         <Text>Some text in the modal body.</Text>
@@ -91,8 +85,8 @@ export const withoutCloseButton = () => (
   </PageWithModal>
 );
 
-export const withTitleAndCloseButton = () => (
-  <PageWithModal {...defaultModal}>
+export const WithTitleAndCloseButton = (args: ModalProps) => (
+  <PageWithModal {...args} {...defaultModal}>
     {({ onClose }) => (
       <ModalWrapper>
         <ModalHeader title="A modal" onClose={onClose} />
@@ -102,8 +96,8 @@ export const withTitleAndCloseButton = () => (
   </PageWithModal>
 );
 
-export const withFooter = () => (
-  <PageWithModal {...defaultModal}>
+export const WithFooter = (args: ModalProps) => (
+  <PageWithModal {...args} {...defaultModal}>
     {({ onClose }) => (
       <ModalWrapper>
         <ModalHeader title="A modal" />
@@ -135,7 +129,7 @@ export const withFooter = () => (
   </PageWithModal>
 );
 
-export const withCustomStyles = () => {
+export const WithCustomStyles = (args: ModalProps) => {
   const Container = styled('div')`
     display: flex;
     justify-content: stretch;
@@ -162,6 +156,7 @@ export const withCustomStyles = () => {
 
   return (
     <PageWithModal
+      {...args}
       {...defaultModal}
       css={css`
         padding: 0;

--- a/src/components/Notification/Notification.docs.mdx
+++ b/src/components/Notification/Notification.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Notification } from './Notification';
 import NotificationBanner from '../NotificationBanner';
 import NotificationList from '../NotificationList';
 
@@ -11,7 +10,7 @@ Notifications are a quick and subtle way of providing contextual feedback for ou
 or fixed cards with a semantical meaning (either success, danger or attention).
 
 <Story id="components-notification--base" />
-<Props of={Notification} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Notification/Notification.stories.tsx
+++ b/src/components/Notification/Notification.stories.tsx
@@ -22,13 +22,16 @@ import { Theme } from '@sumup/design-tokens';
 import Heading from '../Heading';
 import Text from '../Text';
 import Button from '../Button';
+import NotificationList from '../NotificationList';
+import NotificationBanner from '../NotificationBanner';
 
 import docs from './Notification.docs.mdx';
-import { Notification } from './Notification';
+import { Notification, NotificationProps } from './Notification';
 
 export default {
   title: 'Components/Notification',
   component: Notification,
+  subcomponents: { NotificationList, NotificationBanner },
   parameters: {
     docs: { page: docs },
   },
@@ -46,12 +49,8 @@ const headingStyles = (theme: Theme) =>
     margin-bottom: ${theme.spacings.kilo};
   `;
 
-export const base = () => (
-  <Notification
-    variant="success"
-    onClose={action('Notification dismissed')}
-    closeLabel="Close"
-  >
+export const Base = (args: NotificationProps) => (
+  <Notification {...args}>
     <Heading as="h4" size="kilo" noMargin>
       New Feature — Intelligent Reporting
     </Heading>
@@ -64,7 +63,13 @@ export const base = () => (
   </Notification>
 );
 
-export const variants = () => (
+Base.args = {
+  variant: 'success',
+  onClose: action('Notification dismissed'),
+  closeLabel: 'Close',
+};
+
+export const Variants = () => (
   <Fragment>
     <Notification variant="success" css={notificationStyles}>
       <Heading size="kilo" as="h4" noMargin>
@@ -92,3 +97,7 @@ export const variants = () => (
     </Notification>
   </Fragment>
 );
+
+Variants.parameters = {
+  controls: { hideNoControlsWarning: true },
+};

--- a/src/components/NotificationBanner/NotificationBanner.stories.tsx
+++ b/src/components/NotificationBanner/NotificationBanner.stories.tsx
@@ -13,35 +13,39 @@
  * limitations under the License.
  */
 
-/** @jsx jsx */
-import { css, jsx } from '@emotion/core';
+import React from 'react';
+import { action } from '@storybook/addon-actions';
 
-import { base as Notification } from '../Notification/Notification.stories';
+import Notification from '../Notification';
+import Heading from '../Heading';
+import Text from '../Text';
+import Button from '../Button';
 
-import { NotificationBanner } from './NotificationBanner';
+import {
+  NotificationBanner,
+  NotificationBannerProps,
+} from './NotificationBanner';
 
 export default {
   title: 'Components/Notification/NotificationBanner',
   component: NotificationBanner,
+  parameters: {
+    layout: 'fullscreen',
+  },
 };
 
-export const base = () => (
-  <div
-    css={css`
-      min-height: 8rem;
-    `}
-  >
-    <div
-      css={css`
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        right: 0;
-      `}
-    >
-      <NotificationBanner>
-        <Notification />
-      </NotificationBanner>
-    </div>
-  </div>
+export const Base = (args: NotificationBannerProps) => (
+  <NotificationBanner {...args}>
+    <Notification variant="success">
+      <Heading as="h4" size="kilo" noMargin>
+        New Feature — Intelligent Reporting
+      </Heading>
+      <Text>
+        Get automatic insights into your business statistics with one click.
+      </Text>
+      <Button size="kilo" onClick={action('Action clicked')}>
+        Learn more
+      </Button>
+    </Notification>
+  </NotificationBanner>
 );

--- a/src/components/NotificationList/NotificationList.stories.tsx
+++ b/src/components/NotificationList/NotificationList.stories.tsx
@@ -21,15 +21,15 @@ import Text from '../Text';
 import Button from '../Button';
 import Notification from '../Notification';
 
-import { NotificationList } from './NotificationList';
+import { NotificationList, NotificationListProps } from './NotificationList';
 
 export default {
   title: 'Components/Notification/NotificationList',
   component: NotificationList,
 };
 
-export const base = () => (
-  <NotificationList>
+export const Base = (args: NotificationListProps) => (
+  <NotificationList {...args}>
     <Notification variant="success">
       <Heading as="h4" size="kilo" noMargin>
         New Feature — Intelligent Reporting

--- a/src/components/Pagination/Pagination.docs.mdx
+++ b/src/components/Pagination/Pagination.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Pagination } from './Pagination';
 
 # Pagination
 
@@ -8,7 +7,7 @@ import { Pagination } from './Pagination';
 Pagination provides a way for users to visualize bulks of information distributed over multiple pages, while always providing an anchor to move from where they currently are in the list.
 
 <Story id="components-pagination--base" />
-<Props of={Pagination} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -14,7 +14,6 @@
  */
 
 import React, { useState } from 'react';
-import { number, text } from '@storybook/addon-knobs';
 
 import docs from './Pagination.docs.mdx';
 import { Pagination, PaginationProps } from './Pagination';
@@ -27,23 +26,25 @@ export default {
   },
 };
 
-const BasePagination = (props: Partial<PaginationProps>) => {
-  const [page, setPage] = useState(1);
-  return (
-    <Pagination
-      label={text('Label', 'Pagination')}
-      totalPages={number('Total pages', 5)}
-      pageLabel={(p) => `${text('Page label', 'Go to page')} ${p}`}
-      totalLabel={(t) => `${text('Total label', 'of')} ${t}`}
-      previousLabel={text('Previous label', 'Previous page')}
-      nextLabel={text('Next label', 'Next page')}
-      currentPage={page}
-      onChange={setPage}
-      {...props}
-    />
-  );
+const baseArgs = {
+  label: 'Pagination',
+  totalPages: 5,
+  pageLabel: (p: number) => `Go to page ${p}`,
+  totalLabel: (t: number) => `of ${t}`,
+  previousLabel: 'Previous page',
+  nextLabel: 'Next page',
 };
 
-export const base = () => <BasePagination />;
+export const Base = (args: PaginationProps) => {
+  const [page, setPage] = useState(1);
+  return <Pagination {...args} currentPage={page} onChange={setPage} />;
+};
 
-export const manyPages = () => <BasePagination totalPages={10} />;
+Base.args = baseArgs;
+
+export const ManyPages = (args: PaginationProps) => {
+  const [page, setPage] = useState(1);
+  return <Pagination {...args} currentPage={page} onChange={setPage} />;
+};
+
+ManyPages.args = { ...baseArgs, totalPages: 10 };

--- a/src/components/Popover/Popover.stories.js
+++ b/src/components/Popover/Popover.stories.js
@@ -15,46 +15,44 @@
 
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
-import { select, boolean } from '@storybook/addon-knobs';
 
 import Button from '../Button';
 import Card from '../Card';
 
 import Popover from './Popover';
 
-const positions = ['top', 'bottom', 'left', 'right'];
-const alignments = ['start', 'end', 'center'];
-
 export default {
   title: 'Components/Popover',
   component: Popover,
 };
 
-const PopoverWithState = (props) => {
+export const Base = (args) => {
   const [open, setOpen] = useState(false);
 
-  const { closeOnButtonClick, ...restProps } = props;
+  const { closeOnButtonClick, ...props } = args;
 
   return (
     <Popover
       isOpen={open}
-      {...restProps}
+      {...props}
       renderPopover={() => <Card>Popover Content</Card>}
       renderReference={() => (
         <Button size="kilo" onClick={() => setOpen((prev) => !prev)}>
           {open ? 'Hide' : 'Show'}
         </Button>
       )}
-      onReferenceClickClose={() => closeOnButtonClick && setOpen(false)}
+      onReferenceClickClose={() => {
+        if (closeOnButtonClick) {
+          setOpen(false);
+        }
+      }}
       onOutsideClickClose={() => setOpen(false)}
     />
   );
 };
 
-export const base = () => (
-  <PopoverWithState
-    position={select('position', positions, 'bottom')}
-    align={select('align', alignments, 'start')}
-    closeOnButtonClick={boolean('closeOnButton', false)}
-  />
-);
+Base.args = {
+  position: 'bottom',
+  align: 'start',
+  closeOnButtonClick: false,
+};

--- a/src/components/ProgressBar/ProgressBar.docs.mdx
+++ b/src/components/ProgressBar/ProgressBar.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { ProgressBar } from './ProgressBar';
 
 # ProgressBar
 
@@ -8,7 +7,7 @@ import { ProgressBar } from './ProgressBar';
 A progress bar is a UI element used to visualise the progression of a task or operation. The visual element is always combined with a label describing a status value either in percentage or fraction format.
 
 <Story id="components-progressbar--steps" />
-<Props of={ProgressBar} />
+<Props />
 
 ## When to use it
 

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -16,7 +16,6 @@
 /** @jsx jsx */
 import { Fragment } from 'react';
 import { css, jsx } from '@emotion/core';
-import { select, number, boolean } from '@storybook/addon-knobs';
 
 import docs from './ProgressBar.docs.mdx';
 import { ProgressBar, ProgressBarProps } from './ProgressBar';
@@ -32,66 +31,76 @@ export default {
 const variants = ['primary', 'secondary'] as const;
 const sizes = ['byte', 'kilo', 'mega'] as const;
 
-const BaseProgressBar = (props: ProgressBarProps) => (
-  <ProgressBar
-    variant={select('Variant', variants, 'primary')}
-    size={select('Size', sizes, 'kilo')}
-    css={css`
-      width: 90%;
-      min-width: 500px;
-    `}
-    {...props}
-  />
+const progressBarStyles = css`
+  width: 90%;
+  min-width: 500px;
+`;
+
+export const Steps = (args: ProgressBarProps) => (
+  <ProgressBar {...args} css={progressBarStyles} />
 );
 
-export const Steps = () => (
-  <BaseProgressBar
-    value={number('Value', 3)}
-    max={number('Maximum value', 10)}
-  />
+Steps.args = {
+  value: 3,
+  max: 10,
+};
+
+export const Timer = (args: ProgressBarProps) => (
+  <ProgressBar {...args} css={progressBarStyles} />
 );
 
-export const Timer = () => (
-  <BaseProgressBar
-    duration={number('Duration', 3000)}
-    paused={boolean('Paused', false)}
-    loop={boolean('Loop', true)}
-  />
-);
+Timer.args = {
+  duration: 3000,
+  paused: false,
+  loop: true,
+  max: null,
+};
 
-export const Labelled = () => {
-  const max = number('Maximum value', 10);
-  const value = number('Value', 3);
-  const fraction = `${value}/${max}`;
-  const percentage = `${(value / max) * 100}%`;
+export const Labelled = (args: ProgressBarProps) => {
+  const fraction = `${args.value}/${args.max}`;
+  const percentage = `${(args.value! / args.max!) * 100}%`;
   return (
     <Fragment>
-      <BaseProgressBar value={value} max={max}>
+      <ProgressBar {...args} css={progressBarStyles}>
         {fraction}
-      </BaseProgressBar>
-      <BaseProgressBar value={value} max={max}>
+      </ProgressBar>
+      <ProgressBar {...args} css={progressBarStyles}>
         {percentage}
-      </BaseProgressBar>
+      </ProgressBar>
     </Fragment>
   );
 };
 
-export const Variants = () => {
-  const max = number('Maximum value', 10);
-  const value = number('Value', 3);
-  return variants.map((variant) => (
-    <BaseProgressBar key={variant} variant={variant} value={value} max={max}>
-      {variant}
-    </BaseProgressBar>
-  ));
+Labelled.args = {
+  value: 3,
+  max: 10,
 };
 
-export const Sizes = () => {
-  const max = number('Maximum value', 10);
-  const value = number('Value', 3);
-  return sizes.map((size) => (
-    <BaseProgressBar key={size} size={size} value={value} max={max}>
-      {size}
-    </BaseProgressBar>
+export const Variants = (args: ProgressBarProps) =>
+  variants.map((variant) => (
+    <ProgressBar
+      key={variant}
+      {...args}
+      variant={variant}
+      css={progressBarStyles}
+    >
+      {variant}
+    </ProgressBar>
   ));
+
+Variants.args = {
+  value: 3,
+  max: 10,
+};
+
+export const Sizes = (args: ProgressBarProps) =>
+  sizes.map((size) => (
+    <ProgressBar key={size} {...args} size={size} css={progressBarStyles}>
+      {size}
+    </ProgressBar>
+  ));
+
+Sizes.args = {
+  value: 3,
+  max: 10,
 };

--- a/src/components/RadioButton/RadioButton.docs.mdx
+++ b/src/components/RadioButton/RadioButton.docs.mdx
@@ -1,5 +1,5 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { RadioButton } from './RadioButton';
+
 import RadioButtonGroup from '../RadioButtonGroup';
 
 # RadioButton
@@ -10,7 +10,7 @@ A radio button is a quick way to extract a single coded answer from our users by
 possibilities and allowing only one option to be chosen.
 
 <Story id="forms-radiobutton--base" />
-<Props of={RadioButton} />
+<Props />
 
 ## When to use it
 

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -14,7 +14,8 @@
  */
 
 import React, { useState } from 'react';
-import { text } from '@storybook/addon-knobs';
+
+import RadioButtonGroup from '../RadioButtonGroup';
 
 import { RadioButton, RadioButtonProps } from './RadioButton';
 import docs from './RadioButton.docs.mdx';
@@ -22,8 +23,14 @@ import docs from './RadioButton.docs.mdx';
 export default {
   title: 'Forms/RadioButton',
   component: RadioButton,
+  subcomponents: { RadioButtonGroup },
   parameters: {
     docs: { page: docs },
+  },
+  argTypes: {
+    name: { control: 'text' },
+    value: { control: 'text' },
+    disabled: { control: 'boolean' },
   },
 };
 
@@ -37,27 +44,37 @@ const RadioButtonWithState = ({
     setChecked((prev) => !prev);
   };
   return (
-    <RadioButton
-      {...props}
-      checked={checked}
-      onChange={handleChange}
-      tracking={{ label: text('Tracking Label', 'trackingId') }}
-    >
+    <RadioButton {...props} checked={checked} onChange={handleChange}>
       {children || (checked ? 'Checked' : 'Unchecked')}
     </RadioButton>
   );
 };
 
-export const base = () => <RadioButtonWithState value="radio" name="radio" />;
-
-export const invalid = () => (
-  <RadioButtonWithState value="invalid" name="invalid" invalid>
-    Error
-  </RadioButtonWithState>
+export const Base = (args: RadioButtonProps) => (
+  <RadioButtonWithState {...args} />
 );
 
-export const disabled = () => (
-  <RadioButtonWithState value="disabled" name="disabled" disabled>
-    Disabled
-  </RadioButtonWithState>
+Base.args = {
+  name: 'base',
+  value: 'true',
+};
+
+export const Invalid = (args: RadioButtonProps) => (
+  <RadioButtonWithState {...args}>Invalid</RadioButtonWithState>
 );
+
+Invalid.args = {
+  name: 'invalid',
+  value: 'true',
+  invalid: true,
+};
+
+export const Disabled = (args: RadioButtonProps) => (
+  <RadioButtonWithState {...args}>Disabled</RadioButtonWithState>
+);
+
+Disabled.args = {
+  name: 'disabled',
+  value: 'true',
+  disabled: true,
+};

--- a/src/components/RadioButtonGroup/RadioButtonGroup.stories.tsx
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.stories.tsx
@@ -20,43 +20,26 @@ import { RadioButtonGroup, RadioButtonGroupProps } from './RadioButtonGroup';
 export default {
   title: 'Forms/RadioButton/RadioButtonGroup',
   component: RadioButtonGroup,
+  argTypes: {
+    name: { control: 'text' },
+    value: { control: 'text' },
+  },
 };
 
-const options = [
-  {
-    children: 'Apple',
-    value: 'apple',
-  },
-  {
-    children: 'Banana',
-    value: 'banana',
-  },
-  {
-    children: 'Mango',
-    value: 'mango',
-  },
-];
-
-const RadioButtonGroupWithState = ({
-  value: initial,
-  children,
-  ...props
-}: Partial<RadioButtonGroupProps>) => {
-  const [value, setValue] = useState(initial);
+export const Base = (args: RadioButtonGroupProps) => {
+  const [value, setValue] = useState<string>();
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
   };
-  return (
-    <RadioButtonGroup
-      {...props}
-      options={options}
-      value={value}
-      onChange={handleChange}
-      label="Choose your favourite fruit"
-    />
-  );
+  return <RadioButtonGroup {...args} value={value} onChange={handleChange} />;
 };
 
-export const base = () => (
-  <RadioButtonGroupWithState name="radio-button-group" />
-);
+Base.args = {
+  name: 'radio-button-group',
+  label: 'Choose your favourite fruit',
+  options: [
+    { children: 'Apple', value: 'apple' },
+    { children: 'Banana', value: 'banana' },
+    { children: 'Mango', value: 'mango' },
+  ],
+};

--- a/src/components/Row/Row.stories.js
+++ b/src/components/Row/Row.stories.js
@@ -15,7 +15,6 @@
 
 import React from 'react';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
 
 import docs from '../Grid/Grid.docs.mdx';
 import Col from '../Col';
@@ -26,40 +25,34 @@ export default {
   title: 'Layout/Grid/Row',
   component: Row,
   parameters: {
+    layout: 'fullscreen',
+    controls: { hideNoControlsWarning: true },
     docs: { page: docs },
   },
 };
 
-const StyledCol = styled(Col)(
-  ({ theme }) => css`
-    color: ${theme.colors.white};
-    font-size: 14px;
-    font-weight: bold;
-    line-height: 20px;
-    height: 40px;
-    padding: 10px;
-    &:nth-of-type(n) {
-      background-color: ${theme.colors.b500};
-    }
+const StyledCol = styled(Col)`
+  text-align: center;
+  font-size: 16px;
+  font-weight: bold;
+  line-height: 24px;
+  height: 48px;
+  padding: 12px;
+  &:nth-of-type(n) {
+    background-color: ${(p) => p.theme.colors.n300};
+  }
 
-    &:nth-of-type(2n) {
-      background-color: ${theme.colors.b300};
-    }
-  `,
-);
+  &:nth-of-type(2n) {
+    background-color: ${(p) => p.theme.colors.n100};
+  }
+`;
 
-StyledCol.defaultProps = {
-  skip: '0',
-};
+const StyledRow = styled(Row)`
+  border: 1px solid magenta;
+  margin-bottom: 8px;
+`;
 
-const StyledRow = styled(Row)(
-  ({ theme }) => css`
-    border: 2px solid ${theme.colors.y100};
-    margin-bottom: 8px;
-  `,
-);
-
-export const base = () => (
+export const Base = () => (
   <StyledRow>
     <StyledCol span="4">Col 4</StyledCol>
     <StyledCol span="4">Col 4</StyledCol>

--- a/src/components/SearchInput/SearchInput.docs.mdx
+++ b/src/components/SearchInput/SearchInput.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { SearchInput } from './SearchInput';
 
 # SearchInput
 
@@ -9,7 +8,7 @@ Search Input is an input that indicates to the user they can use the field
 to search information on the screen.
 
 <Story id="forms-input-searchinput--base" />
-<Props of={SearchInput} />
+<Props />
 
 ## Component variations
 

--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -14,9 +14,6 @@
  */
 
 import React, { useState, ChangeEvent } from 'react';
-import { identity } from 'lodash/fp';
-
-import { uniqueId } from '../../util/id';
 
 import { SearchInput, SearchInputProps } from './SearchInput';
 import docs from './SearchInput.docs.mdx';
@@ -27,18 +24,25 @@ export default {
   parameters: {
     docs: { page: docs },
   },
+  argTypes: {
+    placeholder: { control: 'text' },
+  },
 };
 
-// SearchInputs always need labels for accessibility.
-const SearchInputWithLabel = (props: SearchInputProps) => {
-  const id = uniqueId();
-  return (
-    <SearchInput placeholder="Search..." {...props} id={id} label="Search" />
-  );
+const baseArgs = {
+  placeholder: 'Type a word...',
+  label: 'Search',
 };
 
-const SearchInputWithClear = (props: SearchInputProps) => {
-  const id = uniqueId();
+export const Base = (args: SearchInputProps) => <SearchInput {...args} />;
+
+Base.args = baseArgs;
+
+export const Disabled = (args: SearchInputProps) => <SearchInput {...args} />;
+
+Disabled.args = { ...baseArgs, disabled: true };
+
+export const Clearable = (args: SearchInputProps) => {
   const [value, setValue] = useState('');
 
   const handleChange = ({
@@ -52,22 +56,13 @@ const SearchInputWithClear = (props: SearchInputProps) => {
   };
 
   return (
-    <div>
-      <SearchInput
-        {...props}
-        id={id}
-        value={value}
-        onClear={handleClear}
-        onChange={handleChange}
-        placeholder="Search..."
-        label="Label"
-      />
-    </div>
+    <SearchInput
+      {...args}
+      value={value}
+      onClear={handleClear}
+      onChange={handleChange}
+    />
   );
 };
 
-export const base = () => <SearchInputWithLabel />;
-
-export const disabled = () => <SearchInputWithLabel disabled />;
-
-export const clearable = () => <SearchInputWithClear onClear={identity} />;
+Clearable.args = baseArgs;

--- a/src/components/Select/Select.docs.mdx
+++ b/src/components/Select/Select.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Select } from './Select';
 
 # Select
 
@@ -9,7 +8,7 @@ A select dropdown is a form field that allows users to choose one of the multipl
 An example being the expiration date for a users credit card.
 
 <Story id="forms-select--base" />
-<Props of={Select} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -14,11 +14,7 @@
  */
 
 import React, { useState, FC } from 'react';
-import { action } from '@storybook/addon-actions';
-import { boolean, text } from '@storybook/addon-knobs';
 import { FlagDe, FlagUs, FlagFr } from '@sumup/icons';
-
-import { uniqueId } from '../../util/id';
 
 import { Select, SelectProps } from './Select';
 import docs from './Select.docs.mdx';
@@ -31,68 +27,62 @@ export default {
   },
 };
 
-const options = [
-  {
-    label: 'United States',
-    value: 'US',
-  },
-  {
-    label: 'Germany',
-    value: 'DE',
-  },
-  {
-    label: 'France',
-    value: 'FR',
-  },
-];
+const baseArgs = {
+  name: 'select',
+  label: 'Countries',
+  options: [
+    {
+      label: 'United States',
+      value: 'US',
+    },
+    {
+      label: 'Germany',
+      value: 'DE',
+    },
+    {
+      label: 'France',
+      value: 'FR',
+    },
+  ],
+};
+
 const flagIconMap: { [key: string]: FC<{ className?: string }> } = {
   DE: FlagDe,
   US: FlagUs,
   FR: FlagFr,
 };
 
-// Selects always need labels for accessibility.
-const StatefulSelect = (props: Partial<SelectProps>) => {
-  const id = uniqueId();
-  const [value, setValue] = useState('US');
+export const Base = (args: SelectProps) => <Select {...args} />;
 
+Base.args = baseArgs;
+
+export const Invalid = (args: SelectProps) => <Select {...args} />;
+
+Invalid.args = {
+  ...baseArgs,
+  validationHint: 'This field is required',
+  invalid: true,
+};
+
+export const WithPrefix = (args: SelectProps) => {
+  const [value, setValue] = useState('US');
   return (
     <Select
-      id={id}
-      name="select"
-      options={options}
+      {...args}
       value={value}
-      onChange={(e) => {
-        action('Option selected')(e);
-        setValue(e.target.value);
+      onChange={(event) => {
+        setValue(event.target.value);
       }}
-      disabled={boolean('Disabled', false)}
-      invalid={boolean('Invalid', false)}
-      validationHint={text('Validation hint', '')}
-      label="Countries"
-      tracking={{ label: text('Tracking Label', 'trackingId') }}
-      {...props}
+      renderPrefix={(props) => {
+        const Icon = props.value && flagIconMap[props.value];
+        return Icon ? <Icon {...props} /> : null;
+      }}
     />
   );
 };
 
-export const base = () => <StatefulSelect />;
+WithPrefix.args = baseArgs;
 
-export const invalid = () => (
-  <StatefulSelect
-    invalid={boolean('Invalid', true)}
-    validationHint={text('Validation hint', 'This field is required')}
-  />
-);
+export const HiddenLabel = (args: SelectProps) => <Select {...args} />;
 
-export const withPrefix = () => (
-  <StatefulSelect
-    name="country_select"
-    renderPrefix={({ className, value }) => {
-      const Icon = value && flagIconMap[value];
-      return Icon ? <Icon {...{ className }} /> : null;
-    }}
-  />
-);
-
-export const hiddenLabel = () => <StatefulSelect hideLabel />;
+HiddenLabel.args = { ...baseArgs, hideLabel: true };

--- a/src/components/Selector/Selector.docs.mdx
+++ b/src/components/Selector/Selector.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Selector } from './Selector';
 import SelectorGroup from '../SelectorGroup';
 
 # Selector
@@ -9,7 +8,7 @@ import SelectorGroup from '../SelectorGroup';
 The selector is a component that allows users to select a single or multiple options from a range of items, keeping that selection highlighted and allowing possible changes to happen on the same screen based on it.
 
 <Story id="forms-selector--base" />
-<Props of={Selector} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Selector/Selector.stories.tsx
+++ b/src/components/Selector/Selector.stories.tsx
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-import React, { useState } from 'react';
-import { boolean, text } from '@storybook/addon-knobs';
+import React from 'react';
+
+import SelectorGroup from '../SelectorGroup';
 
 import docs from './Selector.docs.mdx';
 import { Selector, SelectorProps } from './Selector';
@@ -22,42 +23,31 @@ import { Selector, SelectorProps } from './Selector';
 export default {
   title: 'Forms/Selector',
   component: Selector,
+  subcomponents: { SelectorGroup },
   parameters: {
     docs: { page: docs },
   },
 };
 
-/* eslint-disable react/prop-types */
-const SelectorWithState = (props: Partial<SelectorProps>) => {
-  const [checked, setChecked] = useState(props.checked || false);
-
-  const toggleChecked = () => {
-    setChecked((prev) => !prev);
-  };
-
-  return (
-    <Selector
-      value="default"
-      {...props}
-      checked={checked}
-      onChange={toggleChecked}
-    />
-  );
+const baseArgs = {
+  name: 'selector',
+  value: 'default',
 };
 
-export const base = () => (
-  <SelectorWithState
-    disabled={boolean('Disabled', false)}
-    tracking={{ label: text('Tracking Label', 'trackingId') }}
-  >
-    Select me!
-  </SelectorWithState>
+export const Base = (args: SelectorProps) => (
+  <Selector {...args}>Select me!</Selector>
 );
 
-export const selected = () => (
-  <SelectorWithState checked>I am selected!</SelectorWithState>
+Base.args = baseArgs;
+
+export const Selected = (args: SelectorProps) => (
+  <Selector {...args}>I am selected!</Selector>
 );
 
-export const disabled = () => (
-  <SelectorWithState disabled>I cannot be selected</SelectorWithState>
+Selected.args = { ...baseArgs, checked: true };
+
+export const Disabled = (args: SelectorProps) => (
+  <Selector {...args}>I cannot be selected</Selector>
 );
+
+Disabled.args = { ...baseArgs, disabled: true };

--- a/src/components/SelectorGroup/SelectorGroup.stories.tsx
+++ b/src/components/SelectorGroup/SelectorGroup.stories.tsx
@@ -22,51 +22,45 @@ export default {
   component: SelectorGroup,
 };
 
-const options = [
-  {
-    children: 'Apple',
-    value: 'apple',
-  },
-  {
-    children: 'Banana',
-    value: 'banana',
-  },
-  {
-    children: 'Mango',
-    value: 'mango',
-  },
-];
+const baseArgs = {
+  name: 'selector-group',
+  label: 'Choose your favourite fruit',
+  options: [
+    { children: 'Apple', value: 'apple' },
+    { children: 'Banana', value: 'banana' },
+    { children: 'Mango', value: 'mango' },
+  ],
+};
 
-/* eslint-disable react/prop-types */
-const SelectorGroupWithState = (props: Partial<SelectorGroupProps>) => {
-  const [value, setValue] = useState<string | string[]>(
-    props.multiple ? [] : '',
-  );
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    event.persist();
-    setValue((prev) => {
-      if (!props.multiple) {
-        return event.target.value;
-      }
-      const prevArray = prev as string[];
-      return prevArray.includes(event.target.value)
-        ? prevArray.filter((v) => v !== event.target.value)
-        : [...prevArray, event.target.value];
-    });
-  };
+export const Base = (args: SelectorGroupProps) => {
+  const [value, setValue] = useState<string>('');
+
   return (
     <SelectorGroup
-      name="selector-group"
-      label="Choose your favourite fruit"
-      options={options}
-      onChange={handleChange}
+      {...args}
       value={value}
-      {...props}
+      onChange={(event) => {
+        setValue(event.target.value);
+      }}
     />
   );
 };
-/* eslint-enable react/prop-types */
 
-export const base = () => <SelectorGroupWithState />;
+Base.args = baseArgs;
 
-export const multiple = () => <SelectorGroupWithState multiple />;
+export const Multiple = (args: SelectorGroupProps) => {
+  const [value, setValue] = useState<string[]>([]);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    event.persist();
+    setValue((prev) =>
+      prev.includes(event.target.value)
+        ? prev.filter((v) => v !== event.target.value)
+        : [...prev, event.target.value],
+    );
+  };
+
+  return <SelectorGroup {...args} value={value} onChange={handleChange} />;
+};
+
+Multiple.args = { ...baseArgs, multiple: true };

--- a/src/components/Sidebar/Sidebar.docs.mdx
+++ b/src/components/Sidebar/Sidebar.docs.mdx
@@ -1,9 +1,9 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import Sidebar from './Sidebar';
 
 # Sidebar
 
-<Status.InReview/><Status.Description>Under active development</Status.Description>
+<Status.InReview />
+<Status.Description>Under active development</Status.Description>
 
 The sidebar is the primary navigational component on SumUp's web-based applications. It groups different
 sections of the same product (the user dashboard, for example), allowing easy navigation between first
@@ -11,7 +11,7 @@ and the second level of navigations, keeping a strong anchor for our users to al
 
 <Story id="components-sidebar--base" />
 
-<Props of={Sidebar} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -117,12 +117,6 @@ Sidebar.propTypes = {
   }),
 };
 
-Sidebar.defaultProps = {
-  children: '',
-  open: false,
-  onClose: null,
-};
-
 Sidebar.Header = Header;
 Sidebar.Footer = Footer;
 Sidebar.NavList = NavList;

--- a/src/components/Sidebar/Sidebar.stories.js
+++ b/src/components/Sidebar/Sidebar.stories.js
@@ -14,10 +14,9 @@
  */
 
 /** @jsx jsx */
-import { Fragment, useState } from 'react';
+import { useState } from 'react';
 import { css, jsx } from '@emotion/core';
 import styled from '@emotion/styled';
-import { text } from '@storybook/addon-knobs';
 import {
   House,
   HouseFilled,
@@ -36,25 +35,33 @@ import Separator from './components/Separator';
 
 import Sidebar from '.';
 
-const Viewport = styled.div`
-  height: 100vh;
-  width: 100vw;
-`;
-
 export default {
   title: 'Components/Sidebar',
   component: Sidebar,
+  subcomponents: {
+    Header: Sidebar.Header,
+    NavList: Sidebar.NavList,
+    NavItem: Sidebar.NavItem,
+    Aggregator: Sidebar.Aggregator,
+    Separator: Sidebar.Separator,
+    Footer: Sidebar.Footer,
+  },
   parameters: {
+    layout: 'fullscreen',
     docs: { page: docs },
   },
 };
 
-const SidebarWithState = () => {
+const Viewport = styled.div`
+  min-height: 500px;
+`;
+
+export const Base = (args) => {
   const [open, setOpen] = useState(true);
   const [selected, setSelected] = useState(1);
 
   return (
-    <Fragment>
+    <Viewport>
       {!open && (
         <Button
           onClick={() => setOpen(true)}
@@ -66,75 +73,66 @@ const SidebarWithState = () => {
         </Button>
       )}
 
-      <Viewport>
-        <Sidebar
-          open={open}
-          onClose={() => setOpen(false)}
-          closeButtonLabel="close-button"
-          tracking={{
-            label: text('Tracking Label - onClose', 'trackingId-onClose'),
-          }}
-        >
-          <Sidebar.Header>Header</Sidebar.Header>
-          <Sidebar.NavList>
+      <Sidebar {...args} open={open} onClose={() => setOpen(false)}>
+        <Sidebar.Header>Header</Sidebar.Header>
+        <Sidebar.NavList>
+          <Sidebar.NavItem
+            key="home"
+            label="Home"
+            selected={selected === 1}
+            onClick={() => setSelected(1)}
+            defaultIcon={<House size="large" />}
+            selectedIcon={<HouseFilled size="large" />}
+            tracking={{ label: 'trackingId-home' }}
+          />
+          <Sidebar.Aggregator
+            key="list"
+            selected={selected === 2}
+            label="List"
+            defaultIcon={<Transactions size="large" />}
+            selectedIcon={<TransactionsFilled size="large" />}
+          >
             <Sidebar.NavItem
-              key="home"
-              label="Home"
-              selected={selected === 1}
-              onClick={() => setSelected(1)}
-              defaultIcon={<House size="large" />}
-              selectedIcon={<HouseFilled size="large" />}
-              tracking={{
-                label: text('Tracking Label - NavItem', 'trackingId-home'),
-              }}
+              label="First"
+              selected={selected === 21}
+              onClick={() => setSelected(21)}
             />
-            <Sidebar.Aggregator
-              key="list"
-              selected={selected === 2}
-              label="List"
-              defaultIcon={<Transactions size="large" />}
-              selectedIcon={<TransactionsFilled size="large" />}
-            >
-              <Sidebar.NavItem
-                label="First"
-                selected={selected === 21}
-                onClick={() => setSelected(21)}
-              />
-              <Sidebar.NavItem
-                label="Second"
-                selected={selected === 22}
-                onClick={() => setSelected(22)}
-              />
-              <Sidebar.NavItem
-                label="Third"
-                selected={selected === 23}
-                onClick={() => setSelected(23)}
-              />
-            </Sidebar.Aggregator>
             <Sidebar.NavItem
-              key="shop"
-              label="Shop"
-              disabled
-              selected={selected === 3}
-              defaultIcon={<ShoppingCart size="large" />}
-              selectedIcon={<ShoppingCartFilled size="large" />}
-              onClick={() => setSelected(3)}
+              label="Second"
+              selected={selected === 22}
+              onClick={() => setSelected(22)}
             />
-            <Separator key="separator" />
             <Sidebar.NavItem
-              key="me"
-              label="Me"
-              selected={selected === 4}
-              defaultIcon={<Person size="large" />}
-              selectedIcon={<PersonFilled size="large" />}
-              onClick={() => setSelected(4)}
+              label="Third"
+              selected={selected === 23}
+              onClick={() => setSelected(23)}
             />
-          </Sidebar.NavList>
-          <Sidebar.Footer>Footer</Sidebar.Footer>
-        </Sidebar>
-      </Viewport>
-    </Fragment>
+          </Sidebar.Aggregator>
+          <Sidebar.NavItem
+            key="shop"
+            label="Shop"
+            disabled
+            selected={selected === 3}
+            defaultIcon={<ShoppingCart size="large" />}
+            selectedIcon={<ShoppingCartFilled size="large" />}
+            onClick={() => setSelected(3)}
+          />
+          <Separator key="separator" />
+          <Sidebar.NavItem
+            key="me"
+            label="Me"
+            selected={selected === 4}
+            defaultIcon={<Person size="large" />}
+            selectedIcon={<PersonFilled size="large" />}
+            onClick={() => setSelected(4)}
+          />
+        </Sidebar.NavList>
+        <Sidebar.Footer>Footer</Sidebar.Footer>
+      </Sidebar>
+    </Viewport>
   );
 };
 
-export const base = () => <SidebarWithState />;
+Base.args = {
+  closeButtonLabel: 'close-button',
+};

--- a/src/components/Spacing/Spacing.stories.tsx
+++ b/src/components/Spacing/Spacing.stories.tsx
@@ -13,31 +13,35 @@
  * limitations under the License.
  */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 
 import Button from '../Button';
 
-import { Spacing } from './Spacing';
+import { Spacing, SpacingProps } from './Spacing';
 
 export default {
   title: 'Layout/Spacing',
   component: Spacing,
 };
 
-export const bottomSpacing = () => (
-  <Fragment>
-    <Spacing bottom>
+export const Bottom = (args: SpacingProps) => (
+  <div>
+    <Spacing {...args}>
       <Button variant="primary">Spacing bottom</Button>
     </Spacing>
     <Button>No spacing</Button>
-  </Fragment>
+  </div>
 );
 
-export const topSpacing = () => (
-  <Fragment>
+Bottom.args = { bottom: true };
+
+export const Top = (args: SpacingProps) => (
+  <div>
     <Button>No spacing</Button>
-    <Spacing top>
+    <Spacing {...args} top>
       <Button variant="primary">Spacing top</Button>
     </Spacing>
-  </Fragment>
+  </div>
 );
+
+Top.args = { top: true };

--- a/src/components/Spinner/Spinner.stories.tsx
+++ b/src/components/Spinner/Spinner.stories.tsx
@@ -21,6 +21,9 @@ import Spinner from '.';
 export default {
   title: 'Components/Spinner',
   component: Spinner,
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
 };
 
 export const Base = () => (

--- a/src/components/Step/Step.docs.mdx
+++ b/src/components/Step/Step.docs.mdx
@@ -1,11 +1,10 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import Step from './Step';
 
 # Step
 
 <Status.Stable />
 
-<Props of={Step} />
+<Props />
 
 ## Component usage examples
 

--- a/src/components/Step/Step.js
+++ b/src/components/Step/Step.js
@@ -122,4 +122,7 @@ Step.propTypes = {
   }),
 };
 
+/**
+ * @component
+ */
 export default Step;

--- a/src/components/Step/Step.stories.js
+++ b/src/components/Step/Step.stories.js
@@ -14,7 +14,6 @@
  */
 
 import React from 'react';
-import { object, number, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import Step from './Step';
@@ -41,40 +40,29 @@ export default {
   },
 };
 
-export const slider = () => (
-  <CarouselSlider
-    images={object('images', IMAGES)}
-    stepDuration={number('Step duration', STEP_DURATION)}
-    animationDuration={number('Animation duration', ANIMATION_DURATION)}
-    cycle={boolean('Cycle', true)}
-    autoPlay={boolean('Auto play', false)}
-    onNext={action('onNext')}
-    onPrevious={action('onPrev')}
-    onPlay={action('onPlay')}
-    onPause={action('onPause')}
-    onBeforeChange={action('onBeforeChange')}
-    onAfterChange={action('onAfterChange')}
-  />
-);
+const baseArgs = {
+  images: IMAGES,
+  cycle: true,
+  onNext: action('onNext'),
+  onPrevious: action('onPrev'),
+  onPlay: action('onPlay'),
+  onPause: action('onPause'),
+  onBeforeChange: action('onBeforeChange'),
+  onAfterChange: action('onAfterChange'),
+};
 
-export const swiper = () => (
-  <YesOrNoSlider
-    images={object('images', IMAGES)}
-    cycle={boolean('Cycle', true)}
-    onNext={action('onNext')}
-    onPrevious={action('onPrev')}
-    onPlay={action('onPlay')}
-    onPause={action('onPause')}
-    onBeforeChange={action('onBeforeChange')}
-    onAfterChange={action('onAfterChange')}
-  />
-);
+export const Slider = (args) => <CarouselSlider {...args} />;
 
-export const form = () => (
-  <MultiStepForm
-    onNext={action('onNext')}
-    onPrevious={action('onPrev')}
-    onBeforeChange={action('onBeforeChange')}
-    onAfterChange={action('onAfterChange')}
-  />
-);
+Slider.args = {
+  ...baseArgs,
+  stepDuration: STEP_DURATION,
+  animationDuration: ANIMATION_DURATION,
+};
+
+export const Swiper = (args) => <YesOrNoSlider {...args} />;
+
+Swiper.args = baseArgs;
+
+export const Form = (args) => <MultiStepForm {...args} />;
+
+Form.args = baseArgs;

--- a/src/components/SubHeading/SubHeading.docs.mdx
+++ b/src/components/SubHeading/SubHeading.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { SubHeading } from './SubHeading';
 
 # SubHeading
 
@@ -9,7 +8,7 @@ Subheadings help users break through larger related contents in the same section
 They are usually used to separate sections within a card.
 
 <Story id="typography-subheading--base" />
-<Props of={SubHeading} />
+<Props />
 
 ## Usage guidelines
 

--- a/src/components/SubHeading/SubHeading.docs.mdx
+++ b/src/components/SubHeading/SubHeading.docs.mdx
@@ -1,7 +1,7 @@
 import { Status, Props, Story } from '../../../.storybook/components';
 import { SubHeading } from './SubHeading';
 
-# Subheadings
+# SubHeading
 
 <Status.Stable />
 
@@ -18,4 +18,4 @@ They are usually used to separate sections within a card.
 
 ## Sizes
 
-<Story id="typography-subheading--size" />
+<Story id="typography-subheading--sizes" />

--- a/src/components/SubHeading/SubHeading.stories.tsx
+++ b/src/components/SubHeading/SubHeading.stories.tsx
@@ -14,13 +14,9 @@
  */
 
 import React from 'react';
-import { select, boolean, text } from '@storybook/addon-knobs';
 
-import { SubHeading } from './SubHeading';
+import { SubHeading, SubHeadingProps } from './SubHeading';
 import docs from './SubHeading.docs.mdx';
-
-const elements = ['h2', 'h3', 'h4', 'h5', 'h6'];
-const sizes = ['mega', 'kilo'] as const;
 
 export default {
   title: 'Typography/SubHeading',
@@ -30,19 +26,15 @@ export default {
   },
 };
 
-export const base = () => (
-  <SubHeading
-    as={select('Element', elements, elements[0])}
-    size={select('Size', sizes, sizes[0])}
-    noMargin={boolean('No margin', false)}
-  >
-    {text('Text', 'This is a subheading')}
-  </SubHeading>
+export const Base = (args: SubHeadingProps) => (
+  <SubHeading {...args}>This is a subheading</SubHeading>
 );
 
-export const size = () =>
+const sizes = ['mega', 'kilo'] as const;
+
+export const Sizes = (args: SubHeadingProps) =>
   sizes.map((s) => (
-    <SubHeading key={s} size={s}>
+    <SubHeading key={s} {...args} size={s}>
       This is a {s} subheading.
     </SubHeading>
   ));

--- a/src/components/Table/Table.docs.mdx
+++ b/src/components/Table/Table.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import Table from './Table';
 
 # Table
 
@@ -10,7 +9,7 @@ a task revolves around comparing or analyzing the information set.
 
 <Story id="components-table--base" />
 
-<Props of={Table} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Table/Table.stories.js
+++ b/src/components/Table/Table.stories.js
@@ -14,128 +14,124 @@
  */
 
 import React from 'react';
-import { boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import Badge from '../Badge';
 
 import docs from './Table.docs.mdx';
-import Table from './Table';
+
+import Table, { TableHeader, TableRow, TableCell } from '.';
 
 export default {
   title: 'Components/Table',
   component: Table,
+  subcomponents: { TableHeader, TableRow, TableCell },
   parameters: {
     docs: { page: docs },
   },
 };
 
-export const base = () => (
-  <Table
-    headers={[
-      { children: 'Name', sortable: true },
-      { children: 'Created at', sortable: true },
-      'Permissions',
-      { children: 'Status', align: 'right' },
-    ]}
-    rows={[
-      {
-        'cells': [
-          'Lorem ipsum dolor',
-          {
-            'children': '12/01/2017',
-            'sortByValue': 0,
-            'data-selector': 'item-1-cell-date-12/01/2017',
-          },
-          '-',
-          { children: 'Disabled', align: 'right' },
-        ],
-        'data-selector': 'item-1',
-      },
-      [
-        'Ipsum dolor sit amet',
-        { children: '13/01/2017', sortByValue: 1 },
-        'Virtual Terminal',
-        { children: 'Enabled', align: 'right' },
-      ],
-      [
-        'Dolor sit amet, consectetur adipiscing',
-        { children: '14/01/2017', sortByValue: 2 },
+export const Base = ({ onSortBy, ...args }) => <Table {...args} />;
+
+Base.args = {
+  headers: [
+    { children: 'Name', sortable: true },
+    { children: 'Created at', sortable: true },
+    'Permissions',
+    { children: 'Status', align: 'right' },
+  ],
+  rows: [
+    {
+      'cells': [
+        'Lorem ipsum dolor',
+        {
+          'children': '12/01/2017',
+          'sortByValue': 0,
+          'data-selector': 'item-1-cell-date-12/01/2017',
+        },
         '-',
         { children: 'Disabled', align: 'right' },
       ],
-    ]}
-    rowHeaders={boolean('Mobile rows', true)}
-    condensed={boolean('Condensed', false)}
-    scrollable={boolean('Scrollable', false)}
-    noShadow={boolean('Without Shadow', false)}
-    onRowClick={action('onRowClick')}
-    borderCollapsed={boolean('Border collapsed', false)}
-  />
-);
+      'data-selector': 'item-1',
+    },
+    [
+      'Ipsum dolor sit amet',
+      { children: '13/01/2017', sortByValue: 1 },
+      'Virtual Terminal',
+      { children: 'Enabled', align: 'right' },
+    ],
+    [
+      'Dolor sit amet, consectetur adipiscing',
+      { children: '14/01/2017', sortByValue: 2 },
+      '-',
+      { children: 'Disabled', align: 'right' },
+    ],
+  ],
+  rowHeaders: true,
+  onRowClick: action('onRowClick'),
+};
 
-export const withComponentRows = () => (
-  <Table
-    headers={['Name', 'Type']}
-    rows={[
-      ['Apple', { children: <Badge color={'danger'}>Fruit</Badge> }],
-      [
-        'Broccoli',
-        {
-          children: <Badge color={'success'}>Vegetable</Badge>,
-        },
-      ],
-      ['Chickpeas', { children: <Badge color={'warning'}>Legume</Badge> }],
-    ]}
-  />
-);
+export const WithComponentRows = ({ onSortBy, ...args }) => <Table {...args} />;
 
-export const sortable = () => (
-  <Table
-    headers={[
-      { children: 'Name', sortable: true },
-      { children: 'Date added', sortable: true },
-    ]}
-    rows={[
-      [
-        { children: 'Apple' },
-        {
-          children: '12/12/18',
-          sortByValue: new Date('12/12/18'),
-        },
-      ],
-      [
-        { children: 'Broccoli' },
-        {
-          children: '12/13/18',
-          sortByValue: new Date('12/13/18'),
-        },
-      ],
-      [
-        { children: 'Chickpeas' },
-        {
-          children: '12/14/18',
-          sortByValue: new Date('12/14/18'),
-        },
-      ],
-    ]}
-  />
-);
+WithComponentRows.args = {
+  headers: ['Name', 'Type'],
+  rows: [
+    ['Apple', { children: <Badge color={'danger'}>Fruit</Badge> }],
+    ['Broccoli', { children: <Badge color={'success'}>Vegetable</Badge> }],
+    ['Chickpeas', { children: <Badge color={'warning'}>Legume</Badge> }],
+  ],
+};
 
-export const customSort = () => (
+export const Sortable = ({ onSortBy, ...args }) => <Table {...args} />;
+
+Sortable.args = {
+  headers: [
+    { children: 'Name', sortable: true },
+    { children: 'Date added', sortable: true },
+  ],
+  rows: [
+    [
+      { children: 'Apple' },
+      {
+        children: '12/12/18',
+        sortByValue: new Date('12/12/18'),
+      },
+    ],
+    [
+      { children: 'Broccoli' },
+      {
+        children: '12/13/18',
+        sortByValue: new Date('12/13/18'),
+      },
+    ],
+    [
+      { children: 'Chickpeas' },
+      {
+        children: '12/14/18',
+        sortByValue: new Date('12/14/18'),
+      },
+    ],
+  ],
+};
+
+export const CustomSort = (args) => (
   <Table
-    headers={[{ children: 'Country', sortable: true }]}
+    {...args}
     onSortBy={(i, direction, rows) =>
       direction === 'ascending'
         ? rows.sort((a, b) => a[0].localeCompare(b[0]))
         : rows.sort((a, b) => b[0].localeCompare(a[0]))
     }
-    rows={[
-      ['Schweiz'],
-      ['Österreich'],
-      ['Deutschland'],
-      ['Liechtenstein'],
-      ['Italien'],
-    ]}
   />
 );
+
+CustomSort.args = {
+  headers: [{ children: 'Country', sortable: true }],
+  rows: [
+    ['Schweiz'],
+    ['Österreich'],
+    ['Deutschland'],
+    ['Liechtenstein'],
+    ['Italien'],
+  ],
+};

--- a/src/components/Table/components/TableCell/TableCell.stories.js
+++ b/src/components/Table/components/TableCell/TableCell.stories.js
@@ -14,7 +14,6 @@
  */
 
 import React from 'react';
-import { boolean, text, select } from '@storybook/addon-knobs';
 
 import TableCell from '.';
 
@@ -23,12 +22,8 @@ export default {
   component: TableCell,
 };
 
-export const base = () => (
-  <TableCell
-    style={{ width: '300px', alignSelf: 'center' }}
-    align={select('Align', ['left', 'right', 'center'])}
-    isHovered={boolean('Hover styles', false)}
-  >
-    {text('Content', 'Header')}
+export const Base = (args) => (
+  <TableCell style={{ width: '300px', alignSelf: 'center' }} {...args}>
+    Cell
   </TableCell>
 );

--- a/src/components/Table/components/TableHeader/TableHeader.stories.js
+++ b/src/components/Table/components/TableHeader/TableHeader.stories.js
@@ -14,7 +14,6 @@
  */
 
 import React from 'react';
-import { boolean, text, select } from '@storybook/addon-knobs';
 
 import TableHeader from '.';
 
@@ -23,12 +22,8 @@ export default {
   component: TableHeader,
 };
 
-export const base = () => (
-  <TableHeader
-    style={{ width: '300px', alignSelf: 'center' }}
-    align={select('Align', ['left', 'right', 'center'])}
-    sortable={boolean('Sortable', false)}
-  >
-    {text('Content', 'Header')}
+export const Base = (args) => (
+  <TableHeader style={{ width: '300px', alignSelf: 'center' }} {...args}>
+    Header
   </TableHeader>
 );

--- a/src/components/Tabs/Tabs.docs.mdx
+++ b/src/components/Tabs/Tabs.docs.mdx
@@ -1,13 +1,17 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Tabs, Tab, TabList, TabPanel } from '../../../src/components/Tabs';
+import { Tab, TabList, TabPanel } from '../../../src/components/Tabs';
 
 # Tabs
 
-<Status.InReview/><Status.Description>Does not handle content overflow on mobile. Unclear use case compared to subnavigation.</Status.Description>
+<Status.InReview />
+<Status.Description>
+  Does not handle content overflow on mobile. Unclear use case compared to
+  subnavigation.
+</Status.Description>
 
 <Story id="components-tabs--base" />
 
-<Props of={Tabs} />
+<Props />
 
 ## Variations
 

--- a/src/components/Tabs/Tabs.stories.js
+++ b/src/components/Tabs/Tabs.stories.js
@@ -14,8 +14,6 @@
  */
 
 import React, { useState } from 'react';
-import styled from '@emotion/styled';
-import { boolean } from '@storybook/addon-knobs';
 
 import docs from './Tabs.docs.mdx';
 
@@ -24,7 +22,9 @@ import { Tabs, TabList, TabPanel, Tab } from '.';
 export default {
   title: 'Components/Tabs',
   component: Tabs,
+  subcomponents: { TabList, TabPanel, Tab },
   parameters: {
+    layout: 'fullscreen',
     docs: { page: docs },
   },
 };
@@ -36,21 +36,38 @@ const tabs = [
   { id: 'four', tab: 'Tab 4', panel: 'Content 4' },
 ];
 
-const Wrapper = styled.div`
-  width: 100vw;
+export const Base = (args) => <Tabs {...args} />;
 
-  ${(p) => p.theme.mq.kilo} {
-    width: auto;
-    max-width: 100vw;
-  }
-`;
+Base.args = {
+  items: tabs,
+};
 
-const TabsWithState = (props) => {
+export const Links = () => (
+  <TabList>
+    <Tab selected>Home</Tab>
+    <Tab as="a" href="https://github.com/sumup-oss/circuit-ui" target="_blank">
+      GitHub
+    </Tab>
+    <Tab
+      as="a"
+      href="https://www.npmjs.com/package/@sumup/circuit-ui"
+      target="_blank"
+    >
+      NPM
+    </Tab>
+  </TabList>
+);
+
+Links.parameters = {
+  controls: { hideNoControlsWarning: true },
+};
+
+export const ControlledState = () => {
   const [selected, setSelected] = useState(0);
 
   return (
-    <Wrapper>
-      <TabList {...props}>
+    <>
+      <TabList>
         {tabs.map(({ tab }, index) => (
           <Tab
             key={tab}
@@ -62,30 +79,10 @@ const TabsWithState = (props) => {
         ))}
       </TabList>
       <TabPanel>{tabs[selected].content}</TabPanel>
-    </Wrapper>
+    </>
   );
 };
 
-export const base = () => (
-  <Wrapper>
-    <Tabs items={tabs} />
-  </Wrapper>
-);
-
-export const links = () => (
-  <Wrapper>
-    <TabList>
-      <Tab selected>Home</Tab>
-      <Tab as="a" href="https://www.google.com" target="_blank">
-        Page #1
-      </Tab>
-      <Tab as="a" href="https://www.google.com" target="_blank">
-        Page #2
-      </Tab>
-    </TabList>
-  </Wrapper>
-);
-
-export const controlledState = () => (
-  <TabsWithState stretched={boolean('stretched', false)} />
-);
+ControlledState.parameters = {
+  controls: { hideNoControlsWarning: true },
+};

--- a/src/components/Tag/Tag.docs.mdx
+++ b/src/components/Tag/Tag.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { Tag } from './Tag';
 
 # Tag
 
@@ -9,7 +8,7 @@ Tags enable the user to add or remove attributes to a given content, for
 example: transaction history for a given day or week.
 
 <Story id="components-tag--base" />
-<Props of={Tag} />
+<Props />
 
 ## Best practices
 

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -15,7 +15,6 @@
 
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { boolean, text } from '@storybook/addon-knobs';
 import { Check } from '@sumup/icons';
 
 import docs from './Tag.docs.mdx';
@@ -28,40 +27,41 @@ export default {
     docs: { page: docs },
   },
 };
-
-const BaseTag = (props: Partial<TagProps>) => (
-  <Tag
-    selected={boolean('Selected', false)}
-    prefix={boolean('Prefix', false) ? Check : undefined}
-    suffix={boolean('Suffix', false) ? Check : undefined}
-    onClick={boolean('Clickable', false) ? action('Tag clicked') : undefined}
-    onRemove={boolean('Removable', false) ? action('Tag removed') : undefined}
-    {...props}
-  >
-    Transactions
-  </Tag>
+export const Base = ({ onRemove, ...args }: TagProps) => (
+  <Tag {...args}>Transactions</Tag>
 );
 
-export const base = () => <BaseTag />;
-
-export const selected = () => <BaseTag selected />;
-
-export const withPrefix = () => <BaseTag prefix={Check} />;
-
-export const withSuffix = () => <BaseTag suffix={Check} />;
-
-export const clickable = () => (
-  <BaseTag
-    onClick={action('Tag clicked')}
-    as="button"
-    tracking={{ label: text('Tracking Label', 'trackingId') }}
-  />
+export const Selected = ({ onRemove, ...args }: TagProps) => (
+  <Tag {...args}>Transactions</Tag>
 );
 
-export const removable = () => (
-  <BaseTag
-    onRemove={action('Tag removed')}
-    labelRemoveButton="Remove"
-    tracking={{ label: text('Tracking Label', 'trackingId') }}
-  />
+Selected.args = { selected: true };
+
+export const WithPrefix = ({ onRemove, ...args }: TagProps) => (
+  <Tag {...args}>Transactions</Tag>
 );
+
+WithPrefix.args = { prefix: Check };
+
+export const WithSuffix = ({ onRemove, ...args }: TagProps) => (
+  <Tag {...args}>Transactions</Tag>
+);
+
+WithSuffix.args = { suffix: Check };
+
+export const Clickable = ({ onRemove, ...args }: TagProps) => (
+  <Tag {...args}>Transactions</Tag>
+);
+
+Clickable.args = {
+  onClick: action('Tag clicked'),
+  tracking: { label: 'trackingId' },
+};
+
+export const Removable = (args: TagProps) => <Tag {...args}>Transactions</Tag>;
+
+Removable.args = {
+  onRemove: action('Tag removed'),
+  labelRemoveButton: 'Remove',
+  tracking: { label: 'trackingId' },
+};

--- a/src/components/Text/Text.docs.mdx
+++ b/src/components/Text/Text.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import Text from '.';
 
 # Text
 
@@ -10,7 +9,7 @@ and have `bold` and `italic` attributes to tailor it according to the content we
 presenting.
 
 <Story id="typography-text--base" />
-<Props of={Text} />
+<Props />
 
 ## Usage guidelines
 

--- a/src/components/Text/Text.docs.mdx
+++ b/src/components/Text/Text.docs.mdx
@@ -21,7 +21,7 @@ presenting.
 
 ### Sizes
 
-<Story id="typography-text--size" />
+<Story id="typography-text--sizes" />
 
 ### Bold
 
@@ -34,7 +34,3 @@ presenting.
 ### Strikethrough
 
 <Story id="typography-text--strike" />
-
-### Custom element
-
-<Story id="typography-text--custom-element" />

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -14,14 +14,11 @@
  */
 
 import React from 'react';
-import { select, boolean } from '@storybook/addon-knobs';
 
 import docs from './Text.docs.mdx';
+import { TextProps } from './Text';
 
 import Text from '.';
-
-const elements = ['p', 'article', 'div', 'span', 'strong', 'em'];
-const sizes = ['kilo', 'mega', 'giga'] as const;
 
 const content =
   'An electronic circuit is composed of individual electronic components, such as resistors, transistors, capacitors, inductors and diodes, connected by conductive wires or traces through which electric current can flow.';
@@ -34,30 +31,31 @@ export default {
   },
 };
 
-export const base = () => (
-  <Text
-    as={select('Element', elements, elements[0])}
-    size={select('Size', sizes, sizes[0])}
-    noMargin={boolean('No margin', true)}
-    bold={boolean('Bold', false)}
-    italic={boolean('Italic', false)}
-    strike={boolean('Strike through', false)}
-  >
-    {content}
-  </Text>
-);
+export const Base = (args: TextProps) => <Text {...args}>{content}</Text>;
 
-export const size = () =>
+const sizes = ['kilo', 'mega', 'giga'] as const;
+
+export const Sizes = (args: TextProps) =>
   sizes.map((s) => (
-    <Text key={s} size={s}>
+    <Text key={s} {...args} size={s}>
       This is a {s} text. {content}
     </Text>
   ));
 
-export const bold = () => <Text bold>{content}</Text>;
+export const Bold = (args: TextProps) => (
+  <Text {...args} as="strong" bold>
+    {content}
+  </Text>
+);
 
-export const italic = () => <Text italic>{content}</Text>;
+export const Italic = (args: TextProps) => (
+  <Text {...args} as="em" italic>
+    {content}
+  </Text>
+);
 
-export const strike = () => <Text strike>{content}</Text>;
-
-export const customElement = () => <Text as="span">{content}</Text>;
+export const Strike = (args: TextProps) => (
+  <Text {...args} as="s" strike>
+    {content}
+  </Text>
+);

--- a/src/components/TextArea/TextArea.docs.mdx
+++ b/src/components/TextArea/TextArea.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import { TextArea } from './TextArea';
 
 # Textarea
 
@@ -8,7 +7,7 @@ import { TextArea } from './TextArea';
 It is a type of input that allows mutiple lines of text.
 
 <Story id="forms-textarea--base" />
-<Props of={TextArea} />
+<Props />
 
 ## When to use it
 

--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -15,8 +15,6 @@
 
 import React from 'react';
 
-import { uniqueId } from '../../util/id';
-
 import { TextArea, TextAreaProps } from './TextArea';
 import docs from './TextArea.docs.mdx';
 
@@ -26,41 +24,57 @@ export default {
   parameters: {
     docs: { page: docs },
   },
+  argTypes: {
+    placeholder: { control: 'text' },
+    disabled: { control: 'boolean' },
+  },
 };
 
-// TextAreas always need labels for accessibility.
-const TextAreaWithLabel = (props: Partial<TextAreaProps>) => {
-  const id = uniqueId();
-  return (
-    <TextArea
-      placeholder="Write your text here..."
-      {...props}
-      id={id}
-      label="Label"
-    />
-  );
+const baseArgs = {
+  label: 'Describe your issue',
+  placeholder: 'Be detailed and concise...',
 };
 
-export const base = () => <TextAreaWithLabel />;
+export const Base = (args: TextAreaProps) => <TextArea {...args} />;
 
-export const invalid = () => (
-  <TextAreaWithLabel validationHint="Please fill in this field." invalid />
-);
+Base.args = baseArgs;
 
-export const warning = () => (
-  <TextAreaWithLabel
-    validationHint="We recommend that you fill in this field."
-    hasWarning
-  />
-);
+export const Invalid = (args: TextAreaProps) => <TextArea {...args} />;
 
-export const readonly = () => <TextAreaWithLabel readOnly />;
+Invalid.args = {
+  ...baseArgs,
+  validationHint: 'Please fill in this field.',
+  invalid: true,
+};
 
-export const disabled = () => (
-  <TextAreaWithLabel
-    value="You cannot edit the text because the textarea is disabled"
-    disabled
-  />
-);
+export const Warning = (args: TextAreaProps) => <TextArea {...args} />;
 
-export const hiddenLabel = () => <TextAreaWithLabel hideLabel />;
+Warning.args = {
+  ...baseArgs,
+  validationHint: 'We recommend that you fill in this field.',
+  hasWarning: true,
+};
+
+export const Readonly = (args: TextAreaProps) => <TextArea {...args} />;
+
+Readonly.args = {
+  ...baseArgs,
+  placeholder: 'You can select and copy but not edit me',
+  readOnly: true,
+};
+
+export const Disabled = (args: TextAreaProps) => <TextArea {...args} />;
+
+Disabled.args = {
+  ...baseArgs,
+  value: 'You cannot edit the text because the textarea is disabled',
+  disabled: true,
+};
+
+export const HiddenLabel = (args: TextAreaProps) => <TextArea {...args} />;
+
+HiddenLabel.args = {
+  ...baseArgs,
+  placeholder: 'Describe your issue',
+  hideLabel: true,
+};

--- a/src/components/Toggle/Toggle.docs.mdx
+++ b/src/components/Toggle/Toggle.docs.mdx
@@ -1,7 +1,5 @@
 import { Status, Props, Story } from '../../../.storybook/components';
 
-import { Toggle } from './Toggle';
-
 # Toggle
 
 <Status.Stable />
@@ -9,7 +7,7 @@ import { Toggle } from './Toggle';
 The toggle is a switcher between two mutually exclusive states: on and off.
 
 <Story id="forms-toggle--with-explanation" />
-<Props of={Toggle} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -14,7 +14,6 @@
  */
 
 import React, { useState } from 'react';
-import { text } from '@storybook/addon-knobs';
 
 import docs from './Toggle.docs.mdx';
 import { Toggle, ToggleProps } from './Toggle';
@@ -27,32 +26,33 @@ export default {
   },
 };
 
-const ToggleWithState = (props: Partial<ToggleProps>) => {
+const baseArgs = {
+  label: 'Short label',
+  labelChecked: 'on',
+  labelUnchecked: 'off',
+};
+
+export const Base = (args: ToggleProps) => {
   const [checked, setChecked] = useState(false);
 
   const handleChange = () => {
     setChecked((prev) => !prev);
   };
-
-  return (
-    <Toggle
-      label="Short label"
-      labelChecked="on"
-      labelUnchecked="off"
-      {...props}
-      checked={checked}
-      onChange={handleChange}
-    />
-  );
+  return <Toggle {...args} checked={checked} onChange={handleChange} />;
 };
 
-export const base = () => (
-  <ToggleWithState
-    label="Short label"
-    tracking={{ label: text('Tracking Label', 'trackingId') }}
-  />
-);
+Base.args = baseArgs;
 
-export const withExplanation = () => (
-  <ToggleWithState explanation="Some more detailed text of what this means" />
-);
+export const WithExplanation = (args: ToggleProps) => {
+  const [checked, setChecked] = useState(false);
+
+  const handleChange = () => {
+    setChecked((prev) => !prev);
+  };
+  return <Toggle {...args} checked={checked} onChange={handleChange} />;
+};
+
+WithExplanation.args = {
+  ...baseArgs,
+  explanation: 'Some more detailed text of what this means',
+};

--- a/src/components/Tooltip/Tooltip.docs.mdx
+++ b/src/components/Tooltip/Tooltip.docs.mdx
@@ -1,5 +1,4 @@
 import { Status, Props, Story } from '../../../.storybook/components';
-import Tooltip from './Tooltip';
 
 # Tooltip
 
@@ -10,7 +9,7 @@ They can be activated when users hover, focus, tap, or click.
 
 <Story id="components-tooltip--base" />
 
-<Props of={Tooltip} />
+<Props />
 
 ## When to use it
 

--- a/src/components/Tooltip/Tooltip.js
+++ b/src/components/Tooltip/Tooltip.js
@@ -113,7 +113,11 @@ const getAlignmentStyles = ({ theme, position, align }) => {
   /* eslint-enable max-len */
 };
 
-const positionAndAlignStyles = ({ theme, position, align }) => css`
+const positionAndAlignStyles = ({
+  theme,
+  position = 'right',
+  align = 'center',
+}) => css`
   label: ${`tooltip--${position}-${align}`};
   ${getAlignmentStyles({ theme, position, align })};
   ${getPositionStyles({ theme, position })};
@@ -122,10 +126,7 @@ const positionAndAlignStyles = ({ theme, position, align }) => css`
 /**
  * A Tooltip component
  */
-const Tooltip = styled('div')`
-  ${baseStyles};
-  ${positionAndAlignStyles};
-`;
+const Tooltip = styled('div')(baseStyles, positionAndAlignStyles);
 
 Tooltip.propTypes = {
   /**
@@ -140,11 +141,6 @@ Tooltip.propTypes = {
    * The alignment of the tooltip relative to its position.
    */
   align: PropTypes.oneOf(['top', 'right', 'bottom', 'left', 'center']),
-};
-
-Tooltip.defaultProps = {
-  position: 'right',
-  align: 'center',
 };
 
 /**

--- a/src/components/Tooltip/Tooltip.stories.js
+++ b/src/components/Tooltip/Tooltip.stories.js
@@ -26,6 +26,20 @@ export default {
   parameters: {
     docs: { page: docs },
   },
+  argTypes: {
+    position: {
+      control: {
+        type: 'select',
+        options: ['top', 'bottom', 'left', 'right'],
+      },
+    },
+    align: {
+      control: {
+        type: 'select',
+        options: ['top', 'bottom', 'left', 'right', 'center'],
+      },
+    },
+  },
 };
 
 const TooltipContainer = styled('div')`
@@ -39,25 +53,50 @@ const TooltipContainer = styled('div')`
   }
 `;
 
-const TooltipWithContainer = (props) => (
+export const Base = (args) => (
   <TooltipContainer>
-    <Tooltip {...props}>I am a teeny, tiny tooltip.</Tooltip>
+    <Tooltip {...args}>I am a teeny, tiny tooltip.</Tooltip>
     <CircleInfo />
   </TooltipContainer>
 );
 
-export const base = () => (
-  <TooltipWithContainer position={'right'} align={'center'} />
+Base.args = {
+  position: 'right',
+  align: 'center',
+};
+
+export const TopLeft = (args) => (
+  <TooltipContainer>
+    <Tooltip {...args}>I am a teeny, tiny tooltip.</Tooltip>
+    <CircleInfo />
+  </TooltipContainer>
 );
 
-export const topLeft = () => (
-  <TooltipWithContainer position={'top'} align={'left'} />
+TopLeft.args = {
+  position: 'top',
+  align: 'left',
+};
+
+export const BottomRight = (args) => (
+  <TooltipContainer>
+    <Tooltip {...args}>I am a teeny, tiny tooltip.</Tooltip>
+    <CircleInfo />
+  </TooltipContainer>
 );
 
-export const bottomRight = () => (
-  <TooltipWithContainer position={'bottom'} align={'right'} />
+BottomRight.args = {
+  position: 'bottom',
+  align: 'right',
+};
+
+export const LeftCenter = (args) => (
+  <TooltipContainer>
+    <Tooltip {...args}>I am a teeny, tiny tooltip.</Tooltip>
+    <CircleInfo />
+  </TooltipContainer>
 );
 
-export const leftCenter = () => (
-  <TooltipWithContainer position={'left'} align={'center'} />
-);
+LeftCenter.args = {
+  position: 'left',
+  align: 'center',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,7 +1823,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.0":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
   integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
@@ -2059,17 +2059,7 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/cache@^10.0.9":
-  version "10.0.27"
-  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.27.tgz#7895db204e2c1a991ae33d51262a3a44f6737303"
-  integrity sha512-Zp8BEpbMunFsTcqAK4D7YTm3MvCp1SekflSLJH8lze2fCcSZ/yMkXHo8kb3t1/1Tdd3hAqf3Fb7z9VZ+FMiC9w==
-  dependencies:
-    "@emotion/sheet" "0.9.4"
-    "@emotion/stylis" "0.8.5"
-    "@emotion/utils" "0.11.3"
-    "@emotion/weak-memoize" "0.2.5"
-
-"@emotion/core@10.0.27", "@emotion/core@^10.0.20", "@emotion/core@^10.0.9":
+"@emotion/core@10.0.27", "@emotion/core@^10.0.20":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.27.tgz#7c3f78be681ab2273f3bf11ca3e2edc4a9dd1fdc"
   integrity sha512-XbD5R36pVbohQMnKfajHv43g8EbN4NHdF6Zh9zg/C0nr0jqwOw3gYnC07Xj3yG43OYSRyrGsoQ5qPwc8ycvLZw==
@@ -2081,7 +2071,7 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
+"@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
   integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
@@ -2844,31 +2834,6 @@
     remark-slug "^6.0.0"
     ts-dedent "^1.1.1"
     util-deprecate "^1.0.2"
-
-"@storybook/addon-knobs@^6.0.10":
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-6.0.10.tgz#b5a1b15d6712ffbb8d4cedc9cb74016bbbe010cb"
-  integrity sha512-EnvWgBrHvCnxL8HLK3kTY11QvnGVI+cG/8mFyVKoMGv3JcriOG6nq94S4K9H4BMjQYv+T/Z5140m508RsbRuzg==
-  dependencies:
-    "@storybook/addons" "6.0.10"
-    "@storybook/api" "6.0.10"
-    "@storybook/channels" "6.0.10"
-    "@storybook/client-api" "6.0.10"
-    "@storybook/components" "6.0.10"
-    "@storybook/core-events" "6.0.10"
-    "@storybook/theming" "6.0.10"
-    copy-to-clipboard "^3.0.8"
-    core-js "^3.0.1"
-    escape-html "^1.0.3"
-    fast-deep-equal "^3.1.1"
-    global "^4.3.2"
-    lodash "^4.17.15"
-    prop-types "^15.7.2"
-    qs "^6.6.0"
-    react-color "^2.17.0"
-    react-lifecycles-compat "^3.0.4"
-    react-select "^3.0.8"
-    regenerator-runtime "^0.13.3"
 
 "@storybook/addon-links@^6.0.10":
   version "6.0.10"
@@ -7507,13 +7472,6 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-
 dom-serializer@0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
@@ -7978,7 +7936,7 @@ escalade@^3.0.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.1.tgz#52568a77443f6927cd0ab9c73129137533c965ed"
   integrity sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA==
 
-escape-html@^1.0.3, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -12493,11 +12451,6 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
-  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
-
 memoizerific@^1.11.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/memoizerific/-/memoizerific-1.11.3.tgz#7c87a4646444c32d75438570905f2dbd1b1a805a"
@@ -14908,13 +14861,6 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
-react-input-autosize@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
-  integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
-  dependencies:
-    prop-types "^15.5.8"
-
 react-inspector@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.0.1.tgz#8a30f3d488c4f40203624bbe24800f508ae05d3a"
@@ -14995,20 +14941,6 @@ react-portal@^4.2.0:
   dependencies:
     prop-types "^15.5.8"
 
-react-select@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.0.8.tgz#06ff764e29db843bcec439ef13e196865242e0c1"
-  integrity sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==
-  dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@emotion/cache" "^10.0.9"
-    "@emotion/core" "^10.0.9"
-    "@emotion/css" "^10.0.9"
-    memoize-one "^5.0.0"
-    prop-types "^15.6.0"
-    react-input-autosize "^2.2.2"
-    react-transition-group "^2.2.1"
-
 react-sizeme@^2.5.2, react-sizeme@^2.6.7:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.6.12.tgz#ed207be5476f4a85bf364e92042520499455453e"
@@ -15083,16 +15015,6 @@ react-textarea-autosize@^8.1.1:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
-
-react-transition-group@^2.2.1:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
-  dependencies:
-    dom-helpers "^3.4.0"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react-with-direction@^1.3.1:
   version "1.3.1"


### PR DESCRIPTION
Addresses #578.

## Purpose

[Storybook Controls](https://storybook.js.org/docs/react/essentials/controls) replace [Storybook Knobs](https://www.npmjs.com/package/@storybook/addon-knobs). The new addon is superior because the prop types (or "arg types" as they are called by Storybook) that are extracted from the component are used to generate the controls automatically. This means less boilerplate code and easier maintenance.

_Before_

<img width="1045" alt="No props table can be shown" src="https://user-images.githubusercontent.com/11017722/90333397-acddf480-dfc5-11ea-8de9-a18adec29360.png">

_After_

<img width="1033" alt="A fully interactive props table is shown" src="https://user-images.githubusercontent.com/11017722/90333404-b7988980-dfc5-11ea-8c5e-81e98444f177.png">

## Approach and changes

- refactor all story files to be compatible with Storybook Controls
- remove all references to Storybook Knobs and remove it from dependencies

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
