### PR TITLE
docs(cli): add tips for codemods

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -23,15 +23,17 @@ yarn circuit-ui migrate
 Automatically transforms your source code to Circuit UI's latest APIs
 
 Options:
-  --transform, -t  The transform to be applied to the source code
-                            [string] [required] [choices: "button-variant-enum"]
   --language, -l   The programming language of the files to be transformed
                        [string] [required] [choices: "TypeScript", "JavaScript"]
   --path, -p       A path to the folder that contains the files to be
                    transformed                           [string] [default: "."]
+  --transform, -t  The transform to be applied to the source code
+                            [string] [required] [choices: "button-variant-enum"]
 ```
 
 You can only run one codemod at a time and we encourage you to apply the transforms incrementally and review the changes before continuing. The codemods don't cover all edge cases, so further manual changes might be necessary.
+
+Tip: Provide the `--transform`/`-t` argument at the end of the command, so that as you run further codemods you can easily replace the last argument and reuse the command to run the next codemod.
 
 ## From v1.x to v2
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,13 +28,6 @@ yargs
     "Automatically transforms your source code to Circuit UI's latest APIs",
     (yrgs) =>
       yrgs
-        .option('transform', {
-          alias: 't',
-          desc: 'The transform to be applied to the source code',
-          choices: listTransforms(),
-          type: 'string',
-          required: true,
-        })
         .option('language', {
           alias: 'l',
           desc: 'The programming language of the files to be transformed',
@@ -48,6 +41,13 @@ yargs
             'A path to the folder that contains the files to be transformed',
           type: 'string',
           default: '.',
+        })
+        .option('transform', {
+          alias: 't',
+          desc: 'The transform to be applied to the source code',
+          choices: listTransforms(),
+          type: 'string',
+          required: true,
         }),
     (args) => execute('migrate', args),
   )

--- a/src/cli/migrate/index.ts
+++ b/src/cli/migrate/index.ts
@@ -50,6 +50,8 @@ export function migrate({ transform, language, path }: MigrateArgs): void {
       `${TRANSFORM_DIR}/${transform}.js`,
       '--parser',
       parser,
+      '--ignore-pattern',
+      '**/node_modules/**',
       path,
     ],
     { stdio: 'inherit' },


### PR DESCRIPTION
## Purpose

While upgrading the SumUp Shop to Circuit UI v2, @jmaslate made a couple of great suggestions to improve the migration guide specifically for running codemods.

## Approach and changes

- Exclude `node_modules` from the transforms to significantly speed up the command
- Reshuffle the command arg order so that the `--transform` comes last, this makes it easy to reuse the command

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
