### PR TITLE
Change `first-child` selector to `first-of-type`

### DIFF
--- a/src/components/CardList/components/Item/Item.js
+++ b/src/components/CardList/components/Item/Item.js
@@ -28,7 +28,7 @@ const baseStyles = ({ theme }) => css`
   cursor: pointer;
   border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
 
-  &:first-child {
+  &:first-of-type {
     border-top-left-radius: ${theme.borderRadius.mega};
     border-top-right-radius: ${theme.borderRadius.mega};
   }


### PR DESCRIPTION
Proposed this change because of the warning `emotion` is throwing - https://github.com/emotion-js/emotion/issues/1105

Addresses no ticket.

## Purpose

Prevent getting the error shown in the screenshot, by applying the recommended change.
![Screen Shot 2020-09-02 at 4 27 22 PM](https://user-images.githubusercontent.com/43965625/91989540-4e40a680-ed39-11ea-980c-ebf84b625dc6.png)


## Approach and changes

Change css selector `first-child` to `first-of-type`

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
