### PR TITLE
fix(configs): allow React 17 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "@sumup/icons": "1.x",
     "@sumup/intl": "1.x",
     "emotion-theming": "10.x",
-    "react": ">=16.8.0 < 17",
-    "react-dom": ">=16.8.0 < 17"
+    "react": ">=16.8.0 < 18",
+    "react-dom": ">=16.8.0 < 18"
   }
 }


### PR DESCRIPTION
## Purpose

[React 17](https://reactjs.org/blog/2020/08/10/react-v17-rc.html) is currently in the RC phase. It contains only minor breaking changes, which means Circuit UI is compatible with it.

## Approach and changes

- include React 17 in the allowed peer dependency range

We can't upgrade to React 17 in Circuit UI itself yet since it would conflict with Storybook's version of React. 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
