### PR TITLE
feat(components): add DateInput component

### DIFF
--- a/src/components/DateInput/DateInput.spec.tsx
+++ b/src/components/DateInput/DateInput.spec.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { render, renderToHtml, axe } from '../../util/test-utils';
+
+import DateInput from '.';
+
+describe('DateInput', () => {
+  const baseProps = { label: 'Date' };
+
+  it('should accept a working ref', () => {
+    const tref = React.createRef<HTMLInputElement & HTMLTextAreaElement>();
+    const { container } = render(<DateInput {...baseProps} ref={tref} />);
+    const input = container.querySelector('input');
+    expect(tref.current).toBe(input);
+  });
+
+  it('should meet accessibility guidelines', async () => {
+    const wrapper = renderToHtml(<DateInput {...baseProps} />);
+    const actual = await axe(wrapper);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/src/components/DateInput/DateInput.stories.tsx
+++ b/src/components/DateInput/DateInput.stories.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { DateInput, DateInputProps } from './DateInput';
+
+export default {
+  title: 'Forms/Input/DateInput',
+  component: DateInput,
+  argTypes: {
+    disabled: { control: 'boolean' },
+  },
+};
+
+const baseArgs = {
+  label: 'Date of birth',
+  validationHint: 'You must be at least 18 years old',
+};
+
+export const Base = (args: DateInputProps) => <DateInput {...args} />;
+
+Base.args = baseArgs;

--- a/src/components/DateInput/DateInput.tsx
+++ b/src/components/DateInput/DateInput.tsx
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { forwardRef, useState, useEffect } from 'react';
+import NumberFormat from 'react-number-format';
+
+import styled from '../../styles/styled';
+import { Input, InputProps } from '../Input/Input';
+
+export interface DateInputProps
+  extends Omit<
+    InputProps,
+    'type' | 'value' | 'defaultValue' | 'placeholder' | 'as'
+  > {
+  /**
+   * The value of the input element.
+   */
+  value?: string;
+  /**
+   * The default value of the input element.
+   */
+  defaultValue?: string | number;
+}
+
+const BaseInput = styled(Input)`
+  height: 42px;
+  min-width: 8ch;
+`;
+
+/**
+ * DateInput component for forms.
+ * The input value is always a string in the format `YYYY-MM-DD`.
+ */
+export const DateInput = forwardRef(
+  (props: Omit<DateInputProps, 'ref'>, ref: DateInputProps['ref']) => {
+    // When server-side rendering, we assume that the user's browser supports
+    // the native date input.
+    const [supportsDate, setSupportsDate] = useState(true);
+
+    // We check the browser support after the first render to avoid React's
+    // hydration mismatch warning.
+    useEffect(() => {
+      // Browsers fall back to a text input when the date type isn't supported.
+      // Adapted from https://stackoverflow.com/questions/10193294/how-can-i-tell-if-a-browser-supports-input-type-date
+      const input = document.createElement('input');
+      input.setAttribute('type', 'date');
+
+      setSupportsDate(input.type === 'date');
+    }, []);
+
+    const placeholder = 'yyyy-mm-dd';
+
+    // TODO: Fallback explainer, with enforced format
+    if (!supportsDate) {
+      return (
+        <NumberFormat
+          // NumberFormat props
+          placeholder={placeholder}
+          format="####-##-##"
+          mask={['y', 'y', 'y', 'y', 'm', 'm', 'd', 'd']}
+          customInput={Input}
+          getInputRef={ref}
+          // Circuit input props
+          type="text"
+          inputMode="numeric"
+          {...props}
+        />
+      );
+    }
+
+    return (
+      <BaseInput
+        {...props}
+        ref={ref}
+        type="date"
+        pattern="\d{4}-\d{2}-\d{2}"
+        placeholder={placeholder}
+      />
+    );
+  },
+);
+
+DateInput.displayName = 'DateInput';

--- a/src/components/DateInput/index.ts
+++ b/src/components/DateInput/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DateInput as default } from './DateInput';

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -18,6 +18,7 @@ import { css, jsx } from '@emotion/core';
 
 import SearchInput from '../SearchInput';
 import CurrencyInput from '../CurrencyInput';
+import DateInput from '../DateInput';
 
 import docs from './Input.docs.mdx';
 import { Input, InputProps } from './Input';
@@ -25,7 +26,7 @@ import { Input, InputProps } from './Input';
 export default {
   title: 'Forms/Input',
   component: Input,
-  subcomponents: { SearchInput, CurrencyInput },
+  subcomponents: { SearchInput, CurrencyInput, DateInput },
   parameters: {
     docs: { page: docs },
   },

--- a/src/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -64,14 +64,13 @@ export interface RadioButtonGroupProps
   showValid?: boolean;
 }
 
-const legendBaseStyles = ({ theme }: StyleProps) => css`
+const legendStyles = ({ theme }: StyleProps) => css`
+  label: radio-button-group__legend;
   ${textKilo({ theme })};
   margin-bottom: ${theme.spacings.bit};
 `;
 
-const StyledLegend = styled('legend')<HTMLProps<HTMLLegendElement>>(
-  legendBaseStyles,
-);
+const Legend = styled('legend')(legendStyles);
 
 /**
  * A group of RadioButtons.
@@ -96,7 +95,7 @@ export const RadioButtonGroup = React.forwardRef(
     const name = customName || uniqueId('radio-button-group_');
     return (
       <fieldset name={name} ref={ref} {...props}>
-        {label && <StyledLegend>{label}</StyledLegend>}
+        {label && <Legend>{label}</Legend>}
         {options &&
           options.map(({ children, value, className, style, ...rest }) => (
             <div

--- a/src/components/SearchInput/SearchInput.spec.tsx
+++ b/src/components/SearchInput/SearchInput.spec.tsx
@@ -17,21 +17,22 @@ import React from 'react';
 import { identity } from 'lodash/fp';
 
 import { create, render, renderToHtml, axe } from '../../util/test-utils';
-import Label from '../Label';
 
 import SearchInput from '.';
 
 describe('SearchInput', () => {
+  const baseProps = { label: 'Search' };
+
   /**
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(<SearchInput />);
+    const actual = create(<SearchInput {...baseProps} />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should grey out icon when disabled', () => {
-    const actual = create(<SearchInput disabled />);
+    const actual = create(<SearchInput {...baseProps} disabled />);
     expect(actual).toMatchSnapshot();
   });
 
@@ -39,7 +40,7 @@ describe('SearchInput', () => {
     const onClear = jest.fn(identity);
 
     const { getByTestId } = render(
-      <SearchInput value="search value" onClear={onClear} />,
+      <SearchInput {...baseProps} value="search value" onClear={onClear} />,
     );
     expect(getByTestId('input-clear')).toBeVisible();
   });
@@ -50,7 +51,7 @@ describe('SearchInput', () => {
      */
     it('should accept a working ref', () => {
       const tref = React.createRef<HTMLInputElement & HTMLTextAreaElement>();
-      const { container } = render(<SearchInput ref={tref} />);
+      const { container } = render(<SearchInput {...baseProps} ref={tref} />);
       const input = container.querySelector('input');
       expect(tref.current).toBe(input);
     });
@@ -60,12 +61,7 @@ describe('SearchInput', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(
-      <Label htmlFor="search">
-        <SearchInput id="search" />
-        Search
-      </Label>,
-    );
+    const wrapper = renderToHtml(<SearchInput {...baseProps} />);
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });

--- a/src/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
+++ b/src/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
@@ -1,11 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchInput should grey out icon when disabled 1`] = `
-.circuit-2 {
+.circuit-0 {
+  display: inline-block;
+  margin-bottom: 4px;
+}
+
+.circuit-3 {
   position: relative;
 }
 
-.circuit-0 {
+.circuit-1 {
   position: absolute;
   top: 1px;
   left: 1px;
@@ -16,7 +21,7 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
   width: 40px;
 }
 
-.circuit-3 {
+.circuit-4 {
   font-size: 13px;
   line-height: 20px;
   display: block;
@@ -26,12 +31,12 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
   margin-top: 4px;
 }
 
-.circuit-1 {
+.circuit-2 {
   -webkit-appearance: none;
   background-color: #FFF;
   border: none;
@@ -50,40 +55,45 @@ label + .circuit-3:not(label) {
   box-shadow: 0 0 0 1px #999;
 }
 
-.circuit-1::-webkit-input-placeholder {
+.circuit-2::-webkit-input-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1::-moz-placeholder {
+.circuit-2::-moz-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1:-ms-input-placeholder {
+.circuit-2:-ms-input-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1::placeholder {
+.circuit-2::placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-<div
-  class="circuit-3"
+<label
+  class="circuit-4"
   disabled=""
   for="input_2"
 >
+  <span
+    class="circuit-0"
+  >
+    Search
+  </span>
   <div
-    class="circuit-2"
+    class="circuit-3"
   >
     <svg
-      class="circuit-0"
+      class="circuit-1"
       fill="none"
       height="16"
       viewBox="0 0 16 16"
@@ -98,34 +108,39 @@ label + .circuit-3:not(label) {
       />
     </svg>
     <input
-      class="circuit-1"
+      class="circuit-2"
       disabled=""
       id="input_2"
       type="text"
       value=""
     />
   </div>
-</div>
+</label>
 `;
 
 exports[`SearchInput should render with default styles 1`] = `
-.circuit-3 {
+.circuit-4 {
   font-size: 13px;
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
   margin-top: 4px;
 }
 
-.circuit-2 {
+.circuit-0 {
+  display: inline-block;
+  margin-bottom: 4px;
+}
+
+.circuit-3 {
   position: relative;
 }
 
-.circuit-0 {
+.circuit-1 {
   position: absolute;
   top: 1px;
   left: 1px;
@@ -136,7 +151,7 @@ label + .circuit-3:not(label) {
   width: 40px;
 }
 
-.circuit-1 {
+.circuit-2 {
   -webkit-appearance: none;
   background-color: #FFF;
   border: none;
@@ -154,51 +169,56 @@ label + .circuit-3:not(label) {
   box-shadow: 0 0 0 1px #999;
 }
 
-.circuit-1::-webkit-input-placeholder {
+.circuit-2::-webkit-input-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1::-moz-placeholder {
+.circuit-2::-moz-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1:-ms-input-placeholder {
+.circuit-2:-ms-input-placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1::placeholder {
+.circuit-2::placeholder {
   color: #999;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   box-shadow: 0 0 0 1px #666;
 }
 
-.circuit-1:focus {
+.circuit-2:focus {
   box-shadow: 0 0 0 2px #3063E9;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   box-shadow: 0 0 0 1px #3063E9;
 }
 
-<div
-  class="circuit-3"
+<label
+  class="circuit-4"
   for="input_1"
 >
+  <span
+    class="circuit-0"
+  >
+    Search
+  </span>
   <div
-    class="circuit-2"
+    class="circuit-3"
   >
     <svg
-      class="circuit-0"
+      class="circuit-1"
       fill="none"
       height="16"
       viewBox="0 0 16 16"
@@ -213,11 +233,11 @@ label + .circuit-3:not(label) {
       />
     </svg>
     <input
-      class="circuit-1"
+      class="circuit-2"
       id="input_1"
       type="text"
       value=""
     />
   </div>
-</div>
+</label>
 `;

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ export { default as Input } from './components/Input';
 export { default as RadioButton } from './components/RadioButton';
 export { default as RadioButtonGroup } from './components/RadioButtonGroup';
 export { default as SearchInput } from './components/SearchInput';
+export { default as DateInput } from './components/DateInput';
 export { default as Select } from './components/Select';
 export { default as TextArea } from './components/TextArea';
 export { default as CurrencyInput } from './components/CurrencyInput';


### PR DESCRIPTION
Addresses #537 and [TL-106](https://sumupteam.atlassian.net/browse/TL-106).

## Purpose

Based on my research into datepickers which I've documented in https://github.com/sumup-oss/circuit-ui/issues/537#issuecomment-762791276, this PR adds a DateInput component which is an optimized Input with `type="date"`. It's most suited for simple use cases where a user is expected to enter a single date with basic validation, if any. 

## Approach and changes

- Add and export the DateInput component: it's a thin wrapper around the basic Input component to handle cross-browser inconsistencies. Each browser displays the datepicker differently, here's an overview:

_Firefox on macOS:_

<img width="317" alt="" src="https://user-images.githubusercontent.com/11017722/105231646-7eada380-5b67-11eb-8546-32f2a71f3bff.png">

_Brave (Chromium) on macOS:_

<img width="265" alt="" src="https://user-images.githubusercontent.com/11017722/105231712-92590a00-5b67-11eb-9821-b2652d1d3323.png">

_Safari on macOS — falls back to a masked text input:_ 

<img width="318" alt="" src="https://user-images.githubusercontent.com/11017722/105231832-c5030280-5b67-11eb-9d20-05da87d7aab0.png">

_Edge on Windows:_

<img width="270" alt="" src="https://user-images.githubusercontent.com/11017722/105231783-b4eb2300-5b67-11eb-87b5-b9a3674ca5c4.png">

_Chrome on Android:_

<img width="353" alt="" src="https://user-images.githubusercontent.com/11017722/105231735-9d139f00-5b67-11eb-9afc-b62a96d124d6.png">

_Safari on iOS:_

<img width="353" alt="" src="https://user-images.githubusercontent.com/11017722/105232167-49558580-5b68-11eb-8a29-0e7f14f7053b.PNG">

A note about the placeholder: It's black, not grey like other inputs. On Android and iOS, there's no placeholder shown at all. I could not find a way to show a custom placeholder in a performant and accessible manner.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
