### PR TITLE
fix(components): allow common decimal signs in CurrencyInput

### DIFF
--- a/src/components/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/CurrencyInput/CurrencyInput.tsx
@@ -99,6 +99,8 @@ export const CurrencyInput = React.forwardRef(
       minimumFractionDigits,
       maximumFractionDigits,
     });
+    // Allow common decimal signs as well as the one from resolveCurrencyFormat()
+    const allowedDecimalSeparators = ['.', ',', decimalDelimiter];
 
     const renderPrefix =
       currencyPosition === 'prefix'
@@ -122,7 +124,7 @@ export const CurrencyInput = React.forwardRef(
         decimalScale={maximumFractionDigits}
         customInput={Input}
         getInputRef={ref}
-        allowedDecimalSeparators={[decimalDelimiter]}
+        allowedDecimalSeparators={allowedDecimalSeparators}
         // Circuit input props
         renderPrefix={renderPrefix}
         renderSuffix={renderSuffix}


### PR DESCRIPTION
## Purpose

For now, the CurrencyInput only allows a single decimal sign (a.k.a decimal separator, decimal delimiter), the one coming back from `resolveCurrencyFormat()` in `@sumup/intl` (that falls back to the default `.`).

This means that, for example, users with a `de-DE` locale will not be able to input a `.` as a decimal sign, because the CurrencyInput will only allow the official `,` (the `.` is the thousands indicator in `de-DE`).

This may sound like an expected behavior, however there is one edge case where this can cause issues.

On mobile devices, the input's `inputmode="decimal"` will cause a decimal keypad to open instead of a normal keyboard. The disposition of this keypad can change depending on the device, but in some cases, it will only show a single decimal sign from **the phone's locale settings**.

![Screenshots from decimal keypads for Android and iOS](https://i0.wp.com/css-tricks.com/wp-content/uploads/2019/05/inputmode-03.png)

_On the right, we see that the decimal keypad in iOS (12.2) only shows a `.`, not a `,`._

Now imagine that an iOS user has their phone in `en-GB`, but views the Circuit component in their mobile browser in `de-DE`.

In that case, the component would only accept `,` but the keypad would only show `.`. This would effectively prevent the user to input decimal numbers.

## Approach and changes

We can pass `react-number-format` an array of allowed decimal signs as a `allowedDecimalSeparators` prop. I suggest passing it two common values ([source](https://en.wikipedia.org/wiki/Decimal_separator#/media/File:DecimalSeparator.svg)), `.` and `,`, in addition to the `decimalDelimiter` from `@sumup/intl`.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
