### PR TITLE
feat(components): deprecate default component spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Stars](https://img.shields.io/github/stars/sumup-oss/circuit-ui?style=social)](https://github.com/sumup-oss/circuit-ui/) [![Version](https://img.shields.io/npm/v/@sumup/circuit-ui)](https://www.npmjs.com/package/@sumup/circuit-ui) [![Coverage](https://img.shields.io/codecov/c/github/sumup-oss/circuit-ui)](https://codecov.io/gh/sumup-oss/circuit-ui) [![License](https://img.shields.io/github/license/sumup-oss/circuit-ui)](https://github.com/sumup-oss/circuit-ui/blob/main/LICENSE)
 
-[Circuit UI](https://circuit.sumup.com) is the web incarnation of the [SumUp](https://sumup.com) Circuit Design System. Our primary goal is to create a system that can be used to build a wide variety of SumUp websites and apps, while providing a consistent user experience to our end users. In addition, the design system and component library should be easy to use for developers and designers.
+[Circuit UI Web](https://circuit.sumup.com) is the web incarnation of the [SumUp](https://sumup.com) Circuit UI Design System. Our primary goal is to create a system that can be used to build a wide variety of SumUp websites and apps, while providing a consistent user experience to our end users. In addition, the design system and component library should be easy to use for developers and designers.
 
 </div>
 

--- a/src/components/Anchor/Anchor.tsx
+++ b/src/components/Anchor/Anchor.tsx
@@ -21,8 +21,7 @@ import { Dispatch as TrackingProps } from '@sumup/collector';
 import styled, { StyleProps } from '../../styles/styled';
 import { focusOutline } from '../../styles/style-helpers';
 import { ReturnType } from '../../types/return-type';
-import Text from '../Text';
-import { TextProps } from '../Text/Text';
+import { Text, TextProps } from '../Text/Text';
 import { useComponents } from '../ComponentsContext';
 import useClickHandler from '../../hooks/use-click-handler';
 

--- a/src/components/Checkbox/Checkbox.spec.tsx
+++ b/src/components/Checkbox/Checkbox.spec.tsx
@@ -55,6 +55,11 @@ describe('Checkbox', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render with noMargin styles when passed the noMargin prop', () => {
+    const actual = create(<Checkbox noMargin {...defaultProps} />);
+    expect(actual).toMatchSnapshot();
+  });
+
   it('should render with a tooltip when passed a validation hint', () => {
     const actual = create(
       <Checkbox validationHint="This field is required." {...defaultProps} />,

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -66,7 +66,7 @@ const CheckboxWithState = ({
     setChecked((prev) => !prev);
   };
   return (
-    <Checkbox {...props} checked={checked} onChange={handleChange}>
+    <Checkbox {...props} checked={checked} onChange={handleChange} noMargin>
       {children || (checked ? 'Checked' : 'Unchecked')}
     </Checkbox>
   );

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -19,15 +19,16 @@ import { css, jsx } from '@emotion/core';
 import { Check } from '@sumup/icons';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 
-import styled, { NoTheme, StyleProps } from '../../styles/styled';
+import styled, { StyleProps } from '../../styles/styled';
 import {
   disableVisually,
   hideVisually,
   focusOutline,
 } from '../../styles/style-helpers';
 import { uniqueId } from '../../util/id';
-import Tooltip from '../Tooltip';
+import deprecate from '../../util/deprecate';
 import useClickHandler from '../../hooks/use-click-handler';
+import Tooltip from '../Tooltip';
 
 export interface CheckboxProps extends HTMLProps<HTMLInputElement> {
   /**
@@ -38,6 +39,10 @@ export interface CheckboxProps extends HTMLProps<HTMLInputElement> {
    * Warning or error message, displayed in a tooltip.
    */
   validationHint?: string;
+  /**
+   * Removes the default bottom margin from the input.
+   */
+  noMargin?: boolean;
   /**
    * Additional data that is dispatched with the tracking event.
    */
@@ -123,7 +128,9 @@ const CheckboxLabel = styled('label')<LabelElProps>(
   labelInvalidStyles,
 );
 
-const checkboxWrapperStyles = ({ theme }: StyleProps) => css`
+type WrapperElProps = Pick<CheckboxProps, 'noMargin'>;
+
+const wrapperBaseStyles = ({ theme }: StyleProps) => css`
   label: checkbox;
   position: relative;
 
@@ -132,7 +139,30 @@ const checkboxWrapperStyles = ({ theme }: StyleProps) => css`
   }
 `;
 
-const CheckboxWrapper = styled('div')<NoTheme>(checkboxWrapperStyles);
+const wrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
+  if (!noMargin) {
+    deprecate(
+      [
+        'The default outer spacing in the Input component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      ].join(' '),
+    );
+
+    return null;
+  }
+  return css`
+    label: checkbox--no-margin;
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  `;
+};
+
+const CheckboxWrapper = styled('div')<WrapperElProps>(
+  wrapperBaseStyles,
+  wrapperNoMarginStyles,
+);
 
 type InputElProps = Omit<CheckboxProps, 'tracking'>;
 
@@ -204,6 +234,7 @@ export const Checkbox = React.forwardRef(
       className,
       style,
       invalid,
+      noMargin,
       tracking,
       ...props
     }: CheckboxProps,
@@ -213,7 +244,7 @@ export const Checkbox = React.forwardRef(
     const handleChange = useClickHandler(onChange, tracking, 'checkbox');
 
     return (
-      <CheckboxWrapper className={className} style={style}>
+      <CheckboxWrapper className={className} style={style} noMargin={noMargin}>
         <CheckboxInput
           {...props}
           id={id}

--- a/src/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -142,14 +142,14 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 >
   <input
     class="circuit-0"
-    id="checkbox_5"
+    id="checkbox_6"
     name="name"
     type="checkbox"
     value=""
   />
   <label
     class="circuit-1"
-    for="checkbox_5"
+    for="checkbox_6"
   >
     <svg
       aria-hidden="true"
@@ -704,6 +704,140 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   <label
     class="circuit-1"
     for="checkbox_4"
+  >
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M2 8.79L6 13l8-9"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`Checkbox should render with noMargin styles when passed the noMargin prop 1`] = `
+.circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-0:hover + label::before {
+  border-color: #666;
+}
+
+.circuit-0:focus + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:checked + label > svg {
+  -webkit-transform: translateY(-50%) scale(1,1);
+  -ms-transform: translateY(-50%) scale(1,1);
+  transform: translateY(-50%) scale(1,1);
+  opacity: 1;
+}
+
+.circuit-0:checked + label::before {
+  border-color: #3063E9;
+  background-color: #3063E9;
+}
+
+.circuit-1 {
+  color: #1A1A1A;
+  display: inline-block;
+  padding-left: 26px;
+  position: relative;
+  cursor: pointer;
+}
+
+.circuit-1::before {
+  height: 18px;
+  width: 18px;
+  box-sizing: border-box;
+  box-shadow: 0;
+  background-color: #FFF;
+  border: 1px solid #999;
+  border-radius: 3px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: border 120ms ease-in-out, background-color 120ms ease-in-out;
+  transition: border 120ms ease-in-out, background-color 120ms ease-in-out;
+}
+
+.circuit-1 svg {
+  height: 18px;
+  width: 18px;
+  padding: 2px;
+  box-sizing: border-box;
+  color: #FFF;
+  display: block;
+  line-height: 0;
+  opacity: 0;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%) scale(0,0);
+  -ms-transform: translateY(-50%) scale(0,0);
+  transform: translateY(-50%) scale(0,0);
+  -webkit-transition: -webkit-transform 120ms ease-in-out, opacity 120ms ease-in-out;
+  -webkit-transition: transform 120ms ease-in-out, opacity 120ms ease-in-out;
+  transition: transform 120ms ease-in-out, opacity 120ms ease-in-out;
+}
+
+.circuit-2 {
+  position: relative;
+}
+
+.circuit-2:last-of-type {
+  margin-bottom: 16px;
+}
+
+.circuit-2:last-of-type {
+  margin-bottom: 0;
+}
+
+<div
+  class="circuit-2"
+>
+  <input
+    class="circuit-0"
+    id="checkbox_5"
+    name="name"
+    type="checkbox"
+    value=""
+  />
+  <label
+    class="circuit-1"
+    for="checkbox_5"
   >
     <svg
       aria-hidden="true"

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -27,14 +27,16 @@ export default {
 };
 
 export const Base = (args: HeadingProps) => (
-  <Heading {...args}>This is a heading</Heading>
+  <Heading {...args} noMargin>
+    This is a heading
+  </Heading>
 );
 
 const sizes = ['zetta', 'exa', 'peta', 'tera', 'giga', 'mega', 'kilo'] as const;
 
 export const Sizes = (args: HeadingProps) =>
   sizes.map((s) => (
-    <Heading key={s} {...args} size={s}>
+    <Heading key={s} {...args} size={s} noMargin>
       This is a {s} heading
     </Heading>
   ));

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -18,6 +18,7 @@ import { css } from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
+import deprecate from '../../util/deprecate';
 
 type Size = 'kilo' | 'mega' | 'giga' | 'tera' | 'peta' | 'exa' | 'zetta';
 
@@ -67,12 +68,23 @@ const sizeStyles = ({ theme, size = 'peta' }: StyleProps & HeadingProps) =>
     }
   `;
 
-const noMarginStyles = ({ noMargin }: HeadingProps) =>
-  noMargin &&
-  css`
+const noMarginStyles = ({ noMargin }: HeadingProps) => {
+  if (!noMargin) {
+    deprecate(
+      [
+        'The default outer spacing in the Heading component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      ].join(' '),
+    );
+    return null;
+  }
+
+  return css`
     label: heading--no-margin;
     margin-bottom: 0;
   `;
+};
 
 /**
  * A flexible heading component capable of rendering using any HTML heading tag.

--- a/src/components/InlineMessage/InlineMessage.stories.tsx
+++ b/src/components/InlineMessage/InlineMessage.stories.tsx
@@ -37,19 +37,20 @@ export const Base = (args: InlineMessageProps) => (
 
 Base.args = {
   variant: 'warning',
+  noMargin: true,
 };
 
 export const Variants = (args: InlineMessageProps) => (
   <Card spacing={args.size}>
-    <InlineMessage {...args} variant="success">
+    <InlineMessage {...args} variant="success" noMargin>
       Something has gone wonderfully right.
     </InlineMessage>
 
-    <InlineMessage {...args} variant="warning">
+    <InlineMessage {...args} variant="warning" noMargin>
       Something might go sideways.
     </InlineMessage>
 
-    <InlineMessage {...args} variant="danger">
+    <InlineMessage {...args} variant="danger" noMargin>
       Something has gone terribly wrong.
     </InlineMessage>
   </Card>
@@ -58,12 +59,12 @@ export const Variants = (args: InlineMessageProps) => (
 export const Sizes = (args: InlineMessageProps) => (
   <Stack>
     <Card spacing="mega">
-      <InlineMessage {...args} variant="success" size="mega">
+      <InlineMessage {...args} variant="success" size="mega" noMargin>
         Something has gone wonderfully right with a smaller card.
       </InlineMessage>
     </Card>
     <Card>
-      <InlineMessage {...args} variant="success" size="giga">
+      <InlineMessage {...args} variant="success" size="giga" noMargin>
         Something has gone wonderfully right with a larger card.
       </InlineMessage>
     </Card>

--- a/src/components/InlineMessage/InlineMessage.tsx
+++ b/src/components/InlineMessage/InlineMessage.tsx
@@ -16,6 +16,7 @@
 import { css } from '@emotion/core';
 
 import styled, { StyleProps } from '../../styles/styled';
+import deprecate from '../../util/deprecate';
 
 type Variant = 'danger' | 'success' | 'warning';
 
@@ -38,12 +39,23 @@ const baseStyles = css`
   label: inline-message;
 `;
 
-const marginStyles = ({ noMargin }: InlineMessageProps) =>
-  noMargin &&
-  css`
+const marginStyles = ({ noMargin }: InlineMessageProps) => {
+  if (!noMargin) {
+    deprecate(
+      [
+        'The default outer spacing in the InlineMessage component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      ].join(' '),
+    );
+    return null;
+  }
+
+  return css`
     label: text--no-margin;
     margin-bottom: 0;
   `;
+};
 
 const createLeftBorderStyles = (variantName: Variant) => ({
   theme,

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -44,6 +44,7 @@ const baseArgs = {
   label: 'First name',
   placeholder: 'Jane',
   validationHint: 'Maximum 100 characters',
+  noMargin: true,
 };
 
 export const Base = (args: InputProps) => <Input {...args} css={inputStyles} />;
@@ -59,6 +60,7 @@ Valid.args = {
   placeholder: 'jane123',
   validationHint: 'Yay! That username is available.',
   showValid: true,
+  noMargin: true,
 };
 
 export const Invalid = (args: InputProps) => (

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -114,19 +114,40 @@ const InputContainer = styled('div')(containerStyles);
 
 type LabelElProps = Pick<InputProps, 'noMargin'>;
 
-const labelCustomStyles = ({ theme, noMargin }: StyleProps & LabelElProps) =>
-  !noMargin &&
-  css`
-    label: input__label--margin;
-    margin-bottom: ${theme.spacings.mega};
+const labelCustomStyles = ({ theme }: StyleProps) => css`
+  label: input__label;
 
-    label &:not(label),
-    label + &:not(label) {
-      margin-top: ${theme.spacings.bit};
-    }
-  `;
+  label &:not(label),
+  label + &:not(label) {
+    margin-top: ${theme.spacings.bit};
+  }
+`;
 
-const InputLabel = styled(Label)<LabelElProps>(labelCustomStyles);
+const labelNoMarginStyles = ({
+  theme,
+  noMargin,
+}: StyleProps & LabelElProps) => {
+  if (!noMargin) {
+    deprecate(
+      [
+        'The default outer spacing in the Input component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      ].join(' '),
+    );
+
+    return css`
+      label: input__label--margin;
+      margin-bottom: ${theme.spacings.mega};
+    `;
+  }
+  return null;
+};
+
+const InputLabel = styled(Label)<LabelElProps>(
+  labelCustomStyles,
+  labelNoMarginStyles,
+);
 
 type InputElProps = InputProps & {
   hasPrefix: boolean;
@@ -309,7 +330,7 @@ export const Input = forwardRef(
     if (!label) {
       deprecate(
         [
-          'The label is now built into the input component.',
+          'The label is now built into the Input component.',
           'Use the `label` prop to pass in the label content and',
           'remove the Label component from your code.',
           'The label will become required in the next major version.',

--- a/src/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/src/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -977,6 +977,11 @@ exports[`Input should render with no margin styles when passed the noMargin prop
   display: block;
 }
 
+label .circuit-2:not(label),
+label + .circuit-2:not(label) {
+  margin-top: 4px;
+}
+
 <div
   class="circuit-2"
   for="input_14"

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -34,7 +34,7 @@ const ListItems = () => (
 );
 
 export const Base = (args: ListProps) => (
-  <List {...args}>
+  <List {...args} noMargin>
     <ListItems />
   </List>
 );
@@ -43,7 +43,7 @@ const variants = ['unordered', 'ordered'] as const;
 
 export const Variants = (args: ListProps) =>
   variants.map((variant) => (
-    <List key={variant} {...args} variant={variant}>
+    <List key={variant} {...args} variant={variant} noMargin>
       <ListItems />
     </List>
   ));
@@ -52,13 +52,13 @@ const sizes = ['kilo', 'mega', 'giga'] as const;
 
 export const Sizes = (args: ListProps) =>
   sizes.map((size) => (
-    <List key={size} {...args} size={size}>
+    <List key={size} {...args} size={size} noMargin>
       <ListItems />
     </List>
   ));
 
 export const Nested = (args: ListProps) => (
-  <List {...args}>
+  <List {...args} noMargin>
     <ListItems />
     <List {...args}>
       <li>Sometimes a nested list</li>

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -44,6 +44,7 @@ const baseArgs = {
       value: 'FR',
     },
   ],
+  noMargin: true,
 };
 
 const flagIconMap: { [key: string]: FC<{ className?: string }> } = {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -144,12 +144,22 @@ const SelectContainer = styled('div')<ContainerElProps>(
 
 type LabelElProps = Pick<SelectProps, 'noMargin' | 'inline'>;
 
-const labelMarginStyles = ({ theme, noMargin }: StyleProps & LabelElProps) =>
-  !noMargin &&
-  css`
-    label: input__label--margin;
-    margin-bottom: ${theme.spacings.mega};
-  `;
+const labelMarginStyles = ({ theme, noMargin }: StyleProps & LabelElProps) => {
+  if (!noMargin) {
+    deprecate(
+      [
+        'The default outer spacing in the Select component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      ].join(' '),
+    );
+    return css`
+      label: input__label--margin;
+      margin-bottom: ${theme.spacings.mega};
+    `;
+  }
+  return null;
+};
 
 const labelInlineStyles = ({ inline }: LabelElProps) =>
   inline &&

--- a/src/components/Selector/Selector.spec.tsx
+++ b/src/components/Selector/Selector.spec.tsx
@@ -57,6 +57,15 @@ describe('Selector', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render a noMargin selector', () => {
+    const actual = create(
+      <Selector {...defaultProps} noMargin>
+        Label
+      </Selector>,
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
   it('should render a radio input by default', () => {
     const { getByLabelText } = render(
       <Selector {...defaultProps}>Label</Selector>,

--- a/src/components/Selector/Selector.stories.tsx
+++ b/src/components/Selector/Selector.stories.tsx
@@ -32,6 +32,7 @@ export default {
 const baseArgs = {
   name: 'selector',
   value: 'default',
+  noMargin: true,
 };
 
 export const Base = (args: SelectorProps) => (

--- a/src/components/Selector/Selector.tsx
+++ b/src/components/Selector/Selector.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../styles/style-helpers';
 import { uniqueId } from '../../util/id';
 import useClickHandler from '../../hooks/use-click-handler';
+import deprecate from '../../util/deprecate';
 
 export interface SelectorProps extends HTMLProps<HTMLInputElement> {
   /**
@@ -53,6 +54,10 @@ export interface SelectorProps extends HTMLProps<HTMLInputElement> {
    */
   multiple?: boolean;
   /**
+   * Removes the default bottom margin from the input.
+   */
+  noMargin?: boolean;
+  /**
    * The ref to the html dom element
    */
   ref?: Ref<HTMLInputElement>;
@@ -62,7 +67,7 @@ export interface SelectorProps extends HTMLProps<HTMLInputElement> {
   tracking?: TrackingProps;
 }
 
-type LabelElProps = Pick<SelectorProps, 'disabled'>;
+type LabelElProps = Pick<SelectorProps, 'disabled' | 'noMargin'>;
 
 const baseStyles = ({ theme }: StyleProps) => css`
   label: selector__label;
@@ -114,7 +119,28 @@ const disabledStyles = ({ disabled }: LabelElProps) =>
     ${disableVisually()};
   `;
 
-const SelectorLabel = styled('label')<LabelElProps>(baseStyles, disabledStyles);
+const noMarginStyles = ({ noMargin }: LabelElProps) => {
+  if (!noMargin) {
+    deprecate(
+      [
+        'The default outer spacing in the Selector component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      ].join(' '),
+    );
+    return null;
+  }
+  return css`
+    label: selector__label--no-margin;
+    margin-bottom: 0;
+  `;
+};
+
+const SelectorLabel = styled('label')<LabelElProps>(
+  baseStyles,
+  disabledStyles,
+  noMarginStyles,
+);
 
 const inputStyles = ({ theme }: StyleProps) => css`
   label: selector__input;
@@ -153,6 +179,7 @@ export const Selector = React.forwardRef(
       tracking,
       className,
       style,
+      noMargin,
       ...props
     }: SelectorProps,
     ref: SelectorProps['ref'],
@@ -187,6 +214,7 @@ export const Selector = React.forwardRef(
           disabled={disabled}
           className={className}
           style={style}
+          noMargin={noMargin}
         >
           {children}
         </SelectorLabel>

--- a/src/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/src/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -278,3 +278,95 @@ HTMLCollection [
   </label>,
 ]
 `;
+
+exports[`Selector should render a noMargin selector 1`] = `
+HTMLCollection [
+  .circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-0:focus + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:checked + label {
+  background-color: #F0F6FF;
+}
+
+.circuit-0:checked + label::before {
+  border: 2px solid #3063E9;
+}
+
+<input
+    class="circuit-0"
+    id="selector_4"
+    name="name"
+    type="radio"
+    value="value"
+  />,
+  .circuit-0 {
+  display: block;
+  cursor: pointer;
+  padding: 16px 24px;
+  border-radius: 6px;
+  background-color: #FFF;
+  text-align: center;
+  position: relative;
+  margin-bottom: 16px;
+  margin-bottom: 0;
+}
+
+.circuit-0::before {
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 6px;
+  border: 1px solid #CCC;
+  -webkit-transition: border 0.1s ease-in-out;
+  transition: border 0.1s ease-in-out;
+}
+
+.circuit-0:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-0:hover::before {
+  border-color: #999;
+}
+
+.circuit-0:active {
+  background-color: #E6E6E6;
+}
+
+.circuit-0:active::before {
+  border-color: #666;
+}
+
+<label
+    class="circuit-0"
+    for="selector_4"
+  >
+    Label
+  </label>,
+]
+`;

--- a/src/components/SelectorGroup/SelectorGroup.stories.tsx
+++ b/src/components/SelectorGroup/SelectorGroup.stories.tsx
@@ -26,9 +26,9 @@ const baseArgs = {
   name: 'selector-group',
   label: 'Choose your favourite fruit',
   options: [
-    { children: 'Apple', value: 'apple' },
-    { children: 'Banana', value: 'banana' },
-    { children: 'Mango', value: 'mango' },
+    { children: 'Apple', value: 'apple', noMargin: true },
+    { children: 'Banana', value: 'banana', noMargin: true },
+    { children: 'Mango', value: 'mango', noMargin: true },
   ],
 };
 

--- a/src/components/SubHeading/SubHeading.stories.tsx
+++ b/src/components/SubHeading/SubHeading.stories.tsx
@@ -27,14 +27,16 @@ export default {
 };
 
 export const Base = (args: SubHeadingProps) => (
-  <SubHeading {...args}>This is a subheading</SubHeading>
+  <SubHeading {...args} noMargin>
+    This is a subheading
+  </SubHeading>
 );
 
 const sizes = ['mega', 'kilo'] as const;
 
 export const Sizes = (args: SubHeadingProps) =>
   sizes.map((s) => (
-    <SubHeading key={s} {...args} size={s}>
+    <SubHeading key={s} {...args} size={s} noMargin>
       This is a {s} subheading.
     </SubHeading>
   ));

--- a/src/components/SubHeading/SubHeading.tsx
+++ b/src/components/SubHeading/SubHeading.tsx
@@ -18,6 +18,7 @@ import { css } from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
+import deprecate from '../../util/deprecate';
 
 type Size = 'kilo' | 'mega';
 
@@ -53,12 +54,22 @@ const sizeStyles = ({ theme, size = 'kilo' }: StyleProps & SubHeadingProps) =>
     line-height: ${theme.typography.subHeadings[size].lineHeight};
   `;
 
-const noMarginStyles = ({ noMargin }: SubHeadingProps) =>
-  noMargin &&
-  css`
+const noMarginStyles = ({ noMargin }: SubHeadingProps) => {
+  if (!noMargin) {
+    deprecate(
+      [
+        'The default outer spacing in the SubHeading component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      ].join(' '),
+    );
+    return null;
+  }
+  return css`
     label: sub-heading--no-margin;
     margin-bottom: 0;
   `;
+};
 
 /**
  * A flexible subheading component capable of rendering using any HTML heading

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -31,31 +31,35 @@ export default {
   },
 };
 
-export const Base = (args: TextProps) => <Text {...args}>{content}</Text>;
+export const Base = (args: TextProps) => (
+  <Text {...args} noMargin>
+    {content}
+  </Text>
+);
 
 const sizes = ['kilo', 'mega', 'giga'] as const;
 
 export const Sizes = (args: TextProps) =>
   sizes.map((s) => (
-    <Text key={s} {...args} size={s}>
+    <Text key={s} {...args} size={s} noMargin>
       This is a {s} text. {content}
     </Text>
   ));
 
 export const Bold = (args: TextProps) => (
-  <Text {...args} as="strong" bold>
+  <Text {...args} as="strong" bold noMargin>
     {content}
   </Text>
 );
 
 export const Italic = (args: TextProps) => (
-  <Text {...args} as="em" italic>
+  <Text {...args} as="em" italic noMargin>
     {content}
   </Text>
 );
 
 export const Strike = (args: TextProps) => (
-  <Text {...args} as="s" strike>
+  <Text {...args} as="s" strike noMargin>
     {content}
   </Text>
 );

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -18,6 +18,7 @@ import { css } from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
+import deprecate from '../../util/deprecate';
 
 type Size = 'kilo' | 'mega' | 'giga';
 
@@ -103,12 +104,23 @@ const strikeThroughStyles = ({ strike }: TextProps & StyleProps) =>
     text-decoration: line-through;
   `;
 
-const marginStyles = ({ noMargin }: TextProps & StyleProps) =>
-  noMargin &&
-  css`
+const marginStyles = ({ noMargin }: TextProps & StyleProps) => {
+  if (!noMargin) {
+    deprecate(
+      [
+        'The default outer spacing in the Text component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      ].join(' '),
+    );
+    return null;
+  }
+
+  return css`
     label: text--no-margin;
     margin-bottom: 0;
   `;
+};
 
 /**
  * The Text component is used to present the core textual content

--- a/src/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
+++ b/src/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
@@ -901,6 +901,11 @@ exports[`TextArea should render with no margin styles when passed the noMargin p
   display: block;
 }
 
+label .circuit-2:not(label),
+label + .circuit-2:not(label) {
+  margin-top: 4px;
+}
+
 <div
   class="circuit-2"
   for="input_13"

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -30,6 +30,7 @@ const baseArgs = {
   label: 'Short label',
   labelChecked: 'on',
   labelUnchecked: 'off',
+  noMargin: true,
 };
 
 export const Base = (args: ToggleProps) => {

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -19,6 +19,7 @@ import { css } from '@emotion/core';
 import styled, { NoTheme, StyleProps } from '../../styles/styled';
 import { disableVisually } from '../../styles/style-helpers';
 import { uniqueId } from '../../util/id';
+import deprecate from '../../util/deprecate';
 import { Text, TextProps } from '../Text/Text';
 
 import { Switch, SwitchProps } from './components/Switch/Switch';
@@ -91,12 +92,22 @@ const toggleWrapperDisabledStyles = ({ disabled }: WrapperElProps) =>
     ${disableVisually()};
   `;
 
-const toggleWrapperNoMarginStyles = ({ noMargin }: WrapperElProps) =>
-  noMargin &&
-  css`
+const toggleWrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
+  if (!noMargin) {
+    deprecate(
+      [
+        'The default outer spacing in the Toggle component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      ].join(' '),
+    );
+    return null;
+  }
+  return css`
     label: toggle--no-margin;
     margin-bottom: 0;
   `;
+};
 
 const ToggleWrapper = styled('div')<WrapperElProps>(
   toggleWrapperStyles,

--- a/src/util/deprecate.ts
+++ b/src/util/deprecate.ts
@@ -18,7 +18,10 @@ import warning from 'tiny-warning';
 const warned: { [key: string]: true } = {};
 
 export default function deprecate(explanation: string): void {
-  if (process.env.NODE_ENV !== 'production') {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test'
+  ) {
     const message = `DEPRECATION: ${explanation}`;
 
     if (!warned[message]) {


### PR DESCRIPTION
Addresses #534.

## Purpose

This PR addresses steps 2 and 3 of the spacing migration:

> 2. Any Circuit UI components that have external spacing should have a `noMargin` prop to remove this spacing.
> 3. Whenever a component is used without the `noMargin` prop, a deprecation warning should be logged. This way, developers can track down the components that rely on the built-in spacing and replace it with custom styles or a style helper.

## Approach and changes

- disable deprecation warnings in unit tests
- log a deprecation warning when using the Heading, SubHeading, Text, List, InlineMessage, Input, Select, Checkbox, Toggle, or Selector components without the `noMargin` prop
- fix a bug in the Input component where the spacing between the label and input wasn't applied when the `noMargin` prop was used

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
