### PR TITLE
fix(components): allow decimal values in CurrencyInput on mobile

### DIFF
--- a/src/components/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/CurrencyInput/CurrencyInput.tsx
@@ -129,6 +129,7 @@ export const CurrencyInput = React.forwardRef(
         placeholder={placeholderString}
         textAlign="right"
         type="text"
+        inputMode="decimal"
         {...props}
       />
     );

--- a/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/src/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -120,7 +120,7 @@ label + .circuit-4:not(label) {
     <input
       class="circuit-2"
       id="input_2"
-      inputmode="numeric"
+      inputmode="decimal"
       placeholder="123,45"
       type="text"
       value=""
@@ -249,7 +249,7 @@ label + .circuit-4:not(label) {
     <input
       class="circuit-2"
       id="input_1"
-      inputmode="numeric"
+      inputmode="decimal"
       type="text"
       value=""
     />


### PR DESCRIPTION
## Purpose

The default numeric input mode triggers a keyboard on iOS that doesn't allow entering a decimal separator (dot or comma). Switching to the decimal input mode shows the number keyboard with the decimal separator for the user's device's locale.

See also https://github.com/s-yadav/react-number-format/issues/189 and [`inputmode` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).


## Approach and changes

- change the CurrencyInput's input mode to `decimal`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
