### PR TITLE
docs: fix @sumup/design-tokens URL in Theme docs

### DIFF
--- a/docs/advanced/theme.stories.mdx
+++ b/docs/advanced/theme.stories.mdx
@@ -7,7 +7,7 @@ import {
   BorderRadius,
   BorderWidth,
   Type,
-  MediaQueriesTable
+  MediaQueriesTable,
 } from '../../.storybook/components';
 import { Heading, SubHeading, Text } from '../../src';
 
@@ -33,7 +33,7 @@ export default function App() {
 }
 ```
 
-In most cases, the default SumUp themes provided by [@sumup/design-tokens](https://www.npmjs.com/package/sumup/design-tokens) should cover your needs. If you need to create a custom theme, we recommend overriding or making a copy of one of the [default themes](https://github.com/sumup-oss/design-tokens/blob/main/src/themes) to ensure that no values are missing.
+In most cases, the default SumUp themes provided by [@sumup/design-tokens](https://www.npmjs.com/package/@sumup/design-tokens) should cover your needs. If you need to create a custom theme, we recommend overriding or making a copy of one of the [default themes](https://github.com/sumup-oss/design-tokens/blob/main/src/themes) to ensure that no values are missing.
 
 Refer to the [Emotion theming](https://emotion.sh/docs/theming) documentation to learn how to use the theme in your own components.
 
@@ -282,7 +282,7 @@ const ResponsiveDiv = styled('div')(
     ${theme.mq.mega} {
       padding-top: ${theme.spacings.peta};
     }
-  `
+  `,
 );
 ```
 


### PR DESCRIPTION
fix/design-tokens-npm-url

## Purpose

One link to the @sumup/design-tokens package on NPM is broken.

## Approach and changes

Fix the link.

**Note**: the linter also added trailing commas that were introduced in Foundry v2 - I left them there but happy to take them out of this PR.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned

(n/a 👇)
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
