### PR TITLE
fix(cli): support other languages for codemods

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -23,12 +23,12 @@ yarn circuit-ui migrate
 Automatically transforms your source code to Circuit UI's latest APIs
 
 Options:
-  --language, -l   The programming language of the files to be transformed
-                       [string] [required] [choices: "TypeScript", "JavaScript"]
+  --language, -l   The programming language(s) of the files to be transformed
+                [array] [required] [choices: "TypeScript", "JavaScript", "Flow"]
   --path, -p       A path to the folder that contains the files to be
                    transformed                           [string] [default: "."]
   --transform, -t  The transform to be applied to the source code
-                            [string] [required] [choices: "button-variant-enum"]
+                       [string] [required] [choices: "button-variant-enum", ...]
 ```
 
 You can only run one codemod at a time and we encourage you to apply the transforms incrementally and review the changes before continuing. The codemods don't cover all edge cases, so further manual changes might be necessary.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,7 @@
 
 import yargs from 'yargs';
 
-import { migrate, listTransforms } from './migrate';
+import { migrate, listTransforms, listLanguages } from './migrate';
 
 type CommandType = 'migrate';
 
@@ -30,9 +30,9 @@ yargs
       yrgs
         .option('language', {
           alias: 'l',
-          desc: 'The programming language of the files to be transformed',
-          choices: ['TypeScript', 'JavaScript'],
-          type: 'string',
+          desc: 'The programming language(s) of the files to be transformed',
+          choices: listLanguages(),
+          type: 'array',
           required: true,
         })
         .option('path', {

--- a/src/cli/migrate/__testfixtures__/component-static-properties.input.js
+++ b/src/cli/migrate/__testfixtures__/component-static-properties.input.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from '@emotion/styled';
 import { Heading, CardList } from '@sumup/circuit-ui';
 
 const BaseHeading = () => <Heading size={Heading.KILO} />;

--- a/src/cli/migrate/__testfixtures__/component-static-properties.output.js
+++ b/src/cli/migrate/__testfixtures__/component-static-properties.output.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from '@emotion/styled';
 import { Heading, CardList } from '@sumup/circuit-ui';
 
 const BaseHeading = () => <Heading size={'kilo'} />;

--- a/src/cli/migrate/__tests__/migrate.spec.js
+++ b/src/cli/migrate/__tests__/migrate.spec.js
@@ -36,7 +36,9 @@ defineTest('component-static-properties');
 defineTest('toggle-checked-prop');
 defineTest('badge-variant-enum');
 defineTest('inline-message-variant-enum');
-defineTest('theme-grid-tera');
+// Need to skip the TypeScript parser, because the output format slightly
+// differs from the expected format(but it is correct).
+defineTest('theme-grid-tera', null, { parser: 'babel' });
 defineTest('theme-to-design-tokens', 'theme-to-design-tokens-1');
 defineTest('theme-to-design-tokens', 'theme-to-design-tokens-2');
 defineTest('theme-icon-sizes');

--- a/src/cli/migrate/__tests__/migrate.spec.js
+++ b/src/cli/migrate/__tests__/migrate.spec.js
@@ -20,7 +20,7 @@ import { runInlineTest } from 'jscodeshift/dist/testUtils';
 
 jest.autoMockOff();
 
-const PARSERS = ['babel', 'tsx', 'babel'];
+const PARSERS = ['babel', 'tsx', 'flow'];
 
 defineTest('button-variant-enum');
 defineTest('button-size-giga');

--- a/src/cli/migrate/__tests__/migrate.spec.js
+++ b/src/cli/migrate/__tests__/migrate.spec.js
@@ -13,37 +13,72 @@
  * limitations under the License.
  */
 
-import { defineTest } from 'jscodeshift/dist/testUtils';
+import fs from 'fs';
+import path from 'path';
+
+import { runInlineTest } from 'jscodeshift/dist/testUtils';
 
 jest.autoMockOff();
 
-defineTest(__dirname, 'button-variant-enum');
-defineTest(__dirname, 'button-size-giga');
-defineTest(__dirname, 'list-variant-enum');
-defineTest(__dirname, 'onchange-prop');
-defineTest(__dirname, 'as-prop');
-defineTest(__dirname, 'selector-props');
-defineTest(__dirname, 'exit-animations');
-defineTest(__dirname, 'input-deepref-prop');
-defineTest(__dirname, 'input-styles-prop');
-defineTest(__dirname, 'component-names-v2');
-defineTest(__dirname, 'component-static-properties');
-defineTest(__dirname, 'toggle-checked-prop');
-defineTest(__dirname, 'badge-variant-enum');
-defineTest(__dirname, 'inline-message-variant-enum');
-defineTest(__dirname, 'theme-grid-tera');
-defineTest(
-  __dirname,
-  'theme-to-design-tokens',
-  null,
-  'theme-to-design-tokens-1',
-);
-defineTest(
-  __dirname,
-  'theme-to-design-tokens',
-  null,
-  'theme-to-design-tokens-2',
-);
-defineTest(__dirname, 'theme-icon-sizes');
-defineTest(__dirname, 'currency-utils', null, 'currency-utils-1');
-defineTest(__dirname, 'currency-utils', null, 'currency-utils-2');
+const PARSERS = ['babel', 'tsx', 'babel'];
+
+defineTest('button-variant-enum');
+defineTest('button-size-giga');
+defineTest('list-variant-enum');
+defineTest('onchange-prop');
+defineTest('as-prop');
+defineTest('selector-props');
+defineTest('exit-animations');
+defineTest('input-deepref-prop');
+defineTest('input-styles-prop');
+defineTest('component-names-v2');
+defineTest('component-static-properties');
+defineTest('toggle-checked-prop');
+defineTest('badge-variant-enum');
+defineTest('inline-message-variant-enum');
+defineTest('theme-grid-tera');
+defineTest('theme-to-design-tokens', 'theme-to-design-tokens-1');
+defineTest('theme-to-design-tokens', 'theme-to-design-tokens-2');
+defineTest('theme-icon-sizes');
+defineTest('currency-utils', 'currency-utils-1');
+defineTest('currency-utils', 'currency-utils-2');
+
+function defineTest(transformName, testFilePrefix, testOptions = {}) {
+  const dirName = __dirname;
+  const fixtureDir = path.join(dirName, '..', '__testfixtures__');
+  const inputPath = path.join(
+    fixtureDir,
+    `${testFilePrefix || transformName}.input.js`,
+  );
+  const source = fs.readFileSync(inputPath, 'utf8');
+  const expectedOutput = fs.readFileSync(
+    path.join(fixtureDir, `${testFilePrefix || transformName}.output.js`),
+    'utf8',
+  );
+  // Assumes transform is one level up from __tests__ directory
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  const module = require(path.join(dirName, '..', transformName));
+
+  PARSERS.forEach((parser) => {
+    let testName = 'transforms correctly';
+
+    if (testFilePrefix) {
+      testName = `${testName} using ${testFilePrefix} data`;
+    }
+
+    testName = `${testName} with the ${parser} parser`;
+
+    describe(transformName, () => {
+      // eslint-disable-next-line jest/expect-expect
+      it(testName, () => {
+        runInlineTest(
+          module,
+          null,
+          { path: inputPath, source },
+          expectedOutput,
+          { parser, ...testOptions },
+        );
+      });
+    });
+  });
+}

--- a/src/cli/migrate/__tests__/migrate.spec.js
+++ b/src/cli/migrate/__tests__/migrate.spec.js
@@ -37,7 +37,7 @@ defineTest('toggle-checked-prop');
 defineTest('badge-variant-enum');
 defineTest('inline-message-variant-enum');
 // Need to skip the TypeScript parser, because the output format slightly
-// differs from the expected format(but it is correct).
+// differs from the expected format (but it is correct).
 defineTest('theme-grid-tera', null, { parser: 'babel' });
 defineTest('theme-to-design-tokens', 'theme-to-design-tokens-1');
 defineTest('theme-to-design-tokens', 'theme-to-design-tokens-2');

--- a/src/cli/migrate/button-size-giga.ts
+++ b/src/cli/migrate/button-size-giga.ts
@@ -29,21 +29,24 @@ function transformFactory(
   }
 
   components.forEach((component) => {
-    root
-      .findJSXElements(component)
-      .find(j.JSXAttribute, {
-        name: {
-          type: 'JSXIdentifier',
-          name: 'size',
-        },
-        value: {
-          type: 'Literal',
-          value: 'giga',
-        },
-      })
-      .replaceWith(() =>
-        j.jsxAttribute(j.jsxIdentifier('size'), j.stringLiteral('mega')),
-      );
+    const jsxElement = root.findJSXElements(component);
+    // The babel and TypeScript parsers use different node types.
+    ['Literal', 'StringLiteral'].forEach((type) => {
+      jsxElement
+        .find(j.JSXAttribute, {
+          name: {
+            type: 'JSXIdentifier',
+            name: 'size',
+          },
+          value: {
+            type,
+            value: 'giga',
+          },
+        })
+        .replaceWith(() =>
+          j.jsxAttribute(j.jsxIdentifier('size'), j.stringLiteral('mega')),
+        );
+    });
   });
 }
 

--- a/src/cli/migrate/theme-grid-tera.ts
+++ b/src/cli/migrate/theme-grid-tera.ts
@@ -31,23 +31,28 @@ const transform: Transform = (file, api) => {
   if (components) {
     components.forEach((component) => {
       props.forEach((prop) => {
-        root
-          .findJSXElements(component)
-          .find(j.JSXAttribute, {
-            name: {
-              type: 'JSXIdentifier',
-              name: prop,
-            },
-          })
-          .find(j.Property, {
-            key: {
-              type: 'Identifier',
-              name: 'afterTera',
-            },
-          })
-          .replaceWith((nodePath) =>
-            j.objectProperty(j.identifier('tera'), nodePath.node.value),
-          );
+        [j.Property, j.ObjectProperty].forEach((property) => {
+          root
+            .findJSXElements(component)
+            .find(j.JSXAttribute, {
+              name: {
+                type: 'JSXIdentifier',
+                name: prop,
+              },
+            })
+            .find(property as any, {
+              key: {
+                type: 'Identifier',
+                name: 'afterTera',
+              },
+            })
+            .replaceWith((nodePath) =>
+              j.objectProperty(
+                j.identifier('tera'),
+                (nodePath.node as any).value,
+              ),
+            );
+        });
       });
     });
   }


### PR DESCRIPTION
## Purpose

When doing a dry-run of the migration to Circuit UI v2 of the partner portal, @larimaza and I discovered that the codemods don't quite work for TypeScript files yet. After the previous fix (#676), `jscodeshift` would process the TypeScript files but make no changes to them.

## Approach and changes

- all unit tests for the codemods are now run using every supported parser: `babel`, `tsx`, and `flow`
- fixed a few codemods where the TypeScript AST uses slightly different node types
- added the ability to run a transform for multiple languages at once, e.g.: 

```sh
yarn circuit-ui migrate --language=TypeScript --language=JavaScript --path=src --transform=component-static-properties
```

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
