### PR TITLE
fix(components): fix Modal overflow shadow in Safari

### DIFF
--- a/src/components/Modal/components/ModalFooter/ModalFooter.tsx
+++ b/src/components/Modal/components/ModalFooter/ModalFooter.tsx
@@ -35,7 +35,10 @@ const footerStyles = ({ theme }: StyleProps) => css`
       right: 0;
       width: 100%;
       height: ${theme.spacings.giga};
-      background: linear-gradient(transparent, ${theme.colors.white});
+      background: linear-gradient(
+        rgba(256, 256, 256, 0),
+        ${theme.colors.white}
+      );
     }
   }
 `;

--- a/src/components/Modal/components/ModalFooter/__snapshots__/ModalFooter.spec.tsx.snap
+++ b/src/components/Modal/components/ModalFooter/__snapshots__/ModalFooter.spec.tsx.snap
@@ -49,7 +49,7 @@ exports[`ModalFooter should render with default styles 1`] = `
     right: 0;
     width: 100%;
     height: 24px;
-    background: linear-gradient(transparent,#FFF);
+    background: linear-gradient( rgba(256,256,256,0), #FFF );
   }
 }
 


### PR DESCRIPTION
## Purpose

Jessica reported a bug with the Modal componen on Safari: 

<img width="320" alt="Weird dark shadow on ModalFooter" src="https://user-images.githubusercontent.com/11017722/97344302-da2e0500-1888-11eb-846b-dd64f8490003.jpg">

Turns out, Safari interprets `transparent` in a linear gradient as `black` 😳

## Approach and changes

- replace `transparent` with `rgba(256,256,256,0)` (or in other words _white_ transparent)

<img width="320" alt="Beautiful white transparent shadow on ModalFooter" src="https://user-images.githubusercontent.com/11017722/97344632-490b5e00-1889-11eb-9546-559bddd1e1ed.png">

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
