### PR TITLE
chore: upgrade to Node 14

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Use Node.js v10
+      - name: Use Node.js v14
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 14.x
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Use Node.js v10
+      - name: Use Node.js v14
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 14.x
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Use Node.js v10
+      - name: Use Node.js v14
         uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 14.x
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/fermium

--- a/src/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/src/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -81,9 +81,7 @@ describe('CurrencyInput', () => {
       expect(input.value).toBe('1,234.56');
     });
 
-    // FIXME: Our current Node version only supports English locales.
-    // Unskip when we upgrade to Node 13+.
-    it.skip('should format a de-DE amount correctly', () => {
+    it('should format a de-DE amount correctly', () => {
       const { getByLabelText } = render(
         <CurrencyInput
           locale="de-DE"


### PR DESCRIPTION
## Purpose

Node 10 will go out of maintenance in 2021, so we are upgrading to the latest LTS.

https://nodejs.org/en/about/releases/

## Approach and changes

* Update .nvmrc
* Update GitHub actions
* Unskip test in CurrencyInput

Note: there are some warnings [in the CI](https://github.com/sumup-oss/circuit-ui/runs/1498471142), which were not introduced by the upgrades. I've left them out of scope for this PR

## Definition of done

* [x] Development completed
* [x] Reviewers assigned

(n/a 👇)

* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
