### PR TITLE
fix(components): add margins to all ButtonGroup child elements

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -44,7 +44,7 @@ const getInlineStyles = ({ theme }: StyleProps) => css`
   > a {
     width: auto;
 
-    &:not(:last-of-type) {
+    &:not(:last-child) {
       margin-right: ${theme.spacings.mega};
       margin-bottom: 0;
     }
@@ -62,7 +62,7 @@ const baseStyles = ({ theme }: StyleProps) => css`
   > a {
     width: 100%;
 
-    &:not(:last-of-type) {
+    &:not(:last-child) {
       margin-bottom: ${theme.spacings.mega};
     }
   }

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -145,8 +145,8 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
   width: 100%;
 }
 
-.circuit-2 > button:not(:last-of-type),
-.circuit-2 > a:not(:last-of-type) {
+.circuit-2 > button:not(:last-child),
+.circuit-2 > a:not(:last-child) {
   margin-bottom: 16px;
 }
 
@@ -162,8 +162,8 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
     width: auto;
   }
 
-  .circuit-2 > button:not(:last-of-type),
-  .circuit-2 > a:not(:last-of-type) {
+  .circuit-2 > button:not(:last-child),
+  .circuit-2 > a:not(:last-child) {
     margin-right: 16px;
     margin-bottom: 0;
   }
@@ -330,8 +330,8 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
   width: 100%;
 }
 
-.circuit-2 > button:not(:last-of-type),
-.circuit-2 > a:not(:last-of-type) {
+.circuit-2 > button:not(:last-child),
+.circuit-2 > a:not(:last-child) {
   margin-bottom: 16px;
 }
 
@@ -347,8 +347,8 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
     width: auto;
   }
 
-  .circuit-2 > button:not(:last-of-type),
-  .circuit-2 > a:not(:last-of-type) {
+  .circuit-2 > button:not(:last-child),
+  .circuit-2 > a:not(:last-child) {
     margin-right: 16px;
     margin-bottom: 0;
   }
@@ -395,8 +395,8 @@ exports[`ButtonGroup should render with default styles 1`] = `
   width: 100%;
 }
 
-.circuit-2 > button:not(:last-of-type),
-.circuit-2 > a:not(:last-of-type) {
+.circuit-2 > button:not(:last-child),
+.circuit-2 > a:not(:last-child) {
   margin-bottom: 16px;
 }
 
@@ -412,8 +412,8 @@ exports[`ButtonGroup should render with default styles 1`] = `
     width: auto;
   }
 
-  .circuit-2 > button:not(:last-of-type),
-  .circuit-2 > a:not(:last-of-type) {
+  .circuit-2 > button:not(:last-child),
+  .circuit-2 > a:not(:last-child) {
     margin-right: 16px;
     margin-bottom: 0;
   }


### PR DESCRIPTION
Fixes #688.

## Purpose

Bottom and right margins are currently only added to all except the last `button` or `a` elements within ButtonGroup. This results in inconsistent margins when there's different combinations of element types within the ButtonGroup.

## Approach and changes

I changed the `:not(:last-of-type)` selector to `:not(:last-child)`, this way it applies margins to all child elements within the ButtonGroup except the last one regardless of their type. 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
