### PR TITLE
feat(components): add promo variant to Badge

### DIFF
--- a/src/components/Badge/Badge.spec.tsx
+++ b/src/components/Badge/Badge.spec.tsx
@@ -35,23 +35,17 @@ describe('Badge', () => {
     expect(actual).toMatchSnapshot();
   });
 
-  it('should render with success styles', () => {
-    const actual = create(<Badge variant="success" />);
-    expect(actual).toMatchSnapshot();
-  });
+  const variants = [
+    'neutral',
+    'success',
+    'warning',
+    'danger',
+    'primary',
+    'promo',
+  ] as const;
 
-  it('should render with warning styles', () => {
-    const actual = create(<Badge variant="warning" />);
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should render with danger styles', () => {
-    const actual = create(<Badge variant="danger" />);
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should render with primary styles', () => {
-    const actual = create(<Badge variant="primary" />);
+  it.each(variants)('should render with %s styles', (variant) => {
+    const actual = create(<Badge variant={variant} />);
     expect(actual).toMatchSnapshot();
   });
 

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -28,39 +28,52 @@ export default {
   },
 };
 
-export const Base = (args: BadgeProps) => <Badge {...args} />;
+/* eslint-disable no-param-reassign */
+export const Base = (args: BadgeProps) => {
+  delete args.onClick;
+  return <Badge {...args} />;
+};
 
 Base.args = {
   children: 'Badge',
 };
 
-export const Variants = (args: BadgeProps) => (
-  <Stack>
-    <Badge {...args} variant="neutral">
-      Neutral
-    </Badge>
-    <Badge {...args} variant="success">
-      Success
-    </Badge>
-    <Badge {...args} variant="warning">
-      Warning
-    </Badge>
-    <Badge {...args} variant="danger">
-      Danger
-    </Badge>
-  </Stack>
-);
+export const Variants = (args: BadgeProps) => {
+  delete args.onClick;
+  return (
+    <Stack>
+      <Badge {...args} variant="neutral">
+        Neutral
+      </Badge>
+      <Badge {...args} variant="success">
+        Success
+      </Badge>
+      <Badge {...args} variant="warning">
+        Warning
+      </Badge>
+      <Badge {...args} variant="danger">
+        Danger
+      </Badge>
+      <Badge {...args} variant="promo">
+        Promo
+      </Badge>
+    </Stack>
+  );
+};
 
-export const Circular = (args: BadgeProps) => (
-  <Stack>
-    <Badge {...args} circle>
-      1
-    </Badge>
-    <Badge {...args} circle>
-      42
-    </Badge>
-    <Badge {...args} circle>
-      999
-    </Badge>
-  </Stack>
-);
+export const Circular = (args: BadgeProps) => {
+  delete args.onClick;
+  return (
+    <Stack>
+      <Badge {...args} circle>
+        1
+      </Badge>
+      <Badge {...args} circle>
+        42
+      </Badge>
+      <Badge {...args} circle>
+        999
+      </Badge>
+    </Stack>
+  );
+};

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -30,7 +30,7 @@ export interface BadgeProps extends HTMLProps<HTMLDivElement> {
   /**
    * Choose from 4 style variants. Default: 'neutral'.
    */
-  variant?: 'neutral' | 'success' | 'warning' | 'danger' | 'primary';
+  variant?: 'neutral' | 'success' | 'warning' | 'danger' | 'primary' | 'promo';
   /**
    * Use the circular badge to indicate a count of items related to an element.
    */
@@ -73,6 +73,11 @@ const COLOR_MAP = {
     text: 'bodyColor',
     default: 'n200',
     hover: 'n300',
+  },
+  promo: {
+    text: 'white',
+    default: 'v500',
+    hover: 'v700',
   },
 } as const;
 

--- a/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/src/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -126,6 +126,29 @@ exports[`Badge should render with default styles 1`] = `
 />
 `;
 
+exports[`Badge should render with neutral styles 1`] = `
+.circuit-0 {
+  border-radius: 999999px;
+  color: #FFF;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #E6E6E6;
+  color: #1A1A1A;
+}
+
+<div
+  class="circuit-0"
+/>
+`;
+
 exports[`Badge should render with primary styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
@@ -141,6 +164,29 @@ exports[`Badge should render with primary styles 1`] = `
   -ms-letter-spacing: 0.25px;
   letter-spacing: 0.25px;
   background-color: #3063E9;
+  color: #FFF;
+}
+
+<div
+  class="circuit-0"
+/>
+`;
+
+exports[`Badge should render with promo styles 1`] = `
+.circuit-0 {
+  border-radius: 999999px;
+  color: #FFF;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #CA58FF;
   color: #FFF;
 }
 

--- a/src/components/Step/Step.stories.js
+++ b/src/components/Step/Step.stories.js
@@ -27,7 +27,7 @@ const IMAGES = [
   'https://source.unsplash.com/6ArTTluciuA/1600x900',
   'https://source.unsplash.com/uanoYn1AmPs/1600x900',
   'https://source.unsplash.com/Ai2TRdvI6gM/1600x900',
-  'https://source.unsplash.com/wxGwllldlIQ/1600x900',
+  'https://source.unsplash.com/oQl0eVYd_n8/1600x900',
 ];
 const STEP_DURATION = 2000;
 const ANIMATION_DURATION = 300;


### PR DESCRIPTION
Addresses an [internal Slack message](https://sumup.slack.com/archives/C8VJTUADU/p1614847156002900).

## Purpose

The Badge component on mobile includes a "promo" variant. We were planning to add this to the web in the future, but a specific request for it prompted us to do it now.

## Approach and changes

- add the "promo" variant to the Badge component
- simplify the variant unit tests
- disable the `onClick` prop in Storybook since the prop has been deprecated and should not be advertised

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
