### PR TITLE
feat(components): update colors for brand refresh

### DIFF
--- a/.storybook/util/theme.js
+++ b/.storybook/util/theme.js
@@ -15,7 +15,7 @@ export const theme = create({
   fontBase: light.fontStack.default,
   colorPrimary: light.colors.p500,
   colorSecondary: light.colors.p500,
-  appBg: light.colors.n100
+  appBg: light.colors.bodyBg
 });
 
 // FIXME: BaseStyles should only be included once, however, I couldn't find

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@storybook/react": "^6.0.10",
     "@storybook/source-loader": "^6.0.10",
     "@sumup/collector": "^1.0.0",
-    "@sumup/design-tokens": "^1.0.0",
+    "@sumup/design-tokens": "^2.0.0-alpha",
     "@sumup/foundry": "^3.0.0",
     "@sumup/icons": "^1.0.0",
     "@sumup/intl": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@storybook/react": "^6.0.10",
     "@storybook/source-loader": "^6.0.10",
     "@sumup/collector": "^1.0.0",
-    "@sumup/design-tokens": "^2.0.0-alpha",
+    "@sumup/design-tokens": "^2.0.1",
     "@sumup/foundry": "^3.0.0",
     "@sumup/icons": "^1.0.0",
     "@sumup/intl": "^1.0.0",
@@ -164,11 +164,11 @@
     "@emotion/styled": "10.x",
     "@emotion/stylis": "0.8.x",
     "@sumup/collector": "1.x",
-    "@sumup/design-tokens": "1.x",
+    "@sumup/design-tokens": ">=1.0.0 <3.0.0",
     "@sumup/icons": "1.x",
     "@sumup/intl": "1.x",
     "emotion-theming": "10.x",
-    "react": ">=16.8.0 < 18",
-    "react-dom": ">=16.8.0 < 18"
+    "react": ">=16.8.0 <18.0.0",
+    "react-dom": ">=16.8.0 <18.0.0"
   }
 }

--- a/scripts/static-styles/__snapshots__/component-styles.spec.js.snap
+++ b/scripts/static-styles/__snapshots__/component-styles.spec.js.snap
@@ -2,4 +2,4 @@
 
 exports[`Component styles component types should extract the styles from a functional component 1`] = `".functional-component__wrapper{padding:8px;}.functional-component__label{margin-bottom:4px;color:gray;}.functional-component{border:1px solid blue;}"`;
 
-exports[`Component styles component types should extract the styles from a styled component 1`] = `".styled-component{border:1px solid #3388FF;}.styled-component--disabled{pointer-events:none;opacity:0.5;}"`;
+exports[`Component styles component types should extract the styles from a styled component 1`] = `".styled-component{border:1px solid #3063E9;}.styled-component--disabled{pointer-events:none;opacity:0.5;}"`;

--- a/src/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
+++ b/src/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`Anchor styles should render as a \`button\` when an onClick is passed 1
   margin-top: 0;
   margin-left: 0;
   margin-right: 0;
-  color: #1760CE;
+  color: #234BC3;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
 }
@@ -33,7 +33,7 @@ exports[`Anchor styles should render as a \`button\` when an onClick is passed 1
 
 .circuit-0:hover,
 .circuit-0:active {
-  color: #003C8B;
+  color: #1A368E;
   cursor: pointer;
 }
 
@@ -105,7 +105,7 @@ exports[`Anchor styles should render as an \`a\` when an href (and onClick) is p
   margin-top: 0;
   margin-left: 0;
   margin-right: 0;
-  color: #1760CE;
+  color: #234BC3;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
 }
@@ -119,7 +119,7 @@ exports[`Anchor styles should render as an \`a\` when an href (and onClick) is p
 
 .circuit-0:hover,
 .circuit-0:active {
-  color: #003C8B;
+  color: #1A368E;
   cursor: pointer;
 }
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -71,8 +71,8 @@ const COLOR_MAP = {
   },
   neutral: {
     text: 'bodyColor',
-    default: 'n300',
-    hover: 'n500',
+    default: 'n200',
+    hover: 'n300',
   },
 } as const;
 

--- a/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Badge should have hover/active styles only when the onClick handler is provided 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFFFFF;
+  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -14,8 +14,8 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #D8DDE1;
-  color: #0F131A;
+  background-color: #E6E6E6;
+  color: #000;
   border: 0;
   outline: 0;
   cursor: pointer;
@@ -25,7 +25,7 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
 
 .circuit-0:hover,
 .circuit-0:active {
-  background-color: #9DA7B1;
+  background-color: #999999;
 }
 
 .circuit-0:focus {
@@ -45,7 +45,7 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
 exports[`Badge should have the correct circle styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFFFFF;
+  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -56,8 +56,8 @@ exports[`Badge should have the correct circle styles 1`] = `
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #D8DDE1;
-  color: #0F131A;
+  background-color: #E6E6E6;
+  color: #000;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -83,7 +83,7 @@ exports[`Badge should have the correct circle styles 1`] = `
 exports[`Badge should render with danger styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFFFFF;
+  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -94,8 +94,8 @@ exports[`Badge should render with danger styles 1`] = `
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #DB4D4D;
-  color: #FFFFFF;
+  background-color: #D23F47;
+  color: #FFF;
 }
 
 <div
@@ -106,7 +106,7 @@ exports[`Badge should render with danger styles 1`] = `
 exports[`Badge should render with default styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFFFFF;
+  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -117,8 +117,8 @@ exports[`Badge should render with default styles 1`] = `
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #D8DDE1;
-  color: #0F131A;
+  background-color: #E6E6E6;
+  color: #000;
 }
 
 <div
@@ -129,7 +129,7 @@ exports[`Badge should render with default styles 1`] = `
 exports[`Badge should render with primary styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFFFFF;
+  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -140,8 +140,8 @@ exports[`Badge should render with primary styles 1`] = `
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #3388FF;
-  color: #FFFFFF;
+  background-color: #3063E9;
+  color: #FFF;
 }
 
 <div
@@ -152,7 +152,7 @@ exports[`Badge should render with primary styles 1`] = `
 exports[`Badge should render with success styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFFFFF;
+  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -164,7 +164,7 @@ exports[`Badge should render with success styles 1`] = `
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
   background-color: #47995A;
-  color: #FFFFFF;
+  color: #FFF;
 }
 
 <div
@@ -175,7 +175,7 @@ exports[`Badge should render with success styles 1`] = `
 exports[`Badge should render with warning styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFFFFF;
+  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -187,7 +187,7 @@ exports[`Badge should render with warning styles 1`] = `
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
   background-color: #F6CC1B;
-  color: #0F131A;
+  color: #000;
 }
 
 <div

--- a/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #CCC;
+  background-color: #E6E6E6;
   color: #0F131A;
   border: 0;
   outline: 0;
@@ -25,7 +25,7 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
 
 .circuit-0:hover,
 .circuit-0:active {
-  background-color: #999;
+  background-color: #CCC;
 }
 
 .circuit-0:focus {
@@ -56,7 +56,7 @@ exports[`Badge should have the correct circle styles 1`] = `
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #CCC;
+  background-color: #E6E6E6;
   color: #0F131A;
   display: -webkit-box;
   display: -webkit-flex;
@@ -117,7 +117,7 @@ exports[`Badge should render with default styles 1`] = `
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #CCC;
+  background-color: #E6E6E6;
   color: #0F131A;
 }
 

--- a/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #E6E6E6;
+  background-color: #CCC;
   color: #000;
   border: 0;
   outline: 0;
@@ -25,7 +25,7 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
 
 .circuit-0:hover,
 .circuit-0:active {
-  background-color: #999999;
+  background-color: #999;
 }
 
 .circuit-0:focus {
@@ -56,7 +56,7 @@ exports[`Badge should have the correct circle styles 1`] = `
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #E6E6E6;
+  background-color: #CCC;
   color: #000;
   display: -webkit-box;
   display: -webkit-flex;
@@ -117,7 +117,7 @@ exports[`Badge should render with default styles 1`] = `
   -moz-letter-spacing: 0.25px;
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
-  background-color: #E6E6E6;
+  background-color: #CCC;
   color: #000;
 }
 

--- a/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`Badge should have hover/active styles only when the onClick handler is 
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
   background-color: #CCC;
-  color: #000;
+  color: #0F131A;
   border: 0;
   outline: 0;
   cursor: pointer;
@@ -57,7 +57,7 @@ exports[`Badge should have the correct circle styles 1`] = `
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
   background-color: #CCC;
-  color: #000;
+  color: #0F131A;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -118,7 +118,7 @@ exports[`Badge should render with default styles 1`] = `
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
   background-color: #CCC;
-  color: #000;
+  color: #0F131A;
 }
 
 <div
@@ -187,7 +187,7 @@ exports[`Badge should render with warning styles 1`] = `
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
   background-color: #F6CC1B;
-  color: #000;
+  color: #0F131A;
 }
 
 <div

--- a/src/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
+++ b/src/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
@@ -173,7 +173,7 @@ exports[`BaseStylesService should return the global base styles 1`] = `
 
   body {
     background-color: #FAFBFC;
-    color: #0F131A;
+    color: #000;
     
       font-size: 16px;
       line-height: 24px;

--- a/src/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
+++ b/src/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
@@ -172,7 +172,7 @@ exports[`BaseStylesService should return the global base styles 1`] = `
   }
 
   body {
-    background-color: #FAFBFC;
+    background-color: #F5F5F5;
     color: #000;
     
       font-size: 16px;

--- a/src/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
+++ b/src/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
@@ -172,8 +172,8 @@ exports[`BaseStylesService should return the global base styles 1`] = `
   }
 
   body {
-    background-color: #F5F5F5;
-    color: #000;
+    background-color: #FAFBFC;
+    color: #0F131A;
     
       font-size: 16px;
       line-height: 24px;

--- a/src/components/Blockquote/__snapshots__/Blockquote.spec.tsx.snap
+++ b/src/components/Blockquote/__snapshots__/Blockquote.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`Blockquote should render with default styles 1`] = `
   line-height: 24px;
   font-style: italic;
   padding-left: 12px;
-  border-left: 2px solid #3388FF;
+  border-left: 2px solid #3063E9;
 }
 
 @media (min-width:480px) {
@@ -33,9 +33,9 @@ exports[`Blockquote should render with giga styles 1`] = `
   line-height: 24px;
   font-style: italic;
   padding-left: 12px;
-  border-left: 2px solid #3388FF;
+  border-left: 2px solid #3063E9;
   padding-left: 16px;
-  border-left: 3px solid #3388FF;
+  border-left: 3px solid #3063E9;
 }
 
 @media (min-width:480px) {
@@ -60,7 +60,7 @@ exports[`Blockquote should render with kilo styles 1`] = `
   line-height: 20px;
   font-style: italic;
   padding-left: 12px;
-  border-left: 2px solid #3388FF;
+  border-left: 2px solid #3063E9;
 }
 
 @media (min-width:480px) {

--- a/src/components/Button/__snapshots__/Button.spec.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.spec.tsx.snap
@@ -28,9 +28,9 @@ exports[`Button styles should render a button with icon 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -53,12 +53,12 @@ exports[`Button styles should render a button with icon 1`] = `
 
 .circuit-1:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-1:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-0 {
@@ -118,9 +118,9 @@ exports[`Button styles should render a disabled button 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -143,12 +143,12 @@ exports[`Button styles should render a disabled button 1`] = `
 
 .circuit-0:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 <button
@@ -187,9 +187,9 @@ exports[`Button styles should render a kilo button 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 4px calc(16px - 1px);
   border-radius: 6px;
 }
@@ -212,12 +212,12 @@ exports[`Button styles should render a kilo button 1`] = `
 
 .circuit-0:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 <button
@@ -255,9 +255,9 @@ exports[`Button styles should render a mega button 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -280,12 +280,12 @@ exports[`Button styles should render a mega button 1`] = `
 
 .circuit-0:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 <button
@@ -323,9 +323,9 @@ exports[`Button styles should render a primary button by default 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -348,12 +348,12 @@ exports[`Button styles should render a primary button by default 1`] = `
 
 .circuit-0:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 <button
@@ -391,9 +391,9 @@ exports[`Button styles should render a secondary button 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -416,12 +416,12 @@ exports[`Button styles should render a secondary button 1`] = `
 
 .circuit-0:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 <button
@@ -459,9 +459,9 @@ exports[`Button styles should render a stretched button 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   width: 100%;
@@ -485,12 +485,12 @@ exports[`Button styles should render a stretched button 1`] = `
 
 .circuit-0:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 <button
@@ -530,7 +530,7 @@ exports[`Button styles should render a tertiary button 1`] = `
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: transparent;
   border-color: transparent;
-  color: #3388FF;
+  color: #3063E9;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -552,11 +552,11 @@ exports[`Button styles should render a tertiary button 1`] = `
 }
 
 .circuit-0:hover {
-  color: #1760CE;
+  color: #234BC3;
 }
 
 .circuit-0:active {
-  color: #003C8B;
+  color: #1A368E;
 }
 
 <button

--- a/src/components/Button/__snapshots__/Button.spec.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.spec.tsx.snap
@@ -29,8 +29,8 @@ exports[`Button styles should render a button with icon 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -52,13 +52,13 @@ exports[`Button styles should render a button with icon 1`] = `
 }
 
 .circuit-1:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-1:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-0 {
@@ -119,8 +119,8 @@ exports[`Button styles should render a disabled button 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -142,13 +142,13 @@ exports[`Button styles should render a disabled button 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 <button
@@ -188,8 +188,8 @@ exports[`Button styles should render a kilo button 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 4px calc(16px - 1px);
   border-radius: 6px;
 }
@@ -211,13 +211,13 @@ exports[`Button styles should render a kilo button 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 <button
@@ -256,8 +256,8 @@ exports[`Button styles should render a mega button 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -279,13 +279,13 @@ exports[`Button styles should render a mega button 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 <button
@@ -324,8 +324,8 @@ exports[`Button styles should render a primary button by default 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -347,13 +347,13 @@ exports[`Button styles should render a primary button by default 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 <button
@@ -392,8 +392,8 @@ exports[`Button styles should render a secondary button 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -415,13 +415,13 @@ exports[`Button styles should render a secondary button 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 <button
@@ -460,8 +460,8 @@ exports[`Button styles should render a stretched button 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   width: 100%;
@@ -484,13 +484,13 @@ exports[`Button styles should render a stretched button 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 <button

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -28,9 +28,9 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -53,12 +53,12 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
 
 .circuit-0:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-1 {
@@ -88,9 +88,9 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #3388FF;
-  border-color: #3388FF;
-  color: #FFFFFF;
+  background-color: #3063E9;
+  border-color: #3063E9;
+  color: #FFF;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -112,13 +112,13 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
 }
 
 .circuit-1:hover {
-  background-color: #1760CE;
-  border-color: #1760CE;
+  background-color: #234BC3;
+  border-color: #234BC3;
 }
 
 .circuit-1:active {
-  background-color: #003C8B;
-  border-color: #003C8B;
+  background-color: #1A368E;
+  border-color: #1A368E;
 }
 
 .circuit-2 {
@@ -213,9 +213,9 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -238,12 +238,12 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
 
 .circuit-0:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-1 {
@@ -273,9 +273,9 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #3388FF;
-  border-color: #3388FF;
-  color: #FFFFFF;
+  background-color: #3063E9;
+  border-color: #3063E9;
+  color: #FFF;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -297,13 +297,13 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
 }
 
 .circuit-1:hover {
-  background-color: #1760CE;
-  border-color: #1760CE;
+  background-color: #234BC3;
+  border-color: #234BC3;
 }
 
 .circuit-1:active {
-  background-color: #003C8B;
-  border-color: #003C8B;
+  background-color: #1A368E;
+  border-color: #1A368E;
 }
 
 .circuit-2 {
@@ -446,9 +446,9 @@ exports[`ButtonGroup should render with default styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -471,12 +471,12 @@ exports[`ButtonGroup should render with default styles 1`] = `
 
 .circuit-0:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-1 {
@@ -506,9 +506,9 @@ exports[`ButtonGroup should render with default styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #3388FF;
-  border-color: #3388FF;
-  color: #FFFFFF;
+  background-color: #3063E9;
+  border-color: #3063E9;
+  color: #FFF;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -530,13 +530,13 @@ exports[`ButtonGroup should render with default styles 1`] = `
 }
 
 .circuit-1:hover {
-  background-color: #1760CE;
-  border-color: #1760CE;
+  background-color: #234BC3;
+  border-color: #234BC3;
 }
 
 .circuit-1:active {
-  background-color: #003C8B;
-  border-color: #003C8B;
+  background-color: #1A368E;
+  border-color: #1A368E;
 }
 
 <div

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -29,8 +29,8 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -52,13 +52,13 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-1 {
@@ -214,8 +214,8 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -237,13 +237,13 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-1 {
@@ -447,8 +447,8 @@ exports[`ButtonGroup should render with default styles 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
 }
@@ -470,13 +470,13 @@ exports[`ButtonGroup should render with default styles 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-1 {

--- a/src/components/Calendar/__snapshots__/RangePicker.spec.js.snap
+++ b/src/components/Calendar/__snapshots__/RangePicker.spec.js.snap
@@ -1086,63 +1086,63 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .CalendarDay__default {
-  border: 1px solid #D8DDE1;
-  color: #212933;
-  background: #FFFFFF;
+  border: 1px solid #E6E6E6;
+  color: #000000;
+  background: #FFF;
   vertical-align: middle;
 }
 
 .circuit-2 .CalendarDay__default:hover {
-  background: #D8DDE1;
-  border: 1px double #9DA7B1;
+  background: #E6E6E6;
+  border: 1px double #999999;
   color: inherit;
 }
 
 .circuit-2 .CalendarDay__hovered_span,
 .circuit-2 .CalendarDay__hovered_span:hover {
-  background: #EDF4FC;
-  border: 1px solid #3388FF;
+  background: #F0F6FF;
+  border: 1px solid #3063E9;
 }
 
 .circuit-2 .CalendarDay__hovered_span:active {
-  background: #EDF4FC;
-  border: 1px solid #3388FF;
+  background: #F0F6FF;
+  border: 1px solid #3063E9;
 }
 
 .circuit-2 .CalendarDay__selected_span {
-  background: #EDF4FC;
+  background: #F0F6FF;
   border: 1px solid #AFD0FE;
 }
 
 .circuit-2 .CalendarDay__selected_span:hover {
-  color: #FFFFFF;
+  color: #FFF;
   background: #AFD0FE;
-  border: 1px solid #3388FF;
+  border: 1px solid #3063E9;
 }
 
 .circuit-2 .CalendarDay__last_in_range {
-  border-right: #3388FF;
+  border-right: #3063E9;
 }
 
 .circuit-2 .CalendarDay__selected,
 .circuit-2 .CalendarDay__selected:active,
 .circuit-2 .CalendarDay__selected:hover {
-  background: #3388FF;
-  border: 1px solid #1760CE;
-  color: #FFFFFF;
+  background: #3063E9;
+  border: 1px solid #234BC3;
+  color: #FFF;
 }
 
 .circuit-2 .CalendarDay__blocked_out_of_range,
 .circuit-2 .CalendarDay__blocked_out_of_range:active,
 .circuit-2 .CalendarDay__blocked_out_of_range:hover {
   background: #fff;
-  border: 1px solid #D8DDE1;
-  color: #D8DDE1;
+  border: 1px solid #E6E6E6;
+  color: #E6E6E6;
 }
 
 .circuit-2 .DateRangePickerInput,
 .circuit-2 .SingleDatePickerInput {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   padding: 8px 12px;
   -webkit-transition: border-color 120ms ease-in-out;
   transition: border-color 120ms ease-in-out;
@@ -1157,7 +1157,7 @@ exports[`RangePicker should render with default styles 1`] = `
 .circuit-2 .SingleDatePickerInput.SingleDatePickerInput__withBorder {
   border-width: 1px;
   border-style: solid;
-  border-color: #D8DDE1;
+  border-color: #E6E6E6;
   border-radius: 4px;
 }
 
@@ -1182,7 +1182,7 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .DateInput_input {
-  color: #212933;
+  color: #000000;
   font-size: 16px;
   line-height: 24px;
   font-weight: 200;
@@ -1193,25 +1193,25 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .DateInput_input::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-2 .DateInput_input::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-2 .DateInput_input:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-2 .DateInput_input::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -1237,9 +1237,9 @@ exports[`RangePicker should render with default styles 1`] = `
   height: auto;
   cursor: pointer;
   text-align: center;
-  border: 1px solid #9DA7B1;
-  background-color: #FFFFFF;
-  color: #323E49;
+  border: 1px solid #999999;
+  background-color: #FFF;
+  color: #1A1A1A;
   padding: 8px;
   border-radius: 6px;
   -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
@@ -1248,12 +1248,12 @@ exports[`RangePicker should render with default styles 1`] = `
 
 .circuit-2 .DayPickerNavigation_button__horizontal:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-2 .DayPickerNavigation_button__horizontal:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-2 .DayPickerNavigation_button__horizontal:focus {
@@ -1294,7 +1294,7 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .CalendarMonth_caption {
-  color: #212933;
+  color: #000000;
   font-size: 18px;
   text-align: center;
   padding-top: 22px;
@@ -1303,7 +1303,7 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .DayPicker_weekHeader {
-  color: #212933;
+  color: #000000;
   position: absolute;
   top: 67px;
   z-index: 2;
@@ -1317,7 +1317,7 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-0 {
-  color: #3388FF;
+  color: #3063E9;
 }
 
 <div

--- a/src/components/Calendar/__snapshots__/RangePicker.spec.js.snap
+++ b/src/components/Calendar/__snapshots__/RangePicker.spec.js.snap
@@ -1086,15 +1086,15 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .CalendarDay__default {
-  border: 1px solid #E6E6E6;
-  color: #000000;
+  border: 1px solid #CCC;
+  color: #1A1A1A;
   background: #FFF;
   vertical-align: middle;
 }
 
 .circuit-2 .CalendarDay__default:hover {
-  background: #E6E6E6;
-  border: 1px double #999999;
+  background: #CCC;
+  border: 1px double #999;
   color: inherit;
 }
 
@@ -1136,8 +1136,8 @@ exports[`RangePicker should render with default styles 1`] = `
 .circuit-2 .CalendarDay__blocked_out_of_range:active,
 .circuit-2 .CalendarDay__blocked_out_of_range:hover {
   background: #fff;
-  border: 1px solid #E6E6E6;
-  color: #E6E6E6;
+  border: 1px solid #CCC;
+  color: #CCC;
 }
 
 .circuit-2 .DateRangePickerInput,
@@ -1157,7 +1157,7 @@ exports[`RangePicker should render with default styles 1`] = `
 .circuit-2 .SingleDatePickerInput.SingleDatePickerInput__withBorder {
   border-width: 1px;
   border-style: solid;
-  border-color: #E6E6E6;
+  border-color: #CCC;
   border-radius: 4px;
 }
 
@@ -1182,7 +1182,7 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .DateInput_input {
-  color: #000000;
+  color: #1A1A1A;
   font-size: 16px;
   line-height: 24px;
   font-weight: 200;
@@ -1193,25 +1193,25 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .DateInput_input::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-2 .DateInput_input::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-2 .DateInput_input:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-2 .DateInput_input::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -1237,9 +1237,9 @@ exports[`RangePicker should render with default styles 1`] = `
   height: auto;
   cursor: pointer;
   text-align: center;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   background-color: #FFF;
-  color: #1A1A1A;
+  color: #333;
   padding: 8px;
   border-radius: 6px;
   -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
@@ -1247,13 +1247,13 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .DayPickerNavigation_button__horizontal:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-2 .DayPickerNavigation_button__horizontal:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-2 .DayPickerNavigation_button__horizontal:focus {
@@ -1294,7 +1294,7 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .CalendarMonth_caption {
-  color: #000000;
+  color: #1A1A1A;
   font-size: 18px;
   text-align: center;
   padding-top: 22px;
@@ -1303,7 +1303,7 @@ exports[`RangePicker should render with default styles 1`] = `
 }
 
 .circuit-2 .DayPicker_weekHeader {
-  color: #000000;
+  color: #1A1A1A;
   position: absolute;
   top: 67px;
   z-index: 2;

--- a/src/components/Calendar/__snapshots__/SingleDayPicker.spec.js.snap
+++ b/src/components/Calendar/__snapshots__/SingleDayPicker.spec.js.snap
@@ -1086,63 +1086,63 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .CalendarDay__default {
-  border: 1px solid #D8DDE1;
-  color: #212933;
-  background: #FFFFFF;
+  border: 1px solid #E6E6E6;
+  color: #000000;
+  background: #FFF;
   vertical-align: middle;
 }
 
 .circuit-0 .CalendarDay__default:hover {
-  background: #D8DDE1;
-  border: 1px double #9DA7B1;
+  background: #E6E6E6;
+  border: 1px double #999999;
   color: inherit;
 }
 
 .circuit-0 .CalendarDay__hovered_span,
 .circuit-0 .CalendarDay__hovered_span:hover {
-  background: #EDF4FC;
-  border: 1px solid #3388FF;
+  background: #F0F6FF;
+  border: 1px solid #3063E9;
 }
 
 .circuit-0 .CalendarDay__hovered_span:active {
-  background: #EDF4FC;
-  border: 1px solid #3388FF;
+  background: #F0F6FF;
+  border: 1px solid #3063E9;
 }
 
 .circuit-0 .CalendarDay__selected_span {
-  background: #EDF4FC;
+  background: #F0F6FF;
   border: 1px solid #AFD0FE;
 }
 
 .circuit-0 .CalendarDay__selected_span:hover {
-  color: #FFFFFF;
+  color: #FFF;
   background: #AFD0FE;
-  border: 1px solid #3388FF;
+  border: 1px solid #3063E9;
 }
 
 .circuit-0 .CalendarDay__last_in_range {
-  border-right: #3388FF;
+  border-right: #3063E9;
 }
 
 .circuit-0 .CalendarDay__selected,
 .circuit-0 .CalendarDay__selected:active,
 .circuit-0 .CalendarDay__selected:hover {
-  background: #3388FF;
-  border: 1px solid #1760CE;
-  color: #FFFFFF;
+  background: #3063E9;
+  border: 1px solid #234BC3;
+  color: #FFF;
 }
 
 .circuit-0 .CalendarDay__blocked_out_of_range,
 .circuit-0 .CalendarDay__blocked_out_of_range:active,
 .circuit-0 .CalendarDay__blocked_out_of_range:hover {
   background: #fff;
-  border: 1px solid #D8DDE1;
-  color: #D8DDE1;
+  border: 1px solid #E6E6E6;
+  color: #E6E6E6;
 }
 
 .circuit-0 .DateRangePickerInput,
 .circuit-0 .SingleDatePickerInput {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   padding: 8px 12px;
   -webkit-transition: border-color 120ms ease-in-out;
   transition: border-color 120ms ease-in-out;
@@ -1157,7 +1157,7 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 .circuit-0 .SingleDatePickerInput.SingleDatePickerInput__withBorder {
   border-width: 1px;
   border-style: solid;
-  border-color: #D8DDE1;
+  border-color: #E6E6E6;
   border-radius: 4px;
 }
 
@@ -1182,7 +1182,7 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .DateInput_input {
-  color: #212933;
+  color: #000000;
   font-size: 16px;
   line-height: 24px;
   font-weight: 200;
@@ -1193,25 +1193,25 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .DateInput_input::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -1237,9 +1237,9 @@ exports[`SingleDayPicker should render with default styles 1`] = `
   height: auto;
   cursor: pointer;
   text-align: center;
-  border: 1px solid #9DA7B1;
-  background-color: #FFFFFF;
-  color: #323E49;
+  border: 1px solid #999999;
+  background-color: #FFF;
+  color: #1A1A1A;
   padding: 8px;
   border-radius: 6px;
   -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
@@ -1248,12 +1248,12 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 
 .circuit-0 .DayPickerNavigation_button__horizontal:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0 .DayPickerNavigation_button__horizontal:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-0 .DayPickerNavigation_button__horizontal:focus {
@@ -1294,7 +1294,7 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .CalendarMonth_caption {
-  color: #212933;
+  color: #000000;
   font-size: 18px;
   text-align: center;
   padding-top: 22px;
@@ -1303,7 +1303,7 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .DayPicker_weekHeader {
-  color: #212933;
+  color: #000000;
   position: absolute;
   top: 67px;
   z-index: 2;

--- a/src/components/Calendar/__snapshots__/SingleDayPicker.spec.js.snap
+++ b/src/components/Calendar/__snapshots__/SingleDayPicker.spec.js.snap
@@ -1086,15 +1086,15 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .CalendarDay__default {
-  border: 1px solid #E6E6E6;
-  color: #000000;
+  border: 1px solid #CCC;
+  color: #1A1A1A;
   background: #FFF;
   vertical-align: middle;
 }
 
 .circuit-0 .CalendarDay__default:hover {
-  background: #E6E6E6;
-  border: 1px double #999999;
+  background: #CCC;
+  border: 1px double #999;
   color: inherit;
 }
 
@@ -1136,8 +1136,8 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 .circuit-0 .CalendarDay__blocked_out_of_range:active,
 .circuit-0 .CalendarDay__blocked_out_of_range:hover {
   background: #fff;
-  border: 1px solid #E6E6E6;
-  color: #E6E6E6;
+  border: 1px solid #CCC;
+  color: #CCC;
 }
 
 .circuit-0 .DateRangePickerInput,
@@ -1157,7 +1157,7 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 .circuit-0 .SingleDatePickerInput.SingleDatePickerInput__withBorder {
   border-width: 1px;
   border-style: solid;
-  border-color: #E6E6E6;
+  border-color: #CCC;
   border-radius: 4px;
 }
 
@@ -1182,7 +1182,7 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .DateInput_input {
-  color: #000000;
+  color: #1A1A1A;
   font-size: 16px;
   line-height: 24px;
   font-weight: 200;
@@ -1193,25 +1193,25 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .DateInput_input::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -1237,9 +1237,9 @@ exports[`SingleDayPicker should render with default styles 1`] = `
   height: auto;
   cursor: pointer;
   text-align: center;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   background-color: #FFF;
-  color: #1A1A1A;
+  color: #333;
   padding: 8px;
   border-radius: 6px;
   -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
@@ -1247,13 +1247,13 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .DayPickerNavigation_button__horizontal:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0 .DayPickerNavigation_button__horizontal:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-0 .DayPickerNavigation_button__horizontal:focus {
@@ -1294,7 +1294,7 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .CalendarMonth_caption {
-  color: #000000;
+  color: #1A1A1A;
   font-size: 18px;
   text-align: center;
   padding-top: 22px;
@@ -1303,7 +1303,7 @@ exports[`SingleDayPicker should render with default styles 1`] = `
 }
 
 .circuit-0 .DayPicker_weekHeader {
-  color: #000000;
+  color: #1A1A1A;
   position: absolute;
   top: 67px;
   z-index: 2;

--- a/src/components/Calendar/components/CalendarWrapper/__snapshots__/CalendarWrapper.spec.js.snap
+++ b/src/components/Calendar/components/CalendarWrapper/__snapshots__/CalendarWrapper.spec.js.snap
@@ -1086,63 +1086,63 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .CalendarDay__default {
-  border: 1px solid #D8DDE1;
-  color: #212933;
-  background: #FFFFFF;
+  border: 1px solid #E6E6E6;
+  color: #000000;
+  background: #FFF;
   vertical-align: middle;
 }
 
 .circuit-0 .CalendarDay__default:hover {
-  background: #D8DDE1;
-  border: 1px double #9DA7B1;
+  background: #E6E6E6;
+  border: 1px double #999999;
   color: inherit;
 }
 
 .circuit-0 .CalendarDay__hovered_span,
 .circuit-0 .CalendarDay__hovered_span:hover {
-  background: #EDF4FC;
-  border: 1px solid #3388FF;
+  background: #F0F6FF;
+  border: 1px solid #3063E9;
 }
 
 .circuit-0 .CalendarDay__hovered_span:active {
-  background: #EDF4FC;
-  border: 1px solid #3388FF;
+  background: #F0F6FF;
+  border: 1px solid #3063E9;
 }
 
 .circuit-0 .CalendarDay__selected_span {
-  background: #EDF4FC;
+  background: #F0F6FF;
   border: 1px solid #AFD0FE;
 }
 
 .circuit-0 .CalendarDay__selected_span:hover {
-  color: #FFFFFF;
+  color: #FFF;
   background: #AFD0FE;
-  border: 1px solid #3388FF;
+  border: 1px solid #3063E9;
 }
 
 .circuit-0 .CalendarDay__last_in_range {
-  border-right: #3388FF;
+  border-right: #3063E9;
 }
 
 .circuit-0 .CalendarDay__selected,
 .circuit-0 .CalendarDay__selected:active,
 .circuit-0 .CalendarDay__selected:hover {
-  background: #3388FF;
-  border: 1px solid #1760CE;
-  color: #FFFFFF;
+  background: #3063E9;
+  border: 1px solid #234BC3;
+  color: #FFF;
 }
 
 .circuit-0 .CalendarDay__blocked_out_of_range,
 .circuit-0 .CalendarDay__blocked_out_of_range:active,
 .circuit-0 .CalendarDay__blocked_out_of_range:hover {
   background: #fff;
-  border: 1px solid #D8DDE1;
-  color: #D8DDE1;
+  border: 1px solid #E6E6E6;
+  color: #E6E6E6;
 }
 
 .circuit-0 .DateRangePickerInput,
 .circuit-0 .SingleDatePickerInput {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   padding: 8px 12px;
   -webkit-transition: border-color 120ms ease-in-out;
   transition: border-color 120ms ease-in-out;
@@ -1157,7 +1157,7 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 .circuit-0 .SingleDatePickerInput.SingleDatePickerInput__withBorder {
   border-width: 1px;
   border-style: solid;
-  border-color: #D8DDE1;
+  border-color: #E6E6E6;
   border-radius: 4px;
 }
 
@@ -1182,7 +1182,7 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .DateInput_input {
-  color: #212933;
+  color: #000000;
   font-size: 16px;
   line-height: 24px;
   font-weight: 200;
@@ -1193,25 +1193,25 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .DateInput_input::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -1237,9 +1237,9 @@ exports[`CalendarWrapper should render with default styles 1`] = `
   height: auto;
   cursor: pointer;
   text-align: center;
-  border: 1px solid #9DA7B1;
-  background-color: #FFFFFF;
-  color: #323E49;
+  border: 1px solid #999999;
+  background-color: #FFF;
+  color: #1A1A1A;
   padding: 8px;
   border-radius: 6px;
   -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
@@ -1248,12 +1248,12 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 
 .circuit-0 .DayPickerNavigation_button__horizontal:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0 .DayPickerNavigation_button__horizontal:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-0 .DayPickerNavigation_button__horizontal:focus {
@@ -1294,7 +1294,7 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .CalendarMonth_caption {
-  color: #212933;
+  color: #000000;
   font-size: 18px;
   text-align: center;
   padding-top: 22px;
@@ -1303,7 +1303,7 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .DayPicker_weekHeader {
-  color: #212933;
+  color: #000000;
   position: absolute;
   top: 67px;
   z-index: 2;

--- a/src/components/Calendar/components/CalendarWrapper/__snapshots__/CalendarWrapper.spec.js.snap
+++ b/src/components/Calendar/components/CalendarWrapper/__snapshots__/CalendarWrapper.spec.js.snap
@@ -1086,15 +1086,15 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .CalendarDay__default {
-  border: 1px solid #E6E6E6;
-  color: #000000;
+  border: 1px solid #CCC;
+  color: #1A1A1A;
   background: #FFF;
   vertical-align: middle;
 }
 
 .circuit-0 .CalendarDay__default:hover {
-  background: #E6E6E6;
-  border: 1px double #999999;
+  background: #CCC;
+  border: 1px double #999;
   color: inherit;
 }
 
@@ -1136,8 +1136,8 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 .circuit-0 .CalendarDay__blocked_out_of_range:active,
 .circuit-0 .CalendarDay__blocked_out_of_range:hover {
   background: #fff;
-  border: 1px solid #E6E6E6;
-  color: #E6E6E6;
+  border: 1px solid #CCC;
+  color: #CCC;
 }
 
 .circuit-0 .DateRangePickerInput,
@@ -1157,7 +1157,7 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 .circuit-0 .SingleDatePickerInput.SingleDatePickerInput__withBorder {
   border-width: 1px;
   border-style: solid;
-  border-color: #E6E6E6;
+  border-color: #CCC;
   border-radius: 4px;
 }
 
@@ -1182,7 +1182,7 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .DateInput_input {
-  color: #000000;
+  color: #1A1A1A;
   font-size: 16px;
   line-height: 24px;
   font-weight: 200;
@@ -1193,25 +1193,25 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .DateInput_input::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0 .DateInput_input::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -1237,9 +1237,9 @@ exports[`CalendarWrapper should render with default styles 1`] = `
   height: auto;
   cursor: pointer;
   text-align: center;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   background-color: #FFF;
-  color: #1A1A1A;
+  color: #333;
   padding: 8px;
   border-radius: 6px;
   -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
@@ -1247,13 +1247,13 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .DayPickerNavigation_button__horizontal:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-0 .DayPickerNavigation_button__horizontal:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-0 .DayPickerNavigation_button__horizontal:focus {
@@ -1294,7 +1294,7 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .CalendarMonth_caption {
-  color: #000000;
+  color: #1A1A1A;
   font-size: 18px;
   text-align: center;
   padding-top: 22px;
@@ -1303,7 +1303,7 @@ exports[`CalendarWrapper should render with default styles 1`] = `
 }
 
 .circuit-0 .DayPicker_weekHeader {
-  color: #000000;
+  color: #1A1A1A;
   position: absolute;
   top: 67px;
   z-index: 2;

--- a/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -16,11 +16,11 @@ exports[`CalendarTag should render with default styles 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   cursor: pointer;
@@ -28,12 +28,12 @@ exports[`CalendarTag should render with default styles 1`] = `
 }
 
 .circuit-0:active {
-  color: #0F131A;
+  color: #000;
 }
 
 .circuit-0:hover {
-  background-color: #EEF0F2;
-  border-color: #9DA7B1;
+  background-color: #F5F5F5;
+  border-color: #999999;
 }
 
 .circuit-0:focus {

--- a/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -28,7 +28,7 @@ exports[`CalendarTag should render with default styles 1`] = `
 }
 
 .circuit-0:active {
-  color: #000;
+  color: #0F131A;
 }
 
 .circuit-0:hover {

--- a/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -16,7 +16,7 @@ exports[`CalendarTag should render with default styles 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
@@ -32,8 +32,8 @@ exports[`CalendarTag should render with default styles 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #F5F5F5;
-  border-color: #999999;
+  background-color: #E6E6E6;
+  border-color: #999;
 }
 
 .circuit-0:focus {

--- a/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -16,11 +16,11 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   cursor: pointer;
@@ -28,12 +28,12 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
 }
 
 .circuit-0:active {
-  color: #0F131A;
+  color: #000;
 }
 
 .circuit-0:hover {
-  background-color: #EEF0F2;
-  border-color: #9DA7B1;
+  background-color: #F5F5F5;
+  border-color: #999999;
 }
 
 .circuit-0:focus {

--- a/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -28,7 +28,7 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
 }
 
 .circuit-0:active {
-  color: #000;
+  color: #0F131A;
 }
 
 .circuit-0:hover {

--- a/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -16,7 +16,7 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
@@ -32,8 +32,8 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #F5F5F5;
-  border-color: #999999;
+  background-color: #E6E6E6;
+  border-color: #999;
 }
 
 .circuit-0:focus {

--- a/src/components/Card/__snapshots__/Card.spec.js.snap
+++ b/src/components/Card/__snapshots__/Card.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Card should render with default styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -26,7 +26,7 @@ exports[`Card should render with default styles 1`] = `
 
 exports[`Card should render with shadow styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -50,7 +50,7 @@ exports[`Card should render with shadow styles 1`] = `
 
 exports[`Card should render with shadow styles 2`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -74,7 +74,7 @@ exports[`Card should render with shadow styles 2`] = `
 
 exports[`Card should render with shadow styles 3`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -98,7 +98,7 @@ exports[`Card should render with shadow styles 3`] = `
 
 exports[`Card should render with spacing styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -122,7 +122,7 @@ exports[`Card should render with spacing styles 1`] = `
 
 exports[`Card should render with spacing styles 2`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/components/CardList/__snapshots__/CardList.spec.js.snap
+++ b/src/components/CardList/__snapshots__/CardList.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CardList should render with default styles 1`] = `
 .circuit-8 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -27,7 +27,7 @@ exports[`CardList should render with default styles 1`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #D8DDE1;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
 }
 
@@ -53,7 +53,7 @@ exports[`CardList should render with default styles 1`] = `
     height: 100%;
     left: 0;
     top: 0;
-    box-shadow: 0px 0px 0px 2px #3388FF;
+    box-shadow: 0px 0px 0px 2px #3063E9;
     border-radius: 4px;
   }
 }
@@ -69,7 +69,7 @@ exports[`CardList should render with default styles 1`] = `
   height: 100%;
   left: 0;
   top: 0;
-  box-shadow: 0px 0px 0px 2px #3388FF;
+  box-shadow: 0px 0px 0px 2px #3063E9;
   border-radius: 4px;
 }
 
@@ -80,9 +80,9 @@ exports[`CardList should render with default styles 1`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #D8DDE1;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
-  background: #EDF4FC;
+  background: #F0F6FF;
   outline: none;
 }
 
@@ -103,7 +103,7 @@ exports[`CardList should render with default styles 1`] = `
   height: 100%;
   left: 0;
   top: 0;
-  box-shadow: 0px 0px 0px 2px #3388FF;
+  box-shadow: 0px 0px 0px 2px #3063E9;
   border-radius: 4px;
 }
 
@@ -119,7 +119,7 @@ exports[`CardList should render with default styles 1`] = `
     height: 100%;
     left: 0;
     top: 0;
-    box-shadow: 0px 0px 0px 2px #3388FF;
+    box-shadow: 0px 0px 0px 2px #3063E9;
     border-radius: 4px;
   }
 }
@@ -135,7 +135,7 @@ exports[`CardList should render with default styles 1`] = `
   height: 100%;
   left: 0;
   top: 0;
-  box-shadow: 0px 0px 0px 2px #3388FF;
+  box-shadow: 0px 0px 0px 2px #3063E9;
   border-radius: 4px;
 }
 

--- a/src/components/CardList/__snapshots__/CardList.spec.js.snap
+++ b/src/components/CardList/__snapshots__/CardList.spec.js.snap
@@ -27,7 +27,7 @@ exports[`CardList should render with default styles 1`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
 }
 
@@ -80,7 +80,7 @@ exports[`CardList should render with default styles 1`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   background: #F0F6FF;
   outline: none;

--- a/src/components/CardList/components/Item/__snapshots__/Item.spec.js.snap
+++ b/src/components/CardList/components/Item/__snapshots__/Item.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Item should render with all paddings 1`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #D8DDE1;
+  border-bottom: 1px solid #E6E6E6;
   padding: 12px;
 }
 
@@ -34,7 +34,7 @@ exports[`Item should render with all paddings 1`] = `
     height: 100%;
     left: 0;
     top: 0;
-    box-shadow: 0px 0px 0px 2px #3388FF;
+    box-shadow: 0px 0px 0px 2px #3063E9;
     border-radius: 4px;
   }
 }
@@ -50,7 +50,7 @@ exports[`Item should render with all paddings 1`] = `
   height: 100%;
   left: 0;
   top: 0;
-  box-shadow: 0px 0px 0px 2px #3388FF;
+  box-shadow: 0px 0px 0px 2px #3063E9;
   border-radius: 4px;
 }
 
@@ -71,7 +71,7 @@ exports[`Item should render with all paddings 2`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #D8DDE1;
+  border-bottom: 1px solid #E6E6E6;
   padding: 16px;
 }
 
@@ -97,7 +97,7 @@ exports[`Item should render with all paddings 2`] = `
     height: 100%;
     left: 0;
     top: 0;
-    box-shadow: 0px 0px 0px 2px #3388FF;
+    box-shadow: 0px 0px 0px 2px #3063E9;
     border-radius: 4px;
   }
 }
@@ -113,7 +113,7 @@ exports[`Item should render with all paddings 2`] = `
   height: 100%;
   left: 0;
   top: 0;
-  box-shadow: 0px 0px 0px 2px #3388FF;
+  box-shadow: 0px 0px 0px 2px #3063E9;
   border-radius: 4px;
 }
 
@@ -134,7 +134,7 @@ exports[`Item should render with all paddings 3`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #D8DDE1;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
 }
 
@@ -160,7 +160,7 @@ exports[`Item should render with all paddings 3`] = `
     height: 100%;
     left: 0;
     top: 0;
-    box-shadow: 0px 0px 0px 2px #3388FF;
+    box-shadow: 0px 0px 0px 2px #3063E9;
     border-radius: 4px;
   }
 }
@@ -176,7 +176,7 @@ exports[`Item should render with all paddings 3`] = `
   height: 100%;
   left: 0;
   top: 0;
-  box-shadow: 0px 0px 0px 2px #3388FF;
+  box-shadow: 0px 0px 0px 2px #3063E9;
   border-radius: 4px;
 }
 
@@ -197,7 +197,7 @@ exports[`Item should render with default styles 1`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #D8DDE1;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
 }
 
@@ -223,7 +223,7 @@ exports[`Item should render with default styles 1`] = `
     height: 100%;
     left: 0;
     top: 0;
-    box-shadow: 0px 0px 0px 2px #3388FF;
+    box-shadow: 0px 0px 0px 2px #3063E9;
     border-radius: 4px;
   }
 }
@@ -239,7 +239,7 @@ exports[`Item should render with default styles 1`] = `
   height: 100%;
   left: 0;
   top: 0;
-  box-shadow: 0px 0px 0px 2px #3388FF;
+  box-shadow: 0px 0px 0px 2px #3063E9;
   border-radius: 4px;
 }
 
@@ -260,7 +260,7 @@ exports[`Item should render with selected styles 1`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #D8DDE1;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
 }
 
@@ -286,7 +286,7 @@ exports[`Item should render with selected styles 1`] = `
     height: 100%;
     left: 0;
     top: 0;
-    box-shadow: 0px 0px 0px 2px #3388FF;
+    box-shadow: 0px 0px 0px 2px #3063E9;
     border-radius: 4px;
   }
 }
@@ -302,7 +302,7 @@ exports[`Item should render with selected styles 1`] = `
   height: 100%;
   left: 0;
   top: 0;
-  box-shadow: 0px 0px 0px 2px #3388FF;
+  box-shadow: 0px 0px 0px 2px #3063E9;
   border-radius: 4px;
 }
 

--- a/src/components/CardList/components/Item/__snapshots__/Item.spec.js.snap
+++ b/src/components/CardList/components/Item/__snapshots__/Item.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Item should render with all paddings 1`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 12px;
 }
 
@@ -71,7 +71,7 @@ exports[`Item should render with all paddings 2`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 16px;
 }
 
@@ -134,7 +134,7 @@ exports[`Item should render with all paddings 3`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
 }
 
@@ -197,7 +197,7 @@ exports[`Item should render with default styles 1`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
 }
 
@@ -260,7 +260,7 @@ exports[`Item should render with selected styles 1`] = `
   align-items: center;
   position: relative;
   cursor: pointer;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
 }
 

--- a/src/components/Carousel/__snapshots__/Carousel.spec.js.snap
+++ b/src/components/Carousel/__snapshots__/Carousel.spec.js.snap
@@ -245,7 +245,7 @@ exports[`Carousel styles should render with children as a function 1`] = `
 }
 
 .circuit-38 {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -260,7 +260,7 @@ exports[`Carousel styles should render with children as a function 1`] = `
   top: 0;
   bottom: 0;
   left: 0;
-  background-color: #3388FF;
+  background-color: #3063E9;
   -webkit-transition: width 0.05s ease-out;
   transition: width 0.05s ease-out;
   height: 100%;
@@ -268,7 +268,7 @@ exports[`Carousel styles should render with children as a function 1`] = `
 }
 
 .circuit-38::after {
-  background-color: #212933;
+  background-color: #000000;
 }
 
 .circuit-38::after {
@@ -340,9 +340,9 @@ exports[`Carousel styles should render with children as a function 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -367,12 +367,12 @@ exports[`Carousel styles should render with children as a function 1`] = `
 
 .circuit-44:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-44:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-44:first-of-type {
@@ -827,7 +827,7 @@ exports[`Carousel styles should render with children as a node 1`] = `
 }
 
 .circuit-38 {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -842,7 +842,7 @@ exports[`Carousel styles should render with children as a node 1`] = `
   top: 0;
   bottom: 0;
   left: 0;
-  background-color: #3388FF;
+  background-color: #3063E9;
   -webkit-transition: width 0.05s ease-out;
   transition: width 0.05s ease-out;
   height: 100%;
@@ -850,7 +850,7 @@ exports[`Carousel styles should render with children as a node 1`] = `
 }
 
 .circuit-38::after {
-  background-color: #212933;
+  background-color: #000000;
 }
 
 .circuit-38::after {
@@ -922,9 +922,9 @@ exports[`Carousel styles should render with children as a node 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -949,12 +949,12 @@ exports[`Carousel styles should render with children as a node 1`] = `
 
 .circuit-44:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-44:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-44:first-of-type {
@@ -1462,9 +1462,9 @@ exports[`Carousel styles should render with default paused styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -1489,12 +1489,12 @@ exports[`Carousel styles should render with default paused styles 1`] = `
 
 .circuit-44:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-44:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-44:first-of-type {
@@ -1515,7 +1515,7 @@ exports[`Carousel styles should render with default paused styles 1`] = `
 }
 
 .circuit-38 {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -1530,7 +1530,7 @@ exports[`Carousel styles should render with default paused styles 1`] = `
   top: 0;
   bottom: 0;
   left: 0;
-  background-color: #3388FF;
+  background-color: #3063E9;
   -webkit-transition: width 0.05s ease-out;
   transition: width 0.05s ease-out;
   height: 100%;
@@ -1538,7 +1538,7 @@ exports[`Carousel styles should render with default paused styles 1`] = `
 }
 
 .circuit-38::after {
-  background-color: #212933;
+  background-color: #000000;
 }
 
 .circuit-38::after {
@@ -1964,7 +1964,7 @@ exports[`Carousel styles should render with default styles 1`] = `
 }
 
 .circuit-38 {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -1979,7 +1979,7 @@ exports[`Carousel styles should render with default styles 1`] = `
   top: 0;
   bottom: 0;
   left: 0;
-  background-color: #3388FF;
+  background-color: #3063E9;
   -webkit-transition: width 0.05s ease-out;
   transition: width 0.05s ease-out;
   height: 100%;
@@ -1987,7 +1987,7 @@ exports[`Carousel styles should render with default styles 1`] = `
 }
 
 .circuit-38::after {
-  background-color: #212933;
+  background-color: #000000;
 }
 
 .circuit-38::after {
@@ -2059,9 +2059,9 @@ exports[`Carousel styles should render with default styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -2086,12 +2086,12 @@ exports[`Carousel styles should render with default styles 1`] = `
 
 .circuit-44:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-44:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-44:first-of-type {

--- a/src/components/Carousel/__snapshots__/Carousel.spec.js.snap
+++ b/src/components/Carousel/__snapshots__/Carousel.spec.js.snap
@@ -110,7 +110,7 @@ exports[`Carousel styles should render with children as a function 1`] = `
   height: 0;
   width: 100%;
   padding-top: 56%;
-  background: #FAFBFC;
+  background: #F5F5F5;
 }
 
 .circuit-0 {
@@ -245,7 +245,7 @@ exports[`Carousel styles should render with children as a function 1`] = `
 }
 
 .circuit-38 {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -268,7 +268,7 @@ exports[`Carousel styles should render with children as a function 1`] = `
 }
 
 .circuit-38::after {
-  background-color: #000000;
+  background-color: #1A1A1A;
 }
 
 .circuit-38::after {
@@ -341,8 +341,8 @@ exports[`Carousel styles should render with children as a function 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -366,13 +366,13 @@ exports[`Carousel styles should render with children as a function 1`] = `
 }
 
 .circuit-44:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-44:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-44:first-of-type {
@@ -692,7 +692,7 @@ exports[`Carousel styles should render with children as a node 1`] = `
   height: 0;
   width: 100%;
   padding-top: 56%;
-  background: #FAFBFC;
+  background: #F5F5F5;
 }
 
 .circuit-0 {
@@ -827,7 +827,7 @@ exports[`Carousel styles should render with children as a node 1`] = `
 }
 
 .circuit-38 {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -850,7 +850,7 @@ exports[`Carousel styles should render with children as a node 1`] = `
 }
 
 .circuit-38::after {
-  background-color: #000000;
+  background-color: #1A1A1A;
 }
 
 .circuit-38::after {
@@ -923,8 +923,8 @@ exports[`Carousel styles should render with children as a node 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -948,13 +948,13 @@ exports[`Carousel styles should render with children as a node 1`] = `
 }
 
 .circuit-44:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-44:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-44:first-of-type {
@@ -1273,7 +1273,7 @@ exports[`Carousel styles should render with default paused styles 1`] = `
   height: 0;
   width: 100%;
   padding-top: 56%;
-  background: #FAFBFC;
+  background: #F5F5F5;
 }
 
 .circuit-0 {
@@ -1463,8 +1463,8 @@ exports[`Carousel styles should render with default paused styles 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -1488,13 +1488,13 @@ exports[`Carousel styles should render with default paused styles 1`] = `
 }
 
 .circuit-44:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-44:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-44:first-of-type {
@@ -1515,7 +1515,7 @@ exports[`Carousel styles should render with default paused styles 1`] = `
 }
 
 .circuit-38 {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -1538,7 +1538,7 @@ exports[`Carousel styles should render with default paused styles 1`] = `
 }
 
 .circuit-38::after {
-  background-color: #000000;
+  background-color: #1A1A1A;
 }
 
 .circuit-38::after {
@@ -1829,7 +1829,7 @@ exports[`Carousel styles should render with default styles 1`] = `
   height: 0;
   width: 100%;
   padding-top: 56%;
-  background: #FAFBFC;
+  background: #F5F5F5;
 }
 
 .circuit-0 {
@@ -1964,7 +1964,7 @@ exports[`Carousel styles should render with default styles 1`] = `
 }
 
 .circuit-38 {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -1987,7 +1987,7 @@ exports[`Carousel styles should render with default styles 1`] = `
 }
 
 .circuit-38::after {
-  background-color: #000000;
+  background-color: #1A1A1A;
 }
 
 .circuit-38::after {
@@ -2060,8 +2060,8 @@ exports[`Carousel styles should render with default styles 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -2085,13 +2085,13 @@ exports[`Carousel styles should render with default styles 1`] = `
 }
 
 .circuit-44:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-44:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-44:first-of-type {

--- a/src/components/Carousel/components/Buttons/__snapshots__/Buttons.spec.js.snap
+++ b/src/components/Carousel/components/Buttons/__snapshots__/Buttons.spec.js.snap
@@ -43,9 +43,9 @@ exports[`Buttons styles should render with default styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -70,12 +70,12 @@ exports[`Buttons styles should render with default styles 1`] = `
 
 .circuit-2:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-2:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-2:first-of-type {

--- a/src/components/Carousel/components/Buttons/__snapshots__/Buttons.spec.js.snap
+++ b/src/components/Carousel/components/Buttons/__snapshots__/Buttons.spec.js.snap
@@ -44,8 +44,8 @@ exports[`Buttons styles should render with default styles 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -69,13 +69,13 @@ exports[`Buttons styles should render with default styles 1`] = `
 }
 
 .circuit-2:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-2:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-2:first-of-type {

--- a/src/components/Carousel/components/SlideImage/__snapshots__/SlideImage.spec.js.snap
+++ b/src/components/Carousel/components/SlideImage/__snapshots__/SlideImage.spec.js.snap
@@ -35,7 +35,7 @@ exports[`SlideImage styles should render with custom aspect ratio 1`] = `
   height: 0;
   width: 100%;
   padding-top: 50%;
-  background: #FAFBFC;
+  background: #F5F5F5;
 }
 
 <div
@@ -59,7 +59,7 @@ exports[`SlideImage styles should render with default styles 1`] = `
   height: 0;
   width: 100%;
   padding-top: 56%;
-  background: #FAFBFC;
+  background: #F5F5F5;
 }
 
 .circuit-0 {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -98,12 +98,12 @@ const labelInvalidStyles = ({ theme, invalid }: StyleProps & LabelElProps) =>
   css`
     label: checkbox--error;
     &:not(:focus)::before {
-      border-color: ${theme.colors.r500};
+      border-color: ${theme.colors.danger};
       background-color: ${theme.colors.r100};
     }
 
     &:not(:focus) svg {
-      color: ${theme.colors.r500};
+      color: ${theme.colors.danger};
     }
   `;
 
@@ -176,7 +176,7 @@ const inputInvalidStyles = ({ theme, invalid }: StyleProps & InputElProps) =>
     }
 
     &:checked + label::before {
-      border-color: ${theme.colors.r500};
+      border-color: ${theme.colors.danger};
     }
   `;
 

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 }
 
 .circuit-0:hover + label::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:focus + label::before {
@@ -43,11 +43,11 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 }
 
 .circuit-0:checked + label::before {
-  border-color: #3388FF;
+  border-color: #3063E9;
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: inline-block;
   padding-left: 26px;
   position: relative;
@@ -59,8 +59,8 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   width: 18px;
   box-sizing: border-box;
   box-shadow: 0;
-  background-color: #FFFFFF;
-  border: 1px solid #9DA7B1;
+  background-color: #FFF;
+  border: 1px solid #999999;
   border-radius: 3px;
   content: '';
   display: block;
@@ -79,7 +79,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   width: 18px;
   padding: 2px;
   box-sizing: border-box;
-  color: #3388FF;
+  color: #3063E9;
   display: block;
   line-height: 0;
   opacity: 0;
@@ -99,8 +99,8 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -132,7 +132,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 
 .circuit-2::after {
   top: 100%;
-  border-top-color: #212933;
+  border-top-color: #000000;
 }
 
 <div
@@ -197,7 +197,7 @@ exports[`Checkbox should render with checked styles when passed the checked prop
 }
 
 .circuit-0:hover + label::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:focus + label::before {
@@ -217,11 +217,11 @@ exports[`Checkbox should render with checked styles when passed the checked prop
 }
 
 .circuit-0:checked + label::before {
-  border-color: #3388FF;
+  border-color: #3063E9;
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: inline-block;
   padding-left: 26px;
   position: relative;
@@ -233,8 +233,8 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   width: 18px;
   box-sizing: border-box;
   box-shadow: 0;
-  background-color: #FFFFFF;
-  border: 1px solid #9DA7B1;
+  background-color: #FFF;
+  border: 1px solid #999999;
   border-radius: 3px;
   content: '';
   display: block;
@@ -253,7 +253,7 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   width: 18px;
   padding: 2px;
   box-sizing: border-box;
-  color: #3388FF;
+  color: #3063E9;
   display: block;
   line-height: 0;
   opacity: 0;
@@ -326,7 +326,7 @@ exports[`Checkbox should render with default styles 1`] = `
 }
 
 .circuit-0:hover + label::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:focus + label::before {
@@ -346,11 +346,11 @@ exports[`Checkbox should render with default styles 1`] = `
 }
 
 .circuit-0:checked + label::before {
-  border-color: #3388FF;
+  border-color: #3063E9;
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: inline-block;
   padding-left: 26px;
   position: relative;
@@ -362,8 +362,8 @@ exports[`Checkbox should render with default styles 1`] = `
   width: 18px;
   box-sizing: border-box;
   box-shadow: 0;
-  background-color: #FFFFFF;
-  border: 1px solid #9DA7B1;
+  background-color: #FFF;
+  border: 1px solid #999999;
   border-radius: 3px;
   content: '';
   display: block;
@@ -382,7 +382,7 @@ exports[`Checkbox should render with default styles 1`] = `
   width: 18px;
   padding: 2px;
   box-sizing: border-box;
-  color: #3388FF;
+  color: #3063E9;
   display: block;
   line-height: 0;
   opacity: 0;
@@ -454,7 +454,7 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 }
 
 .circuit-0:hover + label::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:focus + label::before {
@@ -474,11 +474,11 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 }
 
 .circuit-0:checked + label::before {
-  border-color: #3388FF;
+  border-color: #3063E9;
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: inline-block;
   padding-left: 26px;
   position: relative;
@@ -493,8 +493,8 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   width: 18px;
   box-sizing: border-box;
   box-shadow: 0;
-  background-color: #FFFFFF;
-  border: 1px solid #9DA7B1;
+  background-color: #FFF;
+  border: 1px solid #999999;
   border-radius: 3px;
   content: '';
   display: block;
@@ -513,7 +513,7 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   width: 18px;
   padding: 2px;
   box-sizing: border-box;
-  color: #3388FF;
+  color: #3063E9;
   display: block;
   line-height: 0;
   opacity: 0;
@@ -532,15 +532,15 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  border-color: #5C656F;
-  background-color: #EEF0F2;
+  border-color: #333333;
+  background-color: #F5F5F5;
 }
 
 .circuit-1 svg {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  color: #5C656F;
+  color: #333333;
 }
 
 <div
@@ -602,7 +602,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 }
 
 .circuit-0:hover + label::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:focus + label::before {
@@ -622,19 +622,19 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 }
 
 .circuit-0:checked + label::before {
-  border-color: #3388FF;
+  border-color: #3063E9;
 }
 
 .circuit-0:hover + label::before {
-  border-color: #B22828;
+  border-color: #B22426;
 }
 
 .circuit-0:checked + label::before {
-  border-color: #DB4D4D;
+  border-color: #D23F47;
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: inline-block;
   padding-left: 26px;
   position: relative;
@@ -646,8 +646,8 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   width: 18px;
   box-sizing: border-box;
   box-shadow: 0;
-  background-color: #FFFFFF;
-  border: 1px solid #9DA7B1;
+  background-color: #FFF;
+  border: 1px solid #999999;
   border-radius: 3px;
   content: '';
   display: block;
@@ -666,7 +666,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   width: 18px;
   padding: 2px;
   box-sizing: border-box;
-  color: #3388FF;
+  color: #3063E9;
   display: block;
   line-height: 0;
   opacity: 0;
@@ -682,12 +682,12 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 }
 
 .circuit-1:not(:focus)::before {
-  border-color: #DB4D4D;
+  border-color: #D23F47;
   background-color: #F4CBCB;
 }
 
 .circuit-1:not(:focus) svg {
-  color: #DB4D4D;
+  color: #D23F47;
 }
 
 <div

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 }
 
 .circuit-0:hover + label::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 .circuit-0:focus + label::before {
@@ -47,7 +47,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: inline-block;
   padding-left: 26px;
   position: relative;
@@ -60,7 +60,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   box-sizing: border-box;
   box-shadow: 0;
   background-color: #FFF;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   border-radius: 3px;
   content: '';
   display: block;
@@ -99,7 +99,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -132,7 +132,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 
 .circuit-2::after {
   top: 100%;
-  border-top-color: #000000;
+  border-top-color: #1A1A1A;
 }
 
 <div
@@ -197,7 +197,7 @@ exports[`Checkbox should render with checked styles when passed the checked prop
 }
 
 .circuit-0:hover + label::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 .circuit-0:focus + label::before {
@@ -221,7 +221,7 @@ exports[`Checkbox should render with checked styles when passed the checked prop
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: inline-block;
   padding-left: 26px;
   position: relative;
@@ -234,7 +234,7 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   box-sizing: border-box;
   box-shadow: 0;
   background-color: #FFF;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   border-radius: 3px;
   content: '';
   display: block;
@@ -326,7 +326,7 @@ exports[`Checkbox should render with default styles 1`] = `
 }
 
 .circuit-0:hover + label::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 .circuit-0:focus + label::before {
@@ -350,7 +350,7 @@ exports[`Checkbox should render with default styles 1`] = `
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: inline-block;
   padding-left: 26px;
   position: relative;
@@ -363,7 +363,7 @@ exports[`Checkbox should render with default styles 1`] = `
   box-sizing: border-box;
   box-shadow: 0;
   background-color: #FFF;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   border-radius: 3px;
   content: '';
   display: block;
@@ -454,7 +454,7 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 }
 
 .circuit-0:hover + label::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 .circuit-0:focus + label::before {
@@ -478,7 +478,7 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: inline-block;
   padding-left: 26px;
   position: relative;
@@ -494,7 +494,7 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   box-sizing: border-box;
   box-shadow: 0;
   background-color: #FFF;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   border-radius: 3px;
   content: '';
   display: block;
@@ -532,15 +532,15 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  border-color: #333333;
-  background-color: #F5F5F5;
+  border-color: #666;
+  background-color: #E6E6E6;
 }
 
 .circuit-1 svg {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  color: #333333;
+  color: #666;
 }
 
 <div
@@ -602,7 +602,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 }
 
 .circuit-0:hover + label::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 .circuit-0:focus + label::before {
@@ -634,7 +634,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: inline-block;
   padding-left: 26px;
   position: relative;
@@ -647,7 +647,7 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   box-sizing: border-box;
   box-shadow: 0;
   background-color: #FFF;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   border-radius: 3px;
   content: '';
   display: block;

--- a/src/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
+++ b/src/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
@@ -28,9 +28,9 @@ exports[`CloseButton should render with default styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -55,12 +55,12 @@ exports[`CloseButton should render with default styles 1`] = `
 
 .circuit-1:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-1:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-0 {

--- a/src/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
+++ b/src/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
@@ -29,8 +29,8 @@ exports[`CloseButton should render with default styles 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -54,13 +54,13 @@ exports[`CloseButton should render with default styles 1`] = `
 }
 
 .circuit-1:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-1:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-0 {

--- a/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -35,7 +35,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #5C656F;
+  color: #333333;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -43,7 +43,7 @@ label + .circuit-2 {
 
 .circuit-1 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -56,43 +56,43 @@ label + .circuit-2 {
   line-height: 24px;
   text-align: right;
   padding-left: 40px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-1:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -153,7 +153,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #5C656F;
+  color: #333333;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -161,7 +161,7 @@ label + .circuit-2 {
 
 .circuit-1 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -174,43 +174,43 @@ label + .circuit-2 {
   line-height: 24px;
   text-align: right;
   padding-left: 40px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-1:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div

--- a/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -35,7 +35,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #333333;
+  color: #666;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -56,35 +56,35 @@ label + .circuit-2 {
   line-height: 24px;
   text-align: right;
   padding-left: 40px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-1:focus {
@@ -153,7 +153,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #333333;
+  color: #666;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -174,35 +174,35 @@ label + .circuit-2 {
   line-height: 24px;
   text-align: right;
   padding-left: 40px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-1:focus {

--- a/src/components/Hamburger/__snapshots__/Hamburger.spec.tsx.snap
+++ b/src/components/Hamburger/__snapshots__/Hamburger.spec.tsx.snap
@@ -28,9 +28,9 @@ exports[`Hamburger should render with active styles when passed the isActive pro
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -55,12 +55,12 @@ exports[`Hamburger should render with active styles when passed the isActive pro
 
 .circuit-3:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-3:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-1 {
@@ -205,9 +205,9 @@ exports[`Hamburger should render with default styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -232,12 +232,12 @@ exports[`Hamburger should render with default styles 1`] = `
 
 .circuit-3:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-3:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-1 {

--- a/src/components/Hamburger/__snapshots__/Hamburger.spec.tsx.snap
+++ b/src/components/Hamburger/__snapshots__/Hamburger.spec.tsx.snap
@@ -29,8 +29,8 @@ exports[`Hamburger should render with active styles when passed the isActive pro
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -54,13 +54,13 @@ exports[`Hamburger should render with active styles when passed the isActive pro
 }
 
 .circuit-3:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-3:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-1 {
@@ -206,8 +206,8 @@ exports[`Hamburger should render with default styles 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -231,13 +231,13 @@ exports[`Hamburger should render with default styles 1`] = `
 }
 
 .circuit-3:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-3:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-1 {

--- a/src/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Header/__snapshots__/Header.spec.js.snap
@@ -20,7 +20,7 @@ exports[`Header styles should render and match snapshot for mobileOnly styles 1`
   -ms-flex-align: center;
   align-items: center;
   min-height: 64px;
-  background-color: #212933;
+  background-color: #000000;
   padding: 16px;
   z-index: 600;
   position: -webkit-sticky;
@@ -56,7 +56,7 @@ exports[`Header styles should render with default styles 1`] = `
   -ms-flex-align: center;
   align-items: center;
   min-height: 64px;
-  background-color: #212933;
+  background-color: #000000;
   padding: 16px;
   z-index: 600;
   position: -webkit-sticky;

--- a/src/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Header/__snapshots__/Header.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Header styles should render and match snapshot for mobileOnly styles 1`
   font-size: 17px;
   line-height: 24px;
   font-weight: 700;
-  color: #FAFBFC;
+  color: #F5F5F5;
   margin-left: 16px;
 }
 
@@ -20,7 +20,7 @@ exports[`Header styles should render and match snapshot for mobileOnly styles 1`
   -ms-flex-align: center;
   align-items: center;
   min-height: 64px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   padding: 16px;
   z-index: 600;
   position: -webkit-sticky;
@@ -56,7 +56,7 @@ exports[`Header styles should render with default styles 1`] = `
   -ms-flex-align: center;
   align-items: center;
   min-height: 64px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   padding: 16px;
   z-index: 600;
   position: -webkit-sticky;
@@ -67,7 +67,7 @@ exports[`Header styles should render with default styles 1`] = `
   font-size: 17px;
   line-height: 24px;
   font-weight: 700;
-  color: #FAFBFC;
+  color: #F5F5F5;
   margin-left: 16px;
 }
 

--- a/src/components/Header/components/Title/__snapshots__/Title.spec.js.snap
+++ b/src/components/Header/components/Title/__snapshots__/Title.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Title styles should render with default styles 1`] = `
   font-size: 17px;
   line-height: 24px;
   font-weight: 700;
-  color: #FAFBFC;
+  color: #F5F5F5;
   margin-left: 16px;
 }
 

--- a/src/components/Hr/__snapshots__/Hr.spec.tsx.snap
+++ b/src/components/Hr/__snapshots__/Hr.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`Hr should render with default styles 1`] = `
 .circuit-0 {
   display: block;
   width: 100%;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   margin-top: 16px;
   margin-bottom: 16px;
 }

--- a/src/components/Hr/__snapshots__/Hr.spec.tsx.snap
+++ b/src/components/Hr/__snapshots__/Hr.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`Hr should render with default styles 1`] = `
 .circuit-0 {
   display: block;
   width: 100%;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   margin-top: 16px;
   margin-bottom: 16px;
 }

--- a/src/components/IconButton/__snapshots__/IconButton.spec.tsx.snap
+++ b/src/components/IconButton/__snapshots__/IconButton.spec.tsx.snap
@@ -28,9 +28,9 @@ exports[`IconButton should render with the default styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -54,12 +54,12 @@ exports[`IconButton should render with the default styles 1`] = `
 
 .circuit-1:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-1:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-0 {

--- a/src/components/IconButton/__snapshots__/IconButton.spec.tsx.snap
+++ b/src/components/IconButton/__snapshots__/IconButton.spec.tsx.snap
@@ -29,8 +29,8 @@ exports[`IconButton should render with the default styles 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -53,13 +53,13 @@ exports[`IconButton should render with the default styles 1`] = `
 }
 
 .circuit-1:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-1:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-0 {

--- a/src/components/InlineMessage/__snapshots__/InlineMessage.spec.tsx.snap
+++ b/src/components/InlineMessage/__snapshots__/InlineMessage.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InlineMessage should render with danger styles 1`] = `
 .circuit-0 {
-  color: #DB4D4D;
+  color: #D23F47;
   position: relative;
   margin-bottom: 16px;
 }
@@ -16,7 +16,7 @@ exports[`InlineMessage should render with danger styles 1`] = `
   left: -24px;
   top: 0;
   height: 100%;
-  background-color: #DB4D4D;
+  background-color: #D23F47;
   width: 3px;
 }
 
@@ -27,7 +27,7 @@ exports[`InlineMessage should render with danger styles 1`] = `
 
 exports[`InlineMessage should render with giga spacing 1`] = `
 .circuit-0 {
-  color: #DB4D4D;
+  color: #D23F47;
   position: relative;
   margin-bottom: 16px;
 }
@@ -41,7 +41,7 @@ exports[`InlineMessage should render with giga spacing 1`] = `
   left: -16px;
   top: 0;
   height: 100%;
-  background-color: #DB4D4D;
+  background-color: #D23F47;
   width: 3px;
 }
 
@@ -52,7 +52,7 @@ exports[`InlineMessage should render with giga spacing 1`] = `
 
 exports[`InlineMessage should render with success styles 1`] = `
 .circuit-0 {
-  color: #0F131A;
+  color: #000;
   position: relative;
   margin-bottom: 16px;
 }
@@ -66,7 +66,7 @@ exports[`InlineMessage should render with success styles 1`] = `
   left: -24px;
   top: 0;
   height: 100%;
-  background-color: #47995A;
+  background-color: #138849;
   width: 3px;
 }
 
@@ -77,7 +77,7 @@ exports[`InlineMessage should render with success styles 1`] = `
 
 exports[`InlineMessage should render with warning styles 1`] = `
 .circuit-0 {
-  color: #0F131A;
+  color: #000;
   position: relative;
   margin-bottom: 16px;
 }
@@ -91,7 +91,7 @@ exports[`InlineMessage should render with warning styles 1`] = `
   left: -24px;
   top: 0;
   height: 100%;
-  background-color: #D8A413;
+  background-color: #F5C625;
   width: 3px;
 }
 

--- a/src/components/Input/Input.spec.tsx
+++ b/src/components/Input/Input.spec.tsx
@@ -92,7 +92,7 @@ describe('Input', () => {
   });
 
   it('should prioritize disabled over warning styles', () => {
-    const actual = create(<Input invalid hasWarning />);
+    const actual = create(<Input hasWarning disabled />);
     expect(actual).toMatchSnapshot();
   });
 

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -163,7 +163,7 @@ const inputWarningStyles = ({
   css`
     label: input--warning;
     &:not(:focus)::placeholder {
-      color: ${theme.colors.y500};
+      color: ${theme.colors.warning};
     }
   `;
 

--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -22,7 +22,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -33,44 +33,44 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #EEF0F2;
-  box-shadow: 0 0 0 1px #DB4D4D;
+  background-color: #F5F5F5;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22828;
+  box-shadow: 0 0 0 1px #B22426;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #DB4D4D;
+  box-shadow: 0 0 0 2px #D23F47;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <div
@@ -111,7 +111,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -122,29 +122,29 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -182,15 +182,15 @@ label + .circuit-1 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22828;
+  box-shadow: 0 0 0 1px #B22426;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #DB4D4D;
+  box-shadow: 0 0 0 2px #D23F47;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <div
@@ -229,7 +229,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -240,43 +240,43 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-2 {
@@ -291,7 +291,7 @@ label + .circuit-1 {
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #5C656F;
+  color: #333333;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -339,7 +339,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #5C656F;
+  color: #333333;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -347,7 +347,7 @@ label + .circuit-2 {
 
 .circuit-1 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -359,43 +359,43 @@ label + .circuit-2 {
   font-size: 16px;
   line-height: 24px;
   padding-left: 40px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-1:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -437,7 +437,7 @@ label + .circuit-2 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -449,43 +449,43 @@ label + .circuit-2 {
   font-size: 16px;
   line-height: 24px;
   padding-right: 40px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-1 {
@@ -493,7 +493,7 @@ label + .circuit-2 {
   top: 1px;
   right: 1px;
   pointer-events: none;
-  color: #5C656F;
+  color: #333333;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -541,7 +541,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -552,44 +552,44 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
   color: red;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -627,7 +627,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -638,43 +638,43 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -715,7 +715,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -726,44 +726,44 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #EEF0F2;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  background-color: #F5F5F5;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -796,7 +796,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -807,43 +807,43 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-2 {
@@ -890,7 +890,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -901,29 +901,29 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -945,15 +945,15 @@ label + .circuit-1 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22828;
+  box-shadow: 0 0 0 1px #B22426;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #DB4D4D;
+  box-shadow: 0 0 0 2px #D23F47;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <div
@@ -985,7 +985,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -996,43 +996,43 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-2 {
@@ -1076,7 +1076,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -1087,44 +1087,44 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #EEF0F2;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  background-color: #F5F5F5;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -1163,7 +1163,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -1175,43 +1175,43 @@ label + .circuit-1 {
   font-size: 16px;
   line-height: 24px;
   text-align: right;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -1249,7 +1249,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -1260,43 +1260,43 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -1334,7 +1334,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -1349,25 +1349,25 @@ label + .circuit-1 {
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }

--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -34,7 +34,7 @@ label + .circuit-1 {
   font-size: 16px;
   line-height: 24px;
   background-color: #E6E6E6;
-  box-shadow: 0 0 0 1px #D23F47;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
@@ -59,18 +59,6 @@ label + .circuit-1 {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
-}
-
-.circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22426;
-}
-
-.circuit-0:focus {
-  box-shadow: 0 0 0 2px #D23F47;
-}
-
-.circuit-0:active {
-  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <div
@@ -93,13 +81,6 @@ label + .circuit-1 {
 `;
 
 exports[`Input should prioritize disabled over warning styles 1`] = `
-.circuit-2 {
-  font-size: 13px;
-  line-height: 20px;
-  display: block;
-  margin-bottom: 16px;
-}
-
 .circuit-1 {
   position: relative;
 }
@@ -107,6 +88,16 @@ exports[`Input should prioritize disabled over warning styles 1`] = `
 label .circuit-1,
 label + .circuit-1 {
   margin-top: 4px;
+}
+
+.circuit-2 {
+  font-size: 13px;
+  line-height: 20px;
+  display: block;
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+  margin-bottom: 16px;
 }
 
 .circuit-0 {
@@ -122,7 +113,8 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #D23F47;
+  background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
@@ -149,60 +141,17 @@ label + .circuit-1 {
   transition: color 120ms ease-in-out;
 }
 
-.circuit-0:not(:focus)::-webkit-input-placeholder {
-  color: #D8A413;
-}
-
-.circuit-0:not(:focus)::-moz-placeholder {
-  color: #D8A413;
-}
-
-.circuit-0:not(:focus):-ms-input-placeholder {
-  color: #D8A413;
-}
-
-.circuit-0:not(:focus)::placeholder {
-  color: #D8A413;
-}
-
-.circuit-0:not(:focus)::-webkit-input-placeholder {
-  color: #EA7A7A;
-}
-
-.circuit-0:not(:focus)::-moz-placeholder {
-  color: #EA7A7A;
-}
-
-.circuit-0:not(:focus):-ms-input-placeholder {
-  color: #EA7A7A;
-}
-
-.circuit-0:not(:focus)::placeholder {
-  color: #EA7A7A;
-}
-
-.circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22426;
-}
-
-.circuit-0:focus {
-  box-shadow: 0 0 0 2px #D23F47;
-}
-
-.circuit-0:active {
-  box-shadow: 0 0 0 1px #D23F47;
-}
-
 <div
   class="circuit-2"
+  disabled=""
   for="input_12"
 >
   <div
     class="circuit-1"
   >
     <input
-      aria-invalid="true"
       class="circuit-0"
+      disabled=""
       id="input_12"
       value=""
     />
@@ -752,18 +701,6 @@ label + .circuit-1 {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
-}
-
-.circuit-0:hover {
-  box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-0:focus {
-  box-shadow: 0 0 0 2px #3063E9;
-}
-
-.circuit-0:active {
-  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -1345,7 +1282,7 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #D8A413;
+  box-shadow: 0 0 0 1px #F5C625;
 }
 
 .circuit-0::-webkit-input-placeholder {
@@ -1373,19 +1310,19 @@ label + .circuit-1 {
 }
 
 .circuit-0:not(:focus)::-webkit-input-placeholder {
-  color: #D8A413;
+  color: #F5C625;
 }
 
 .circuit-0:not(:focus)::-moz-placeholder {
-  color: #D8A413;
+  color: #F5C625;
 }
 
 .circuit-0:not(:focus):-ms-input-placeholder {
-  color: #D8A413;
+  color: #F5C625;
 }
 
 .circuit-0:not(:focus)::placeholder {
-  color: #D8A413;
+  color: #F5C625;
 }
 
 .circuit-0:hover {
@@ -1393,11 +1330,11 @@ label + .circuit-1 {
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #D8A413;
+  box-shadow: 0 0 0 2px #F5C625;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #D8A413;
+  box-shadow: 0 0 0 1px #F5C625;
 }
 
 <div

--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -33,30 +33,30 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   box-shadow: 0 0 0 1px #D23F47;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -126,25 +126,25 @@ label + .circuit-1 {
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -240,35 +240,35 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -291,7 +291,7 @@ label + .circuit-1 {
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #333333;
+  color: #666;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -339,7 +339,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #333333;
+  color: #666;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -359,35 +359,35 @@ label + .circuit-2 {
   font-size: 16px;
   line-height: 24px;
   padding-left: 40px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-1:focus {
@@ -449,35 +449,35 @@ label + .circuit-2 {
   font-size: 16px;
   line-height: 24px;
   padding-right: 40px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -493,7 +493,7 @@ label + .circuit-2 {
   top: 1px;
   right: 1px;
   pointer-events: none;
-  color: #333333;
+  color: #666;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -552,36 +552,36 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
   color: red;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -638,35 +638,35 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -726,36 +726,36 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999999;
+  background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -807,35 +807,35 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -905,25 +905,25 @@ label + .circuit-1 {
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -996,35 +996,35 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -1087,36 +1087,36 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999999;
+  background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -1175,35 +1175,35 @@ label + .circuit-1 {
   font-size: 16px;
   line-height: 24px;
   text-align: right;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -1260,35 +1260,35 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -1349,25 +1349,25 @@ label + .circuit-1 {
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }

--- a/src/components/LoadingButton/__snapshots__/LoadingButton.spec.tsx.snap
+++ b/src/components/LoadingButton/__snapshots__/LoadingButton.spec.tsx.snap
@@ -42,9 +42,9 @@ exports[`LoadingButton styles should render with default styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   position: relative;
@@ -69,12 +69,12 @@ exports[`LoadingButton styles should render with default styles 1`] = `
 
 .circuit-3:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-3:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-1 {
@@ -198,9 +198,9 @@ exports[`LoadingButton styles should render with loading styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   position: relative;
@@ -225,12 +225,12 @@ exports[`LoadingButton styles should render with loading styles 1`] = `
 
 .circuit-3:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-3:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 .circuit-0 {

--- a/src/components/LoadingButton/__snapshots__/LoadingButton.spec.tsx.snap
+++ b/src/components/LoadingButton/__snapshots__/LoadingButton.spec.tsx.snap
@@ -43,8 +43,8 @@ exports[`LoadingButton styles should render with default styles 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   position: relative;
@@ -68,13 +68,13 @@ exports[`LoadingButton styles should render with default styles 1`] = `
 }
 
 .circuit-3:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-3:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-1 {
@@ -199,8 +199,8 @@ exports[`LoadingButton styles should render with loading styles 1`] = `
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   position: relative;
@@ -224,13 +224,13 @@ exports[`LoadingButton styles should render with loading styles 1`] = `
 }
 
 .circuit-3:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-3:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 .circuit-0 {

--- a/src/components/Modal/components/ModalFooter/__snapshots__/ModalFooter.spec.tsx.snap
+++ b/src/components/Modal/components/ModalFooter/__snapshots__/ModalFooter.spec.tsx.snap
@@ -38,7 +38,7 @@ exports[`ModalFooter should render with default styles 1`] = `
     margin: 0 -16px;
     padding: 16px;
     width: calc(100% + 2 * 16px);
-    background: #FFFFFF;
+    background: #FFF;
   }
 
   .circuit-0::before {
@@ -49,7 +49,7 @@ exports[`ModalFooter should render with default styles 1`] = `
     right: 0;
     width: 100%;
     height: 24px;
-    background: linear-gradient(transparent,#FFFFFF);
+    background: linear-gradient(transparent,#FFF);
   }
 }
 

--- a/src/components/Modal/components/ModalWrapper/__snapshots__/ModalWrapper.spec.tsx.snap
+++ b/src/components/Modal/components/ModalWrapper/__snapshots__/ModalWrapper.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ModalWrapper should render with default styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -16,7 +16,11 @@
 /** @jsx jsx */
 import { FC, SVGProps, ReactNode, MouseEvent, KeyboardEvent } from 'react';
 import { css, jsx } from '@emotion/core';
-import { CircleCheckmark, CircleCross, CircleWarning } from '@sumup/icons';
+import {
+  CircleCheckmarkFilled,
+  CircleCrossFilled,
+  CircleWarningFilled,
+} from '@sumup/icons';
 import { Theme } from '@sumup/design-tokens';
 
 import styled, { StyleProps } from '../../styles/styled';
@@ -57,9 +61,9 @@ const colorMap = {
 } as const;
 
 const iconMap = {
-  success: CircleCheckmark,
-  error: CircleCross,
-  warning: CircleWarning,
+  success: CircleCheckmarkFilled,
+  error: CircleCrossFilled,
+  warning: CircleWarningFilled,
 } as const;
 
 const iconStyles = (variant: Variant) => (theme: Theme) =>
@@ -102,7 +106,7 @@ export const Notification = ({
 
   return (
     <Container {...props}>
-      {Icon && <Icon css={iconStyles(variant)} size="large" />}
+      {Icon && <Icon css={iconStyles(variant)} />}
 
       <Content>{children}</Content>
 

--- a/src/components/Notification/__snapshots__/Notification.spec.tsx.snap
+++ b/src/components/Notification/__snapshots__/Notification.spec.tsx.snap
@@ -35,7 +35,7 @@ exports[`Notification should render with error styles 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   line-height: 0;
-  color: #DB4D4D;
+  color: #D23F47;
 }
 
 <div
@@ -98,7 +98,7 @@ exports[`Notification should render with success styles 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   line-height: 0;
-  color: #47995A;
+  color: #138849;
 }
 
 .circuit-1 {
@@ -176,7 +176,7 @@ exports[`Notification should render with warning styles 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   line-height: 0;
-  color: #D8A413;
+  color: #F5C625;
 }
 
 <div

--- a/src/components/Notification/__snapshots__/Notification.spec.tsx.snap
+++ b/src/components/Notification/__snapshots__/Notification.spec.tsx.snap
@@ -50,11 +50,10 @@ exports[`Notification should render with error styles 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M8.786 15.214l6.429-6.428m-6.429 0l6.429 6.428M12 21a9 9 0 100-18 9 9 0 000 18z"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
+      clip-rule="evenodd"
+      d="M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10zM9.493 8.079a1 1 0 10-1.414 1.414L10.586 12l-2.507 2.507a1 1 0 101.414 1.414L12 13.414l2.507 2.507a1 1 0 001.414-1.414L13.414 12l2.507-2.507a1 1 0 00-1.414-1.414L12 10.586 9.493 8.079z"
+      fill="currentColor"
+      fill-rule="evenodd"
     />
   </svg>
   <div
@@ -117,18 +116,10 @@ exports[`Notification should render with success styles 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M8.183 12.684l2.571 2.571 5.143-6.428"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-    />
-    <path
-      d="M12 21a9 9 0 100-18 9 9 0 000 18z"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
+      clip-rule="evenodd"
+      d="M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10zm-5.322-2.549a1 1 0 00-1.562-1.249l-4.444 5.556-1.782-1.781a1 1 0 00-1.414 1.414l2.571 2.571a1 1 0 001.488-.082l5.143-6.429z"
+      fill="currentColor"
+      fill-rule="evenodd"
     />
   </svg>
   <div
@@ -191,11 +182,10 @@ exports[`Notification should render with warning styles 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M12 12.643V6.857m0 10.286V16.5m0 4.5a9 9 0 100-18 9 9 0 000 18z"
-      stroke="currentColor"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
+      clip-rule="evenodd"
+      d="M22 12c0 5.523-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2s10 4.477 10 10zm-9-5.143a1 1 0 10-2 0v5.786a1 1 0 102 0V6.857zm0 9.643a1 1 0 10-2 0v.643a1 1 0 102 0V16.5z"
+      fill="currentColor"
+      fill-rule="evenodd"
     />
   </svg>
   <div

--- a/src/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
+++ b/src/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`NotificationBanner should render with default styles 1`] = `
 .circuit-1 {
   width: 100%;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   box-shadow: 0 0 0 1px rgba(12,15,20,0.07), 0 0 1px 0 rgba(12,15,20,0.07),0 2px 2px 0 rgba(12,15,20,0.07);
   border-radius: 4px;
 }

--- a/src/components/NotificationList/__snapshots__/NotificationList.spec.tsx.snap
+++ b/src/components/NotificationList/__snapshots__/NotificationList.spec.tsx.snap
@@ -30,7 +30,7 @@ exports[`NotificationList should render with default styles 1`] = `
 }
 
 .circuit-0 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-radius: 4px;
   display: -webkit-box;
   display: -webkit-flex;

--- a/src/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
@@ -47,7 +47,7 @@ exports[`Pagination with 2 to 5 pages should render with default styles 1`] = `
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: transparent;
   border-color: transparent;
-  color: #3388FF;
+  color: #3063E9;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -74,11 +74,11 @@ exports[`Pagination with 2 to 5 pages should render with default styles 1`] = `
 }
 
 .circuit-1:hover {
-  color: #1760CE;
+  color: #234BC3;
 }
 
 .circuit-1:active {
-  color: #003C8B;
+  color: #1A368E;
 }
 
 .circuit-0 {
@@ -133,9 +133,9 @@ exports[`Pagination with 2 to 5 pages should render with default styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #3388FF;
-  border-color: #3388FF;
-  color: #FFFFFF;
+  background-color: #3063E9;
+  border-color: #3063E9;
+  color: #FFF;
   padding: 4px calc(16px - 1px);
   border-radius: 6px;
 }
@@ -157,13 +157,13 @@ exports[`Pagination with 2 to 5 pages should render with default styles 1`] = `
 }
 
 .circuit-2:hover {
-  background-color: #1760CE;
-  border-color: #1760CE;
+  background-color: #234BC3;
+  border-color: #234BC3;
 }
 
 .circuit-2:active {
-  background-color: #003C8B;
-  border-color: #003C8B;
+  background-color: #1A368E;
+  border-color: #1A368E;
 }
 
 .circuit-3 {
@@ -195,7 +195,7 @@ exports[`Pagination with 2 to 5 pages should render with default styles 1`] = `
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: transparent;
   border-color: transparent;
-  color: #3388FF;
+  color: #3063E9;
   padding: 4px calc(16px - 1px);
   border-radius: 6px;
 }
@@ -217,11 +217,11 @@ exports[`Pagination with 2 to 5 pages should render with default styles 1`] = `
 }
 
 .circuit-3:hover {
-  color: #1760CE;
+  color: #234BC3;
 }
 
 .circuit-3:active {
-  color: #003C8B;
+  color: #1A368E;
 }
 
 .circuit-9 {
@@ -253,7 +253,7 @@ exports[`Pagination with 2 to 5 pages should render with default styles 1`] = `
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: transparent;
   border-color: transparent;
-  color: #3388FF;
+  color: #3063E9;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -280,11 +280,11 @@ exports[`Pagination with 2 to 5 pages should render with default styles 1`] = `
 }
 
 .circuit-9:hover {
-  color: #1760CE;
+  color: #234BC3;
 }
 
 .circuit-9:active {
-  color: #003C8B;
+  color: #1A368E;
 }
 
 <nav
@@ -450,7 +450,7 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: transparent;
   border-color: transparent;
-  color: #3388FF;
+  color: #3063E9;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -477,11 +477,11 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
 }
 
 .circuit-1:hover {
-  color: #1760CE;
+  color: #234BC3;
 }
 
 .circuit-1:active {
-  color: #003C8B;
+  color: #1A368E;
 }
 
 .circuit-0 {
@@ -526,7 +526,7 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: transparent;
   border-color: transparent;
-  color: #3388FF;
+  color: #3063E9;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -553,11 +553,11 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
 }
 
 .circuit-10:hover {
-  color: #1760CE;
+  color: #234BC3;
 }
 
 .circuit-10:active {
-  color: #003C8B;
+  color: #1A368E;
 }
 
 .circuit-7 {
@@ -567,7 +567,7 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
 }
 
 .circuit-6 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -577,12 +577,12 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -598,7 +598,7 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-3:-moz-focusring {
@@ -611,19 +611,19 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
 }
 
 .circuit-3:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-3:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-3:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-4 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -640,7 +640,7 @@ select:active ~ .circuit-4 {
 }
 
 .circuit-5 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;

--- a/src/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
@@ -567,7 +567,7 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
 }
 
 .circuit-6 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -582,7 +582,7 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -598,7 +598,7 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-3:-moz-focusring {
@@ -611,7 +611,7 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
 }
 
 .circuit-3:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-3:focus {
@@ -623,7 +623,7 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
 }
 
 .circuit-4 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -640,7 +640,7 @@ select:active ~ .circuit-4 {
 }
 
 .circuit-5 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;

--- a/src/components/Pagination/components/PageList/__snapshots__/PageList.spec.tsx.snap
+++ b/src/components/Pagination/components/PageList/__snapshots__/PageList.spec.tsx.snap
@@ -40,9 +40,9 @@ exports[`PageList styles should render with default styles 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #3388FF;
-  border-color: #3388FF;
-  color: #FFFFFF;
+  background-color: #3063E9;
+  border-color: #3063E9;
+  color: #FFF;
   padding: 4px calc(16px - 1px);
   border-radius: 6px;
 }
@@ -64,13 +64,13 @@ exports[`PageList styles should render with default styles 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #1760CE;
-  border-color: #1760CE;
+  background-color: #234BC3;
+  border-color: #234BC3;
 }
 
 .circuit-0:active {
-  background-color: #003C8B;
-  border-color: #003C8B;
+  background-color: #1A368E;
+  border-color: #1A368E;
 }
 
 .circuit-1 {
@@ -102,7 +102,7 @@ exports[`PageList styles should render with default styles 1`] = `
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: transparent;
   border-color: transparent;
-  color: #3388FF;
+  color: #3063E9;
   padding: 4px calc(16px - 1px);
   border-radius: 6px;
 }
@@ -124,11 +124,11 @@ exports[`PageList styles should render with default styles 1`] = `
 }
 
 .circuit-1:hover {
-  color: #1760CE;
+  color: #234BC3;
 }
 
 .circuit-1:active {
-  color: #003C8B;
+  color: #1A368E;
 }
 
 <ol

--- a/src/components/Pagination/components/PageSelect/__snapshots__/PageSelect.spec.tsx.snap
+++ b/src/components/Pagination/components/PageSelect/__snapshots__/PageSelect.spec.tsx.snap
@@ -22,7 +22,7 @@ HTMLCollection [
 }
 
 .circuit-4 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -32,12 +32,12 @@ HTMLCollection [
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -53,7 +53,7 @@ HTMLCollection [
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-1:-moz-focusring {
@@ -66,19 +66,19 @@ HTMLCollection [
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-1:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -95,7 +95,7 @@ select:active ~ .circuit-2 {
 }
 
 .circuit-3 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;

--- a/src/components/Pagination/components/PageSelect/__snapshots__/PageSelect.spec.tsx.snap
+++ b/src/components/Pagination/components/PageSelect/__snapshots__/PageSelect.spec.tsx.snap
@@ -22,7 +22,7 @@ HTMLCollection [
 }
 
 .circuit-4 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -37,7 +37,7 @@ HTMLCollection [
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -53,7 +53,7 @@ HTMLCollection [
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1:-moz-focusring {
@@ -66,7 +66,7 @@ HTMLCollection [
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-1:focus {
@@ -78,7 +78,7 @@ HTMLCollection [
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -95,7 +95,7 @@ select:active ~ .circuit-2 {
 }
 
 .circuit-3 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;

--- a/src/components/ProgressBar/__snapshots__/ProgressBar.spec.tsx.snap
+++ b/src/components/ProgressBar/__snapshots__/ProgressBar.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`ProgressBar step-based should render with default styles 1`] = `
 }
 
 .circuit-0 {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -28,7 +28,7 @@ exports[`ProgressBar step-based should render with default styles 1`] = `
   top: 0;
   bottom: 0;
   left: 0;
-  background-color: #3388FF;
+  background-color: #3063E9;
   -webkit-transition: width 0.05s ease-out;
   transition: width 0.05s ease-out;
   height: 100%;
@@ -36,7 +36,7 @@ exports[`ProgressBar step-based should render with default styles 1`] = `
 }
 
 .circuit-0::after {
-  background-color: #3388FF;
+  background-color: #3063E9;
 }
 
 .circuit-0::after {
@@ -98,7 +98,7 @@ exports[`ProgressBar time-based should render with default styles 1`] = `
 }
 
 .circuit-0 {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -113,7 +113,7 @@ exports[`ProgressBar time-based should render with default styles 1`] = `
   top: 0;
   bottom: 0;
   left: 0;
-  background-color: #3388FF;
+  background-color: #3063E9;
   -webkit-transition: width 0.05s ease-out;
   transition: width 0.05s ease-out;
   height: 100%;
@@ -121,7 +121,7 @@ exports[`ProgressBar time-based should render with default styles 1`] = `
 }
 
 .circuit-0::after {
-  background-color: #3388FF;
+  background-color: #3063E9;
 }
 
 .circuit-0::after {
@@ -194,7 +194,7 @@ exports[`ProgressBar time-based should render with loop styles 1`] = `
 }
 
 .circuit-0 {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -209,7 +209,7 @@ exports[`ProgressBar time-based should render with loop styles 1`] = `
   top: 0;
   bottom: 0;
   left: 0;
-  background-color: #3388FF;
+  background-color: #3063E9;
   -webkit-transition: width 0.05s ease-out;
   transition: width 0.05s ease-out;
   height: 100%;
@@ -217,7 +217,7 @@ exports[`ProgressBar time-based should render with loop styles 1`] = `
 }
 
 .circuit-0::after {
-  background-color: #3388FF;
+  background-color: #3063E9;
 }
 
 .circuit-0::after {
@@ -288,7 +288,7 @@ exports[`ProgressBar time-based should render with paused styles 1`] = `
 }
 
 .circuit-0 {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -303,7 +303,7 @@ exports[`ProgressBar time-based should render with paused styles 1`] = `
   top: 0;
   bottom: 0;
   left: 0;
-  background-color: #3388FF;
+  background-color: #3063E9;
   -webkit-transition: width 0.05s ease-out;
   transition: width 0.05s ease-out;
   height: 100%;
@@ -311,7 +311,7 @@ exports[`ProgressBar time-based should render with paused styles 1`] = `
 }
 
 .circuit-0::after {
-  background-color: #3388FF;
+  background-color: #3063E9;
 }
 
 .circuit-0::after {

--- a/src/components/ProgressBar/__snapshots__/ProgressBar.spec.tsx.snap
+++ b/src/components/ProgressBar/__snapshots__/ProgressBar.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`ProgressBar step-based should render with default styles 1`] = `
 }
 
 .circuit-0 {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -98,7 +98,7 @@ exports[`ProgressBar time-based should render with default styles 1`] = `
 }
 
 .circuit-0 {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -194,7 +194,7 @@ exports[`ProgressBar time-based should render with loop styles 1`] = `
 }
 
 .circuit-0 {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   border-radius: 999999px;
   position: relative;
   width: 100%;
@@ -288,7 +288,7 @@ exports[`ProgressBar time-based should render with paused styles 1`] = `
 }
 
 .circuit-0 {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   border-radius: 999999px;
   position: relative;
   width: 100%;

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -90,12 +90,12 @@ const labelInvalidStyles = ({ theme, invalid }: StyleProps & LabelElProps) =>
   css`
     label: radio-button--error;
     &:not(:focus)::before {
-      border-color: ${theme.colors.r500};
+      border-color: ${theme.colors.danger};
       background-color: ${theme.colors.r100};
     }
 
     &:not(:focus)::after {
-      background-color: ${theme.colors.r500};
+      background-color: ${theme.colors.danger};
     }
   `;
 
@@ -159,7 +159,7 @@ const inputInvalidStyles = ({ theme, invalid }: StyleProps & InputElProps) =>
     }
 
     &:checked + label::before {
-      border-color: ${theme.colors.r500};
+      border-color: ${theme.colors.danger};
     }
   `;
 

--- a/src/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
+++ b/src/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
@@ -16,7 +16,7 @@ HTMLCollection [
 }
 
 .circuit-0:hover + label::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:focus + label::before {
@@ -29,7 +29,7 @@ HTMLCollection [
 }
 
 .circuit-0:checked + label::before {
-  border-color: #3388FF;
+  border-color: #3063E9;
 }
 
 .circuit-0:checked + label::after {
@@ -47,7 +47,7 @@ HTMLCollection [
     value=""
   />,
   .circuit-0 {
-  color: #5C656F;
+  color: #333333;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -58,8 +58,8 @@ HTMLCollection [
   height: 18px;
   width: 18px;
   box-shadow: 0;
-  background-color: #FFFFFF;
-  border: 1px solid #9DA7B1;
+  background-color: #FFF;
+  border: 1px solid #999999;
   border-radius: 100%;
   content: '';
   display: block;
@@ -77,7 +77,7 @@ HTMLCollection [
   box-sizing: border-box;
   height: 10px;
   width: 10px;
-  background-color: #3388FF;
+  background-color: #3063E9;
   border-radius: 100%;
   content: '';
   display: block;
@@ -116,7 +116,7 @@ HTMLCollection [
 }
 
 .circuit-0:hover + label::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:focus + label::before {
@@ -129,7 +129,7 @@ HTMLCollection [
 }
 
 .circuit-0:checked + label::before {
-  border-color: #3388FF;
+  border-color: #3063E9;
 }
 
 .circuit-0:checked + label::after {
@@ -146,7 +146,7 @@ HTMLCollection [
     value=""
   />,
   .circuit-0 {
-  color: #5C656F;
+  color: #333333;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -157,8 +157,8 @@ HTMLCollection [
   height: 18px;
   width: 18px;
   box-shadow: 0;
-  background-color: #FFFFFF;
-  border: 1px solid #9DA7B1;
+  background-color: #FFF;
+  border: 1px solid #999999;
   border-radius: 100%;
   content: '';
   display: block;
@@ -176,7 +176,7 @@ HTMLCollection [
   box-sizing: border-box;
   height: 10px;
   width: 10px;
-  background-color: #3388FF;
+  background-color: #3063E9;
   border-radius: 100%;
   content: '';
   display: block;
@@ -215,7 +215,7 @@ HTMLCollection [
 }
 
 .circuit-0:hover + label::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:focus + label::before {
@@ -228,7 +228,7 @@ HTMLCollection [
 }
 
 .circuit-0:checked + label::before {
-  border-color: #3388FF;
+  border-color: #3063E9;
 }
 
 .circuit-0:checked + label::after {
@@ -246,7 +246,7 @@ HTMLCollection [
     value=""
   />,
   .circuit-0 {
-  color: #5C656F;
+  color: #333333;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -260,8 +260,8 @@ HTMLCollection [
   height: 18px;
   width: 18px;
   box-shadow: 0;
-  background-color: #FFFFFF;
-  border: 1px solid #9DA7B1;
+  background-color: #FFF;
+  border: 1px solid #999999;
   border-radius: 100%;
   content: '';
   display: block;
@@ -279,7 +279,7 @@ HTMLCollection [
   box-sizing: border-box;
   height: 10px;
   width: 10px;
-  background-color: #3388FF;
+  background-color: #3063E9;
   border-radius: 100%;
   content: '';
   display: block;
@@ -299,15 +299,15 @@ HTMLCollection [
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  border-color: #5C656F;
-  background-color: #EEF0F2;
+  border-color: #333333;
+  background-color: #F5F5F5;
 }
 
 .circuit-0::after {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  background-color: #5C656F;
+  background-color: #333333;
 }
 
 <label
@@ -334,7 +334,7 @@ HTMLCollection [
 }
 
 .circuit-0:hover + label::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-0:focus + label::before {
@@ -347,7 +347,7 @@ HTMLCollection [
 }
 
 .circuit-0:checked + label::before {
-  border-color: #3388FF;
+  border-color: #3063E9;
 }
 
 .circuit-0:checked + label::after {
@@ -358,11 +358,11 @@ HTMLCollection [
 }
 
 .circuit-0:hover + label::before {
-  border-color: #B22828;
+  border-color: #B22426;
 }
 
 .circuit-0:checked + label::before {
-  border-color: #DB4D4D;
+  border-color: #D23F47;
 }
 
 <input
@@ -372,7 +372,7 @@ HTMLCollection [
     value=""
   />,
   .circuit-0 {
-  color: #5C656F;
+  color: #333333;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -383,8 +383,8 @@ HTMLCollection [
   height: 18px;
   width: 18px;
   box-shadow: 0;
-  background-color: #FFFFFF;
-  border: 1px solid #9DA7B1;
+  background-color: #FFF;
+  border: 1px solid #999999;
   border-radius: 100%;
   content: '';
   display: block;
@@ -402,7 +402,7 @@ HTMLCollection [
   box-sizing: border-box;
   height: 10px;
   width: 10px;
-  background-color: #3388FF;
+  background-color: #3063E9;
   border-radius: 100%;
   content: '';
   display: block;
@@ -419,12 +419,12 @@ HTMLCollection [
 }
 
 .circuit-0:not(:focus)::before {
-  border-color: #DB4D4D;
+  border-color: #D23F47;
   background-color: #F4CBCB;
 }
 
 .circuit-0:not(:focus)::after {
-  background-color: #DB4D4D;
+  background-color: #D23F47;
 }
 
 <label

--- a/src/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
+++ b/src/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
@@ -16,7 +16,7 @@ HTMLCollection [
 }
 
 .circuit-0:hover + label::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 .circuit-0:focus + label::before {
@@ -47,7 +47,7 @@ HTMLCollection [
     value=""
   />,
   .circuit-0 {
-  color: #333333;
+  color: #666;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -59,7 +59,7 @@ HTMLCollection [
   width: 18px;
   box-shadow: 0;
   background-color: #FFF;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   border-radius: 100%;
   content: '';
   display: block;
@@ -116,7 +116,7 @@ HTMLCollection [
 }
 
 .circuit-0:hover + label::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 .circuit-0:focus + label::before {
@@ -146,7 +146,7 @@ HTMLCollection [
     value=""
   />,
   .circuit-0 {
-  color: #333333;
+  color: #666;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -158,7 +158,7 @@ HTMLCollection [
   width: 18px;
   box-shadow: 0;
   background-color: #FFF;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   border-radius: 100%;
   content: '';
   display: block;
@@ -215,7 +215,7 @@ HTMLCollection [
 }
 
 .circuit-0:hover + label::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 .circuit-0:focus + label::before {
@@ -246,7 +246,7 @@ HTMLCollection [
     value=""
   />,
   .circuit-0 {
-  color: #333333;
+  color: #666;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -261,7 +261,7 @@ HTMLCollection [
   width: 18px;
   box-shadow: 0;
   background-color: #FFF;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   border-radius: 100%;
   content: '';
   display: block;
@@ -299,15 +299,15 @@ HTMLCollection [
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  border-color: #333333;
-  background-color: #F5F5F5;
+  border-color: #666;
+  background-color: #E6E6E6;
 }
 
 .circuit-0::after {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  background-color: #333333;
+  background-color: #666;
 }
 
 <label
@@ -334,7 +334,7 @@ HTMLCollection [
 }
 
 .circuit-0:hover + label::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 .circuit-0:focus + label::before {
@@ -372,7 +372,7 @@ HTMLCollection [
     value=""
   />,
   .circuit-0 {
-  color: #333333;
+  color: #666;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -384,7 +384,7 @@ HTMLCollection [
   width: 18px;
   box-shadow: 0;
   background-color: #FFF;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   border-radius: 100%;
   content: '';
   display: block;

--- a/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
+++ b/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
 }
 
 .circuit-1:hover + label::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-1:focus + label::before {
@@ -34,7 +34,7 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
 }
 
 .circuit-1:checked + label::before {
-  border-color: #3388FF;
+  border-color: #3063E9;
 }
 
 .circuit-1:checked + label::after {
@@ -45,7 +45,7 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -56,8 +56,8 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
   height: 18px;
   width: 18px;
   box-shadow: 0;
-  background-color: #FFFFFF;
-  border: 1px solid #9DA7B1;
+  background-color: #FFF;
+  border: 1px solid #999999;
   border-radius: 100%;
   content: '';
   display: block;
@@ -75,7 +75,7 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
   box-sizing: border-box;
   height: 10px;
   width: 10px;
-  background-color: #3388FF;
+  background-color: #3063E9;
   border-radius: 100%;
   content: '';
   display: block;

--- a/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
+++ b/src/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
 }
 
 .circuit-1:hover + label::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 .circuit-1:focus + label::before {
@@ -45,7 +45,7 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -57,7 +57,7 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
   width: 18px;
   box-shadow: 0;
   background-color: #FFF;
-  border: 1px solid #999999;
+  border: 1px solid #999;
   border-radius: 100%;
   content: '';
   display: block;

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
@@ -15,7 +15,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #5C656F;
+  color: #333333;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -33,7 +33,7 @@ label + .circuit-2 {
 
 .circuit-1 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -44,46 +44,46 @@ label + .circuit-2 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
   padding-left: 40px;
   padding-right: 40px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-1:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -142,7 +142,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #5C656F;
+  color: #333333;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -150,7 +150,7 @@ label + .circuit-2 {
 
 .circuit-1 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -163,43 +163,43 @@ label + .circuit-2 {
   line-height: 24px;
   padding-left: 40px;
   padding-right: 40px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-1:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
@@ -74,18 +74,6 @@ label + .circuit-2 {
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1:hover {
-  box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-1:focus {
-  box-shadow: 0 0 0 2px #3063E9;
-}
-
-.circuit-1:active {
-  box-shadow: 0 0 0 1px #3063E9;
-}
-
 <div
   class="circuit-3"
   disabled=""

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
@@ -15,7 +15,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #333333;
+  color: #666;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -44,38 +44,38 @@ label + .circuit-2 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   padding-left: 40px;
   padding-right: 40px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-1:focus {
@@ -142,7 +142,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #333333;
+  color: #666;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -163,35 +163,35 @@ label + .circuit-2 {
   line-height: 24px;
   padding-left: 40px;
   padding-right: 40px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-1:focus {

--- a/src/components/Select/__snapshots__/Select.spec.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Select should not render with invalid styles when also passed the disabled prop 1`] = `
 .circuit-3 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -13,7 +13,7 @@ label + .circuit-3 {
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -30,7 +30,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -61,12 +61,12 @@ select:not(:active) ~ .circuit-2 {
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -82,7 +82,7 @@ select:not(:active) ~ .circuit-2 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 .circuit-0:-moz-focusring {
@@ -95,15 +95,15 @@ select:not(:active) ~ .circuit-2 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22828;
+  box-shadow: 0 0 0 1px #B22426;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #DB4D4D;
+  box-shadow: 0 0 0 2px #D23F47;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <span
@@ -186,7 +186,7 @@ exports[`Select should render with a label 1`] = `
 }
 
 .circuit-4 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -201,12 +201,12 @@ label + .circuit-4 {
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -222,7 +222,7 @@ label + .circuit-4 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-1:-moz-focusring {
@@ -235,19 +235,19 @@ label + .circuit-4 {
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-1:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -264,7 +264,7 @@ select:active ~ .circuit-2 {
 }
 
 .circuit-3 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -362,7 +362,7 @@ exports[`Select should render with a prefix when passed the prefix prop 1`] = `
 }
 
 .circuit-4 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -373,7 +373,7 @@ label + .circuit-4 {
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -390,7 +390,7 @@ select:active ~ .circuit-2 {
 }
 
 .circuit-3 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -423,12 +423,12 @@ select:not(:active) ~ .circuit-3 {
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -445,7 +445,7 @@ select:not(:active) ~ .circuit-3 {
   font-size: 16px;
   line-height: 24px;
   padding-left: 40px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-1:-moz-focusring {
@@ -458,15 +458,15 @@ select:not(:active) ~ .circuit-3 {
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-1:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <span
@@ -550,7 +550,7 @@ exports[`Select should render with a tooltip when passed a validation hint 1`] =
 }
 
 .circuit-3 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -565,12 +565,12 @@ label + .circuit-3 {
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -586,7 +586,7 @@ label + .circuit-3 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0:-moz-focusring {
@@ -599,19 +599,19 @@ label + .circuit-3 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -628,7 +628,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -656,7 +656,7 @@ select:not(:active) ~ .circuit-2 {
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #5C656F;
+  color: #333333;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -747,12 +747,12 @@ exports[`Select should render with a visually-hidden label 1`] = `
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -768,7 +768,7 @@ exports[`Select should render with a visually-hidden label 1`] = `
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-1:-moz-focusring {
@@ -781,19 +781,19 @@ exports[`Select should render with a visually-hidden label 1`] = `
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-1:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -810,7 +810,7 @@ select:active ~ .circuit-2 {
 }
 
 .circuit-3 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -840,7 +840,7 @@ select:not(:active) ~ .circuit-3 {
 }
 
 .circuit-4 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -927,7 +927,7 @@ exports[`Select should render with default styles 1`] = `
 }
 
 .circuit-3 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -942,12 +942,12 @@ label + .circuit-3 {
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -963,7 +963,7 @@ label + .circuit-3 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0:-moz-focusring {
@@ -976,19 +976,19 @@ label + .circuit-3 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1005,7 +1005,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1091,7 +1091,7 @@ select:not(:active) ~ .circuit-2 {
 
 exports[`Select should render with disabled styles when passed the disabled prop 1`] = `
 .circuit-3 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -1106,12 +1106,12 @@ label + .circuit-3 {
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -1127,7 +1127,7 @@ label + .circuit-3 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0:-moz-focusring {
@@ -1140,19 +1140,19 @@ label + .circuit-3 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1169,7 +1169,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1267,7 +1267,7 @@ select:not(:active) ~ .circuit-2 {
 
 exports[`Select should render with inline styles when passed the inline prop 1`] = `
 .circuit-3 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -1282,12 +1282,12 @@ label + .circuit-3 {
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -1303,7 +1303,7 @@ label + .circuit-3 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0:-moz-focusring {
@@ -1316,19 +1316,19 @@ label + .circuit-3 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1345,7 +1345,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1448,7 +1448,7 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
 }
 
 .circuit-3 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -1459,7 +1459,7 @@ label + .circuit-3 {
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1476,7 +1476,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1497,12 +1497,12 @@ select:not(:active) ~ .circuit-2 {
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -1519,7 +1519,7 @@ select:not(:active) ~ .circuit-2 {
   font-size: 16px;
   line-height: 24px;
   padding-right: 56px;
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 .circuit-0:-moz-focusring {
@@ -1532,15 +1532,15 @@ select:not(:active) ~ .circuit-2 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22828;
+  box-shadow: 0 0 0 1px #B22426;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #DB4D4D;
+  box-shadow: 0 0 0 2px #D23F47;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <span
@@ -1614,7 +1614,7 @@ select:not(:active) ~ .circuit-2 {
 
 exports[`Select should render with no margin styles when passed the noMargin prop 1`] = `
 .circuit-3 {
-  color: #212933;
+  color: #000000;
   display: block;
   position: relative;
 }
@@ -1629,12 +1629,12 @@ label + .circuit-3 {
   -moz-appearance: none;
   appearance: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   outline: none;
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #212933;
+  color: #000000;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -1650,7 +1650,7 @@ label + .circuit-3 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
 }
 
 .circuit-0:-moz-focusring {
@@ -1663,19 +1663,19 @@ label + .circuit-3 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-1 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1692,7 +1692,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #5C656F;
+  color: #333333;
   display: block;
   z-index: 21;
   pointer-events: none;

--- a/src/components/Select/__snapshots__/Select.spec.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.spec.tsx.snap
@@ -82,7 +82,7 @@ select:not(:active) ~ .circuit-2 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #D23F47;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0:-moz-focusring {
@@ -92,18 +92,6 @@ select:not(:active) ~ .circuit-2 {
 
 .circuit-0::-ms-expand {
   display: none;
-}
-
-.circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22426;
-}
-
-.circuit-0:focus {
-  box-shadow: 0 0 0 2px #D23F47;
-}
-
-.circuit-0:active {
-  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <span
@@ -1101,56 +1089,6 @@ label + .circuit-3 {
   margin-top: 4px;
 }
 
-.circuit-0 {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  cursor: pointer;
-  background-color: #FFF;
-  outline: none;
-  border: 0;
-  border-radius: 8px;
-  box-shadow: none;
-  color: #1A1A1A;
-  margin: 0;
-  padding-top: calc(8px + 1px);
-  padding-right: 32px;
-  padding-bottom: calc(8px + 1px);
-  padding-left: 12px;
-  position: relative;
-  width: 100%;
-  z-index: 20;
-  overflow-x: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
-  transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
-  font-size: 16px;
-  line-height: 24px;
-  box-shadow: 0 0 0 1px #999;
-}
-
-.circuit-0:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #000;
-}
-
-.circuit-0::-ms-expand {
-  display: none;
-}
-
-.circuit-0:hover {
-  box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-0:focus {
-  box-shadow: 0 0 0 2px #3063E9;
-}
-
-.circuit-0:active {
-  box-shadow: 0 0 0 1px #3063E9;
-}
-
 .circuit-1 {
   color: #666;
   display: block;
@@ -1193,6 +1131,44 @@ select:not(:active) ~ .circuit-2 {
   pointer-events: none;
   box-shadow: none;
   margin-bottom: 16px;
+}
+
+.circuit-0 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  background-color: #FFF;
+  outline: none;
+  border: 0;
+  border-radius: 8px;
+  box-shadow: none;
+  color: #1A1A1A;
+  margin: 0;
+  padding-top: calc(8px + 1px);
+  padding-right: 32px;
+  padding-bottom: calc(8px + 1px);
+  padding-left: 12px;
+  position: relative;
+  width: 100%;
+  z-index: 20;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  -webkit-transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
+  font-size: 16px;
+  line-height: 24px;
+  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-0:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.circuit-0::-ms-expand {
+  display: none;
 }
 
 <span

--- a/src/components/Select/__snapshots__/Select.spec.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Select should not render with invalid styles when also passed the disabled prop 1`] = `
 .circuit-3 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -13,7 +13,7 @@ label + .circuit-3 {
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -30,7 +30,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -66,7 +66,7 @@ select:not(:active) ~ .circuit-2 {
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -186,7 +186,7 @@ exports[`Select should render with a label 1`] = `
 }
 
 .circuit-4 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -206,7 +206,7 @@ label + .circuit-4 {
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -222,7 +222,7 @@ label + .circuit-4 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1:-moz-focusring {
@@ -235,7 +235,7 @@ label + .circuit-4 {
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-1:focus {
@@ -247,7 +247,7 @@ label + .circuit-4 {
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -264,7 +264,7 @@ select:active ~ .circuit-2 {
 }
 
 .circuit-3 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -362,7 +362,7 @@ exports[`Select should render with a prefix when passed the prefix prop 1`] = `
 }
 
 .circuit-4 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -373,7 +373,7 @@ label + .circuit-4 {
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -390,7 +390,7 @@ select:active ~ .circuit-2 {
 }
 
 .circuit-3 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -428,7 +428,7 @@ select:not(:active) ~ .circuit-3 {
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -445,7 +445,7 @@ select:not(:active) ~ .circuit-3 {
   font-size: 16px;
   line-height: 24px;
   padding-left: 40px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1:-moz-focusring {
@@ -458,7 +458,7 @@ select:not(:active) ~ .circuit-3 {
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-1:focus {
@@ -550,7 +550,7 @@ exports[`Select should render with a tooltip when passed a validation hint 1`] =
 }
 
 .circuit-3 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -570,7 +570,7 @@ label + .circuit-3 {
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -586,7 +586,7 @@ label + .circuit-3 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0:-moz-focusring {
@@ -599,7 +599,7 @@ label + .circuit-3 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -611,7 +611,7 @@ label + .circuit-3 {
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -628,7 +628,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -656,7 +656,7 @@ select:not(:active) ~ .circuit-2 {
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #333333;
+  color: #666;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -752,7 +752,7 @@ exports[`Select should render with a visually-hidden label 1`] = `
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -768,7 +768,7 @@ exports[`Select should render with a visually-hidden label 1`] = `
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1:-moz-focusring {
@@ -781,7 +781,7 @@ exports[`Select should render with a visually-hidden label 1`] = `
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-1:focus {
@@ -793,7 +793,7 @@ exports[`Select should render with a visually-hidden label 1`] = `
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -810,7 +810,7 @@ select:active ~ .circuit-2 {
 }
 
 .circuit-3 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -840,7 +840,7 @@ select:not(:active) ~ .circuit-3 {
 }
 
 .circuit-4 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -927,7 +927,7 @@ exports[`Select should render with default styles 1`] = `
 }
 
 .circuit-3 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -947,7 +947,7 @@ label + .circuit-3 {
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -963,7 +963,7 @@ label + .circuit-3 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0:-moz-focusring {
@@ -976,7 +976,7 @@ label + .circuit-3 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -988,7 +988,7 @@ label + .circuit-3 {
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1005,7 +1005,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1091,7 +1091,7 @@ select:not(:active) ~ .circuit-2 {
 
 exports[`Select should render with disabled styles when passed the disabled prop 1`] = `
 .circuit-3 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -1111,7 +1111,7 @@ label + .circuit-3 {
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -1127,7 +1127,7 @@ label + .circuit-3 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0:-moz-focusring {
@@ -1140,7 +1140,7 @@ label + .circuit-3 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -1152,7 +1152,7 @@ label + .circuit-3 {
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1169,7 +1169,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1267,7 +1267,7 @@ select:not(:active) ~ .circuit-2 {
 
 exports[`Select should render with inline styles when passed the inline prop 1`] = `
 .circuit-3 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -1287,7 +1287,7 @@ label + .circuit-3 {
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -1303,7 +1303,7 @@ label + .circuit-3 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0:-moz-focusring {
@@ -1316,7 +1316,7 @@ label + .circuit-3 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -1328,7 +1328,7 @@ label + .circuit-3 {
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1345,7 +1345,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1448,7 +1448,7 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
 }
 
 .circuit-3 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -1459,7 +1459,7 @@ label + .circuit-3 {
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1476,7 +1476,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1502,7 +1502,7 @@ select:not(:active) ~ .circuit-2 {
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -1614,7 +1614,7 @@ select:not(:active) ~ .circuit-2 {
 
 exports[`Select should render with no margin styles when passed the noMargin prop 1`] = `
 .circuit-3 {
-  color: #000000;
+  color: #1A1A1A;
   display: block;
   position: relative;
 }
@@ -1634,7 +1634,7 @@ label + .circuit-3 {
   border: 0;
   border-radius: 8px;
   box-shadow: none;
-  color: #000000;
+  color: #1A1A1A;
   margin: 0;
   padding-top: calc(8px + 1px);
   padding-right: 32px;
@@ -1650,7 +1650,7 @@ label + .circuit-3 {
   transition: box-shadow 120ms ease-in-out, padding 120ms ease-in-out;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0:-moz-focusring {
@@ -1663,7 +1663,7 @@ label + .circuit-3 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -1675,7 +1675,7 @@ label + .circuit-3 {
 }
 
 .circuit-1 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;
@@ -1692,7 +1692,7 @@ select:active ~ .circuit-1 {
 }
 
 .circuit-2 {
-  color: #333333;
+  color: #666;
   display: block;
   z-index: 21;
   pointer-events: none;

--- a/src/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/src/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -25,11 +25,11 @@ HTMLCollection [
 }
 
 .circuit-0:checked + label {
-  background-color: #EDF4FC;
+  background-color: #F0F6FF;
 }
 
 .circuit-0:checked + label::before {
-  border: 2px solid #3388FF;
+  border: 2px solid #3063E9;
 }
 
 <input
@@ -45,7 +45,7 @@ HTMLCollection [
   cursor: pointer;
   padding: 16px 24px;
   border-radius: 6px;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
@@ -62,7 +62,7 @@ HTMLCollection [
   width: 100%;
   height: 100%;
   border-radius: 6px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   -webkit-transition: border 0.1s ease-in-out;
   transition: border 0.1s ease-in-out;
 }
@@ -72,15 +72,15 @@ HTMLCollection [
 }
 
 .circuit-0:hover::before {
-  border-color: #9DA7B1;
+  border-color: #999999;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:active::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 <label
@@ -117,11 +117,11 @@ HTMLCollection [
 }
 
 .circuit-0:checked + label {
-  background-color: #EDF4FC;
+  background-color: #F0F6FF;
 }
 
 .circuit-0:checked + label::before {
-  border: 2px solid #3388FF;
+  border: 2px solid #3063E9;
 }
 
 <input
@@ -136,7 +136,7 @@ HTMLCollection [
   cursor: pointer;
   padding: 16px 24px;
   border-radius: 6px;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
@@ -153,7 +153,7 @@ HTMLCollection [
   width: 100%;
   height: 100%;
   border-radius: 6px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   -webkit-transition: border 0.1s ease-in-out;
   transition: border 0.1s ease-in-out;
 }
@@ -163,15 +163,15 @@ HTMLCollection [
 }
 
 .circuit-0:hover::before {
-  border-color: #9DA7B1;
+  border-color: #999999;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:active::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 <label
@@ -208,11 +208,11 @@ HTMLCollection [
 }
 
 .circuit-0:checked + label {
-  background-color: #EDF4FC;
+  background-color: #F0F6FF;
 }
 
 .circuit-0:checked + label::before {
-  border: 2px solid #3388FF;
+  border: 2px solid #3063E9;
 }
 
 <input
@@ -228,7 +228,7 @@ HTMLCollection [
   cursor: pointer;
   padding: 16px 24px;
   border-radius: 6px;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
@@ -248,7 +248,7 @@ HTMLCollection [
   width: 100%;
   height: 100%;
   border-radius: 6px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   -webkit-transition: border 0.1s ease-in-out;
   transition: border 0.1s ease-in-out;
 }
@@ -258,15 +258,15 @@ HTMLCollection [
 }
 
 .circuit-0:hover::before {
-  border-color: #9DA7B1;
+  border-color: #999999;
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:active::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 <label

--- a/src/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/src/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -62,25 +62,25 @@ HTMLCollection [
   width: 100%;
   height: 100%;
   border-radius: 6px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   -webkit-transition: border 0.1s ease-in-out;
   transition: border 0.1s ease-in-out;
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-}
-
-.circuit-0:hover::before {
-  border-color: #999999;
-}
-
-.circuit-0:active {
   background-color: #F5F5F5;
 }
 
+.circuit-0:hover::before {
+  border-color: #999;
+}
+
+.circuit-0:active {
+  background-color: #E6E6E6;
+}
+
 .circuit-0:active::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 <label
@@ -153,25 +153,25 @@ HTMLCollection [
   width: 100%;
   height: 100%;
   border-radius: 6px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   -webkit-transition: border 0.1s ease-in-out;
   transition: border 0.1s ease-in-out;
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-}
-
-.circuit-0:hover::before {
-  border-color: #999999;
-}
-
-.circuit-0:active {
   background-color: #F5F5F5;
 }
 
+.circuit-0:hover::before {
+  border-color: #999;
+}
+
+.circuit-0:active {
+  background-color: #E6E6E6;
+}
+
 .circuit-0:active::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 <label
@@ -248,25 +248,25 @@ HTMLCollection [
   width: 100%;
   height: 100%;
   border-radius: 6px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   -webkit-transition: border 0.1s ease-in-out;
   transition: border 0.1s ease-in-out;
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
-}
-
-.circuit-0:hover::before {
-  border-color: #999999;
-}
-
-.circuit-0:active {
   background-color: #F5F5F5;
 }
 
+.circuit-0:hover::before {
+  border-color: #999;
+}
+
+.circuit-0:active {
+  background-color: #E6E6E6;
+}
+
 .circuit-0:active::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 <label

--- a/src/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/src/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -24,11 +24,11 @@ exports[`SelectorGroup should render with default styles 1`] = `
 }
 
 .circuit-0:checked + label {
-  background-color: #EDF4FC;
+  background-color: #F0F6FF;
 }
 
 .circuit-0:checked + label::before {
-  border: 2px solid #3388FF;
+  border: 2px solid #3063E9;
 }
 
 .circuit-1 {
@@ -36,7 +36,7 @@ exports[`SelectorGroup should render with default styles 1`] = `
   cursor: pointer;
   padding: 16px 24px;
   border-radius: 6px;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
@@ -53,7 +53,7 @@ exports[`SelectorGroup should render with default styles 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   -webkit-transition: border 0.1s ease-in-out;
   transition: border 0.1s ease-in-out;
 }
@@ -63,15 +63,15 @@ exports[`SelectorGroup should render with default styles 1`] = `
 }
 
 .circuit-1:hover::before {
-  border-color: #9DA7B1;
+  border-color: #999999;
 }
 
 .circuit-1:active {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
 }
 
 .circuit-1:active::before {
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 <div

--- a/src/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/src/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -53,25 +53,25 @@ exports[`SelectorGroup should render with default styles 1`] = `
   width: 100%;
   height: 100%;
   border-radius: 6px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   -webkit-transition: border 0.1s ease-in-out;
   transition: border 0.1s ease-in-out;
 }
 
 .circuit-1:hover {
-  background-color: #FAFBFC;
-}
-
-.circuit-1:hover::before {
-  border-color: #999999;
-}
-
-.circuit-1:active {
   background-color: #F5F5F5;
 }
 
+.circuit-1:hover::before {
+  border-color: #999;
+}
+
+.circuit-1:active {
+  background-color: #E6E6E6;
+}
+
 .circuit-1:active::before {
-  border-color: #333333;
+  border-color: #666;
 }
 
 <div

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -12,7 +12,7 @@ HTMLCollection [
   flex-direction: column;
   height: 100%;
   min-width: 256px;
-  background-color: #212933;
+  background-color: #000000;
   -webkit-transition: -webkit-transform 120ms ease-in-out;
   -webkit-transition: transform 120ms ease-in-out;
   transition: transform 120ms ease-in-out;
@@ -51,7 +51,7 @@ HTMLCollection [
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: #212933;
+  background-color: #000000;
   -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   visibility: hidden;
@@ -111,9 +111,9 @@ HTMLCollection [
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -149,12 +149,12 @@ HTMLCollection [
 
 .circuit-2:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-2:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 @media (min-width:960px) {
@@ -205,7 +205,7 @@ HTMLCollection [
   flex-direction: column;
   height: 100%;
   min-width: 256px;
-  background-color: #212933;
+  background-color: #000000;
   -webkit-transition: -webkit-transform 120ms ease-in-out;
   -webkit-transition: transform 120ms ease-in-out;
   transition: transform 120ms ease-in-out;
@@ -232,7 +232,7 @@ HTMLCollection [
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: #212933;
+  background-color: #000000;
   -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   visibility: hidden;
@@ -277,9 +277,9 @@ HTMLCollection [
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -313,12 +313,12 @@ HTMLCollection [
 
 .circuit-2:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-2:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 @media (min-width:960px) {

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -12,7 +12,7 @@ HTMLCollection [
   flex-direction: column;
   height: 100%;
   min-width: 256px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   -webkit-transition: -webkit-transform 120ms ease-in-out;
   -webkit-transition: transform 120ms ease-in-out;
   transition: transform 120ms ease-in-out;
@@ -51,7 +51,7 @@ HTMLCollection [
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: #000000;
+  background-color: #1A1A1A;
   -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   visibility: hidden;
@@ -112,8 +112,8 @@ HTMLCollection [
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -148,13 +148,13 @@ HTMLCollection [
 }
 
 .circuit-2:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-2:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 @media (min-width:960px) {
@@ -205,7 +205,7 @@ HTMLCollection [
   flex-direction: column;
   height: 100%;
   min-width: 256px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   -webkit-transition: -webkit-transform 120ms ease-in-out;
   -webkit-transition: transform 120ms ease-in-out;
   transition: transform 120ms ease-in-out;
@@ -232,7 +232,7 @@ HTMLCollection [
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: #000000;
+  background-color: #1A1A1A;
   -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   visibility: hidden;
@@ -278,8 +278,8 @@ HTMLCollection [
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -312,13 +312,13 @@ HTMLCollection [
 }
 
 .circuit-2:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-2:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 @media (min-width:960px) {

--- a/src/components/Sidebar/components/Aggregator/__snapshots__/Aggregator.spec.tsx.snap
+++ b/src/components/Sidebar/components/Aggregator/__snapshots__/Aggregator.spec.tsx.snap
@@ -18,11 +18,11 @@ HTMLCollection [
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #9DA7B1;
+  color: #999999;
 }
 
 .circuit-2:hover {
-  color: #D8DDE1;
+  color: #E6E6E6;
 }
 
 .circuit-0 {
@@ -59,7 +59,7 @@ HTMLCollection [
 .circuit-0::after {
   content: '';
   width: 2px;
-  background: #3388FF;
+  background: #3063E9;
   height: 32px;
   border-radius: 1px;
   position: absolute;
@@ -71,7 +71,7 @@ HTMLCollection [
 .circuit-0::before {
   content: '';
   width: 2px;
-  background: #5C656F;
+  background: #333333;
   height: calc(32px * );
   position: absolute;
   top: 0;
@@ -108,11 +108,11 @@ HTMLCollection [
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #9DA7B1;
+  color: #999999;
 }
 
 .circuit-2:hover {
-  color: #D8DDE1;
+  color: #E6E6E6;
 }
 
 .circuit-0 {
@@ -143,7 +143,7 @@ HTMLCollection [
 .circuit-0::after {
   content: '';
   width: 2px;
-  background: #3388FF;
+  background: #3063E9;
   height: 32px;
   border-radius: 1px;
   position: absolute;
@@ -155,7 +155,7 @@ HTMLCollection [
 .circuit-0::before {
   content: '';
   width: 2px;
-  background: #5C656F;
+  background: #333333;
   height: calc(32px * );
   position: absolute;
   top: 0;
@@ -195,9 +195,9 @@ exports[`Aggregator styles should render with disabled state styles and match th
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #9DA7B1;
+  color: #999999;
   cursor: not-allowed;
-  color: #5C656F;
+  color: #333333;
 }
 
 <div

--- a/src/components/Sidebar/components/Aggregator/__snapshots__/Aggregator.spec.tsx.snap
+++ b/src/components/Sidebar/components/Aggregator/__snapshots__/Aggregator.spec.tsx.snap
@@ -18,11 +18,11 @@ HTMLCollection [
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #999999;
+  color: #999;
 }
 
 .circuit-2:hover {
-  color: #E6E6E6;
+  color: #CCC;
 }
 
 .circuit-0 {
@@ -71,7 +71,7 @@ HTMLCollection [
 .circuit-0::before {
   content: '';
   width: 2px;
-  background: #333333;
+  background: #666;
   height: calc(32px * );
   position: absolute;
   top: 0;
@@ -108,11 +108,11 @@ HTMLCollection [
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #999999;
+  color: #999;
 }
 
 .circuit-2:hover {
-  color: #E6E6E6;
+  color: #CCC;
 }
 
 .circuit-0 {
@@ -155,7 +155,7 @@ HTMLCollection [
 .circuit-0::before {
   content: '';
   width: 2px;
-  background: #333333;
+  background: #666;
   height: calc(32px * );
   position: absolute;
   top: 0;
@@ -195,9 +195,9 @@ exports[`Aggregator styles should render with disabled state styles and match th
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #999999;
+  color: #999;
   cursor: not-allowed;
-  color: #333333;
+  color: #666;
 }
 
 <div

--- a/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
+++ b/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Backdrop styles should render with default styles when not visible 1`] 
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: #212933;
+  background-color: #000000;
   -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   visibility: hidden;
@@ -29,7 +29,7 @@ exports[`Backdrop styles should render with default styles when visible 1`] = `
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: #212933;
+  background-color: #000000;
   -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   visibility: hidden;

--- a/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
+++ b/src/components/Sidebar/components/Backdrop/__snapshots__/Backdrop.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Backdrop styles should render with default styles when not visible 1`] 
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: #000000;
+  background-color: #1A1A1A;
   -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   visibility: hidden;
@@ -29,7 +29,7 @@ exports[`Backdrop styles should render with default styles when visible 1`] = `
   width: 100%;
   height: 100%;
   position: absolute;
-  background-color: #000000;
+  background-color: #1A1A1A;
   -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
   visibility: hidden;

--- a/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -28,9 +28,9 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -64,12 +64,12 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
 
 .circuit-2:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-2:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 @media (min-width:960px) {
@@ -160,9 +160,9 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #FFFFFF;
-  border-color: #9DA7B1;
-  color: #323E49;
+  background-color: #FFF;
+  border-color: #999999;
+  color: #1A1A1A;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -198,12 +198,12 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
 
 .circuit-2:hover {
   background-color: #FAFBFC;
-  border-color: #5C656F;
+  border-color: #333333;
 }
 
 .circuit-2:active {
-  background-color: #EEF0F2;
-  border-color: #323E49;
+  background-color: #F5F5F5;
+  border-color: #1A1A1A;
 }
 
 @media (min-width:960px) {

--- a/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/src/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -29,8 +29,8 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -63,13 +63,13 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
 }
 
 .circuit-2:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-2:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 @media (min-width:960px) {
@@ -161,8 +161,8 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   background-color: #FFF;
-  border-color: #999999;
-  color: #1A1A1A;
+  border-color: #999;
+  color: #333;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 12px;
@@ -197,13 +197,13 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
 }
 
 .circuit-2:hover {
-  background-color: #FAFBFC;
-  border-color: #333333;
+  background-color: #F5F5F5;
+  border-color: #666;
 }
 
 .circuit-2:active {
-  background-color: #F5F5F5;
-  border-color: #1A1A1A;
+  background-color: #E6E6E6;
+  border-color: #333;
 }
 
 @media (min-width:960px) {

--- a/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
@@ -4,7 +4,7 @@ exports[`Footer styles should render with default styles 1`] = `
 .circuit-0 {
   margin-top: auto;
   padding: 24px;
-  background-color: #212933;
+  background-color: #000000;
   color: #FAFBFC;
 }
 

--- a/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Sidebar/components/Footer/__snapshots__/Footer.spec.js.snap
@@ -4,8 +4,8 @@ exports[`Footer styles should render with default styles 1`] = `
 .circuit-0 {
   margin-top: auto;
   padding: 24px;
-  background-color: #000000;
-  color: #FAFBFC;
+  background-color: #1A1A1A;
+  color: #F5F5F5;
 }
 
 <footer

--- a/src/components/Sidebar/components/Header/Header.js
+++ b/src/components/Sidebar/components/Header/Header.js
@@ -26,7 +26,7 @@ const baseStyles = ({ theme }) => css`
   min-height: 64px;
   width: 100%;
   padding: ${theme.spacings.mega};
-  background-color: ${theme.colors.bodyColor};
+  background-color: ${theme.colors.black};
   color: ${theme.colors.n100};
 `;
 

--- a/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
@@ -20,7 +20,7 @@ exports[`Header styles should render with default styles 1`] = `
   min-height: 64px;
   width: 100%;
   padding: 16px;
-  background-color: #0F131A;
+  background-color: #000;
   color: #FAFBFC;
 }
 

--- a/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
@@ -20,7 +20,7 @@ exports[`Header styles should render with default styles 1`] = `
   min-height: 64px;
   width: 100%;
   padding: 16px;
-  background-color: #000;
+  background-color: #0F131A;
   color: #F5F5F5;
 }
 

--- a/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
@@ -20,7 +20,7 @@ exports[`Header styles should render with default styles 1`] = `
   min-height: 64px;
   width: 100%;
   padding: 16px;
-  background-color: #0F131A;
+  background-color: #000;
   color: #F5F5F5;
 }
 

--- a/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Sidebar/components/Header/__snapshots__/Header.spec.js.snap
@@ -21,7 +21,7 @@ exports[`Header styles should render with default styles 1`] = `
   width: 100%;
   padding: 16px;
   background-color: #000;
-  color: #FAFBFC;
+  color: #F5F5F5;
 }
 
 <header

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -22,13 +22,13 @@ exports[`NavItem styles should render with default styles and match the snapshot
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #9DA7B1;
+  color: #999999;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .circuit-2:hover {
-  color: #D8DDE1;
+  color: #E6E6E6;
 }
 
 .circuit-0 {
@@ -70,7 +70,7 @@ exports[`NavItem styles should render with default styles and match the snapshot
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #9DA7B1;
+  color: #999999;
   -webkit-text-decoration: none;
   text-decoration: none;
   margin: 0px 24px;
@@ -80,7 +80,7 @@ exports[`NavItem styles should render with default styles and match the snapshot
 }
 
 .circuit-2:hover {
-  color: #D8DDE1;
+  color: #E6E6E6;
 }
 
 .circuit-0 {
@@ -131,11 +131,11 @@ exports[`NavItem styles should render with disabled state styles and match the s
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #9DA7B1;
+  color: #999999;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: not-allowed;
-  color: #5C656F;
+  color: #333333;
 }
 
 <li
@@ -178,7 +178,7 @@ exports[`NavItem styles should render with selected state styles and match the s
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #9DA7B1;
+  color: #999999;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 700;

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -22,13 +22,13 @@ exports[`NavItem styles should render with default styles and match the snapshot
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #999999;
+  color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 .circuit-2:hover {
-  color: #E6E6E6;
+  color: #CCC;
 }
 
 .circuit-0 {
@@ -70,7 +70,7 @@ exports[`NavItem styles should render with default styles and match the snapshot
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #999999;
+  color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
   margin: 0px 24px;
@@ -80,7 +80,7 @@ exports[`NavItem styles should render with default styles and match the snapshot
 }
 
 .circuit-2:hover {
-  color: #E6E6E6;
+  color: #CCC;
 }
 
 .circuit-0 {
@@ -131,11 +131,11 @@ exports[`NavItem styles should render with disabled state styles and match the s
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #999999;
+  color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: not-allowed;
-  color: #333333;
+  color: #666;
 }
 
 <li
@@ -178,11 +178,11 @@ exports[`NavItem styles should render with selected state styles and match the s
   margin: 16px;
   padding: 4px;
   cursor: pointer;
-  color: #999999;
+  color: #999;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-weight: 700;
-  color: #FAFBFC;
+  color: #F5F5F5;
 }
 
 <li

--- a/src/components/Sidebar/components/Separator/__snapshots__/Separator.spec.js.snap
+++ b/src/components/Sidebar/components/Separator/__snapshots__/Separator.spec.js.snap
@@ -4,10 +4,10 @@ exports[`Separator should render with default styles 1`] = `
 .circuit-0 {
   display: block;
   width: 100%;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   margin-top: 16px;
   margin-bottom: 16px;
-  border: 1px solid #323E49;
+  border: 1px solid #1A1A1A;
 }
 
 <hr

--- a/src/components/Sidebar/components/Separator/__snapshots__/Separator.spec.js.snap
+++ b/src/components/Sidebar/components/Separator/__snapshots__/Separator.spec.js.snap
@@ -4,10 +4,10 @@ exports[`Separator should render with default styles 1`] = `
 .circuit-0 {
   display: block;
   width: 100%;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   margin-top: 16px;
   margin-bottom: 16px;
-  border: 1px solid #1A1A1A;
+  border: 1px solid #333;
 }
 
 <hr

--- a/src/components/Sidebar/components/SubNavList/__snapshots__/SubNavList.spec.js.snap
+++ b/src/components/Sidebar/components/SubNavList/__snapshots__/SubNavList.spec.js.snap
@@ -14,7 +14,7 @@ exports[`SubNavList styles should render with default styles when there is a sel
 .circuit-0::after {
   content: '';
   width: 2px;
-  background: #3388FF;
+  background: #3063E9;
   height: 32px;
   border-radius: 1px;
   position: absolute;
@@ -26,7 +26,7 @@ exports[`SubNavList styles should render with default styles when there is a sel
 .circuit-0::before {
   content: '';
   width: 2px;
-  background: #5C656F;
+  background: #333333;
   height: calc(32px * 2);
   position: absolute;
   top: 0;
@@ -59,7 +59,7 @@ exports[`SubNavList styles should render with default styles when there is no se
 .circuit-0::before {
   content: '';
   width: 2px;
-  background: #5C656F;
+  background: #333333;
   height: calc(32px * 2);
   position: absolute;
   top: 0;
@@ -92,7 +92,7 @@ exports[`SubNavList styles should render without children 1`] = `
 .circuit-0::after {
   content: '';
   width: 2px;
-  background: #3388FF;
+  background: #3063E9;
   height: 32px;
   border-radius: 1px;
   position: absolute;

--- a/src/components/Sidebar/components/SubNavList/__snapshots__/SubNavList.spec.js.snap
+++ b/src/components/Sidebar/components/SubNavList/__snapshots__/SubNavList.spec.js.snap
@@ -26,7 +26,7 @@ exports[`SubNavList styles should render with default styles when there is a sel
 .circuit-0::before {
   content: '';
   width: 2px;
-  background: #333333;
+  background: #666;
   height: calc(32px * 2);
   position: absolute;
   top: 0;
@@ -59,7 +59,7 @@ exports[`SubNavList styles should render with default styles when there is no se
 .circuit-0::before {
   content: '';
   width: 2px;
-  background: #333333;
+  background: #666;
   height: calc(32px * 2);
   position: absolute;
   top: 0;

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -19,7 +19,7 @@ exports[`Table Style tests should not render a scrollable table if the rowHeader
 }
 
 .circuit-54 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-collapse: separate;
   width: 100%;
 }
@@ -51,14 +51,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -103,7 +103,7 @@ tbody .circuit-20:last-child td {
 .circuit-6:focus-within,
 .circuit-6:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-6:focus-within > button,
@@ -134,7 +134,7 @@ tbody .circuit-20:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -170,8 +170,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-8 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -194,14 +194,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-16 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -236,7 +236,7 @@ tbody .circuit-20:last-child td {
 .circuit-16:focus-within,
 .circuit-16:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-16:focus-within > button,
@@ -245,14 +245,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-18 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -260,8 +260,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-24 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -280,8 +280,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-26 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -301,8 +301,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-28 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -570,14 +570,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -622,7 +622,7 @@ tbody .circuit-20:last-child td {
 .circuit-6:focus-within,
 .circuit-6:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-6:focus-within > button,
@@ -653,7 +653,7 @@ tbody .circuit-20:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -689,8 +689,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-8 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -713,14 +713,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-16 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -755,7 +755,7 @@ tbody .circuit-20:last-child td {
 .circuit-16:focus-within,
 .circuit-16:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-16:focus-within > button,
@@ -764,14 +764,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-18 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -779,8 +779,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-24 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -799,8 +799,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-26 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -820,8 +820,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-28 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -831,7 +831,7 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-54 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-collapse: separate;
   width: 100%;
   border-collapse: collapse;
@@ -1104,7 +1104,7 @@ exports[`Table Style tests should render a condensed table 1`] = `
 }
 
 .circuit-54 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-collapse: separate;
   width: 100%;
 }
@@ -1158,7 +1158,7 @@ tbody .circuit-20:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -1194,14 +1194,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -1251,7 +1251,7 @@ tbody .circuit-20:last-child td {
 .circuit-6:focus-within,
 .circuit-6:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-6:focus-within > button,
@@ -1260,8 +1260,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-8 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -1291,14 +1291,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-16 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -1338,7 +1338,7 @@ tbody .circuit-20:last-child td {
 .circuit-16:focus-within,
 .circuit-16:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-16:focus-within > button,
@@ -1347,14 +1347,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-18 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -1367,8 +1367,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-24 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -1391,8 +1391,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-26 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -1418,8 +1418,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-28 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -1695,7 +1695,7 @@ tbody .circuit-18:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -1731,14 +1731,14 @@ tbody .circuit-18:last-child td {
 }
 
 .circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -1773,7 +1773,7 @@ tbody .circuit-18:last-child td {
 .circuit-6:focus-within,
 .circuit-6:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-6:focus-within > button,
@@ -1782,14 +1782,14 @@ tbody .circuit-18:last-child td {
 }
 
 .circuit-16 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -1797,8 +1797,8 @@ tbody .circuit-18:last-child td {
 }
 
 .circuit-22 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -1820,7 +1820,7 @@ tbody .circuit-18:last-child td {
 }
 
 .circuit-46 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-collapse: separate;
   width: 100%;
 }
@@ -2063,7 +2063,7 @@ exports[`Table Style tests should render with default styles 1`] = `
 }
 
 .circuit-54 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-collapse: separate;
   width: 100%;
 }
@@ -2095,14 +2095,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2147,7 +2147,7 @@ tbody .circuit-20:last-child td {
 .circuit-6:focus-within,
 .circuit-6:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-6:focus-within > button,
@@ -2178,7 +2178,7 @@ tbody .circuit-20:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -2214,8 +2214,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-8 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2238,14 +2238,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-16 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2280,7 +2280,7 @@ tbody .circuit-20:last-child td {
 .circuit-16:focus-within,
 .circuit-16:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-16:focus-within > button,
@@ -2289,14 +2289,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-18 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2304,8 +2304,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-24 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -2324,8 +2324,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-26 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2345,8 +2345,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-28 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2605,7 +2605,7 @@ exports[`Table Style tests should render with rowHeader styles 1`] = `
 }
 
 .circuit-54 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-collapse: separate;
   width: 100%;
 }
@@ -2637,14 +2637,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2689,7 +2689,7 @@ tbody .circuit-20:last-child td {
 .circuit-6:focus-within,
 .circuit-6:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-6:focus-within > button,
@@ -2720,7 +2720,7 @@ tbody .circuit-20:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -2756,8 +2756,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-8 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2780,14 +2780,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-16 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2822,7 +2822,7 @@ tbody .circuit-20:last-child td {
 .circuit-16:focus-within,
 .circuit-16:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-16:focus-within > button,
@@ -2831,14 +2831,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-18 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2846,8 +2846,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-24 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -2866,8 +2866,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-26 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2887,8 +2887,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-28 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -3142,7 +3142,7 @@ exports[`Table Style tests should render without the table shadow 1`] = `
 }
 
 .circuit-54 {
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border-collapse: separate;
   width: 100%;
 }
@@ -3174,14 +3174,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -3226,7 +3226,7 @@ tbody .circuit-20:last-child td {
 .circuit-6:focus-within,
 .circuit-6:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-6:focus-within > button,
@@ -3257,7 +3257,7 @@ tbody .circuit-20:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -3293,8 +3293,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-8 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -3317,14 +3317,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-16 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -3359,7 +3359,7 @@ tbody .circuit-20:last-child td {
 .circuit-16:focus-within,
 .circuit-16:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-16:focus-within > button,
@@ -3368,14 +3368,14 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-18 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -3383,8 +3383,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-24 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -3403,8 +3403,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-26 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -3424,8 +3424,8 @@ tbody .circuit-20:last-child td {
 }
 
 .circuit-28 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;

--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -52,13 +52,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-6 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -102,7 +102,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-6:focus-within,
 .circuit-6:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -171,7 +171,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-8 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -195,13 +195,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-16 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -235,7 +235,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-16:focus-within,
 .circuit-16:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -246,13 +246,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-18 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -261,7 +261,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-24 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -281,7 +281,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-26 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -302,7 +302,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-28 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -571,13 +571,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-6 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -621,7 +621,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-6:focus-within,
 .circuit-6:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -690,7 +690,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-8 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -714,13 +714,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-16 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -754,7 +754,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-16:focus-within,
 .circuit-16:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -765,13 +765,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-18 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -780,7 +780,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-24 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -800,7 +800,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-26 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -821,7 +821,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-28 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -1195,13 +1195,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-6 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -1250,7 +1250,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-6:focus-within,
 .circuit-6:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -1261,7 +1261,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-8 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -1292,13 +1292,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-16 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -1337,7 +1337,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-16:focus-within,
 .circuit-16:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -1348,13 +1348,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-18 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -1368,7 +1368,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-24 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -1392,7 +1392,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-26 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -1419,7 +1419,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-28 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -1732,13 +1732,13 @@ tbody .circuit-18:last-child td {
 
 .circuit-6 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -1772,7 +1772,7 @@ tbody .circuit-18:last-child td {
 
 .circuit-6:focus-within,
 .circuit-6:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -1783,13 +1783,13 @@ tbody .circuit-18:last-child td {
 
 .circuit-16 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -1798,7 +1798,7 @@ tbody .circuit-18:last-child td {
 
 .circuit-22 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2096,13 +2096,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-6 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2146,7 +2146,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-6:focus-within,
 .circuit-6:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -2215,7 +2215,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-8 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2239,13 +2239,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-16 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2279,7 +2279,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-16:focus-within,
 .circuit-16:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -2290,13 +2290,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-18 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2305,7 +2305,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-24 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -2325,7 +2325,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-26 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2346,7 +2346,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-28 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2638,13 +2638,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-6 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2688,7 +2688,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-6:focus-within,
 .circuit-6:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -2757,7 +2757,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-8 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2781,13 +2781,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-16 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2821,7 +2821,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-16:focus-within,
 .circuit-16:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -2832,13 +2832,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-18 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -2847,7 +2847,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-24 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -2867,7 +2867,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-26 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -2888,7 +2888,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-28 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -3175,13 +3175,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-6 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -3225,7 +3225,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-6:focus-within,
 .circuit-6:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -3294,7 +3294,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-8 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -3318,13 +3318,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-16 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -3358,7 +3358,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-16:focus-within,
 .circuit-16:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -3369,13 +3369,13 @@ tbody .circuit-20:last-child td {
 
 .circuit-18 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -3384,7 +3384,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-24 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -3404,7 +3404,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-26 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -3425,7 +3425,7 @@ tbody .circuit-20:last-child td {
 
 .circuit-28 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;

--- a/src/components/Table/components/SortArrow/__snapshots__/SortArrow.spec.js.snap
+++ b/src/components/Table/components/SortArrow/__snapshots__/SortArrow.spec.js.snap
@@ -24,7 +24,7 @@ exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -112,7 +112,7 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -216,7 +216,7 @@ exports[`SortArrow Style tests should render with descending arrow styles 1`] = 
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;

--- a/src/components/Table/components/TableBody/__snapshots__/TableBody.spec.js.snap
+++ b/src/components/Table/components/TableBody/__snapshots__/TableBody.spec.js.snap
@@ -11,8 +11,8 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -53,8 +53,8 @@ tbody .circuit-6:last-child td {
 }
 
 .circuit-4 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -64,8 +64,8 @@ tbody .circuit-6:last-child td {
 }
 
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -84,8 +84,8 @@ tbody .circuit-6:last-child td {
 }
 
 .circuit-2 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -144,8 +144,8 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -186,8 +186,8 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-2 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -197,8 +197,8 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;

--- a/src/components/Table/components/TableBody/__snapshots__/TableBody.spec.js.snap
+++ b/src/components/Table/components/TableBody/__snapshots__/TableBody.spec.js.snap
@@ -12,7 +12,7 @@ tbody .circuit-4:last-child td {
 
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -54,7 +54,7 @@ tbody .circuit-6:last-child td {
 
 .circuit-4 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -65,7 +65,7 @@ tbody .circuit-6:last-child td {
 
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -85,7 +85,7 @@ tbody .circuit-6:last-child td {
 
 .circuit-2 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -145,7 +145,7 @@ tbody .circuit-4:last-child td {
 
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -187,7 +187,7 @@ tbody .circuit-4:last-child td {
 
 .circuit-2 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -198,14 +198,14 @@ tbody .circuit-4:last-child td {
 
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
   white-space: nowrap;
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
 }
 
 <tbody>

--- a/src/components/Table/components/TableCell/__snapshots__/TableCell.spec.js.snap
+++ b/src/components/Table/components/TableCell/__snapshots__/TableCell.spec.js.snap
@@ -2,8 +2,8 @@
 
 exports[`TableCell Style tests should render with condensed styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -25,8 +25,8 @@ exports[`TableCell Style tests should render with condensed styles 1`] = `
 
 exports[`TableCell Style tests should render with default styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -45,8 +45,8 @@ exports[`TableCell Style tests should render with default styles 1`] = `
 
 exports[`TableCell Style tests should render with header styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -65,8 +65,8 @@ exports[`TableCell Style tests should render with header styles 1`] = `
 
 exports[`TableCell Style tests should render with isHovered styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;

--- a/src/components/Table/components/TableCell/__snapshots__/TableCell.spec.js.snap
+++ b/src/components/Table/components/TableCell/__snapshots__/TableCell.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`TableCell Style tests should render with condensed styles 1`] = `
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -26,7 +26,7 @@ exports[`TableCell Style tests should render with condensed styles 1`] = `
 exports[`TableCell Style tests should render with default styles 1`] = `
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -46,7 +46,7 @@ exports[`TableCell Style tests should render with default styles 1`] = `
 exports[`TableCell Style tests should render with header styles 1`] = `
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
@@ -66,14 +66,14 @@ exports[`TableCell Style tests should render with header styles 1`] = `
 exports[`TableCell Style tests should render with isHovered styles 1`] = `
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
   white-space: nowrap;
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
 }
 
 <td

--- a/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
+++ b/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
@@ -11,14 +11,14 @@ tbody .circuit-12:last-child td {
 }
 
 .circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -53,7 +53,7 @@ tbody .circuit-12:last-child td {
 .circuit-6:focus-within,
 .circuit-6:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-6:focus-within > button,
@@ -84,7 +84,7 @@ tbody .circuit-12:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -120,14 +120,14 @@ tbody .circuit-12:last-child td {
 }
 
 .circuit-8 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -217,14 +217,14 @@ tbody .circuit-12:last-child td {
 }
 
 .circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -259,7 +259,7 @@ tbody .circuit-12:last-child td {
 .circuit-6:focus-within,
 .circuit-6:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-6:focus-within > button,
@@ -290,7 +290,7 @@ tbody .circuit-12:last-child td {
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -326,14 +326,14 @@ tbody .circuit-12:last-child td {
 }
 
 .circuit-8 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;

--- a/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
+++ b/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
@@ -12,13 +12,13 @@ tbody .circuit-12:last-child td {
 
 .circuit-6 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -52,7 +52,7 @@ tbody .circuit-12:last-child td {
 
 .circuit-6:focus-within,
 .circuit-6:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -121,13 +121,13 @@ tbody .circuit-12:last-child td {
 
 .circuit-8 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -218,13 +218,13 @@ tbody .circuit-12:last-child td {
 
 .circuit-6 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -258,7 +258,7 @@ tbody .circuit-12:last-child td {
 
 .circuit-6:focus-within,
 .circuit-6:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -327,13 +327,13 @@ tbody .circuit-12:last-child td {
 
 .circuit-8 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;

--- a/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
@@ -2,14 +2,14 @@
 
 exports[`TableHeader Style tests should render with condensed styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -31,14 +31,14 @@ exports[`TableHeader Style tests should render with condensed styles 1`] = `
 
 exports[`TableHeader Style tests should render with default styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -55,15 +55,15 @@ exports[`TableHeader Style tests should render with default styles 1`] = `
 
 exports[`TableHeader Style tests should render with hovered styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
   background-color: #FAFBFC;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -80,8 +80,8 @@ exports[`TableHeader Style tests should render with hovered styles 1`] = `
 
 exports[`TableHeader Style tests should render with row styles 1`] = `
 .circuit-0 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -99,14 +99,14 @@ exports[`TableHeader Style tests should render with row styles 1`] = `
 
 exports[`TableHeader Style tests should render with sortable styles 1`] = `
 .circuit-6 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -141,7 +141,7 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
 .circuit-6:focus-within,
 .circuit-6:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-6:focus-within > button,
@@ -172,7 +172,7 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -284,7 +284,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -320,14 +320,14 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 }
 
 .circuit-5 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -362,7 +362,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 .circuit-5:focus-within,
 .circuit-5:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-5:focus-within > button,
@@ -434,7 +434,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   transform: translateY(-50%);
   -webkit-transition: opacity 120ms ease-in-out;
   transition: opacity 120ms ease-in-out;
-  color: #3388FF;
+  color: #3063E9;
   border: 0;
   background: none;
   outline: 0;
@@ -470,14 +470,14 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 }
 
 .circuit-5 {
-  background-color: #FFFFFF;
-  border-bottom: 1px solid #D8DDE1;
+  background-color: #FFF;
+  border-bottom: 1px solid #E6E6E6;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #5C656F;
+  color: #333333;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -512,7 +512,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 .circuit-5:focus-within,
 .circuit-5:hover {
   background-color: #FAFBFC;
-  color: #3388FF;
+  color: #3063E9;
 }
 
 .circuit-5:focus-within > button,

--- a/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
@@ -3,13 +3,13 @@
 exports[`TableHeader Style tests should render with condensed styles 1`] = `
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -32,13 +32,13 @@ exports[`TableHeader Style tests should render with condensed styles 1`] = `
 exports[`TableHeader Style tests should render with default styles 1`] = `
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -56,14 +56,14 @@ exports[`TableHeader Style tests should render with default styles 1`] = `
 exports[`TableHeader Style tests should render with hovered styles 1`] = `
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  background-color: #FAFBFC;
-  color: #333333;
+  background-color: #F5F5F5;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -81,7 +81,7 @@ exports[`TableHeader Style tests should render with hovered styles 1`] = `
 exports[`TableHeader Style tests should render with row styles 1`] = `
 .circuit-0 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
@@ -100,13 +100,13 @@ exports[`TableHeader Style tests should render with row styles 1`] = `
 exports[`TableHeader Style tests should render with sortable styles 1`] = `
 .circuit-6 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -140,7 +140,7 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
 
 .circuit-6:focus-within,
 .circuit-6:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -321,13 +321,13 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 
 .circuit-5 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -361,7 +361,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 
 .circuit-5:focus-within,
 .circuit-5:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 
@@ -471,13 +471,13 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 
 .circuit-5 {
   background-color: #FFF;
-  border-bottom: 1px solid #E6E6E6;
+  border-bottom: 1px solid #CCC;
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   white-space: nowrap;
-  color: #333333;
+  color: #666;
   font-size: 13px;
   font-weight: 700;
   padding: 8px 24px;
@@ -511,7 +511,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 
 .circuit-5:focus-within,
 .circuit-5:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
   color: #3063E9;
 }
 

--- a/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
+++ b/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
@@ -29,7 +29,7 @@ tbody .circuit-0:focus td,
 tbody .circuit-0:hover td,
 tbody .circuit-0:focus th,
 tbody .circuit-0:hover th {
-  color: #3388FF;
+  color: #3063E9;
   background-color: #FAFBFC;
 }
 

--- a/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
+++ b/src/components/Table/components/TableRow/__snapshots__/TableRow.spec.js.snap
@@ -30,7 +30,7 @@ tbody .circuit-0:hover td,
 tbody .circuit-0:focus th,
 tbody .circuit-0:hover th {
   color: #3063E9;
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
 }
 
 <tr

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -8,7 +8,7 @@ exports[`Tabs styles should render with default styles 1`] = `
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
   scrollbar-width: none;
-  background: #FFFFFF;
+  background: #FFF;
   height: 80px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -51,11 +51,11 @@ exports[`Tabs styles should render with default styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #5C656F;
+  color: #333333;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -83,7 +83,7 @@ exports[`Tabs styles should render with default styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:focus {
@@ -99,11 +99,11 @@ exports[`Tabs styles should render with default styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #5C656F;
+  color: #333333;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -125,7 +125,7 @@ exports[`Tabs styles should render with default styles 1`] = `
   justify-content: center;
   outline: none;
   position: relative;
-  color: #212933;
+  color: #000000;
 }
 
 .circuit-2:hover {
@@ -133,7 +133,7 @@ exports[`Tabs styles should render with default styles 1`] = `
 }
 
 .circuit-2:active {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
 }
 
 .circuit-2:focus {
@@ -153,7 +153,7 @@ exports[`Tabs styles should render with default styles 1`] = `
   right: 0;
   width: 100%;
   height: 4px;
-  background: #3388FF;
+  background: #3063E9;
 }
 
 <div
@@ -190,7 +190,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
   scrollbar-width: none;
-  background: #FFFFFF;
+  background: #FFF;
   height: 80px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -207,11 +207,11 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #5C656F;
+  color: #333333;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -239,7 +239,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:focus {
@@ -255,11 +255,11 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #5C656F;
+  color: #333333;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -281,7 +281,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   justify-content: center;
   outline: none;
   position: relative;
-  color: #212933;
+  color: #000000;
 }
 
 .circuit-2:hover {
@@ -289,7 +289,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
 }
 
 .circuit-2:active {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
 }
 
 .circuit-2:focus {
@@ -309,7 +309,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   right: 0;
   width: 100%;
   height: 4px;
-  background: #3388FF;
+  background: #3063E9;
 }
 
 .circuit-4 {

--- a/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -51,7 +51,7 @@ exports[`Tabs styles should render with default styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #333333;
+  color: #666;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -79,11 +79,11 @@ exports[`Tabs styles should render with default styles 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
 }
 
 .circuit-0:focus {
@@ -99,7 +99,7 @@ exports[`Tabs styles should render with default styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #333333;
+  color: #666;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -125,15 +125,15 @@ exports[`Tabs styles should render with default styles 1`] = `
   justify-content: center;
   outline: none;
   position: relative;
-  color: #000000;
+  color: #1A1A1A;
 }
 
 .circuit-2:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
 }
 
 .circuit-2:active {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
 }
 
 .circuit-2:focus {
@@ -207,7 +207,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #333333;
+  color: #666;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -235,11 +235,11 @@ exports[`Tabs styles should render with stretched styles 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
 }
 
 .circuit-0:focus {
@@ -255,7 +255,7 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #333333;
+  color: #666;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -281,15 +281,15 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   justify-content: center;
   outline: none;
   position: relative;
-  color: #000000;
+  color: #1A1A1A;
 }
 
 .circuit-2:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
 }
 
 .circuit-2:active {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
 }
 
 .circuit-2:focus {

--- a/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
+++ b/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
@@ -5,11 +5,11 @@ exports[`Tab styles should render with default styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #5C656F;
+  color: #333333;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -37,7 +37,7 @@ exports[`Tab styles should render with default styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:focus {
@@ -64,11 +64,11 @@ exports[`Tab styles should render with selected styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #5C656F;
+  color: #333333;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   white-space: nowrap;
   height: 100%;
@@ -90,7 +90,7 @@ exports[`Tab styles should render with selected styles 1`] = `
   justify-content: center;
   outline: none;
   position: relative;
-  color: #212933;
+  color: #000000;
 }
 
 .circuit-0:hover {
@@ -98,7 +98,7 @@ exports[`Tab styles should render with selected styles 1`] = `
 }
 
 .circuit-0:active {
-  background-color: #EEF0F2;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:focus {
@@ -118,7 +118,7 @@ exports[`Tab styles should render with selected styles 1`] = `
   right: 0;
   width: 100%;
   height: 4px;
-  background: #3388FF;
+  background: #3063E9;
 }
 
 <button

--- a/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
+++ b/src/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Tab styles should render with default styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #333333;
+  color: #666;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -33,11 +33,11 @@ exports[`Tab styles should render with default styles 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
 }
 
 .circuit-0:focus {
@@ -64,7 +64,7 @@ exports[`Tab styles should render with selected styles 1`] = `
   font-size: 16px;
   line-height: 24px;
   padding: 12px 32px;
-  color: #333333;
+  color: #666;
   -webkit-text-decoration: none;
   text-decoration: none;
   cursor: pointer;
@@ -90,15 +90,15 @@ exports[`Tab styles should render with selected styles 1`] = `
   justify-content: center;
   outline: none;
   position: relative;
-  color: #000000;
+  color: #1A1A1A;
 }
 
 .circuit-0:hover {
-  background-color: #FAFBFC;
+  background-color: #F5F5F5;
 }
 
 .circuit-0:active {
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
 }
 
 .circuit-0:focus {

--- a/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -16,11 +16,11 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   cursor: pointer;
@@ -28,12 +28,12 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
 }
 
 .circuit-0:active {
-  color: #0F131A;
+  color: #000;
 }
 
 .circuit-0:hover {
-  background-color: #EEF0F2;
-  border-color: #9DA7B1;
+  background-color: #F5F5F5;
+  border-color: #999999;
 }
 
 .circuit-0:focus {
@@ -73,11 +73,11 @@ exports[`Tag when is default should render with default styles 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
 }
@@ -109,17 +109,17 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   padding-right: calc(4px + 32px);
-  background-color: #3388FF;
-  border-color: #1760CE;
-  color: #FFFFFF;
+  background-color: #3063E9;
+  border-color: #234BC3;
+  color: #FFF;
 }
 
 .circuit-2 {
@@ -149,9 +149,9 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   border-style: solid;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #3388FF;
-  border-color: #3388FF;
-  color: #FFFFFF;
+  background-color: #3063E9;
+  border-color: #3063E9;
+  color: #FFF;
   padding: 8px calc(24px - 1px);
   border-radius: 8px;
   padding: 8px;
@@ -179,13 +179,13 @@ exports[`Tag when is selected should change the close icon color 1`] = `
 }
 
 .circuit-2:hover {
-  background-color: #1760CE;
-  border-color: #1760CE;
+  background-color: #234BC3;
+  border-color: #234BC3;
 }
 
 .circuit-2:active {
-  background-color: #003C8B;
-  border-color: #003C8B;
+  background-color: #1A368E;
+  border-color: #1A368E;
 }
 
 .circuit-1 {
@@ -255,16 +255,16 @@ exports[`Tag when is selected should change the given icon color 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #3388FF;
-  border-color: #1760CE;
-  color: #FFFFFF;
+  background-color: #3063E9;
+  border-color: #234BC3;
+  color: #FFF;
 }
 
 .circuit-0 {
@@ -303,16 +303,16 @@ exports[`Tag when is selected should render with selected styles 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #D8DDE1;
+  border: 1px solid #E6E6E6;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   -webkit-transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
-  background-color: #3388FF;
-  border-color: #1760CE;
-  color: #FFFFFF;
+  background-color: #3063E9;
+  border-color: #234BC3;
+  color: #FFF;
 }
 
 <div

--- a/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -28,7 +28,7 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
 }
 
 .circuit-0:active {
-  color: #000;
+  color: #0F131A;
 }
 
 .circuit-0:hover {

--- a/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
@@ -32,8 +32,8 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
 }
 
 .circuit-0:hover {
-  background-color: #F5F5F5;
-  border-color: #999999;
+  background-color: #E6E6E6;
+  border-color: #999;
 }
 
 .circuit-0:focus {
@@ -73,7 +73,7 @@ exports[`Tag when is default should render with default styles 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
@@ -109,7 +109,7 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
@@ -255,7 +255,7 @@ exports[`Tag when is selected should change the given icon color 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;
@@ -303,7 +303,7 @@ exports[`Tag when is selected should render with selected styles 1`] = `
   align-items: center;
   font-size: 16px;
   line-height: 24px;
-  border: 1px solid #E6E6E6;
+  border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
   cursor: default;

--- a/src/components/TextArea/TextArea.spec.tsx
+++ b/src/components/TextArea/TextArea.spec.tsx
@@ -86,7 +86,7 @@ describe('TextArea', () => {
   });
 
   it('should prioritize disabled over warning styles', () => {
-    const actual = create(<TextArea invalid hasWarning />);
+    const actual = create(<TextArea hasWarning disabled />);
     expect(actual).toMatchSnapshot();
   });
 

--- a/src/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
@@ -22,7 +22,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -33,46 +33,46 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #EEF0F2;
-  box-shadow: 0 0 0 1px #DB4D4D;
+  background-color: #F5F5F5;
+  box-shadow: 0 0 0 1px #D23F47;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22828;
+  box-shadow: 0 0 0 1px #B22426;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #DB4D4D;
+  box-shadow: 0 0 0 2px #D23F47;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <div
@@ -112,7 +112,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -123,31 +123,31 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -185,15 +185,15 @@ label + .circuit-1 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22828;
+  box-shadow: 0 0 0 1px #B22426;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #DB4D4D;
+  box-shadow: 0 0 0 2px #D23F47;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <div
@@ -231,7 +231,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -242,45 +242,45 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-2 {
@@ -295,7 +295,7 @@ label + .circuit-1 {
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #5C656F;
+  color: #333333;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -342,7 +342,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #5C656F;
+  color: #333333;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -350,7 +350,7 @@ label + .circuit-2 {
 
 .circuit-1 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -362,45 +362,45 @@ label + .circuit-2 {
   font-size: 16px;
   line-height: 24px;
   padding-left: 40px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-1:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -441,7 +441,7 @@ label + .circuit-2 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -453,45 +453,45 @@ label + .circuit-2 {
   font-size: 16px;
   line-height: 24px;
   padding-right: 40px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-1 {
@@ -499,7 +499,7 @@ label + .circuit-2 {
   top: 1px;
   right: 1px;
   pointer-events: none;
-  color: #5C656F;
+  color: #333333;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -545,7 +545,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -556,45 +556,45 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -634,7 +634,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -645,46 +645,46 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #EEF0F2;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  background-color: #F5F5F5;
+  box-shadow: 0 0 0 1px #999999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -716,7 +716,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -727,45 +727,45 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-2 {
@@ -811,7 +811,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -822,31 +822,31 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -868,15 +868,15 @@ label + .circuit-1 {
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22828;
+  box-shadow: 0 0 0 1px #B22426;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #DB4D4D;
+  box-shadow: 0 0 0 2px #D23F47;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #DB4D4D;
+  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <div
@@ -907,7 +907,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -918,45 +918,45 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 .circuit-2 {
@@ -999,7 +999,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -1010,46 +1010,46 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #EEF0F2;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  background-color: #F5F5F5;
+  box-shadow: 0 0 0 1px #999999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -1087,7 +1087,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -1098,45 +1098,45 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #9DA7B1;
+  box-shadow: 0 0 0 1px #999999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #5C656F;
+  box-shadow: 0 0 0 1px #333333;
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #3388FF;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #3388FF;
+  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -1173,7 +1173,7 @@ label + .circuit-1 {
 
 .circuit-0 {
   -webkit-appearance: none;
-  background-color: #FFFFFF;
+  background-color: #FFF;
   border: none;
   outline: 0;
   border-radius: 8px;
@@ -1190,25 +1190,25 @@ label + .circuit-1 {
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #9DA7B1;
+  color: #999999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }

--- a/src/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
@@ -33,32 +33,32 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #F5F5F5;
+  background-color: #E6E6E6;
   box-shadow: 0 0 0 1px #D23F47;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -129,25 +129,25 @@ label + .circuit-1 {
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -242,37 +242,37 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -295,7 +295,7 @@ label + .circuit-1 {
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #333333;
+  color: #666;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -342,7 +342,7 @@ label + .circuit-2 {
   top: 1px;
   left: 1px;
   pointer-events: none;
-  color: #333333;
+  color: #666;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -362,37 +362,37 @@ label + .circuit-2 {
   font-size: 16px;
   line-height: 24px;
   padding-left: 40px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-1::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-1:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-1:focus {
@@ -453,37 +453,37 @@ label + .circuit-2 {
   font-size: 16px;
   line-height: 24px;
   padding-right: 40px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -499,7 +499,7 @@ label + .circuit-2 {
   top: 1px;
   right: 1px;
   pointer-events: none;
-  color: #333333;
+  color: #666;
   padding: 12px;
   height: 40px;
   width: 40px;
@@ -556,37 +556,37 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -645,38 +645,38 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999999;
+  background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -727,37 +727,37 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -828,25 +828,25 @@ label + .circuit-1 {
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -918,37 +918,37 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -1010,38 +1010,38 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999999;
+  background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -1098,37 +1098,37 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #999999;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:hover {
-  box-shadow: 0 0 0 1px #333333;
+  box-shadow: 0 0 0 1px #666;
 }
 
 .circuit-0:focus {
@@ -1190,25 +1190,25 @@ label + .circuit-1 {
 }
 
 .circuit-0::-webkit-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::-moz-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0:-ms-input-placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
 .circuit-0::placeholder {
-  color: #999999;
+  color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }

--- a/src/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
@@ -34,7 +34,7 @@ label + .circuit-1 {
   font-size: 16px;
   line-height: 24px;
   background-color: #E6E6E6;
-  box-shadow: 0 0 0 1px #D23F47;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
@@ -61,18 +61,6 @@ label + .circuit-1 {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
-}
-
-.circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22426;
-}
-
-.circuit-0:focus {
-  box-shadow: 0 0 0 2px #D23F47;
-}
-
-.circuit-0:active {
-  box-shadow: 0 0 0 1px #D23F47;
 }
 
 <div
@@ -94,13 +82,6 @@ label + .circuit-1 {
 `;
 
 exports[`TextArea should prioritize disabled over warning styles 1`] = `
-.circuit-2 {
-  font-size: 13px;
-  line-height: 20px;
-  display: block;
-  margin-bottom: 16px;
-}
-
 .circuit-1 {
   position: relative;
 }
@@ -108,6 +89,16 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
 label .circuit-1,
 label + .circuit-1 {
   margin-top: 4px;
+}
+
+.circuit-2 {
+  font-size: 13px;
+  line-height: 20px;
+  display: block;
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+  margin-bottom: 16px;
 }
 
 .circuit-0 {
@@ -123,7 +114,8 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #D23F47;
+  background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #999;
   overflow: auto;
   resize: vertical;
 }
@@ -152,60 +144,17 @@ label + .circuit-1 {
   transition: color 120ms ease-in-out;
 }
 
-.circuit-0:not(:focus)::-webkit-input-placeholder {
-  color: #D8A413;
-}
-
-.circuit-0:not(:focus)::-moz-placeholder {
-  color: #D8A413;
-}
-
-.circuit-0:not(:focus):-ms-input-placeholder {
-  color: #D8A413;
-}
-
-.circuit-0:not(:focus)::placeholder {
-  color: #D8A413;
-}
-
-.circuit-0:not(:focus)::-webkit-input-placeholder {
-  color: #EA7A7A;
-}
-
-.circuit-0:not(:focus)::-moz-placeholder {
-  color: #EA7A7A;
-}
-
-.circuit-0:not(:focus):-ms-input-placeholder {
-  color: #EA7A7A;
-}
-
-.circuit-0:not(:focus)::placeholder {
-  color: #EA7A7A;
-}
-
-.circuit-0:hover {
-  box-shadow: 0 0 0 1px #B22426;
-}
-
-.circuit-0:focus {
-  box-shadow: 0 0 0 2px #D23F47;
-}
-
-.circuit-0:active {
-  box-shadow: 0 0 0 1px #D23F47;
-}
-
 <div
   class="circuit-2"
+  disabled=""
   for="input_11"
 >
   <div
     class="circuit-1"
   >
     <textarea
-      aria-invalid="true"
       class="circuit-0"
+      disabled=""
       id="input_11"
     />
   </div>
@@ -673,18 +622,6 @@ label + .circuit-1 {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
-}
-
-.circuit-0:hover {
-  box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-0:focus {
-  box-shadow: 0 0 0 2px #3063E9;
-}
-
-.circuit-0:active {
-  box-shadow: 0 0 0 1px #3063E9;
 }
 
 <div
@@ -1184,7 +1121,7 @@ label + .circuit-1 {
   margin: 0;
   font-size: 16px;
   line-height: 24px;
-  box-shadow: 0 0 0 1px #D8A413;
+  box-shadow: 0 0 0 1px #F5C625;
   overflow: auto;
   resize: vertical;
 }
@@ -1214,19 +1151,19 @@ label + .circuit-1 {
 }
 
 .circuit-0:not(:focus)::-webkit-input-placeholder {
-  color: #D8A413;
+  color: #F5C625;
 }
 
 .circuit-0:not(:focus)::-moz-placeholder {
-  color: #D8A413;
+  color: #F5C625;
 }
 
 .circuit-0:not(:focus):-ms-input-placeholder {
-  color: #D8A413;
+  color: #F5C625;
 }
 
 .circuit-0:not(:focus)::placeholder {
-  color: #D8A413;
+  color: #F5C625;
 }
 
 .circuit-0:hover {
@@ -1234,11 +1171,11 @@ label + .circuit-1 {
 }
 
 .circuit-0:focus {
-  box-shadow: 0 0 0 2px #D8A413;
+  box-shadow: 0 0 0 2px #F5C625;
 }
 
 .circuit-0:active {
-  box-shadow: 0 0 0 1px #D8A413;
+  box-shadow: 0 0 0 1px #F5C625;
 }
 
 <div

--- a/src/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -36,7 +36,7 @@ exports[`Toggle should render with default styles 1`] = `
   -webkit-flex: 0 0 40px;
   -ms-flex: 0 0 40px;
   flex: 0 0 40px;
-  background-color: #D8DDE1;
+  background-color: #E6E6E6;
   border-radius: 24px;
   position: relative;
   -webkit-transition: background-color 200ms ease-in-out;
@@ -59,7 +59,7 @@ exports[`Toggle should render with default styles 1`] = `
 .circuit-0 {
   display: block;
   background-color: #FAFBFC;
-  box-shadow: 0 2px 0 0 #9DA7B1;
+  box-shadow: 0 2px 0 0 #999999;
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px,-50%,0);
@@ -121,7 +121,7 @@ exports[`Toggle should render with default styles 1`] = `
   font-size: 13px;
   line-height: 20px;
   margin-bottom: 0;
-  color: #5C656F;
+  color: #333333;
 }
 
 @media (min-width:480px) {
@@ -182,7 +182,7 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
   -webkit-flex: 0 0 40px;
   -ms-flex: 0 0 40px;
   flex: 0 0 40px;
-  background-color: #D8DDE1;
+  background-color: #E6E6E6;
   border-radius: 24px;
   position: relative;
   -webkit-transition: background-color 200ms ease-in-out;
@@ -205,7 +205,7 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
 .circuit-0 {
   display: block;
   background-color: #FAFBFC;
-  box-shadow: 0 2px 0 0 #9DA7B1;
+  box-shadow: 0 2px 0 0 #999999;
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px,-50%,0);
@@ -267,7 +267,7 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
   font-size: 13px;
   line-height: 20px;
   margin-bottom: 0;
-  color: #5C656F;
+  color: #333333;
 }
 
 @media (min-width:480px) {

--- a/src/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -36,7 +36,7 @@ exports[`Toggle should render with default styles 1`] = `
   -webkit-flex: 0 0 40px;
   -ms-flex: 0 0 40px;
   flex: 0 0 40px;
-  background-color: #E6E6E6;
+  background-color: #CCC;
   border-radius: 24px;
   position: relative;
   -webkit-transition: background-color 200ms ease-in-out;
@@ -58,8 +58,8 @@ exports[`Toggle should render with default styles 1`] = `
 
 .circuit-0 {
   display: block;
-  background-color: #FAFBFC;
-  box-shadow: 0 2px 0 0 #999999;
+  background-color: #F5F5F5;
+  box-shadow: 0 2px 0 0 #999;
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px,-50%,0);
@@ -121,7 +121,7 @@ exports[`Toggle should render with default styles 1`] = `
   font-size: 13px;
   line-height: 20px;
   margin-bottom: 0;
-  color: #333333;
+  color: #666;
 }
 
 @media (min-width:480px) {
@@ -182,7 +182,7 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
   -webkit-flex: 0 0 40px;
   -ms-flex: 0 0 40px;
   flex: 0 0 40px;
-  background-color: #E6E6E6;
+  background-color: #CCC;
   border-radius: 24px;
   position: relative;
   -webkit-transition: background-color 200ms ease-in-out;
@@ -204,8 +204,8 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
 
 .circuit-0 {
   display: block;
-  background-color: #FAFBFC;
-  box-shadow: 0 2px 0 0 #999999;
+  background-color: #F5F5F5;
+  box-shadow: 0 2px 0 0 #999;
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px,-50%,0);
@@ -267,7 +267,7 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
   font-size: 13px;
   line-height: 20px;
   margin-bottom: 0;
-  color: #333333;
+  color: #666;
 }
 
 @media (min-width:480px) {

--- a/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.tsx.snap
+++ b/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`Switch should have the correct default styles 1`] = `
   -webkit-flex: 0 0 40px;
   -ms-flex: 0 0 40px;
   flex: 0 0 40px;
-  background-color: #D8DDE1;
+  background-color: #E6E6E6;
   border-radius: 24px;
   position: relative;
   -webkit-transition: background-color 200ms ease-in-out;
@@ -35,7 +35,7 @@ exports[`Switch should have the correct default styles 1`] = `
 .circuit-0 {
   display: block;
   background-color: #FAFBFC;
-  box-shadow: 0 2px 0 0 #9DA7B1;
+  box-shadow: 0 2px 0 0 #999999;
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px,-50%,0);
@@ -104,7 +104,7 @@ exports[`Switch should have the correct on styles 1`] = `
   -webkit-flex: 0 0 40px;
   -ms-flex: 0 0 40px;
   flex: 0 0 40px;
-  background-color: #D8DDE1;
+  background-color: #E6E6E6;
   border-radius: 24px;
   position: relative;
   -webkit-transition: background-color 200ms ease-in-out;
@@ -113,7 +113,7 @@ exports[`Switch should have the correct on styles 1`] = `
   width: 40px;
   overflow: visible;
   cursor: pointer;
-  background-color: #3388FF;
+  background-color: #3063E9;
 }
 
 .circuit-2:focus {
@@ -128,7 +128,7 @@ exports[`Switch should have the correct on styles 1`] = `
 .circuit-0 {
   display: block;
   background-color: #FAFBFC;
-  box-shadow: 0 2px 0 0 #9DA7B1;
+  box-shadow: 0 2px 0 0 #999999;
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px,-50%,0);
@@ -140,7 +140,7 @@ exports[`Switch should have the correct on styles 1`] = `
   height: 16px;
   width: 16px;
   border-radius: 16px;
-  box-shadow: 0 2px 0 0 #1760CE;
+  box-shadow: 0 2px 0 0 #234BC3;
   -webkit-transform: translate3d( calc(40px - 16px - 4px), -50%, 0 );
   -ms-transform: translate3d( calc(40px - 16px - 4px), -50%, 0 );
   transform: translate3d( calc(40px - 16px - 4px), -50%, 0 );

--- a/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.tsx.snap
+++ b/src/components/Toggle/components/Switch/__snapshots__/Switch.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`Switch should have the correct default styles 1`] = `
   -webkit-flex: 0 0 40px;
   -ms-flex: 0 0 40px;
   flex: 0 0 40px;
-  background-color: #E6E6E6;
+  background-color: #CCC;
   border-radius: 24px;
   position: relative;
   -webkit-transition: background-color 200ms ease-in-out;
@@ -34,8 +34,8 @@ exports[`Switch should have the correct default styles 1`] = `
 
 .circuit-0 {
   display: block;
-  background-color: #FAFBFC;
-  box-shadow: 0 2px 0 0 #999999;
+  background-color: #F5F5F5;
+  box-shadow: 0 2px 0 0 #999;
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px,-50%,0);
@@ -104,7 +104,7 @@ exports[`Switch should have the correct on styles 1`] = `
   -webkit-flex: 0 0 40px;
   -ms-flex: 0 0 40px;
   flex: 0 0 40px;
-  background-color: #E6E6E6;
+  background-color: #CCC;
   border-radius: 24px;
   position: relative;
   -webkit-transition: background-color 200ms ease-in-out;
@@ -127,8 +127,8 @@ exports[`Switch should have the correct on styles 1`] = `
 
 .circuit-0 {
   display: block;
-  background-color: #FAFBFC;
-  box-shadow: 0 2px 0 0 #999999;
+  background-color: #F5F5F5;
+  box-shadow: 0 2px 0 0 #999;
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px,-50%,0);

--- a/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -6,8 +6,8 @@ exports[`Tooltip should override alignment styles with position styles 1`] = `
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -43,7 +43,7 @@ exports[`Tooltip should override alignment styles with position styles 1`] = `
 
 .circuit-0::after {
   left: 100%;
-  border-left-color: #212933;
+  border-left-color: #000000;
 }
 
 <div
@@ -59,8 +59,8 @@ exports[`Tooltip should render with align bottom, when passed "bottom" for the a
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -91,7 +91,7 @@ exports[`Tooltip should render with align bottom, when passed "bottom" for the a
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #212933;
+  border-right-color: #000000;
 }
 
 <div
@@ -107,8 +107,8 @@ exports[`Tooltip should render with align center, when passed "center" for the a
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -144,7 +144,7 @@ exports[`Tooltip should render with align center, when passed "center" for the a
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #212933;
+  border-right-color: #000000;
 }
 
 <div
@@ -160,8 +160,8 @@ exports[`Tooltip should render with align left, when passed "left" for the align
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -197,7 +197,7 @@ exports[`Tooltip should render with align left, when passed "left" for the align
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #212933;
+  border-right-color: #000000;
 }
 
 <div
@@ -213,8 +213,8 @@ exports[`Tooltip should render with align right, when passed "right" for the ali
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -250,7 +250,7 @@ exports[`Tooltip should render with align right, when passed "right" for the ali
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #212933;
+  border-right-color: #000000;
 }
 
 <div
@@ -266,8 +266,8 @@ exports[`Tooltip should render with align top, when passed "top" for the align p
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -298,7 +298,7 @@ exports[`Tooltip should render with align top, when passed "top" for the align p
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #212933;
+  border-right-color: #000000;
 }
 
 <div
@@ -314,8 +314,8 @@ exports[`Tooltip should render with position bottom, when passed "bottom" for th
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -351,7 +351,7 @@ exports[`Tooltip should render with position bottom, when passed "bottom" for th
 
 .circuit-0::after {
   bottom: 100%;
-  border-bottom-color: #212933;
+  border-bottom-color: #000000;
 }
 
 <div
@@ -367,8 +367,8 @@ exports[`Tooltip should render with position left, when passed "left" for the po
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -404,7 +404,7 @@ exports[`Tooltip should render with position left, when passed "left" for the po
 
 .circuit-0::after {
   left: 100%;
-  border-left-color: #212933;
+  border-left-color: #000000;
 }
 
 <div
@@ -420,8 +420,8 @@ exports[`Tooltip should render with position right, when passed "right" for the 
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -457,7 +457,7 @@ exports[`Tooltip should render with position right, when passed "right" for the 
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #212933;
+  border-right-color: #000000;
 }
 
 <div
@@ -473,8 +473,8 @@ exports[`Tooltip should render with position top, when passed "top" for the posi
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #212933;
-  color: #FFFFFF;
+  background-color: #000000;
+  color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
   position: absolute;
@@ -510,7 +510,7 @@ exports[`Tooltip should render with position top, when passed "top" for the posi
 
 .circuit-0::after {
   top: 100%;
-  border-top-color: #212933;
+  border-top-color: #000000;
 }
 
 <div

--- a/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.spec.js.snap
@@ -6,7 +6,7 @@ exports[`Tooltip should override alignment styles with position styles 1`] = `
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -43,7 +43,7 @@ exports[`Tooltip should override alignment styles with position styles 1`] = `
 
 .circuit-0::after {
   left: 100%;
-  border-left-color: #000000;
+  border-left-color: #1A1A1A;
 }
 
 <div
@@ -59,7 +59,7 @@ exports[`Tooltip should render with align bottom, when passed "bottom" for the a
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -91,7 +91,7 @@ exports[`Tooltip should render with align bottom, when passed "bottom" for the a
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #000000;
+  border-right-color: #1A1A1A;
 }
 
 <div
@@ -107,7 +107,7 @@ exports[`Tooltip should render with align center, when passed "center" for the a
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -144,7 +144,7 @@ exports[`Tooltip should render with align center, when passed "center" for the a
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #000000;
+  border-right-color: #1A1A1A;
 }
 
 <div
@@ -160,7 +160,7 @@ exports[`Tooltip should render with align left, when passed "left" for the align
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -197,7 +197,7 @@ exports[`Tooltip should render with align left, when passed "left" for the align
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #000000;
+  border-right-color: #1A1A1A;
 }
 
 <div
@@ -213,7 +213,7 @@ exports[`Tooltip should render with align right, when passed "right" for the ali
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -250,7 +250,7 @@ exports[`Tooltip should render with align right, when passed "right" for the ali
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #000000;
+  border-right-color: #1A1A1A;
 }
 
 <div
@@ -266,7 +266,7 @@ exports[`Tooltip should render with align top, when passed "top" for the align p
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -298,7 +298,7 @@ exports[`Tooltip should render with align top, when passed "top" for the align p
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #000000;
+  border-right-color: #1A1A1A;
 }
 
 <div
@@ -314,7 +314,7 @@ exports[`Tooltip should render with position bottom, when passed "bottom" for th
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -351,7 +351,7 @@ exports[`Tooltip should render with position bottom, when passed "bottom" for th
 
 .circuit-0::after {
   bottom: 100%;
-  border-bottom-color: #000000;
+  border-bottom-color: #1A1A1A;
 }
 
 <div
@@ -367,7 +367,7 @@ exports[`Tooltip should render with position left, when passed "left" for the po
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -404,7 +404,7 @@ exports[`Tooltip should render with position left, when passed "left" for the po
 
 .circuit-0::after {
   left: 100%;
-  border-left-color: #000000;
+  border-left-color: #1A1A1A;
 }
 
 <div
@@ -420,7 +420,7 @@ exports[`Tooltip should render with position right, when passed "right" for the 
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -457,7 +457,7 @@ exports[`Tooltip should render with position right, when passed "right" for the 
 
 .circuit-0::after {
   right: 100%;
-  border-right-color: #000000;
+  border-right-color: #1A1A1A;
 }
 
 <div
@@ -473,7 +473,7 @@ exports[`Tooltip should render with position top, when passed "top" for the posi
   width: auto;
   max-width: 280px;
   min-width: 120px;
-  background-color: #000000;
+  background-color: #1A1A1A;
   color: #FFF;
   border-radius: 4px;
   padding: 8px 12px;
@@ -510,7 +510,7 @@ exports[`Tooltip should render with position top, when passed "top" for the posi
 
 .circuit-0::after {
   top: 100%;
-  border-top-color: #000000;
+  border-top-color: #1A1A1A;
 }
 
 <div

--- a/src/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
+++ b/src/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`ValidationHint styles should render with default styles 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #5C656F;
+  color: #333333;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -38,10 +38,10 @@ exports[`ValidationHint styles should render with invalid styles 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #5C656F;
+  color: #333333;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
-  color: #DB4D4D;
+  color: #D23F47;
 }
 
 .circuit-0 {
@@ -52,7 +52,7 @@ exports[`ValidationHint styles should render with invalid styles 1`] = `
   height: 16px;
   margin-top: 0.15em;
   margin-right: 4px;
-  color: #DB4D4D;
+  color: #D23F47;
 }
 
 <span
@@ -105,7 +105,7 @@ exports[`ValidationHint styles should render with valid styles 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #5C656F;
+  color: #333333;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -118,7 +118,7 @@ exports[`ValidationHint styles should render with valid styles 1`] = `
   height: 16px;
   margin-top: 0.15em;
   margin-right: 4px;
-  color: #47995A;
+  color: #138849;
 }
 
 <span
@@ -171,7 +171,7 @@ exports[`ValidationHint styles should render with warning styles 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #5C656F;
+  color: #333333;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -184,7 +184,7 @@ exports[`ValidationHint styles should render with warning styles 1`] = `
   height: 16px;
   margin-top: 0.15em;
   margin-right: 4px;
-  color: #D8A413;
+  color: #F5C625;
 }
 
 <span

--- a/src/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
+++ b/src/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`ValidationHint styles should render with default styles 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #333333;
+  color: #666;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -38,7 +38,7 @@ exports[`ValidationHint styles should render with invalid styles 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #333333;
+  color: #666;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
   color: #D23F47;
@@ -105,7 +105,7 @@ exports[`ValidationHint styles should render with valid styles 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #333333;
+  color: #666;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
@@ -171,7 +171,7 @@ exports[`ValidationHint styles should render with warning styles 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   margin-top: 4px;
-  color: #333333;
+  color: #666;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }

--- a/src/styles/style-helpers.spec.ts
+++ b/src/styles/style-helpers.spec.ts
@@ -285,18 +285,18 @@ describe('Style helpers', () => {
       const { styles } = StyleHelpers.inputOutline(light);
       expect(styles).toMatchInlineSnapshot(`
         "
-            box-shadow: 0 0 0 1px #9DA7B1;
+            box-shadow: 0 0 0 1px #999999;
 
             &:hover {
-              box-shadow: 0 0 0 1px #5C656F;
+              box-shadow: 0 0 0 1px #333333;
             }
 
             &:focus {
-              box-shadow: 0 0 0 2px #3388FF;
+              box-shadow: 0 0 0 2px #3063E9;
             }
 
             &:active {
-              box-shadow: 0 0 0 1px #3388FF;
+              box-shadow: 0 0 0 1px #3063E9;
             }
           "
       `);
@@ -309,18 +309,18 @@ describe('Style helpers', () => {
       });
       expect(styles).toMatchInlineSnapshot(`
         "
-            box-shadow: 0 0 0 1px #DB4D4D;
+            box-shadow: 0 0 0 1px #D23F47;
 
             &:hover {
-              box-shadow: 0 0 0 1px #B22828;
+              box-shadow: 0 0 0 1px #B22426;
             }
 
             &:focus {
-              box-shadow: 0 0 0 2px #DB4D4D;
+              box-shadow: 0 0 0 2px #D23F47;
             }
 
             &:active {
-              box-shadow: 0 0 0 1px #DB4D4D;
+              box-shadow: 0 0 0 1px #D23F47;
             }
           "
       `);

--- a/src/styles/style-helpers.spec.ts
+++ b/src/styles/style-helpers.spec.ts
@@ -285,10 +285,10 @@ describe('Style helpers', () => {
       const { styles } = StyleHelpers.inputOutline(light);
       expect(styles).toMatchInlineSnapshot(`
         "
-            box-shadow: 0 0 0 1px #999999;
+            box-shadow: 0 0 0 1px #999;
 
             &:hover {
-              box-shadow: 0 0 0 1px #333333;
+              box-shadow: 0 0 0 1px #666;
             }
 
             &:focus {

--- a/src/styles/style-helpers.spec.ts
+++ b/src/styles/style-helpers.spec.ts
@@ -333,18 +333,18 @@ describe('Style helpers', () => {
       });
       expect(styles).toMatchInlineSnapshot(`
         "
-            box-shadow: 0 0 0 1px #D8A413;
+            box-shadow: 0 0 0 1px #F5C625;
 
             &:hover {
               box-shadow: 0 0 0 1px #AD7A14;
             }
 
             &:focus {
-              box-shadow: 0 0 0 2px #D8A413;
+              box-shadow: 0 0 0 2px #F5C625;
             }
 
             &:active {
-              box-shadow: 0 0 0 1px #D8A413;
+              box-shadow: 0 0 0 1px #F5C625;
             }
           "
       `);

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -160,32 +160,41 @@ export const inputOutline = (
     | Theme
     | {
         theme: Theme;
+        disabled?: boolean;
         invalid?: boolean;
         hasWarning?: boolean;
         showValid?: boolean;
       },
 ): SerializedStyles => {
   const theme = getTheme(args);
-  const options = isTheme(args) ? { invalid: false, hasWarning: false } : args;
+  const options = isTheme(args)
+    ? { disabled: false, invalid: false, hasWarning: false }
+    : args;
+
+  if (options.disabled) {
+    return css`
+      box-shadow: 0 0 0 1px ${theme.colors.n500};
+    `;
+  }
 
   let colors;
 
   switch (true) {
     case options.invalid: {
       colors = {
-        default: theme.colors.r500,
+        default: theme.colors.danger,
         hover: theme.colors.r700,
-        focus: theme.colors.r500,
-        active: theme.colors.r500,
+        focus: theme.colors.danger,
+        active: theme.colors.danger,
       };
       break;
     }
     case options.hasWarning: {
       colors = {
-        default: theme.colors.y500,
+        default: theme.colors.warning,
         hover: theme.colors.y700,
-        focus: theme.colors.y500,
-        active: theme.colors.y500,
+        focus: theme.colors.warning,
+        active: theme.colors.warning,
       };
       break;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,10 +3295,10 @@
   dependencies:
     tti-polyfill "^0.2.2"
 
-"@sumup/design-tokens@^1.0.0":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@sumup/design-tokens/-/design-tokens-1.0.3.tgz#80bfd7a960c1fda313aaa75f2ee7cda8cb87a42c"
-  integrity sha512-eiKAGMyw968+SWdmNyBFsuT1LnYeeKULjvPF3G92PliCoHtFosebahdIo+yP8SGMImvOgHo4OEl6qqAlf/ZEUQ==
+"@sumup/design-tokens@^2.0.0-alpha":
+  version "2.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@sumup/design-tokens/-/design-tokens-2.0.0-alpha.1.tgz#e7148f30a8525d9f2ec67dcbb2eb860830bb2806"
+  integrity sha512-nJi+cfVvAcmQL+IkJYwaPIHOABYGozDS+Og3Bu01XqQYc0hleNZ/HvZj8YVTxmBzL8gaTLIFlLyyrkSEWqTOjg==
 
 "@sumup/foundry@^3.0.0":
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,10 +3295,10 @@
   dependencies:
     tti-polyfill "^0.2.2"
 
-"@sumup/design-tokens@^2.0.0-alpha":
-  version "2.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@sumup/design-tokens/-/design-tokens-2.0.0-alpha.2.tgz#ca0f8683ed3bcc361248c1c36aa457a52ed51523"
-  integrity sha512-lHkuQ/2Z1o5jSCxxWt9w3NSxV37B04PG+87UqQld1RRmZ2IBS1R4+BL5Joqggl00QPFn69gzxaMwB16iSeiyGg==
+"@sumup/design-tokens@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@sumup/design-tokens/-/design-tokens-2.0.1.tgz#ff93125c8faa2eaa4cb10ae2dfd7c8758f49c716"
+  integrity sha512-VTnGsVoLT0WC4Boeb84hx+dCaNyXZ0sWFI7rxDBJftFY5uefPMQdqd8Xay8jVlaUn4mzZBgTw+YlDmMKu/nWPw==
 
 "@sumup/foundry@^3.0.0":
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3296,9 +3296,9 @@
     tti-polyfill "^0.2.2"
 
 "@sumup/design-tokens@^2.0.0-alpha":
-  version "2.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@sumup/design-tokens/-/design-tokens-2.0.0-alpha.1.tgz#e7148f30a8525d9f2ec67dcbb2eb860830bb2806"
-  integrity sha512-nJi+cfVvAcmQL+IkJYwaPIHOABYGozDS+Og3Bu01XqQYc0hleNZ/HvZj8YVTxmBzL8gaTLIFlLyyrkSEWqTOjg==
+  version "2.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@sumup/design-tokens/-/design-tokens-2.0.0-alpha.2.tgz#ca0f8683ed3bcc361248c1c36aa457a52ed51523"
+  integrity sha512-lHkuQ/2Z1o5jSCxxWt9w3NSxV37B04PG+87UqQld1RRmZ2IBS1R4+BL5Joqggl00QPFn69gzxaMwB16iSeiyGg==
 
 "@sumup/foundry@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
Addresses [TL-321](https://sumupteam.atlassian.net/browse/TL-321). Relates to https://github.com/sumup-oss/design-tokens/pull/10.

## Purpose

The design team has updated the colors as part of SumUp's upcoming brand refresh. They are now AA/AAA compliant. The changes have been applied in [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens), this PR updates the dependency and the snapshots.

## Approach and changes

- upgrade to [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens) v2 (Circuit UI remains compatible with v1 and v2)
- review and update visual tests
- fix a bug where disabled inputs would show error/warning colors

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
