### PR TITLE
feat(components): add spacing mixin

### DIFF
--- a/src/styles/style-helpers.spec.tsx
+++ b/src/styles/style-helpers.spec.tsx
@@ -18,8 +18,8 @@ import { jsx, css } from '@emotion/core';
 import { light, Theme } from '@sumup/design-tokens';
 
 import { create } from '../util/test-utils';
-import * as StyleHelpers from './style-helpers';
 
+import * as StyleHelpers from './style-helpers';
 import {
   cx,
   shadowSingle,
@@ -83,8 +83,9 @@ describe('Style helpers', () => {
           class="circuit-0"
         />
       `);
+    });
+  });
 
-describe('Style helpers', () => {
   describe('spacing', () => {
     it('should apply spacing to four sides when passing a string', () => {
       const { styles } = StyleHelpers.spacing('mega', light);
@@ -106,6 +107,21 @@ describe('Style helpers', () => {
       );
     });
 
+    it('should apply 0px spacing to one side when passing 0 value in an object', () => {
+      const { styles } = StyleHelpers.spacing(
+        { top: 0, right: 'mega', left: 'giga', bottom: 'kilo' },
+        light,
+      );
+      expect(styles).toMatchInlineSnapshot(
+        `"margin-top:0px;margin-bottom:12px;margin-right:16px;margin-left:24px;"`,
+      );
+    });
+
+    it('should apply 0px spacing to all sides when passing 0 value', () => {
+      const { styles } = StyleHelpers.spacing(0, light);
+      expect(styles).toMatchInlineSnapshot(`"margin:0px;"`);
+    });
+
     it('should apply correct margin for the currying behaviour', () => {
       const { styles } = StyleHelpers.spacing('mega')(light);
       expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
@@ -116,11 +132,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = shadowSingle({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-            box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
-              0 0 1px 0 rgba(12, 15, 20, 0.07), 0 2px 2px 0 rgba(12, 15, 20, 0.07);
-          "
-      `);
+                  "
+                      box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
+                        0 0 1px 0 rgba(12, 15, 20, 0.07), 0 2px 2px 0 rgba(12, 15, 20, 0.07);
+                    "
+              `);
     });
   });
 
@@ -128,11 +144,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = shadowDouble({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-            box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
-              0 2px 2px 0 rgba(12, 15, 20, 0.07), 0 4px 4px 0 rgba(12, 15, 20, 0.07);
-          "
-      `);
+                  "
+                      box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
+                        0 2px 2px 0 rgba(12, 15, 20, 0.07), 0 4px 4px 0 rgba(12, 15, 20, 0.07);
+                    "
+              `);
     });
   });
 
@@ -140,11 +156,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = shadowTriple({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-            box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
-              0 4px 4px 0 rgba(12, 15, 20, 0.07), 0 8px 8px 0 rgba(12, 15, 20, 0.07);
-          "
-      `);
+                  "
+                      box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
+                        0 4px 4px 0 rgba(12, 15, 20, 0.07), 0 8px 8px 0 rgba(12, 15, 20, 0.07);
+                    "
+              `);
     });
   });
 
@@ -152,11 +168,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingKilo({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 17px;
-              line-height: 24px;
-            "
-      `);
+                  "
+                        font-size: 17px;
+                        line-height: 24px;
+                      "
+              `);
     });
   });
 
@@ -164,11 +180,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingMega({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 19px;
-              line-height: 24px;
-            "
-      `);
+                  "
+                        font-size: 19px;
+                        line-height: 24px;
+                      "
+              `);
     });
   });
 
@@ -176,11 +192,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingGiga({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 22px;
-              line-height: 24px;
-            "
-      `);
+                  "
+                        font-size: 22px;
+                        line-height: 24px;
+                      "
+              `);
     });
   });
 
@@ -188,11 +204,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingTera({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 24px;
-              line-height: 32px;
-            "
-      `);
+                  "
+                        font-size: 24px;
+                        line-height: 32px;
+                      "
+              `);
     });
   });
 
@@ -200,11 +216,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingPeta({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 28px;
-              line-height: 32px;
-            "
-      `);
+                  "
+                        font-size: 28px;
+                        line-height: 32px;
+                      "
+              `);
     });
   });
 
@@ -212,11 +228,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingExa({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 36px;
-              line-height: 44px;
-            "
-      `);
+                  "
+                        font-size: 36px;
+                        line-height: 44px;
+                      "
+              `);
     });
   });
 
@@ -224,11 +240,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingZetta({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 42px;
-              line-height: 48px;
-            "
-      `);
+                  "
+                        font-size: 42px;
+                        line-height: 48px;
+                      "
+              `);
     });
   });
 
@@ -236,11 +252,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = subHeadingKilo({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 12px;
-              line-height: 20px;
-            "
-      `);
+                  "
+                        font-size: 12px;
+                        line-height: 20px;
+                      "
+              `);
     });
   });
 
@@ -248,11 +264,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = subHeadingMega({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 14px;
-              line-height: 18px;
-            "
-      `);
+                  "
+                        font-size: 14px;
+                        line-height: 18px;
+                      "
+              `);
     });
   });
 
@@ -260,11 +276,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = textKilo({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 13px;
-              line-height: 20px;
-            "
-      `);
+                  "
+                        font-size: 13px;
+                        line-height: 20px;
+                      "
+              `);
     });
   });
 
@@ -272,11 +288,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = textMega({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 16px;
-              line-height: 24px;
-            "
-      `);
+                  "
+                        font-size: 16px;
+                        line-height: 24px;
+                      "
+              `);
     });
   });
 
@@ -284,11 +300,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = textGiga({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-              font-size: 18px;
-              line-height: 28px;
-            "
-      `);
+                  "
+                        font-size: 18px;
+                        line-height: 28px;
+                      "
+              `);
     });
   });
 
@@ -296,12 +312,12 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = disableVisually();
       expect(styles).toMatchInlineSnapshot(`
-        "
-          opacity: 0.5;
-          pointer-events: none;
-          box-shadow: none;
-        "
-      `);
+                  "
+                    opacity: 0.5;
+                    pointer-events: none;
+                    box-shadow: none;
+                  "
+              `);
     });
   });
 
@@ -309,18 +325,18 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = hideVisually();
       expect(styles).toMatchInlineSnapshot(`
-        "
-          border: 0;
-          clip: rect(0 0 0 0);
-          height: 1px;
-          margin: -1px;
-          overflow: hidden;
-          padding: 0;
-          position: absolute;
-          white-space: nowrap;
-          width: 1px;
-        "
-      `);
+                  "
+                    border: 0;
+                    clip: rect(0 0 0 0);
+                    height: 1px;
+                    margin: -1px;
+                    overflow: hidden;
+                    padding: 0;
+                    position: absolute;
+                    white-space: nowrap;
+                    width: 1px;
+                  "
+              `);
     });
   });
 
@@ -328,15 +344,15 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = focusOutline({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-        "
-            outline: 0;
-            box-shadow: 0 0 0 4px #AFD0FE;
+                  "
+                      outline: 0;
+                      box-shadow: 0 0 0 4px #AFD0FE;
 
-            &::-moz-focus-inner {
-              border: 0;
-            }
-          "
-      `);
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                    "
+              `);
     });
   });
 
@@ -344,17 +360,17 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = clearfix();
       expect(styles).toMatchInlineSnapshot(`
-        "
-          &::before,
-          &::after {
-            content: ' ';
-            display: table;
-          }
-          &::after {
-            clear: both;
-          }
-        "
-      `);
+                  "
+                    &::before,
+                    &::after {
+                      content: ' ';
+                      display: table;
+                    }
+                    &::after {
+                      clear: both;
+                    }
+                  "
+              `);
     });
   });
 
@@ -362,15 +378,15 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = hideScrollbar();
       expect(styles).toMatchInlineSnapshot(`
-        "
-          -ms-overflow-style: none;
-          scrollbar-width: none;
+                  "
+                    -ms-overflow-style: none;
+                    scrollbar-width: none;
 
-          &::-webkit-scrollbar {
-            display: none;
-          }
-        "
-      `);
+                    &::-webkit-scrollbar {
+                      display: none;
+                    }
+                  "
+              `);
     });
   });
 
@@ -378,22 +394,22 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = inputOutline(light);
       expect(styles).toMatchInlineSnapshot(`
-        "
-            box-shadow: 0 0 0 1px #999;
+                  "
+                      box-shadow: 0 0 0 1px #999;
 
-            &:hover {
-              box-shadow: 0 0 0 1px #666;
-            }
+                      &:hover {
+                        box-shadow: 0 0 0 1px #666;
+                      }
 
-            &:focus {
-              box-shadow: 0 0 0 2px #3063E9;
-            }
+                      &:focus {
+                        box-shadow: 0 0 0 2px #3063E9;
+                      }
 
-            &:active {
-              box-shadow: 0 0 0 1px #3063E9;
-            }
-          "
-      `);
+                      &:active {
+                        box-shadow: 0 0 0 1px #3063E9;
+                      }
+                    "
+              `);
     });
 
     it('should match the snapshot when invalid', () => {
@@ -402,22 +418,22 @@ describe('Style helpers', () => {
         invalid: true,
       });
       expect(styles).toMatchInlineSnapshot(`
-        "
-            box-shadow: 0 0 0 1px #D23F47;
+                  "
+                      box-shadow: 0 0 0 1px #D23F47;
 
-            &:hover {
-              box-shadow: 0 0 0 1px #B22426;
-            }
+                      &:hover {
+                        box-shadow: 0 0 0 1px #B22426;
+                      }
 
-            &:focus {
-              box-shadow: 0 0 0 2px #D23F47;
-            }
+                      &:focus {
+                        box-shadow: 0 0 0 2px #D23F47;
+                      }
 
-            &:active {
-              box-shadow: 0 0 0 1px #D23F47;
-            }
-          "
-      `);
+                      &:active {
+                        box-shadow: 0 0 0 1px #D23F47;
+                      }
+                    "
+              `);
     });
 
     it('should match the snapshot when it has a warning', () => {
@@ -426,22 +442,22 @@ describe('Style helpers', () => {
         hasWarning: true,
       });
       expect(styles).toMatchInlineSnapshot(`
-        "
-            box-shadow: 0 0 0 1px #F5C625;
+                  "
+                      box-shadow: 0 0 0 1px #F5C625;
 
-            &:hover {
-              box-shadow: 0 0 0 1px #AD7A14;
-            }
+                      &:hover {
+                        box-shadow: 0 0 0 1px #AD7A14;
+                      }
 
-            &:focus {
-              box-shadow: 0 0 0 2px #F5C625;
-            }
+                      &:focus {
+                        box-shadow: 0 0 0 2px #F5C625;
+                      }
 
-            &:active {
-              box-shadow: 0 0 0 1px #F5C625;
-            }
-          "
-      `);
+                      &:active {
+                        box-shadow: 0 0 0 1px #F5C625;
+                      }
+                    "
+              `);
     });
   });
 });

--- a/src/styles/style-helpers.spec.tsx
+++ b/src/styles/style-helpers.spec.tsx
@@ -172,6 +172,13 @@ describe('Style helpers', () => {
         `"margin-top:12px;margin-bottom:12px;margin-right:16px;margin-left:24px;"`,
       );
     });
+
+    it('should apply correct margin for the currying behaviour', () => {
+      const { styles } = StyleHelpers.spacing('mega')(
+        light,
+      ) as SerializedStyles;
+      expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
+    });
   });
 
   describe('shadowSingle', () => {

--- a/src/styles/style-helpers.spec.tsx
+++ b/src/styles/style-helpers.spec.tsx
@@ -82,6 +82,19 @@ describe('Style helpers', () => {
           class="circuit-0"
         />
       `);
+import { SerializedStyles } from '@emotion/core';
+import { light } from '@sumup/design-tokens';
+
+import * as StyleHelpers from './style-helpers';
+
+describe('Style helpers', () => {
+  describe('spacing', () => {
+    it('should apply spacing to four sides when passing a string', () => {
+      const { styles } = StyleHelpers.spacing(
+        'mega',
+        light,
+      ) as SerializedStyles;
+      expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
     });
   });
 

--- a/src/styles/style-helpers.spec.tsx
+++ b/src/styles/style-helpers.spec.tsx
@@ -96,6 +96,82 @@ describe('Style helpers', () => {
       ) as SerializedStyles;
       expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
     });
+
+    it('should apply spacing to four sides when passing an array', () => {
+      const { styles } = StyleHelpers.spacing(
+        ['giga'],
+        light,
+      ) as SerializedStyles;
+      expect(styles).toMatchInlineSnapshot(`"margin:24px;"`);
+    });
+
+    it('should apply vertical and horizontal spacing when passing two values in an array', () => {
+      const { styles } = StyleHelpers.spacing(
+        ['giga', 'mega'],
+        light,
+      ) as SerializedStyles;
+      expect(styles).toMatchInlineSnapshot(
+        `"margin-top:24px;margin-bottom:24px;margin-right:16px;margin-left:16px;"`,
+      );
+    });
+
+    it('should apply only vertical spacing when passing one value and null in an array', () => {
+      const { styles } = StyleHelpers.spacing(
+        ['mega', null],
+        light,
+      ) as SerializedStyles;
+      expect(styles).toMatchInlineSnapshot(
+        `"margin-top:16px;margin-bottom:16px;"`,
+      );
+    });
+
+    it('should apply only horizontal spacing when passing one value and null in an array', () => {
+      const { styles } = StyleHelpers.spacing(
+        [null, 'kilo'],
+        light,
+      ) as SerializedStyles;
+      expect(styles).toMatchInlineSnapshot(
+        `"margin-right:12px;margin-left:12px;"`,
+      );
+    });
+
+    it('should apply vertical and horizontal spacing when passing three values in an array', () => {
+      const { styles } = StyleHelpers.spacing(
+        ['giga', 'mega', 'kilo'],
+        light,
+      ) as SerializedStyles;
+      expect(styles).toMatchInlineSnapshot(
+        `"margin-top:24px;margin-bottom:12px;margin-right:16px;margin-left:16px;"`,
+      );
+    });
+
+    it('should apply individual spacing to each sides when passing all four values in an array', () => {
+      const { styles } = StyleHelpers.spacing(
+        ['giga', 'mega', 'kilo', 'byte'],
+        light,
+      ) as SerializedStyles;
+      expect(styles).toMatchInlineSnapshot(
+        `"margin-top:24px;margin-bottom:12px;margin-right:16px;margin-left:8px;"`,
+      );
+    });
+
+    it('should apply individual spacing for one side when passing an object', () => {
+      const { styles } = StyleHelpers.spacing(
+        { bottom: 'kilo' },
+        light,
+      ) as SerializedStyles;
+      expect(styles).toMatchInlineSnapshot(`"margin-bottom:12px;"`);
+    });
+
+    it('should apply individual spacing to each sides when passing all four values in an object', () => {
+      const { styles } = StyleHelpers.spacing(
+        { top: 'kilo', right: 'mega', left: 'giga', bottom: 'kilo' },
+        light,
+      ) as SerializedStyles;
+      expect(styles).toMatchInlineSnapshot(
+        `"margin-top:12px;margin-bottom:12px;margin-right:16px;margin-left:24px;"`,
+      );
+    });
   });
 
   describe('shadowSingle', () => {

--- a/src/styles/style-helpers.spec.tsx
+++ b/src/styles/style-helpers.spec.tsx
@@ -19,9 +19,9 @@ import { light, Theme } from '@sumup/design-tokens';
 
 import { create } from '../util/test-utils';
 
-import * as StyleHelpers from './style-helpers';
 import {
   cx,
+  spacing,
   shadowSingle,
   shadowDouble,
   shadowTriple,
@@ -88,17 +88,17 @@ describe('Style helpers', () => {
 
   describe('spacing', () => {
     it('should apply spacing to four sides when passing a string', () => {
-      const { styles } = StyleHelpers.spacing('mega', light);
+      const { styles } = spacing('mega', light);
       expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
     });
 
     it('should apply individual spacing for one side when passing an object', () => {
-      const { styles } = StyleHelpers.spacing({ bottom: 'kilo' }, light);
+      const { styles } = spacing({ bottom: 'kilo' }, light);
       expect(styles).toMatchInlineSnapshot(`"margin-bottom:12px;"`);
     });
 
     it('should apply individual spacing to each sides when passing all four values in an object', () => {
-      const { styles } = StyleHelpers.spacing(
+      const { styles } = spacing(
         { top: 'kilo', right: 'mega', left: 'giga', bottom: 'kilo' },
         light,
       );
@@ -108,7 +108,7 @@ describe('Style helpers', () => {
     });
 
     it('should apply 0px spacing to one side when passing 0 value in an object', () => {
-      const { styles } = StyleHelpers.spacing(
+      const { styles } = spacing(
         { top: 0, right: 'mega', left: 'giga', bottom: 'kilo' },
         light,
       );
@@ -118,12 +118,12 @@ describe('Style helpers', () => {
     });
 
     it('should apply 0px spacing to all sides when passing 0 value', () => {
-      const { styles } = StyleHelpers.spacing(0, light);
+      const { styles } = spacing(0, light);
       expect(styles).toMatchInlineSnapshot(`"margin:0px;"`);
     });
 
     it('should apply correct margin for the currying behaviour', () => {
-      const { styles } = StyleHelpers.spacing('mega')(light);
+      const { styles } = spacing('mega')(light);
       expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
     });
   });
@@ -132,11 +132,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = shadowSingle({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                      box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
-                        0 0 1px 0 rgba(12, 15, 20, 0.07), 0 2px 2px 0 rgba(12, 15, 20, 0.07);
-                    "
-              `);
+        "
+            box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
+              0 0 1px 0 rgba(12, 15, 20, 0.07), 0 2px 2px 0 rgba(12, 15, 20, 0.07);
+          "
+      `);
     });
   });
 
@@ -144,11 +144,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = shadowDouble({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                      box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
-                        0 2px 2px 0 rgba(12, 15, 20, 0.07), 0 4px 4px 0 rgba(12, 15, 20, 0.07);
-                    "
-              `);
+        "
+            box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
+              0 2px 2px 0 rgba(12, 15, 20, 0.07), 0 4px 4px 0 rgba(12, 15, 20, 0.07);
+          "
+      `);
     });
   });
 
@@ -156,11 +156,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = shadowTriple({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                      box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
-                        0 4px 4px 0 rgba(12, 15, 20, 0.07), 0 8px 8px 0 rgba(12, 15, 20, 0.07);
-                    "
-              `);
+        "
+            box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),
+              0 4px 4px 0 rgba(12, 15, 20, 0.07), 0 8px 8px 0 rgba(12, 15, 20, 0.07);
+          "
+      `);
     });
   });
 
@@ -168,11 +168,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingKilo({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 17px;
-                        line-height: 24px;
-                      "
-              `);
+        "
+              font-size: 17px;
+              line-height: 24px;
+            "
+      `);
     });
   });
 
@@ -180,11 +180,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingMega({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 19px;
-                        line-height: 24px;
-                      "
-              `);
+        "
+              font-size: 19px;
+              line-height: 24px;
+            "
+      `);
     });
   });
 
@@ -192,11 +192,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingGiga({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 22px;
-                        line-height: 24px;
-                      "
-              `);
+        "
+              font-size: 22px;
+              line-height: 24px;
+            "
+      `);
     });
   });
 
@@ -204,11 +204,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingTera({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 24px;
-                        line-height: 32px;
-                      "
-              `);
+        "
+              font-size: 24px;
+              line-height: 32px;
+            "
+      `);
     });
   });
 
@@ -216,11 +216,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingPeta({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 28px;
-                        line-height: 32px;
-                      "
-              `);
+        "
+              font-size: 28px;
+              line-height: 32px;
+            "
+      `);
     });
   });
 
@@ -228,11 +228,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingExa({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 36px;
-                        line-height: 44px;
-                      "
-              `);
+        "
+              font-size: 36px;
+              line-height: 44px;
+            "
+      `);
     });
   });
 
@@ -240,11 +240,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = headingZetta({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 42px;
-                        line-height: 48px;
-                      "
-              `);
+        "
+              font-size: 42px;
+              line-height: 48px;
+            "
+      `);
     });
   });
 
@@ -252,11 +252,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = subHeadingKilo({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 12px;
-                        line-height: 20px;
-                      "
-              `);
+        "
+              font-size: 12px;
+              line-height: 20px;
+            "
+      `);
     });
   });
 
@@ -264,11 +264,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = subHeadingMega({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 14px;
-                        line-height: 18px;
-                      "
-              `);
+        "
+              font-size: 14px;
+              line-height: 18px;
+            "
+      `);
     });
   });
 
@@ -276,11 +276,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = textKilo({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 13px;
-                        line-height: 20px;
-                      "
-              `);
+        "
+              font-size: 13px;
+              line-height: 20px;
+            "
+      `);
     });
   });
 
@@ -288,11 +288,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = textMega({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 16px;
-                        line-height: 24px;
-                      "
-              `);
+        "
+              font-size: 16px;
+              line-height: 24px;
+            "
+      `);
     });
   });
 
@@ -300,11 +300,11 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = textGiga({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                        font-size: 18px;
-                        line-height: 28px;
-                      "
-              `);
+        "
+              font-size: 18px;
+              line-height: 28px;
+            "
+      `);
     });
   });
 
@@ -312,12 +312,12 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = disableVisually();
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                    opacity: 0.5;
-                    pointer-events: none;
-                    box-shadow: none;
-                  "
-              `);
+        "
+          opacity: 0.5;
+          pointer-events: none;
+          box-shadow: none;
+        "
+      `);
     });
   });
 
@@ -325,18 +325,18 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = hideVisually();
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                    border: 0;
-                    clip: rect(0 0 0 0);
-                    height: 1px;
-                    margin: -1px;
-                    overflow: hidden;
-                    padding: 0;
-                    position: absolute;
-                    white-space: nowrap;
-                    width: 1px;
-                  "
-              `);
+        "
+          border: 0;
+          clip: rect(0 0 0 0);
+          height: 1px;
+          margin: -1px;
+          overflow: hidden;
+          padding: 0;
+          position: absolute;
+          white-space: nowrap;
+          width: 1px;
+        "
+      `);
     });
   });
 
@@ -344,15 +344,15 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = focusOutline({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                      outline: 0;
-                      box-shadow: 0 0 0 4px #AFD0FE;
+        "
+            outline: 0;
+            box-shadow: 0 0 0 4px #AFD0FE;
 
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                    "
-              `);
+            &::-moz-focus-inner {
+              border: 0;
+            }
+          "
+      `);
     });
   });
 
@@ -360,17 +360,17 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = clearfix();
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                    &::before,
-                    &::after {
-                      content: ' ';
-                      display: table;
-                    }
-                    &::after {
-                      clear: both;
-                    }
-                  "
-              `);
+        "
+          &::before,
+          &::after {
+            content: ' ';
+            display: table;
+          }
+          &::after {
+            clear: both;
+          }
+        "
+      `);
     });
   });
 
@@ -378,15 +378,15 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = hideScrollbar();
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                    -ms-overflow-style: none;
-                    scrollbar-width: none;
+        "
+          -ms-overflow-style: none;
+          scrollbar-width: none;
 
-                    &::-webkit-scrollbar {
-                      display: none;
-                    }
-                  "
-              `);
+          &::-webkit-scrollbar {
+            display: none;
+          }
+        "
+      `);
     });
   });
 
@@ -394,22 +394,22 @@ describe('Style helpers', () => {
     it('should match the snapshot', () => {
       const { styles } = inputOutline(light);
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                      box-shadow: 0 0 0 1px #999;
+        "
+            box-shadow: 0 0 0 1px #999;
 
-                      &:hover {
-                        box-shadow: 0 0 0 1px #666;
-                      }
+            &:hover {
+              box-shadow: 0 0 0 1px #666;
+            }
 
-                      &:focus {
-                        box-shadow: 0 0 0 2px #3063E9;
-                      }
+            &:focus {
+              box-shadow: 0 0 0 2px #3063E9;
+            }
 
-                      &:active {
-                        box-shadow: 0 0 0 1px #3063E9;
-                      }
-                    "
-              `);
+            &:active {
+              box-shadow: 0 0 0 1px #3063E9;
+            }
+          "
+      `);
     });
 
     it('should match the snapshot when invalid', () => {
@@ -418,22 +418,22 @@ describe('Style helpers', () => {
         invalid: true,
       });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                      box-shadow: 0 0 0 1px #D23F47;
+        "
+            box-shadow: 0 0 0 1px #D23F47;
 
-                      &:hover {
-                        box-shadow: 0 0 0 1px #B22426;
-                      }
+            &:hover {
+              box-shadow: 0 0 0 1px #B22426;
+            }
 
-                      &:focus {
-                        box-shadow: 0 0 0 2px #D23F47;
-                      }
+            &:focus {
+              box-shadow: 0 0 0 2px #D23F47;
+            }
 
-                      &:active {
-                        box-shadow: 0 0 0 1px #D23F47;
-                      }
-                    "
-              `);
+            &:active {
+              box-shadow: 0 0 0 1px #D23F47;
+            }
+          "
+      `);
     });
 
     it('should match the snapshot when it has a warning', () => {
@@ -442,22 +442,22 @@ describe('Style helpers', () => {
         hasWarning: true,
       });
       expect(styles).toMatchInlineSnapshot(`
-                  "
-                      box-shadow: 0 0 0 1px #F5C625;
+        "
+            box-shadow: 0 0 0 1px #F5C625;
 
-                      &:hover {
-                        box-shadow: 0 0 0 1px #AD7A14;
-                      }
+            &:hover {
+              box-shadow: 0 0 0 1px #AD7A14;
+            }
 
-                      &:focus {
-                        box-shadow: 0 0 0 2px #F5C625;
-                      }
+            &:focus {
+              box-shadow: 0 0 0 2px #F5C625;
+            }
 
-                      &:active {
-                        box-shadow: 0 0 0 1px #F5C625;
-                      }
-                    "
-              `);
+            &:active {
+              box-shadow: 0 0 0 1px #F5C625;
+            }
+          "
+      `);
     });
   });
 });

--- a/src/styles/style-helpers.spec.tsx
+++ b/src/styles/style-helpers.spec.tsx
@@ -18,6 +18,7 @@ import { jsx, css } from '@emotion/core';
 import { light, Theme } from '@sumup/design-tokens';
 
 import { create } from '../util/test-utils';
+import * as StyleHelpers from './style-helpers';
 
 import {
   cx,
@@ -82,84 +83,16 @@ describe('Style helpers', () => {
           class="circuit-0"
         />
       `);
-import { SerializedStyles } from '@emotion/core';
-import { light } from '@sumup/design-tokens';
-
-import * as StyleHelpers from './style-helpers';
 
 describe('Style helpers', () => {
   describe('spacing', () => {
     it('should apply spacing to four sides when passing a string', () => {
-      const { styles } = StyleHelpers.spacing(
-        'mega',
-        light,
-      ) as SerializedStyles;
+      const { styles } = StyleHelpers.spacing('mega', light);
       expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
     });
 
-    it('should apply spacing to four sides when passing an array', () => {
-      const { styles } = StyleHelpers.spacing(
-        ['giga'],
-        light,
-      ) as SerializedStyles;
-      expect(styles).toMatchInlineSnapshot(`"margin:24px;"`);
-    });
-
-    it('should apply vertical and horizontal spacing when passing two values in an array', () => {
-      const { styles } = StyleHelpers.spacing(
-        ['giga', 'mega'],
-        light,
-      ) as SerializedStyles;
-      expect(styles).toMatchInlineSnapshot(
-        `"margin-top:24px;margin-bottom:24px;margin-right:16px;margin-left:16px;"`,
-      );
-    });
-
-    it('should apply only vertical spacing when passing one value and null in an array', () => {
-      const { styles } = StyleHelpers.spacing(
-        ['mega', null],
-        light,
-      ) as SerializedStyles;
-      expect(styles).toMatchInlineSnapshot(
-        `"margin-top:16px;margin-bottom:16px;"`,
-      );
-    });
-
-    it('should apply only horizontal spacing when passing one value and null in an array', () => {
-      const { styles } = StyleHelpers.spacing(
-        [null, 'kilo'],
-        light,
-      ) as SerializedStyles;
-      expect(styles).toMatchInlineSnapshot(
-        `"margin-right:12px;margin-left:12px;"`,
-      );
-    });
-
-    it('should apply vertical and horizontal spacing when passing three values in an array', () => {
-      const { styles } = StyleHelpers.spacing(
-        ['giga', 'mega', 'kilo'],
-        light,
-      ) as SerializedStyles;
-      expect(styles).toMatchInlineSnapshot(
-        `"margin-top:24px;margin-bottom:12px;margin-right:16px;margin-left:16px;"`,
-      );
-    });
-
-    it('should apply individual spacing to each sides when passing all four values in an array', () => {
-      const { styles } = StyleHelpers.spacing(
-        ['giga', 'mega', 'kilo', 'byte'],
-        light,
-      ) as SerializedStyles;
-      expect(styles).toMatchInlineSnapshot(
-        `"margin-top:24px;margin-bottom:12px;margin-right:16px;margin-left:8px;"`,
-      );
-    });
-
     it('should apply individual spacing for one side when passing an object', () => {
-      const { styles } = StyleHelpers.spacing(
-        { bottom: 'kilo' },
-        light,
-      ) as SerializedStyles;
+      const { styles } = StyleHelpers.spacing({ bottom: 'kilo' }, light);
       expect(styles).toMatchInlineSnapshot(`"margin-bottom:12px;"`);
     });
 
@@ -167,16 +100,14 @@ describe('Style helpers', () => {
       const { styles } = StyleHelpers.spacing(
         { top: 'kilo', right: 'mega', left: 'giga', bottom: 'kilo' },
         light,
-      ) as SerializedStyles;
+      );
       expect(styles).toMatchInlineSnapshot(
         `"margin-top:12px;margin-bottom:12px;margin-right:16px;margin-left:24px;"`,
       );
     });
 
     it('should apply correct margin for the currying behaviour', () => {
-      const { styles } = StyleHelpers.spacing('mega')(
-        light,
-      ) as SerializedStyles;
+      const { styles } = StyleHelpers.spacing('mega')(light);
       expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
     });
   });

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -15,7 +15,7 @@
 
 import { css, SerializedStyles } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';
-import { curry, isObject } from 'lodash';
+import { curry, isObject, isArray } from 'lodash';
 
 type ThemeArgs = Theme | { theme: Theme };
 
@@ -77,11 +77,71 @@ const spacingObject = (
 
   return css(margins);
 };
+const spacingArray = (
+  size: [Spacing, Spacing?, Spacing?, Spacing?],
+  theme: Theme,
+) => {
+  const margins: {
+    marginTop?: string;
+    marginBottom?: string;
+    marginRight?: string;
+    marginLeft?: string;
+  } = {};
+
+  if (size.length === 1) {
+    if (!size[0]) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          'You are trying to reset the spacing which is not supported, because `null` means no margin, not zero margin. Fix it by providing one of the supprted values',
+        );
+      }
+      return null;
+    }
+    return css({ margin: theme.spacings[size[0]] });
+  }
+  if (size.length === 2) {
+    if (size[0]) {
+      margins.marginTop = theme.spacings[size[0]];
+      margins.marginBottom = theme.spacings[size[0]];
+    }
+
+    if (size[1]) {
+      margins.marginRight = theme.spacings[size[1]];
+      margins.marginLeft = theme.spacings[size[1]];
+    }
+
+    return css(margins);
+  }
+  if (size.length === 3) {
+    return spacingObject(
+      {
+        top: size[0],
+        right: size[1],
+        bottom: size[2],
+        left: size[1],
+      },
+      theme,
+    );
+  }
+  if (size.length === 4) {
+    return spacingObject(
+      {
+        top: size[0],
+        right: size[1],
+        bottom: size[2],
+        left: size[3],
+      },
+      theme,
+    );
+  }
+  return null;
+};
 
 export const spacing = curry(
   (
     size:
       | Spacing
+      | [Spacing, Spacing?, Spacing?, Spacing?]
       | { top?: Spacing; bottom?: Spacing; right?: Spacing; left?: Spacing },
     args: ThemeArgs,
   ) => {
@@ -89,6 +149,10 @@ export const spacing = curry(
 
     if (typeof size === 'string') {
       return spacingString(size, theme);
+    }
+
+    if (isArray(size)) {
+      return spacingArray(size, theme);
     }
 
     if (isObject(size)) {

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -15,6 +15,7 @@
 
 import { css, SerializedStyles } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';
+import { curry } from 'lodash';
 
 type ThemeArgs = Theme | { theme: Theme };
 
@@ -34,6 +35,28 @@ type StyleFn =
 
 export const cx = (...styleFns: StyleFn[]) => (theme: Theme) =>
   styleFns.map((styleFn) => styleFn && styleFn(theme));
+type Spacing = keyof Theme['spacings'] | null;
+
+const spacingString = (size: Spacing, theme: Theme) => {
+  if (!size) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        'You are trying to reset the spacing which is not supported, because `null` means no margin, not zero margin. Fix it by providing one of the supported values.',
+      );
+    }
+    return null;
+  }
+  return css({ margin: theme.spacings[size] });
+};
+
+export const spacing = curry((size: Spacing, args: ThemeArgs) => {
+  const theme = getTheme(args);
+
+  if (typeof size === 'string') {
+    return spacingString(size, theme);
+  }
+  return null;
+});
 
 export const shadowSingle = (args: ThemeArgs): SerializedStyles => {
   const theme = getTheme(args);

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -15,7 +15,7 @@
 
 import { css, SerializedStyles } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';
-import { curry } from 'lodash';
+import { curry, isObject } from 'lodash';
 
 type ThemeArgs = Theme | { theme: Theme };
 
@@ -49,14 +49,55 @@ const spacingString = (size: Spacing, theme: Theme) => {
   return css({ margin: theme.spacings[size] });
 };
 
-export const spacing = curry((size: Spacing, args: ThemeArgs) => {
-  const theme = getTheme(args);
-
-  if (typeof size === 'string') {
-    return spacingString(size, theme);
+const spacingObject = (
+  size: { top?: Spacing; bottom?: Spacing; right?: Spacing; left?: Spacing },
+  theme: Theme,
+) => {
+  const margins: {
+    marginTop?: string;
+    marginBottom?: string;
+    marginRight?: string;
+    marginLeft?: string;
+  } = {};
+  if (size.top) {
+    margins.marginTop = theme.spacings[size.top];
   }
-  return null;
-});
+
+  if (size.bottom) {
+    margins.marginBottom = theme.spacings[size.bottom];
+  }
+
+  if (size.right) {
+    margins.marginRight = theme.spacings[size.right];
+  }
+
+  if (size.left) {
+    margins.marginLeft = theme.spacings[size.left];
+  }
+
+  return css(margins);
+};
+
+export const spacing = curry(
+  (
+    size:
+      | Spacing
+      | { top?: Spacing; bottom?: Spacing; right?: Spacing; left?: Spacing },
+    args: ThemeArgs,
+  ) => {
+    const theme = getTheme(args);
+
+    if (typeof size === 'string') {
+      return spacingString(size, theme);
+    }
+
+    if (isObject(size)) {
+      return spacingObject(size, theme);
+    }
+
+    return null;
+  },
+);
 
 export const shadowSingle = (args: ThemeArgs): SerializedStyles => {
   const theme = getTheme(args);

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -15,7 +15,7 @@
 
 import { css, SerializedStyles } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';
-import { curry, isObject, isArray } from 'lodash/fp';
+import { curry } from 'lodash/fp';
 
 type ThemeArgs = Theme | { theme: Theme };
 
@@ -35,130 +35,46 @@ type StyleFn =
 
 export const cx = (...styleFns: StyleFn[]) => (theme: Theme) =>
   styleFns.map((styleFn) => styleFn && styleFn(theme));
-type Spacing = keyof Theme['spacings'] | null;
 
-const spacingString = (size: Spacing, theme: Theme) => {
-  if (!size) {
-    if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        'A single `null` value was passed to the spacing mixin. This has no effect since `null` represents no set margin, not zero margin. If you are trying to reset the spacing, use custom styles instead.',
-      );
-    }
-    return null;
-  }
-  return css({ margin: theme.spacings[size] });
-};
-
-const spacingObject = (
-  size: { top?: Spacing; bottom?: Spacing; right?: Spacing; left?: Spacing },
-  theme: Theme,
-) => {
-  const margins: {
-    marginTop?: string;
-    marginBottom?: string;
-    marginRight?: string;
-    marginLeft?: string;
-  } = {};
-  if (size.top) {
-    margins.marginTop = theme.spacings[size.top];
-  }
-
-  if (size.bottom) {
-    margins.marginBottom = theme.spacings[size.bottom];
-  }
-
-  if (size.right) {
-    margins.marginRight = theme.spacings[size.right];
-  }
-
-  if (size.left) {
-    margins.marginLeft = theme.spacings[size.left];
-  }
-
-  return css(margins);
-};
-const spacingArray = (
-  size: [Spacing, Spacing?, Spacing?, Spacing?],
-  theme: Theme,
-) => {
-  if (size.length === 1) {
-    if (!size[0]) {
-      if (process.env.NODE_ENV !== 'production') {
-        console.warn(
-          'A single `null` value was passed to the spacing mixin. This has no effect since `null` represents no set margin, not zero margin. If you are trying to reset the spacing, use custom styles instead.',
-        );
-      }
-      return null;
-    }
-    return css({ margin: theme.spacings[size[0]] });
-  }
-  if (size.length === 2) {
-    const margins: {
-      marginTop?: string;
-      marginBottom?: string;
-      marginRight?: string;
-      marginLeft?: string;
-    } = {};
-    if (size[0]) {
-      margins.marginTop = theme.spacings[size[0]];
-      margins.marginBottom = theme.spacings[size[0]];
-    }
-
-    if (size[1]) {
-      margins.marginRight = theme.spacings[size[1]];
-      margins.marginLeft = theme.spacings[size[1]];
-    }
-
-    return css(margins);
-  }
-  if (size.length === 3) {
-    return spacingObject(
-      {
-        top: size[0],
-        right: size[1],
-        bottom: size[2],
-        left: size[1],
-      },
-      theme,
-    );
-  }
-  if (size.length === 4) {
-    return spacingObject(
-      {
-        top: size[0],
-        right: size[1],
-        bottom: size[2],
-        left: size[3],
-      },
-      theme,
-    );
-  }
-  return null;
-};
+type Spacing = keyof Theme['spacings'];
 
 export const spacing = curry(
   (
     size:
       | Spacing
-      | [Spacing, Spacing?, Spacing?, Spacing?]
       | { top?: Spacing; bottom?: Spacing; right?: Spacing; left?: Spacing },
     args: ThemeArgs,
   ) => {
     const theme = getTheme(args);
 
     if (typeof size === 'string') {
-      return spacingString(size, theme);
+      return css({ margin: theme.spacings[size] });
     }
 
-    if (isArray(size)) {
-      return spacingArray(size, theme);
+    const margins: {
+      marginTop?: string;
+      marginBottom?: string;
+      marginRight?: string;
+      marginLeft?: string;
+    } = {};
+
+    if (size.top) {
+      margins.marginTop = theme.spacings[size.top];
     }
 
-    if (isObject(size)) {
-      return spacingObject(size, theme);
+    if (size.bottom) {
+      margins.marginBottom = theme.spacings[size.bottom];
     }
 
-    return null;
+    if (size.right) {
+      margins.marginRight = theme.spacings[size.right];
+    }
+
+    if (size.left) {
+      margins.marginLeft = theme.spacings[size.left];
+    }
+
+    return css(margins);
   },
 );
 

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -36,7 +36,18 @@ type StyleFn =
 export const cx = (...styleFns: StyleFn[]) => (theme: Theme) =>
   styleFns.map((styleFn) => styleFn && styleFn(theme));
 
-type Spacing = keyof Theme['spacings'];
+type Spacing = keyof Theme['spacings'] | 0;
+
+const getSpacingValue = (theme: Theme, size: Spacing) => {
+  if (process.env.NODE_ENV !== 'production') {
+    if (typeof size === 'number' && size !== 0) {
+      console.warn(
+        'A custom number value was passed to the spacing mixing. This is not supported, and you can use custom styles instead and 0 to reset the spacing.',
+      );
+    }
+  }
+  return typeof size === 'string' ? theme.spacings[size] : '0px';
+};
 
 export const spacing = curry(
   (
@@ -47,8 +58,8 @@ export const spacing = curry(
   ) => {
     const theme = getTheme(args);
 
-    if (typeof size === 'string') {
-      return css({ margin: theme.spacings[size] });
+    if (typeof size === 'string' || typeof size === 'number') {
+      return css({ margin: getSpacingValue(theme, size) });
     }
 
     const margins: {
@@ -58,22 +69,21 @@ export const spacing = curry(
       marginLeft?: string;
     } = {};
 
-    if (size.top) {
-      margins.marginTop = theme.spacings[size.top];
+    if (typeof size.top !== 'undefined') {
+      margins.marginTop = getSpacingValue(theme, size.top);
     }
 
-    if (size.bottom) {
-      margins.marginBottom = theme.spacings[size.bottom];
+    if (typeof size.bottom !== 'undefined') {
+      margins.marginBottom = getSpacingValue(theme, size.bottom);
     }
 
-    if (size.right) {
-      margins.marginRight = theme.spacings[size.right];
+    if (typeof size.right !== 'undefined') {
+      margins.marginRight = getSpacingValue(theme, size.right);
     }
 
-    if (size.left) {
-      margins.marginLeft = theme.spacings[size.left];
+    if (typeof size.left !== 'undefined') {
+      margins.marginLeft = getSpacingValue(theme, size.left);
     }
-
     return css(margins);
   },
 );

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -15,7 +15,7 @@
 
 import { css, SerializedStyles } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';
-import { curry, isObject, isArray } from 'lodash';
+import { curry, isObject, isArray } from 'lodash/fp';
 
 type ThemeArgs = Theme | { theme: Theme };
 
@@ -41,7 +41,7 @@ const spacingString = (size: Spacing, theme: Theme) => {
   if (!size) {
     if (process.env.NODE_ENV !== 'production') {
       console.warn(
-        'You are trying to reset the spacing which is not supported, because `null` means no margin, not zero margin. Fix it by providing one of the supported values.',
+        'A single `null` value was passed to the spacing mixin. This has no effect since `null` represents no set margin, not zero margin. If you are trying to reset the spacing, use custom styles instead.',
       );
     }
     return null;
@@ -81,18 +81,11 @@ const spacingArray = (
   size: [Spacing, Spacing?, Spacing?, Spacing?],
   theme: Theme,
 ) => {
-  const margins: {
-    marginTop?: string;
-    marginBottom?: string;
-    marginRight?: string;
-    marginLeft?: string;
-  } = {};
-
   if (size.length === 1) {
     if (!size[0]) {
       if (process.env.NODE_ENV !== 'production') {
         console.warn(
-          'You are trying to reset the spacing which is not supported, because `null` means no margin, not zero margin. Fix it by providing one of the supprted values',
+          'A single `null` value was passed to the spacing mixin. This has no effect since `null` represents no set margin, not zero margin. If you are trying to reset the spacing, use custom styles instead.',
         );
       }
       return null;
@@ -100,6 +93,12 @@ const spacingArray = (
     return css({ margin: theme.spacings[size[0]] });
   }
   if (size.length === 2) {
+    const margins: {
+      marginTop?: string;
+      marginBottom?: string;
+      marginRight?: string;
+      marginLeft?: string;
+    } = {};
     if (size[0]) {
       margins.marginTop = theme.spacings[size[0]];
       margins.marginBottom = theme.spacings[size[0]];

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -42,7 +42,10 @@ const getSpacingValue = (theme: Theme, size: Spacing) => {
   if (process.env.NODE_ENV !== 'production') {
     if (typeof size === 'number' && size !== 0) {
       console.warn(
-        'A custom number value was passed to the spacing mixing. This is not supported, and you can use custom styles instead and 0 to reset the spacing.',
+        [
+          `The number "${size as number}" was passed to the spacing mixin.`,
+          'This is not supported. Pass a spacing constant or 0 instead.',
+        ].join(' '),
       );
     }
   }


### PR DESCRIPTION
Addresses #534.

## Purpose

This PR addresses steps 1 of the spacing migration:

1. Implement the new spacing helpers using style mixins approach. 
( Mixins are functions that accept a space enum + the theme and return styles. They're simple to use, can be responsive, and encourage consistency.)

## Approach and changes

- update`style-helpers.ts` with spacing function that accepts space string, array or an object. The spacing value can take different shapes and make it easy to apply any combination of spacing ( add spacing on all sides, add just horizontal or vertical spacing, add individual spacing for each side)
- add tests for each scenario

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
