### PR TITLE
fix(components): change selector of CardList Item

### DIFF
--- a/src/components/CardList/__snapshots__/CardList.spec.js.snap
+++ b/src/components/CardList/__snapshots__/CardList.spec.js.snap
@@ -31,7 +31,7 @@ exports[`CardList should render with default styles 1`] = `
   padding: 24px;
 }
 
-.circuit-0:first-child {
+.circuit-0:first-of-type {
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }
@@ -86,7 +86,7 @@ exports[`CardList should render with default styles 1`] = `
   outline: none;
 }
 
-.circuit-2:first-child {
+.circuit-2:first-of-type {
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }

--- a/src/components/CardList/components/Item/Item.js
+++ b/src/components/CardList/components/Item/Item.js
@@ -28,7 +28,7 @@ const baseStyles = ({ theme }) => css`
   cursor: pointer;
   border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
 
-  &:first-child {
+  &:first-of-type {
     border-top-left-radius: ${theme.borderRadius.mega};
     border-top-right-radius: ${theme.borderRadius.mega};
   }

--- a/src/components/CardList/components/Item/__snapshots__/Item.spec.js.snap
+++ b/src/components/CardList/components/Item/__snapshots__/Item.spec.js.snap
@@ -12,7 +12,7 @@ exports[`Item should render with all paddings 1`] = `
   padding: 12px;
 }
 
-.circuit-0:first-child {
+.circuit-0:first-of-type {
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }
@@ -75,7 +75,7 @@ exports[`Item should render with all paddings 2`] = `
   padding: 16px;
 }
 
-.circuit-0:first-child {
+.circuit-0:first-of-type {
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }
@@ -138,7 +138,7 @@ exports[`Item should render with all paddings 3`] = `
   padding: 24px;
 }
 
-.circuit-0:first-child {
+.circuit-0:first-of-type {
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }
@@ -201,7 +201,7 @@ exports[`Item should render with default styles 1`] = `
   padding: 24px;
 }
 
-.circuit-0:first-child {
+.circuit-0:first-of-type {
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }
@@ -264,7 +264,7 @@ exports[`Item should render with selected styles 1`] = `
   padding: 24px;
 }
 
-.circuit-0:first-child {
+.circuit-0:first-of-type {
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }


### PR DESCRIPTION
Proposed this change because of the warning `emotion` is throwing - https://github.com/emotion-js/emotion/issues/1105

Addresses no ticket.

## Purpose

Prevent getting the error shown in the screenshot, by applying the recommended change.
![Screen Shot 2020-09-02 at 4 27 22 PM](https://user-images.githubusercontent.com/43965625/91989540-4e40a680-ed39-11ea-980c-ebf84b625dc6.png)

## Approach and changes

Change css selector `first-child` to `first-of-type`.
Update tests.

There is the concern that the `first-of-type` selector will go for the first element of its type(e.g. `<span/>`, `<div/>` in the same CardList.Item group, so could apply for multiple elements instead of only the first). From my checks, seems the CardList.Item can only render a `<div/>`, so I believe this risk is bypassed in the current version.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
