### PR TITLE
fix(components): fix NaN in controlled CurrencyInput

### DIFF
--- a/src/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/src/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -16,7 +16,14 @@
 import React from 'react';
 import NumberFormat from 'react-number-format';
 
-import { create, render, renderToHtml, axe } from '../../util/test-utils';
+import {
+  create,
+  render,
+  renderToHtml,
+  axe,
+  act,
+  userEvent,
+} from '../../util/test-utils';
 
 import CurrencyInput from '.';
 
@@ -54,17 +61,46 @@ describe('CurrencyInput', () => {
       expect(tref.current).toBe(input);
     });
 
-    it('should format an amount correctly', () => {
+    it('should format a en-GB amount correctly', () => {
+      const { getByLabelText } = render(
+        <CurrencyInput
+          locale="en-GB"
+          currency="EUR"
+          value={1234.5}
+          label="Amount"
+        />,
+      );
+
+      const input = getByLabelText(new RegExp('Amount')) as HTMLInputElement;
+      expect(input.value).toBe('1,234.5');
+
+      act(() => {
+        userEvent.type(input, '1234.56');
+      });
+
+      expect(input.value).toBe('1,234.56');
+    });
+
+    // FIXME: Our current Node version only supports English locales.
+    // Unskip when we upgrade to Node 13+.
+    it.skip('should format a de-DE amount correctly', () => {
       const { getByLabelText } = render(
         <CurrencyInput
           locale="de-DE"
           currency="EUR"
-          value={12345.67}
+          value={1234.5}
           label="Amount"
         />,
       );
+
       const input = getByLabelText(new RegExp('Amount')) as HTMLInputElement;
-      expect(input.value).toBe('12,345.67');
+      expect(input.value).toBe('1.234,5');
+
+      act(() => {
+        userEvent.type(input, '1234,56');
+      });
+
+      expect(input.value).toBe('1.234,56');
     });
   });
 

--- a/src/components/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/CurrencyInput/CurrencyInput.tsx
@@ -114,15 +114,12 @@ export const CurrencyInput = React.forwardRef(
           )
         : null;
 
-    const isNumericString = typeof props.value === 'string';
-
     return (
       <NumberFormat
         // NumberFormat props
         thousandSeparator={groupDelimiter}
         decimalSeparator={decimalDelimiter}
         decimalScale={maximumFractionDigits}
-        isNumericString={isNumericString}
         customInput={Input}
         getInputRef={ref}
         allowedDecimalSeparators={[decimalDelimiter]}


### PR DESCRIPTION
Follow-up of #724

## Purpose

#724 had a bug in controlled forms and with some locales (for example de-DE), where entering an invalid character like `,` was causing a NaN error.

We traced this back to our implementation of `react-number-format`.

The `isNumericString` prop should only be used for number values as strings (ex: `"12.50"`), not for formatted number strings (ex for de-DE: `"12,50"`).

## Approach and changes

- Removed the `isNumericString` prop from the NumberFormat
- Added tests to cover the amount formatting, one for en-GB and one for de-DE (skipped until we upgrade Node to 13+ to gain Intl support for non-English locales)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
