### PR TITLE
fix(components): don't mix default and named exports

### DIFF
--- a/src/components/ComponentsContext/index.js
+++ b/src/components/ComponentsContext/index.js
@@ -18,5 +18,4 @@ import withComponents from './withComponents';
 import useComponents from './useComponents';
 import * as defaultComponents from './components';
 
-export { withComponents, useComponents, defaultComponents };
-export default ComponentsContext;
+export { ComponentsContext, withComponents, useComponents, defaultComponents };

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ export { default as Carousel, CarouselComposer } from './components/Carousel';
 export { default as InlineElements } from './components/InlineElements';
 
 export {
-  default as ComponentsContext,
+  ComponentsContext,
   withComponents,
   useComponents,
 } from './components/ComponentsContext';

--- a/src/util/test-utils.tsx
+++ b/src/util/test-utils.tsx
@@ -23,7 +23,8 @@ import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from 'emotion-theming';
 import { light } from '@sumup/design-tokens';
 
-import ComponentsContext, {
+import {
+  ComponentsContext,
   defaultComponents,
 } from '../components/ComponentsContext';
 


### PR DESCRIPTION
Fixes #662.

## Purpose

When importing a named export, Jest got confused and tried to access the property on the default export.

## Approach and changes

- replace default export of `ComponentContext` with named export

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
