### PR TITLE
fix(components): add missing border-radius to NotificationBanner

### DIFF
--- a/src/components/NotificationBanner/NotificationBanner.stories.tsx
+++ b/src/components/NotificationBanner/NotificationBanner.stories.tsx
@@ -29,9 +29,6 @@ import {
 export default {
   title: 'Components/Notification/NotificationBanner',
   component: NotificationBanner,
-  parameters: {
-    layout: 'fullscreen',
-  },
 };
 
 export const Base = (args: NotificationBannerProps) => (

--- a/src/components/NotificationBanner/NotificationBanner.tsx
+++ b/src/components/NotificationBanner/NotificationBanner.tsx
@@ -31,6 +31,7 @@ const outerStyles = ({ theme }: StyleProps) => css`
   width: 100%;
   background-color: ${theme.colors.white};
   ${shadowSingle({ theme })};
+  border-radius: ${theme.borderRadius.mega};
 `;
 
 const NotificationBannerOuter = styled('div')<{}>(outerStyles);

--- a/src/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
+++ b/src/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`NotificationBanner should render with default styles 1`] = `
   width: 100%;
   background-color: #FFFFFF;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.07), 0 0 1px 0 rgba(12,15,20,0.07),0 2px 2px 0 rgba(12,15,20,0.07);
+  border-radius: 4px;
 }
 
 .circuit-0 {


### PR DESCRIPTION
## Purpose

The NotificationBanner's border-radius should match the one of a Card, i.e. `theme.borderRadius.mega` (currently 4px).

This commit also includes removing the full screen config of the NotificationBanner story, which
caused the component's styles to be hidden in Storybook.

## Approach and changes

Added the `mega` border-radius from the theme to the NotificationBanner wrapper.

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/35560568/93867376-3ff70200-fcc9-11ea-8006-de1d2326cedd.png) | ![After](https://user-images.githubusercontent.com/35560568/93867430-54d39580-fcc9-11ea-9b74-a5768111ee96.png) |

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
