### PR TITLE
fix(components): resolve prop type warnings in Sidebar

### DIFF
--- a/src/components/ComponentsContext/withComponents.js
+++ b/src/components/ComponentsContext/withComponents.js
@@ -15,14 +15,23 @@
 
 import React from 'react';
 
+import deprecate from '../../util/deprecate';
 import { getDisplayName } from '../../util/get-display-name';
 
 import useComponents from './useComponents';
 
 /**
+ * @deprecated
+ *
  * Subscribe to the components context with a HOC.
  */
 const withComponents = (Component) => {
+  deprecate(
+    [
+      'The `withComponents` HOC has been deprecated.',
+      'Use the `useComponents` hook instead.',
+    ].join(' '),
+  );
   function WrappedComponent(props) {
     const components = useComponents();
     return <Component {...props} components={components} />;

--- a/src/components/Sidebar/Sidebar.spec.js
+++ b/src/components/Sidebar/Sidebar.spec.js
@@ -17,9 +17,14 @@ import React from 'react';
 
 import Sidebar from './Sidebar';
 
-describe('<Sidebar />', () => {
+describe('Sidebar', () => {
+  const baseProps = {
+    closeButtonLabel: 'Close sidebar',
+  };
+
   it('should render and match the snapshot when closed', () => {
     const props = {
+      ...baseProps,
       open: false,
       onClose: jest.fn(),
     };
@@ -29,6 +34,7 @@ describe('<Sidebar />', () => {
 
   it('should render and match snapshot when open', () => {
     const props = {
+      ...baseProps,
       open: true,
       onClose: jest.fn(),
     };
@@ -38,6 +44,7 @@ describe('<Sidebar />', () => {
 
   it('should dispatch onClose when CloseButton is clicked', () => {
     const props = {
+      ...baseProps,
       open: true,
       onClose: jest.fn(),
     };
@@ -50,6 +57,7 @@ describe('<Sidebar />', () => {
 
   it('should dispatch onClose when the Backdrop is clicked', () => {
     const props = {
+      ...baseProps,
       open: true,
       onClose: jest.fn(),
     };
@@ -62,7 +70,7 @@ describe('<Sidebar />', () => {
 
   describe('accessibility', () => {
     it('should meet accessibility guidelines', async () => {
-      const wrapper = renderToHtml(<Sidebar closeButtonLabel="close" />);
+      const wrapper = renderToHtml(<Sidebar {...baseProps} />);
       const actual = await axe(wrapper);
       expect(actual).toHaveNoViolations();
     });

--- a/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/src/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Sidebar /> should render and match snapshot when open 1`] = `
+exports[`Sidebar should render and match snapshot when open 1`] = `
 HTMLCollection [
   .circuit-0 {
   display: -webkit-box;
@@ -166,7 +166,7 @@ HTMLCollection [
 <button
     class="circuit-1 circuit-2"
     data-testid="sidebar-close-button"
-    title="Close"
+    title="Close sidebar"
     type="button"
   >
     <svg
@@ -187,13 +187,13 @@ HTMLCollection [
     <span
       class="circuit-0"
     >
-      Close
+      Close sidebar
     </span>
   </button>,
 ]
 `;
 
-exports[`<Sidebar /> should render and match the snapshot when closed 1`] = `
+exports[`Sidebar should render and match the snapshot when closed 1`] = `
 HTMLCollection [
   .circuit-0 {
   display: -webkit-box;
@@ -343,7 +343,7 @@ HTMLCollection [
 <button
     class="circuit-1 circuit-2"
     data-testid="sidebar-close-button"
-    title="Close"
+    title="Close sidebar"
     type="button"
   >
     <svg
@@ -364,7 +364,7 @@ HTMLCollection [
     <span
       class="circuit-0"
     >
-      Close
+      Close sidebar
     </span>
   </button>,
 ]

--- a/src/components/Sidebar/components/Aggregator/__snapshots__/Aggregator.spec.tsx.snap
+++ b/src/components/Sidebar/components/Aggregator/__snapshots__/Aggregator.spec.tsx.snap
@@ -34,6 +34,7 @@ HTMLCollection [
 }
 
 .circuit-0 {
+  display: block;
   margin-left: 12px;
 }
 
@@ -83,11 +84,11 @@ HTMLCollection [
         data-testid="aggregator"
       >
         default-icon
-        <div
+        <span
           class="circuit-0 circuit-1"
         >
           Aggregator
-        </div>
+        </span>
       </button>
       <ul
         class="circuit-3 circuit-4"
@@ -136,6 +137,7 @@ exports[`Aggregator styles should render with default styles 1`] = `
 }
 
 .circuit-0 {
+  display: block;
   margin-left: 12px;
 }
 
@@ -179,11 +181,11 @@ exports[`Aggregator styles should render with default styles 1`] = `
       data-testid="aggregator"
     >
       default-icon
-      <div
+      <span
         class="circuit-0 circuit-1"
       >
         Aggregator
-      </div>
+      </span>
     </button>
     <ul
       class="circuit-3 circuit-4"
@@ -200,6 +202,7 @@ exports[`Aggregator styles should render with default styles 1`] = `
 
 exports[`Aggregator styles should render with disabled state styles and match the snapshot 1`] = `
 .circuit-0 {
+  display: block;
   margin-left: 12px;
 }
 
@@ -254,11 +257,11 @@ exports[`Aggregator styles should render with disabled state styles and match th
           stroke-width="2"
         />
       </svg>
-      <div
+      <span
         class="circuit-0 circuit-1"
       >
         Aggregator
-      </div>
+      </span>
     </button>
   </li>
 </ul>

--- a/src/components/Sidebar/components/NavItem/NavItem.js
+++ b/src/components/Sidebar/components/NavItem/NavItem.js
@@ -19,8 +19,8 @@ import styled from '@emotion/styled';
 import { css, jsx } from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 
-import { componentsPropType } from '../../../../util/shared-prop-types';
 import useClickHandler from '../../../../hooks/use-click-handler';
+import { useComponents } from '../../../ComponentsContext';
 import NavLabel from '../NavLabel';
 
 import { getIcon } from './utils';
@@ -75,7 +75,7 @@ const disabledStyles = ({ theme, disabled }) =>
     color: ${theme.colors.n500};
   `;
 
-const StyledLink = styled('a', {
+const NavLink = styled('a', {
   shouldForwardProp: isPropValid,
 })(baseStyles, hoverStyles, selectedStyles, secondaryStyles, disabledStyles);
 
@@ -88,13 +88,13 @@ const NavItem = ({
   selected,
   disabled,
   onClick,
-  components,
   tracking,
   ...props
 }) => {
-  const icon = getIcon({ defaultIcon, selected, selectedIcon, disabled });
-  const Link = StyledLink.withComponent(components.Link);
+  const { Link } = useComponents();
   const handleClick = useClickHandler(onClick, tracking, 'sidebar-nav-item');
+
+  const icon = getIcon({ defaultIcon, selected, selectedIcon, disabled });
 
   return (
     <li
@@ -103,7 +103,8 @@ const NavItem = ({
         display: block;
       `}
     >
-      <Link
+      <NavLink
+        as={Link}
         onClick={disabled ? null : handleClick}
         selected={selected}
         secondary={secondary}
@@ -115,7 +116,7 @@ const NavItem = ({
         <NavLabel secondary={secondary} visible={visible}>
           {label}
         </NavLabel>
-      </Link>
+      </NavLink>
     </li>
   );
 };
@@ -153,7 +154,6 @@ NavItem.propTypes = {
    * The onClick method to handle the click event on NavItems
    */
   onClick: PropTypes.func,
-  components: componentsPropType,
   /**
    * Additional data that is dispatched with click tracking event.
    */

--- a/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
+++ b/src/components/Sidebar/components/NavItem/__snapshots__/NavItem.spec.js.snap
@@ -34,6 +34,7 @@ exports[`NavItem styles should render with default styles and match the snapshot
 }
 
 .circuit-0 {
+  display: block;
   margin-left: 12px;
 }
 
@@ -43,7 +44,7 @@ exports[`NavItem styles should render with default styles and match the snapshot
   <a
     class="circuit-2 circuit-3"
   >
-    <div
+    <span
       class="circuit-0 circuit-1"
     />
   </a>
@@ -88,6 +89,7 @@ exports[`NavItem styles should render with default styles and match the snapshot
 }
 
 .circuit-0 {
+  display: block;
   margin-left: 12px;
   margin-left: 0px;
   margin-top: -12px;
@@ -102,7 +104,7 @@ exports[`NavItem styles should render with default styles and match the snapshot
   <a
     class="circuit-2 circuit-3"
   >
-    <div
+    <span
       class="circuit-0 circuit-1"
     />
   </a>
@@ -115,6 +117,7 @@ exports[`NavItem styles should render with disabled state styles and match the s
 }
 
 .circuit-0 {
+  display: block;
   margin-left: 12px;
 }
 
@@ -151,7 +154,7 @@ exports[`NavItem styles should render with disabled state styles and match the s
     class="circuit-2 circuit-3"
     disabled=""
   >
-    <div
+    <span
       class="circuit-0 circuit-1"
     />
   </a>
@@ -164,6 +167,7 @@ exports[`NavItem styles should render with selected state styles and match the s
 }
 
 .circuit-0 {
+  display: block;
   margin-left: 12px;
 }
 
@@ -199,7 +203,7 @@ exports[`NavItem styles should render with selected state styles and match the s
   <a
     class="circuit-2 circuit-3"
   >
-    <div
+    <span
       class="circuit-0 circuit-1"
     />
   </a>

--- a/src/components/Sidebar/components/NavItem/index.js
+++ b/src/components/Sidebar/components/NavItem/index.js
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { withComponents } from '../../../ComponentsContext';
-
 import NavItem from './NavItem';
 
-export default withComponents(NavItem);
+export default NavItem;

--- a/src/components/Sidebar/components/NavLabel/NavLabel.js
+++ b/src/components/Sidebar/components/NavLabel/NavLabel.js
@@ -19,6 +19,7 @@ import { css } from '@emotion/core';
 
 const baseStyles = ({ theme }) => css`
   label: nav-label;
+  display: block;
   margin-left: ${theme.spacings.kilo};
 `;
 
@@ -39,7 +40,7 @@ const secondaryVisibleStyles = ({ secondary, visible }) =>
     margin-top: 0px;
   `;
 
-const NavLabel = styled.div(
+const NavLabel = styled.span(
   baseStyles,
   secondaryStyles,
   secondaryVisibleStyles,

--- a/src/components/Sidebar/components/NavLabel/__snapshots__/NavLabel.spec.js.snap
+++ b/src/components/Sidebar/components/NavLabel/__snapshots__/NavLabel.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`NavLabel styles should render and match snapshot when secondary 1`] = `
 .circuit-0 {
+  display: block;
   margin-left: 12px;
   margin-left: 0px;
   margin-top: -12px;
@@ -10,33 +11,35 @@ exports[`NavLabel styles should render and match snapshot when secondary 1`] = `
   margin-top: 0px;
 }
 
-<div
+<span
   class="circuit-0 circuit-1"
 >
   Item 01
-</div>
+</span>
 `;
 
 exports[`NavLabel styles should render and match snapshot when visible 1`] = `
 .circuit-0 {
+  display: block;
   margin-left: 12px;
 }
 
-<div
+<span
   class="circuit-0 circuit-1"
 >
   Item 01
-</div>
+</span>
 `;
 
 exports[`NavLabel styles should render with default styles 1`] = `
 .circuit-0 {
+  display: block;
   margin-left: 12px;
 }
 
-<div
+<span
   class="circuit-0 circuit-1"
 >
   Item 01
-</div>
+</span>
 `;


### PR DESCRIPTION
Fixes #732.

## Approach and changes

- resolve prop type warning in Sidebar NavItem and Sidebar tests
- deprecate `withComponents` HOC, use the `useComponents` hook instead.
- use valid HTML nesting in Sidebar, the HTML spec says that any element that is naturally inline cannot contain naturally block elements

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
