### PR TITLE
fix(components): ensure ref is forwarded in Button and Anchor

### DIFF
--- a/src/components/Anchor/Anchor.tsx
+++ b/src/components/Anchor/Anchor.tsx
@@ -74,27 +74,29 @@ const baseStyles = ({ theme }: StyleProps) => css`
   }
 `;
 
-const BaseAnchor = styled(Text, {
+const StyledAnchor = styled(Text, {
   shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
 })<AnchorProps>(baseStyles);
 
 function AnchorComponent(
   props: AnchorProps,
-  ref?: React.Ref<HTMLButtonElement & HTMLAnchorElement>,
+  ref?: BaseProps['ref'],
 ): ReturnType {
-  const { Link } = useComponents();
-  const AnchorLink = BaseAnchor.withComponent(Link);
+  const components = useComponents();
+
+  // Need to typecast here because the StyledAnchor expects a button-like
+  // component for its `as` prop. It's safe to ignore that constraint here.
+  const Link = components.Link as any;
 
   if (!props.href && !props.onClick) {
     return <Text as="span" {...props} ref={ref} noMargin />;
   }
 
   if (props.href) {
-    // typing issues with with
-    return <AnchorLink {...props} ref={ref} noMargin />;
+    return <StyledAnchor {...props} as={Link} ref={ref} noMargin />;
   }
 
-  return <BaseAnchor as="button" {...props} ref={ref} noMargin />;
+  return <StyledAnchor as="button" {...props} ref={ref} noMargin />;
 }
 
 /**

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -206,7 +206,7 @@ const iconStyles = (theme: Theme) => css`
   margin-right: ${theme.spacings.byte};
 `;
 
-const BaseButton = styled('button', {
+const StyledButton = styled('button', {
   shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
 })<ButtonProps>(
   baseStyles,
@@ -221,9 +221,12 @@ function ButtonComponent(
   { children, icon: Icon, tracking, ...props }: ButtonProps,
   ref?: BaseProps['ref'],
 ): ReturnType {
-  const { Link } = useComponents();
-  const LinkButton = BaseButton.withComponent(Link);
-  const ButtonElement = props.href ? LinkButton : BaseButton;
+  const components = useComponents();
+
+  // Need to typecast here because the StyledButton expects a button-like
+  // component for its `as` prop. It's safe to ignore that constraint here.
+  const Link = components.Link as any;
+
   const handleClick = useClickHandler<MouseEvent<any>>(
     props.onClick,
     tracking,
@@ -231,10 +234,15 @@ function ButtonComponent(
   );
 
   return (
-    <ButtonElement {...props} ref={ref} onClick={handleClick}>
+    <StyledButton
+      {...props}
+      ref={ref}
+      as={props.href ? Link : 'button'}
+      onClick={handleClick}
+    >
       {Icon && <Icon css={iconStyles} role="presentation" />}
       {children}
-    </ButtonElement>
+    </StyledButton>
   );
 }
 


### PR DESCRIPTION
# Purpose


@justman00 reported a `Maximum update depth exceeded` error after upgrading to the latest version of Next.js. The error occured when wrapping a Circuit UI Button or Anchor component in the Next.js Link component. 

After a bit of digging, we found that the issue lies in our use of the `withComponent` API on styled components created with Emotion. The method should not be called inside a
component - which is exactly what we were doing in the Button and Anchor components. This caused the component to be recreated on every render, which in turn caused a cyclic state update in the Next.js Link component.

## Approach and changes

- Replace the `withComponent` method with the `as` prop

This fix might improve the rendering performance significantly.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
