### PR TITLE
fix(components): improve Tag behaviour in edge cases

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -203,6 +203,7 @@ const stretchStyles = ({ stretch }: ButtonProps) =>
 
 const iconStyles = (theme: Theme) => css`
   label: button__icon;
+  flex-shrink: 0;
   margin-right: ${theme.spacings.byte};
 `;
 

--- a/src/components/Button/__snapshots__/Button.spec.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.spec.tsx.snap
@@ -62,6 +62,9 @@ exports[`Button styles should render a button with icon 1`] = `
 }
 
 .circuit-0 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   margin-right: 8px;
 }
 

--- a/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -14,8 +14,10 @@ exports[`CalendarTag should render with default styles 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  margin: 0;
   font-size: 16px;
   line-height: 24px;
+  word-break: break-word;
   border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;

--- a/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/src/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -27,6 +27,7 @@ exports[`CalendarTag should render with default styles 1`] = `
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   cursor: pointer;
   outline: 0;
+  text-align: left;
 }
 
 .circuit-0:active {

--- a/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -14,8 +14,10 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  margin: 0;
   font-size: 16px;
   line-height: 24px;
+  word-break: break-word;
   border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;

--- a/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/src/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -27,6 +27,7 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   cursor: pointer;
   outline: 0;
+  text-align: left;
 }
 
 .circuit-0:active {

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -72,7 +72,9 @@ const tagBaseStyles = ({ theme }: StyleProps) => css`
   label: tag;
   display: inline-flex;
   align-items: center;
+  margin: 0;
   ${textMega({ theme })};
+  word-break: break-word;
   border: ${BORDER_WIDTH} solid ${theme.colors.n300};
   border-radius: ${theme.borderRadius.giga};
   padding: ${theme.spacings.bit} ${theme.spacings.kilo};
@@ -151,12 +153,14 @@ const TagElement = styled('div')<TagElProps>(
 
 const prefixStyles = (theme: Theme) => css`
   label: tag__prefix;
+  flex-shrink: 0;
   margin-left: -${theme.spacings.bit};
   margin-right: ${theme.spacings.bit};
 `;
 
 const suffixStyles = (theme: Theme) => css`
   label: tag__suffix;
+  flex-shrink: 0;
   margin-left: ${theme.spacings.bit};
   margin-right: -${theme.spacings.bit};
 `;

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -99,6 +99,7 @@ const tagClickableStyles = ({ theme, onClick }: StyleProps & TagElProps) =>
     label: tag--clickable;
     cursor: pointer;
     outline: 0;
+    text-align: left;
 
     &:active {
       color: ${theme.colors.bodyColor};
@@ -168,8 +169,9 @@ const suffixStyles = (theme: Theme) => css`
 const closeButtonStyles = ({ theme }: StyleProps) => css`
   label: tag__close-button;
   position: absolute;
-  top: ${BORDER_WIDTH};
+  top: 50%;
   right: ${BORDER_WIDTH};
+  transform: translateY(-50%);
   border-radius: ${theme.borderRadius.mega};
 `;
 

--- a/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -27,6 +27,7 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
   transition: opacity 120ms ease-in-out, color 120ms ease-in-out, background-color 120ms ease-in-out, border-color 120ms ease-in-out;
   cursor: pointer;
   outline: 0;
+  text-align: left;
 }
 
 .circuit-0:active {
@@ -163,8 +164,11 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   padding: 8px;
   border: 0;
   position: absolute;
-  top: 1px;
+  top: 50%;
   right: 1px;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
   border-radius: 4px;
 }
 

--- a/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/src/components/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -14,8 +14,10 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  margin: 0;
   font-size: 16px;
   line-height: 24px;
+  word-break: break-word;
   border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
@@ -71,8 +73,10 @@ exports[`Tag when is default should render with default styles 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  margin: 0;
   font-size: 16px;
   line-height: 24px;
+  word-break: break-word;
   border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
@@ -107,8 +111,10 @@ exports[`Tag when is selected should change the close icon color 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  margin: 0;
   font-size: 16px;
   line-height: 24px;
+  word-break: break-word;
   border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
@@ -253,8 +259,10 @@ exports[`Tag when is selected should change the given icon color 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  margin: 0;
   font-size: 16px;
   line-height: 24px;
+  word-break: break-word;
   border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;
@@ -268,6 +276,9 @@ exports[`Tag when is selected should change the given icon color 1`] = `
 }
 
 .circuit-0 {
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   margin-left: -4px;
   margin-right: 4px;
 }
@@ -301,8 +312,10 @@ exports[`Tag when is selected should render with selected styles 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  margin: 0;
   font-size: 16px;
   line-height: 24px;
+  word-break: break-word;
   border: 1px solid #CCC;
   border-radius: 6px;
   padding: 4px 12px;


### PR DESCRIPTION
## Purpose

@hris27 found a number of edge cases where the behavior of the Tag component could be improved.

## Approach and changes

- Remove the margin to fix the misaligned remove button on Safari
- Add `word-break` rule to ensure that long words don't overflow
- Add `flex-shrink` rule to prevent icons from, well, shrinking when there's little space (also applied to the Button)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
