### PR TITLE
fix: component SingleDayPicker wrong usage example

### DIFF
--- a/src/components/Calendar/SingleDayPicker.stories.js
+++ b/src/components/Calendar/SingleDayPicker.stories.js
@@ -32,7 +32,7 @@ export const Base = (args) => {
       date={date}
       onDateChange={setDate}
       focused={focusedInput}
-      onFocusChange={setFocusedInput}
+      onFocusChange={({ focused }) => setFocusedInput(focused)}
     />
   );
 };


### PR DESCRIPTION
Addresses #ticket-number.

## Purpose

I've found a problem with SingleDayPicker example on storybook. The example passes the whole object event to the state, which causes an always-true state, this results in a calendar that never closes.

## Approach and changes
This is the initial state of focusedInput:
```
const [focusedInput, setFocusedInput] = useState(null);
```
And this is the object passed on `onFocusChange` event:
```
{
   focused: true/false
}
```
Once we have a focusChange event, the state is never falsy again, since we were passing the whole object to the state and the calendar stays open even when the focus is on another component.
I've changed the method passed to onFocusChange to get only the value of the property `focused` and set it to the state.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
