### PR TITLE
fix(components): fix broken table layout for long words in the TableCell

### DIFF
--- a/src/components/Table/__snapshots__/Table.spec.js.snap
+++ b/src/components/Table/__snapshots__/Table.spec.js.snap
@@ -57,7 +57,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -77,7 +76,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -177,7 +176,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
   font-size: 13px;
   font-weight: 700;
@@ -188,7 +187,7 @@ tbody .circuit-20:last-child td {
   .circuit-8 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -200,7 +199,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -251,7 +249,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -266,7 +263,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
 }
 
 @media (max-width:767px) {
@@ -275,7 +271,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -287,7 +283,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
 }
 
@@ -295,7 +291,7 @@ tbody .circuit-20:last-child td {
   .circuit-26 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -308,7 +304,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 <div
@@ -576,7 +572,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -596,7 +591,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -696,7 +691,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
   font-size: 13px;
   font-weight: 700;
@@ -707,7 +702,7 @@ tbody .circuit-20:last-child td {
   .circuit-8 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -719,7 +714,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -770,7 +764,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -785,7 +778,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
 }
 
 @media (max-width:767px) {
@@ -794,7 +786,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -806,7 +798,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
 }
 
@@ -814,7 +806,7 @@ tbody .circuit-20:last-child td {
   .circuit-26 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -827,7 +819,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 .circuit-54 {
@@ -1200,7 +1192,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -1225,7 +1216,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -1267,7 +1258,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   padding: 12px 16px;
   font-size: 13px;
   line-height: 20px;
@@ -1285,7 +1276,7 @@ tbody .circuit-20:last-child td {
   .circuit-8 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -1297,7 +1288,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -1353,7 +1343,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -1373,7 +1362,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   vertical-align: middle;
   font-size: 13px;
   line-height: 20px;
@@ -1386,7 +1374,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -1398,7 +1386,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   padding: 12px 16px;
   font-size: 13px;
   line-height: 20px;
@@ -1412,7 +1400,7 @@ tbody .circuit-20:last-child td {
   .circuit-26 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -1425,7 +1413,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   padding: 12px 16px;
   font-size: 13px;
   line-height: 20px;
@@ -1737,7 +1725,6 @@ tbody .circuit-18:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -1788,7 +1775,6 @@ tbody .circuit-18:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -1804,7 +1790,7 @@ tbody .circuit-18:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 .circuit-50 {
@@ -2101,7 +2087,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -2121,7 +2106,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -2221,7 +2206,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
   font-size: 13px;
   font-weight: 700;
@@ -2232,7 +2217,7 @@ tbody .circuit-20:last-child td {
   .circuit-8 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -2244,7 +2229,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -2295,7 +2279,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -2310,7 +2293,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
 }
 
 @media (max-width:767px) {
@@ -2319,7 +2301,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -2331,7 +2313,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
 }
 
@@ -2339,7 +2321,7 @@ tbody .circuit-20:last-child td {
   .circuit-26 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -2352,7 +2334,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 <div
@@ -2643,7 +2625,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -2663,7 +2644,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -2763,7 +2744,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
   font-size: 13px;
   font-weight: 700;
@@ -2774,7 +2755,7 @@ tbody .circuit-20:last-child td {
   .circuit-8 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -2786,7 +2767,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -2837,7 +2817,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -2852,7 +2831,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
 }
 
 @media (max-width:767px) {
@@ -2861,7 +2839,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -2873,7 +2851,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
 }
 
@@ -2881,7 +2859,7 @@ tbody .circuit-20:last-child td {
   .circuit-26 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -2894,7 +2872,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 <div
@@ -3180,7 +3158,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -3200,7 +3177,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -3300,7 +3277,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
   font-size: 13px;
   font-weight: 700;
@@ -3311,7 +3288,7 @@ tbody .circuit-20:last-child td {
   .circuit-8 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -3323,7 +3300,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -3374,7 +3350,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -3389,7 +3364,6 @@ tbody .circuit-20:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
 }
 
 @media (max-width:767px) {
@@ -3398,7 +3372,7 @@ tbody .circuit-20:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -3410,7 +3384,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
 }
 
@@ -3418,7 +3392,7 @@ tbody .circuit-20:last-child td {
   .circuit-26 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -3431,7 +3405,7 @@ tbody .circuit-20:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 .circuit-58 {

--- a/src/components/Table/components/TableBody/__snapshots__/TableBody.spec.js.snap
+++ b/src/components/Table/components/TableBody/__snapshots__/TableBody.spec.js.snap
@@ -18,7 +18,7 @@ tbody .circuit-4:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 <tbody>
@@ -60,7 +60,7 @@ tbody .circuit-6:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 .circuit-0 {
@@ -70,7 +70,6 @@ tbody .circuit-6:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
 }
 
 @media (max-width:767px) {
@@ -79,7 +78,7 @@ tbody .circuit-6:last-child td {
     top: auto;
     position: absolute;
     width: 145px;
-    white-space: unset;
+    overflow-wrap: break-word;
   }
 }
 
@@ -91,7 +90,7 @@ tbody .circuit-6:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   display: none;
 }
 
@@ -99,7 +98,7 @@ tbody .circuit-6:last-child td {
   .circuit-2 {
     display: table-cell;
     min-width: 145px;
-    white-space: unset;
+    max-width: 145px;
     width: 145px;
   }
 }
@@ -151,7 +150,7 @@ tbody .circuit-4:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 <tbody>
@@ -193,7 +192,7 @@ tbody .circuit-4:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 .circuit-0 {
@@ -204,7 +203,7 @@ tbody .circuit-4:last-child td {
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   background-color: #F5F5F5;
 }
 

--- a/src/components/Table/components/TableCell/TableCell.js
+++ b/src/components/Table/components/TableCell/TableCell.js
@@ -27,7 +27,7 @@ const baseStyles = ({ theme, align }) => css`
   text-align: ${align};
   transition: background-color ${theme.transitions.default};
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 `;
 
 const presentationStyles = ({ theme, role, header }) =>
@@ -46,7 +46,7 @@ const presentationStyles = ({ theme, role, header }) =>
     ${theme.mq.untilMega} {
       display: table-cell;
       min-width: 145px;
-      white-space: unset;
+      max-width: 145px;
       width: 145px;
     }
   `;

--- a/src/components/Table/components/TableCell/__snapshots__/TableCell.spec.js.snap
+++ b/src/components/Table/components/TableCell/__snapshots__/TableCell.spec.js.snap
@@ -9,7 +9,7 @@ exports[`TableCell Style tests should render with condensed styles 1`] = `
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   padding: 12px 16px;
   font-size: 13px;
   line-height: 20px;
@@ -32,7 +32,7 @@ exports[`TableCell Style tests should render with default styles 1`] = `
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 <td
@@ -52,7 +52,7 @@ exports[`TableCell Style tests should render with header styles 1`] = `
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
 }
 
 <td
@@ -72,7 +72,7 @@ exports[`TableCell Style tests should render with isHovered styles 1`] = `
   -webkit-transition: background-color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
-  white-space: nowrap;
+  overflow-wrap: break-word;
   background-color: #F5F5F5;
 }
 

--- a/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
+++ b/src/components/Table/components/TableHead/__snapshots__/TableHead.spec.js.snap
@@ -17,7 +17,6 @@ tbody .circuit-12:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -126,7 +125,6 @@ tbody .circuit-12:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -223,7 +221,6 @@ tbody .circuit-12:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -332,7 +329,6 @@ tbody .circuit-12:last-child td {
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;

--- a/src/components/Table/components/TableHeader/TableHeader.js
+++ b/src/components/Table/components/TableHeader/TableHeader.js
@@ -45,7 +45,6 @@ const baseStyles = ({ theme, align }) => css`
   text-align: ${align};
   transition: background-color ${theme.transitions.default},
     color ${theme.transitions.default};
-  white-space: nowrap;
 `;
 
 const hoveredStyles = ({ theme, isHovered }) =>
@@ -75,7 +74,7 @@ const fixedStyles = ({ theme, fixed }) =>
       top: auto;
       position: absolute;
       width: 145px;
-      white-space: unset;
+      overflow-wrap: break-word;
     }
   `;
 

--- a/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
+++ b/src/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.js.snap
@@ -8,7 +8,6 @@ exports[`TableHeader Style tests should render with condensed styles 1`] = `
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -37,7 +36,6 @@ exports[`TableHeader Style tests should render with default styles 1`] = `
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -61,7 +59,6 @@ exports[`TableHeader Style tests should render with hovered styles 1`] = `
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   background-color: #F5F5F5;
   color: #666;
   font-size: 13px;
@@ -86,7 +83,6 @@ exports[`TableHeader Style tests should render with row styles 1`] = `
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
 }
 
 <th
@@ -105,7 +101,6 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -326,7 +321,6 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;
@@ -476,7 +470,6 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
-  white-space: nowrap;
   color: #666;
   font-size: 13px;
   font-weight: 700;


### PR DESCRIPTION
## Purpose

Right now long words break table layout when using fixed column for small viewports.
<img width="668" alt="CleanShot 2020-12-08 at 16 04 54@2x" src="https://user-images.githubusercontent.com/793851/101634548-298b5780-3a29-11eb-8a4f-d388b919c89e.png">


## Approach and changes

* Remove `white-space: nowrap` for table cells. Table by default will distribute width of its cells proportionally to their content, long text will have wider cells, meaning table by default trying to display as much content in one line as possible. I could not find a need to additionally force one-line layout with `nowrap`.
* Add `overflow-wrap: break-word` for table cells so when a long word does not fit, it'll be broken into multiple lines as a last resort instead of breaking layout.

This is how it looks with the fix:
<img width="660" alt="CleanShot 2020-12-08 at 16 06 17@2x" src="https://user-images.githubusercontent.com/793851/101635559-6ad03700-3a2a-11eb-808b-9e8b354856d0.png">


## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
