### PR TITLE
fix(components): forward custom styles and enable css prop

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
+/** @jsx jsx */
 import React, { HTMLProps, Ref } from 'react';
-import { css } from '@emotion/core';
+import { css, jsx } from '@emotion/core';
 import { Check } from '@sumup/icons';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 
@@ -201,6 +202,7 @@ export const Checkbox = React.forwardRef(
       disabled,
       validationHint,
       className,
+      style,
       invalid,
       tracking,
       ...props
@@ -211,7 +213,7 @@ export const Checkbox = React.forwardRef(
     const handleChange = useClickHandler(onChange, tracking, 'checkbox');
 
     return (
-      <CheckboxWrapper className={className}>
+      <CheckboxWrapper className={className} style={style}>
         <CheckboxInput
           {...props}
           id={id}

--- a/src/components/RadioButton/RadioButton.tsx
+++ b/src/components/RadioButton/RadioButton.tsx
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-import React, { HTMLProps, Ref } from 'react';
-import { css } from '@emotion/core';
+/** @jsx jsx */
+import React, { Fragment, HTMLProps, Ref } from 'react';
+import { css, jsx } from '@emotion/core';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import styled, { StyleProps } from '../../styles/styled';
@@ -187,6 +188,7 @@ export const RadioButton = React.forwardRef(
       disabled,
       tracking,
       className,
+      style,
       ...props
     }: RadioButtonProps,
     ref: RadioButtonProps['ref'],
@@ -195,7 +197,7 @@ export const RadioButton = React.forwardRef(
     const handleChange = useClickHandler(onChange, tracking, 'radio-button');
 
     return (
-      <>
+      <Fragment>
         <RadioButtonInput
           {...props}
           type="radio"
@@ -221,10 +223,11 @@ export const RadioButton = React.forwardRef(
           disabled={disabled}
           invalid={invalid}
           className={className}
+          style={style}
         >
           {children || label}
         </RadioButtonLabel>
-      </>
+      </Fragment>
     );
   },
 );

--- a/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
+/** @jsx jsx */
 import React, { HTMLProps, Ref } from 'react';
-import { css } from '@emotion/core';
+import { css, jsx } from '@emotion/core';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { textKilo } from '../../styles/style-helpers';
@@ -97,8 +98,12 @@ export const RadioButtonGroup = React.forwardRef(
       <fieldset name={name} ref={ref} {...props}>
         {label && <StyledLegend>{label}</StyledLegend>}
         {options &&
-          options.map(({ children, value, className, ...rest }) => (
-            <div key={value && value.toString()} className={className}>
+          options.map(({ children, value, className, style, ...rest }) => (
+            <div
+              key={value && value.toString()}
+              className={className}
+              style={style}
+            >
               <RadioButton
                 {...{ ...rest, value, name, onChange }}
                 checked={value === activeValue}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -304,6 +304,7 @@ export const Select = React.forwardRef(
       label,
       hideLabel,
       className,
+      style,
       id: customId,
       onChange,
       tracking,
@@ -334,6 +335,7 @@ export const Select = React.forwardRef(
     return (
       <SelectLabel
         className={className}
+        style={style}
         htmlFor={id}
         inline={inline}
         disabled={disabled}

--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-import React, { Ref, HTMLProps } from 'react';
-import { css } from '@emotion/core';
+/** @jsx jsx */
+import React, { Fragment, Ref, HTMLProps } from 'react';
+import { css, jsx } from '@emotion/core';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import styled, { StyleProps } from '../../styles/styled';
@@ -151,6 +152,7 @@ export const Selector = React.forwardRef(
       onChange,
       tracking,
       className,
+      style,
       ...props
     }: SelectorProps,
     ref: SelectorProps['ref'],
@@ -160,7 +162,7 @@ export const Selector = React.forwardRef(
     const handleChange = useClickHandler(onChange, tracking, 'selector');
 
     return (
-      <>
+      <Fragment>
         <SelectorInput
           type={type}
           id={inputId}
@@ -184,10 +186,11 @@ export const Selector = React.forwardRef(
           htmlFor={inputId}
           disabled={disabled}
           className={className}
+          style={style}
         >
           {children}
         </SelectorLabel>
-      </>
+      </Fragment>
     );
   },
 );

--- a/src/components/Tabs/components/TabList/TabList.js
+++ b/src/components/Tabs/components/TabList/TabList.js
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-import React from 'react';
+/** @jsx jsx */
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { css } from '@emotion/core';
+import { css, jsx } from '@emotion/core';
 
 import { shadowDouble, hideScrollbar } from '../../../../styles/style-helpers';
 
@@ -72,8 +72,8 @@ const Navigation = styled.div(
 /**
  * TabList component that wraps the Tab components
  */
-const TabList = ({ className, ...props }) => (
-  <Wrapper className={className}>
+const TabList = ({ className, style, ...props }) => (
+  <Wrapper className={className} style={style}>
     <Navigation {...props} role="tablist" />
   </Wrapper>
 );

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -14,7 +14,7 @@
  */
 
 /** @jsx jsx */
-import { forwardRef, HTMLProps, Ref, FC, SVGProps, MouseEvent } from 'react';
+import React, { HTMLProps, Ref, FC, SVGProps, MouseEvent } from 'react';
 import { css, jsx } from '@emotion/core';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 import { Theme } from '@sumup/design-tokens';
@@ -182,7 +182,7 @@ const Container = styled.div`
   position: relative;
 `;
 
-export const Tag = forwardRef(
+export const Tag = React.forwardRef(
   (
     {
       children,
@@ -194,6 +194,7 @@ export const Tag = forwardRef(
       onClick,
       tracking,
       className,
+      style,
       ...props
     }: TagProps,
     ref: BaseProps['ref'],
@@ -207,7 +208,7 @@ export const Tag = forwardRef(
     const removable = Boolean(onRemove);
 
     return (
-      <Container className={className}>
+      <Container className={className} style={style}>
         <TagElement
           removable={removable}
           selected={selected}


### PR DESCRIPTION
## Purpose

Working on a project without Emotion's Babel plugin made me realize that the `styles` prop is an alternative way to pass custom styles to a component. It thus should be forwarded to the same element as the `className` prop.

## Approach and changes

- All components that forward a `className` prop to a specific element now also forward the `styles` prop to the same element. 
- The same components now use the `jsx` pragma from Emotion to enable users to use the `css` prop to pass custom styles.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
