### PR TITLE
fix(components): enable use of sticky position

### DIFF
--- a/src/components/BaseStyles/BaseStylesService.ts
+++ b/src/components/BaseStyles/BaseStylesService.ts
@@ -184,6 +184,7 @@ export const createBaseStyles = ({ theme }: StyleProps) => css`
 
   html {
     box-sizing: border-box;
+    overflow-x: hidden;
 
     [type='button'] {
       appearance: none;

--- a/src/components/BaseStyles/BaseStylesService.ts
+++ b/src/components/BaseStyles/BaseStylesService.ts
@@ -212,7 +212,6 @@ export const createBaseStyles = ({ theme }: StyleProps) => css`
     font-feature-settings: 'kern';
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    overflow-x: hidden;
     text-rendering: optimizeLegibility;
   }
 

--- a/src/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
+++ b/src/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
@@ -196,7 +196,6 @@ exports[`BaseStylesService should return the global base styles 1`] = `
     font-feature-settings: 'kern';
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    overflow-x: hidden;
     text-rendering: optimizeLegibility;
   }
 

--- a/src/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
+++ b/src/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
@@ -165,6 +165,7 @@ exports[`BaseStylesService should return the global base styles 1`] = `
 
   html {
     box-sizing: border-box;
+    overflow-x: hidden;
 
     [type='button'] {
       appearance: none;


### PR DESCRIPTION
## Purpose

As reported by @felixjung:

> For `position: sticky` to work, non of the parent elements can have `overflow` set to something other than the default `visible`.

Read more on [CSS Tricks](https://css-tricks.com/dealing-with-overflow-and-position-sticky/).

## Approach and changes

- Move `overflow` style rule from `body` to `html` element in the BaseStyles component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
