### PR TITLE
fix(components): export SelectorGroup

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -221,7 +221,15 @@ export const Checkbox = React.forwardRef(
           disabled={disabled}
           invalid={invalid}
           ref={ref}
-          onChange={handleChange}
+          onClick={handleChange}
+          onChange={() => {
+            /**
+             * Noop to silence React warning:
+             * https://github.com/facebook/react/issues/3070#issuecomment-73311114
+             * Change is handled by onClick which has better browser support:
+             * https://stackoverflow.com/a/5575369/4620154
+             */
+          }}
         />
         <CheckboxLabel htmlFor={id} disabled={disabled} invalid={invalid}>
           {children}

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -206,6 +206,14 @@ export const RadioButton = React.forwardRef(
           disabled={disabled}
           checked={checked}
           onClick={handleChange}
+          onChange={() => {
+            /**
+             * Noop to silence React warning:
+             * https://github.com/facebook/react/issues/3070#issuecomment-73311114
+             * Change is handled by onClick which has better browser support:
+             * https://stackoverflow.com/a/5575369/4620154
+             */
+          }}
           ref={ref}
         />
         <RadioButtonLabel

--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -169,6 +169,14 @@ export const Selector = React.forwardRef(
           checked={checked}
           disabled={disabled}
           onClick={handleChange}
+          onChange={() => {
+            /**
+             * Noop to silence React warning:
+             * https://github.com/facebook/react/issues/3070#issuecomment-73311114
+             * Change is handled by onClick which has better browser support:
+             * https://stackoverflow.com/a/5575369/4620154
+             */
+          }}
           ref={ref}
           {...props}
         />

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ export { default as CloseButton } from './components/CloseButton';
 export { default as IconButton } from './components/IconButton';
 export { default as Toggle } from './components/Toggle';
 export { default as Selector } from './components/Selector';
+export { default as SelectorGroup } from './components/SelectorGroup';
 
 // Notifications
 export { default as Notification } from './components/Notification';


### PR DESCRIPTION
Fixes #726.

## Purpose

The SelectorGroup is not exported publicly which is an oversight. The prop types warning about a missing change handler is incorrect because we use click handler instead for better browser compatibility. 

## Approach and changes

- add missing export
- add noop change handlers to silence React warnings

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
