### PR TITLE
fix: format amounts correctly in CurrencyInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,8 @@
     "prop-types": "^15.7.2",
     "react-dates": "^21.2.0",
     "react-modal": "^3.8.1",
+    "react-number-format": "^4.4.1",
     "react-popper": "^1.3.3",
-    "react-text-mask": "^5.4.3",
-    "text-mask-addons": "^3.8.0",
     "tiny-warning": "^1.0.3",
     "yargs": "^14.0.0"
   },
@@ -115,7 +114,6 @@
     "@types/react": "^16.9.32",
     "@types/react-dom": "^16.9.6",
     "@types/react-modal": "^3.10.5",
-    "@types/react-text-mask": "^5.4.6",
     "audit-ci": "^2.1.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^25.0.0",

--- a/src/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/src/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -25,13 +25,13 @@ describe('CurrencyInput', () => {
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(<CurrencyInput currency="EUR" />);
+    const actual = create(<CurrencyInput currency="EUR" label="Amount" />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should adjust input padding and suffix width to match currency symbol width', () => {
     const actual = create(
-      <CurrencyInput placeholder="123,45" currency="CHF" />,
+      <CurrencyInput placeholder="123,45" currency="CHF" label="Amount" />,
     );
     expect(actual).toMatchSnapshot();
   });
@@ -43,7 +43,12 @@ describe('CurrencyInput', () => {
     it('should accept a working ref', () => {
       const tref = React.createRef<NumberFormat>();
       const { container } = render(
-        <CurrencyInput locale="de-DE" currency="EUR" ref={tref} />,
+        <CurrencyInput
+          locale="de-DE"
+          currency="EUR"
+          ref={tref}
+          label="Amount"
+        />,
       );
       const input = container.querySelector('input');
       expect(tref.current).toBe(input);
@@ -52,10 +57,10 @@ describe('CurrencyInput', () => {
     it('should format an amount correctly', () => {
       const { getByLabelText } = render(
         <CurrencyInput
-          label="Amount"
           locale="de-DE"
           currency="EUR"
           value={12345.67}
+          label="Amount"
         />,
       );
       const input = getByLabelText(new RegExp('Amount'));

--- a/src/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/src/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -14,7 +14,7 @@
  */
 
 import React from 'react';
-import TextMaskInput from 'react-text-mask';
+import NumberFormat from 'react-number-format';
 
 import { create, render, renderToHtml, axe } from '../../util/test-utils';
 
@@ -40,13 +40,26 @@ describe('CurrencyInput', () => {
     /**
      * Should accept a working ref
      */
-    it.skip('should accept a working ref', () => {
-      const tref = React.createRef<TextMaskInput>();
+    it('should accept a working ref', () => {
+      const tref = React.createRef<NumberFormat>();
       const { container } = render(
-        <CurrencyInput id="id" locale="de-DE" currency="EUR" ref={tref} />,
+        <CurrencyInput locale="de-DE" currency="EUR" ref={tref} />,
       );
       const input = container.querySelector('input');
       expect(tref.current).toBe(input);
+    });
+
+    it('should format an amount correctly', () => {
+      const { getByLabelText } = render(
+        <CurrencyInput
+          label="Amount"
+          locale="de-DE"
+          currency="EUR"
+          value={12345.67}
+        />,
+      );
+      const input = getByLabelText(new RegExp('Amount'));
+      expect(input.value).toBe('12,345.67');
     });
   });
 

--- a/src/components/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/CurrencyInput/CurrencyInput.tsx
@@ -15,16 +15,19 @@
 
 import React, { Ref } from 'react';
 import { resolveCurrencyFormat } from '@sumup/intl';
-import TextMaskInput from 'react-text-mask';
+import NumberFormat from 'react-number-format';
 
 import styled from '../../styles/styled';
 import Input from '../Input';
 import { InputProps } from '../Input/Input';
 
-import { createCurrencyMask, formatPlaceholder } from './CurrencyInputService';
+import { formatPlaceholder } from './CurrencyInputService';
 
 export interface CurrencyInputProps
-  extends Omit<InputProps, 'placeholder' | 'ref'> {
+  extends Omit<
+    InputProps,
+    'placeholder' | 'ref' | 'value' | 'defaultValue' | 'type'
+  > {
   /**
    * A ISO 4217 currency code, such as 'USD' for the US dollar,
    * 'EUR' for the Euro, or 'CNY' for the Chinese RMB.
@@ -41,7 +44,18 @@ export interface CurrencyInputProps
    * currency format.
    */
   placeholder?: string | number;
-  ref: Ref<TextMaskInput>;
+  /**
+   * The ref to the html dom element.
+   */
+  ref?: Ref<NumberFormat>;
+  /**
+   * The value of the input element.
+   */
+  value?: string | number;
+  /**
+   * The default value of the input element.
+   */
+  defaultValue?: string | number;
 }
 
 const DEFAULT_FORMAT = {
@@ -49,8 +63,8 @@ const DEFAULT_FORMAT = {
   currencySymbol: '$',
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
-  decimalSymbol: '.',
-  housandsSeparatorSymbol: ',',
+  decimalDelimiter: '.',
+  groupDelimiter: ',',
 };
 
 const CurrencyIcon = styled('span')`
@@ -78,8 +92,9 @@ export const CurrencyInput = React.forwardRef(
       currencySymbol,
       minimumFractionDigits,
       maximumFractionDigits,
+      decimalDelimiter,
+      groupDelimiter,
     } = currencyFormat;
-    const numberMask = createCurrencyMask(currencyFormat, locale);
     const placeholderString = formatPlaceholder(placeholder, locale, {
       minimumFractionDigits,
       maximumFractionDigits,
@@ -87,8 +102,8 @@ export const CurrencyInput = React.forwardRef(
 
     const renderPrefix =
       currencyPosition === 'prefix'
-        ? (preffixProps: { className?: string }) => (
-            <CurrencyIcon {...preffixProps}>{currencySymbol}</CurrencyIcon>
+        ? (prefixProps: { className?: string }) => (
+            <CurrencyIcon {...prefixProps}>{currencySymbol}</CurrencyIcon>
           )
         : null;
 
@@ -99,23 +114,24 @@ export const CurrencyInput = React.forwardRef(
           )
         : null;
 
+    const isNumericString = typeof props.value === 'string';
+
     return (
-      <TextMaskInput
-        ref={ref}
-        guide={false}
-        render={(inputRef, { defaultValue, ...renderProps }) => (
-          <Input
-            ref={inputRef}
-            value={defaultValue}
-            renderPrefix={renderPrefix}
-            renderSuffix={renderSuffix}
-            placeholder={placeholderString}
-            textAlign="right"
-            type="text"
-            {...renderProps}
-          />
-        )}
-        mask={numberMask}
+      <NumberFormat
+        // NumberFormat props
+        thousandSeparator={groupDelimiter}
+        decimalSeparator={decimalDelimiter}
+        decimalScale={maximumFractionDigits}
+        isNumericString={isNumericString}
+        customInput={Input}
+        getInputRef={ref}
+        allowedDecimalSeparators={[decimalDelimiter]}
+        // Circuit input props
+        renderPrefix={renderPrefix}
+        renderSuffix={renderSuffix}
+        placeholder={placeholderString}
+        textAlign="right"
+        type="text"
         {...props}
       />
     );

--- a/src/components/CurrencyInput/CurrencyInputService.spec.ts
+++ b/src/components/CurrencyInput/CurrencyInputService.spec.ts
@@ -13,44 +13,11 @@
  * limitations under the License.
  */
 
-import createNumberMask from 'text-mask-addons/dist/createNumberMask';
-
-import { createCurrencyMask, formatPlaceholder } from './CurrencyInputService';
-
-jest.mock('text-mask-addons/dist/createNumberMask', () => jest.fn());
+import { formatPlaceholder } from './CurrencyInputService';
 
 describe('CurrencyInputService', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-  });
-
-  describe('createCurrencyMask', () => {
-    it('should create a number mask for use with react-text-mask', () => {
-      const currencyFormat = {
-        maximumFractionDigits: 2,
-        decimalDelimiter: '.',
-        groupDelimiter: ',',
-      };
-      createCurrencyMask(currencyFormat);
-      const options = createNumberMask.mock.calls[0][0];
-      const actualAllowDecimal = options.allowDecimal;
-      const actualDecimalLimit = options.decimalLimit;
-      expect(actualAllowDecimal).toBeTruthy();
-      expect(actualDecimalLimit).toBe(2);
-    });
-
-    it('should allow specifying options', () => {
-      const currencyFormat = {
-        maximumFractionDigits: 2,
-        decimalDelimiter: '.',
-        groupDelimiter: ',',
-      };
-      const options = { foo: 'bar' };
-      createCurrencyMask(currencyFormat, options);
-      const expected = options.foo;
-      const actual = createNumberMask.mock.calls[0][0].foo;
-      expect(actual).toEqual(expected);
-    });
   });
 
   describe('formatPlaceholder', () => {

--- a/src/components/CurrencyInput/CurrencyInputService.ts
+++ b/src/components/CurrencyInput/CurrencyInputService.ts
@@ -13,33 +13,7 @@
  * limitations under the License.
  */
 
-import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 import { format } from '@sumup/intl';
-
-export const createCurrencyMask = (
-  currencyFormat: {
-    maximumFractionDigits: number;
-    decimalDelimiter?: string;
-    groupDelimiter?: string;
-  },
-  options = {},
-) => {
-  const {
-    maximumFractionDigits: decimalLimit,
-    decimalDelimiter: decimalSymbol = '.',
-    groupDelimiter: thousandsSeparatorSymbol = ',',
-  } = currencyFormat;
-
-  return createNumberMask({
-    prefix: '',
-    suffix: '',
-    thousandsSeparatorSymbol,
-    allowDecimal: decimalLimit > 0,
-    decimalLimit,
-    decimalSymbol,
-    ...options,
-  });
-};
 
 export function formatPlaceholder(
   placeholder?: string | number,

--- a/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -1,23 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CurrencyInput should adjust input padding and suffix width to match currency symbol width 1`] = `
-.circuit-3 {
+.circuit-4 {
   font-size: 13px;
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
   margin-top: 4px;
 }
 
-.circuit-2 {
+.circuit-0 {
+  display: inline-block;
+  margin-bottom: 4px;
+}
+
+.circuit-3 {
   position: relative;
 }
 
-.circuit-0 {
+.circuit-1 {
   line-height: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -41,7 +46,7 @@ label + .circuit-3:not(label) {
   width: 40px;
 }
 
-.circuit-1 {
+.circuit-2 {
   -webkit-appearance: none;
   background-color: #FFF;
   border: none;
@@ -59,56 +64,61 @@ label + .circuit-3:not(label) {
   box-shadow: 0 0 0 1px #999;
 }
 
-.circuit-1::-webkit-input-placeholder {
+.circuit-2::-webkit-input-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1::-moz-placeholder {
+.circuit-2::-moz-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1:-ms-input-placeholder {
+.circuit-2:-ms-input-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1::placeholder {
+.circuit-2::placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   box-shadow: 0 0 0 1px #666;
 }
 
-.circuit-1:focus {
+.circuit-2:focus {
   box-shadow: 0 0 0 2px #3063E9;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   box-shadow: 0 0 0 1px #3063E9;
 }
 
-<div
-  class="circuit-3"
+<label
+  class="circuit-4"
   for="input_2"
 >
+  <span
+    class="circuit-0"
+  >
+    Amount
+  </span>
   <div
-    class="circuit-2"
+    class="circuit-3"
   >
     <span
-      class="circuit-0"
+      class="circuit-1"
     >
       CHF
     </span>
     <input
-      class="circuit-1"
+      class="circuit-2"
       id="input_2"
       inputmode="numeric"
       placeholder="123,45"
@@ -116,27 +126,32 @@ label + .circuit-3:not(label) {
       value=""
     />
   </div>
-</div>
+</label>
 `;
 
 exports[`CurrencyInput should render with default styles 1`] = `
-.circuit-3 {
+.circuit-4 {
   font-size: 13px;
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
   margin-top: 4px;
 }
 
-.circuit-2 {
+.circuit-0 {
+  display: inline-block;
+  margin-bottom: 4px;
+}
+
+.circuit-3 {
   position: relative;
 }
 
-.circuit-0 {
+.circuit-1 {
   line-height: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -160,7 +175,7 @@ label + .circuit-3:not(label) {
   width: 40px;
 }
 
-.circuit-1 {
+.circuit-2 {
   -webkit-appearance: none;
   background-color: #FFF;
   border: none;
@@ -178,61 +193,66 @@ label + .circuit-3:not(label) {
   box-shadow: 0 0 0 1px #999;
 }
 
-.circuit-1::-webkit-input-placeholder {
+.circuit-2::-webkit-input-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1::-moz-placeholder {
+.circuit-2::-moz-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1:-ms-input-placeholder {
+.circuit-2:-ms-input-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1::placeholder {
+.circuit-2::placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   box-shadow: 0 0 0 1px #666;
 }
 
-.circuit-1:focus {
+.circuit-2:focus {
   box-shadow: 0 0 0 2px #3063E9;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   box-shadow: 0 0 0 1px #3063E9;
 }
 
-<div
-  class="circuit-3"
+<label
+  class="circuit-4"
   for="input_1"
 >
+  <span
+    class="circuit-0"
+  >
+    Amount
+  </span>
   <div
-    class="circuit-2"
+    class="circuit-3"
   >
     <span
-      class="circuit-0"
+      class="circuit-1"
     >
       €
     </span>
     <input
-      class="circuit-1"
+      class="circuit-2"
       id="input_1"
       inputmode="numeric"
       type="text"
       value=""
     />
   </div>
-</div>
+</label>
 `;

--- a/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -110,6 +110,7 @@ label + .circuit-3:not(label) {
     <input
       class="circuit-1"
       id="input_2"
+      inputmode="numeric"
       placeholder="123,45"
       type="text"
       value=""
@@ -228,6 +229,7 @@ label + .circuit-3:not(label) {
     <input
       class="circuit-1"
       id="input_1"
+      inputmode="numeric"
       type="text"
       value=""
     />

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -92,7 +92,7 @@ export interface InputProps extends Omit<HTMLProps<HTMLInputElement>, 'label'> {
    */
   hideLabel?: boolean;
   /**
-   * Emotion style object to overwrite the <input> element styles.
+   * Emotion style object to overwrite the input element styles.
    */
   inputStyles?: InterpolationWithTheme<Theme>;
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3662,13 +3662,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-text-mask@^5.4.6":
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/@types/react-text-mask/-/react-text-mask-5.4.6.tgz#3a81e9de472beb939038e78cb16d737ae94ba14a"
-  integrity sha512-0KkER9oXZY/v1x8aoMTHwANlWnKT5tnmV7Zz+g81gBvcHRtcIHotcpY4KgWRwx0T5JMcsYmEh7wGOz0lwdONew==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-textarea-autosize@^4.3.3":
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz#6c4d2753fa1864c98c0b2b517f67bb1f6e4c46de"
@@ -14293,7 +14286,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -14760,6 +14753,13 @@ react-moment-proptypes@^1.6.0:
   dependencies:
     moment ">=1.6.0"
 
+react-number-format@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.4.1.tgz#d5614dd25edfc21ed48b97356213440081437a94"
+  integrity sha512-ZGFMXZ0U7DcmQ3bSZY3FULOA1mfqreT9NIMYZNoa/ouiSgiTQiYA95Uj2KN8ge6BRr+ghA5vraozqWqsHZQw3Q==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-outside-click-handler@^1.2.4:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz#3831d541ac059deecd38ec5423f81e80ad60e115"
@@ -14868,13 +14868,6 @@ react-test-renderer@^16.8.6:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.19.1"
-
-react-text-mask@^5.4.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/react-text-mask/-/react-text-mask-5.4.3.tgz#991efb4299e30c2e6c2c46d13f617169463e0d2d"
-  integrity sha1-mR77QpnjDC5sLEbRP2FxaUY+DS0=
-  dependencies:
-    prop-types "^15.5.6"
 
 react-textarea-autosize@^7.1.0:
   version "7.1.2"
@@ -17015,11 +17008,6 @@ text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
-
-text-mask-addons@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/text-mask-addons/-/text-mask-addons-3.8.0.tgz#17b61ef665a4f36811f2ea1f01a223b4be61ab26"
-  integrity sha1-F7Ye9mWk82gR8uofAaIjtL5hqyY=
 
 text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Fixes #659.

## Purpose

The [`text-mask`](https://github.com/text-mask/text-mask) library that we were using for masked inputs is deprecated and has a bug where controlled values were not formatted correctly.

## Approach and changes

- switch libraries in favor of [`react-number-format`](https://github.com/s-yadav/react-number-format)
- add a unit test to ensure the bug will not be reintroduced

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
