### PR TITLE
fix(cli): run codemods on TypeScript files

### DIFF
--- a/src/cli/migrate/index.ts
+++ b/src/cli/migrate/index.ts
@@ -28,6 +28,10 @@ const PARSERS = {
   JavaScript: 'babel',
   TypeScript: 'tsx',
 };
+const EXTENSIONS = {
+  JavaScript: 'js,jsx',
+  TypeScript: 'ts,tsx',
+};
 
 export function migrate({ transform, language, path }: MigrateArgs): void {
   const availableTransforms = listTransforms();
@@ -41,6 +45,7 @@ export function migrate({ transform, language, path }: MigrateArgs): void {
   }
 
   const parser = PARSERS[language];
+  const extensions = EXTENSIONS[language];
 
   spawn(
     'npx',
@@ -50,6 +55,8 @@ export function migrate({ transform, language, path }: MigrateArgs): void {
       `${TRANSFORM_DIR}/${transform}.js`,
       '--parser',
       parser,
+      '--extensions',
+      extensions,
       '--ignore-pattern',
       '**/node_modules/**',
       path,


### PR DESCRIPTION
## Purpose

When transforming TypeScript files using codemods, I forgot to pass the `extensions` param to JSCodeshift, so it would parse JavaScript files with the TypeScript parser.

## Approach and changes

- pass correct extensions param to `jscodeshift` when using TypeScript

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
