### PR TITLE
feat(components): deprecate Spacing component

### DIFF
--- a/src/components/Spacing/Spacing.tsx
+++ b/src/components/Spacing/Spacing.tsx
@@ -16,6 +16,7 @@
 import { css } from '@emotion/core';
 
 import styled, { StyleProps } from '../../styles/styled';
+import deprecate from '../../util/deprecate';
 
 export interface SpacingProps {
   /**
@@ -28,9 +29,18 @@ export interface SpacingProps {
   top?: boolean;
 }
 
-const baseStyles = () => css`
-  label: spacing;
-`;
+const baseStyles = () => {
+  deprecate(
+    [
+      'The `Spacing` component has been deprecated.',
+      'Use the `spacing` style mixin instead.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534',
+    ].join(' '),
+  );
+  return css`
+    label: spacing;
+  `;
+};
 
 const marginBottomStyles = ({ theme, bottom }: SpacingProps & StyleProps) =>
   bottom &&
@@ -47,11 +57,12 @@ const marginTopStyles = ({ theme, top }: SpacingProps & StyleProps) =>
   `;
 
 /**
+ * @deprecated Use the `spacing` style mixin instead.
+ *
  * Margin helper component for default margin usage. The idea is to wrap your
  * visual components with this one in order to add top or bottom spacing based
  * on the theme variables.
  */
-
 export const Spacing = styled('div')<SpacingProps>(
   baseStyles,
   marginBottomStyles,

--- a/src/components/Spacing/__snapshots__/Spacing.spec.tsx.snap
+++ b/src/components/Spacing/__snapshots__/Spacing.spec.tsx.snap
@@ -22,6 +22,6 @@ exports[`Spacing margin top should render with margin top styles 1`] = `
 
 exports[`Spacing should render with default styles 1`] = `
 <div
-  class="css-ywy0d0-spacing"
+  class="css-1l0cm9g-spacing"
 />
 `;


### PR DESCRIPTION
Addresses #534.

## Purpose

During the discussion of the new approach to spacing in #534, we reached a consensus that we only want to support the `spacing` style mixin (#832) going forward. 

🤖 Removing the Spacing component in the next major version can be codemodded.

## Approach and changes

- add deprecation warning to the Spacing component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
