### PR TITLE
fix(components): prevent validation icons from shrinking

### DIFF
--- a/src/components/ValidationHint/ValidationHint.tsx
+++ b/src/components/ValidationHint/ValidationHint.tsx
@@ -68,7 +68,7 @@ const iconStyles = (color: 'danger' | 'warning' | 'success') => (
   theme: Theme,
 ) => css`
   label: ${`validation-hint__icon--${color}`};
-  flex-shrink: 1;
+  flex-shrink: 0;
   width: ${theme.iconSizes.kilo};
   height: ${theme.iconSizes.kilo};
   margin-top: 0.15em;

--- a/src/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
+++ b/src/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
@@ -45,9 +45,9 @@ exports[`ValidationHint styles should render with invalid styles 1`] = `
 }
 
 .circuit-0 {
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 16px;
   height: 16px;
   margin-top: 0.15em;
@@ -98,9 +98,9 @@ exports[`ValidationHint styles should render with valid styles 1`] = `
 }
 
 .circuit-0 {
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 16px;
   height: 16px;
   margin-top: 0.15em;
@@ -150,9 +150,9 @@ exports[`ValidationHint styles should render with warning styles 1`] = `
 }
 
 .circuit-0 {
-  -webkit-flex-shrink: 1;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 16px;
   height: 16px;
   margin-top: 0.15em;


### PR DESCRIPTION
## Purpose

When the validation hint exceeds one line, the validation icon shrinks. Discovered this bug on the partner portal.

## Approach and changes

- set `flex-shrink` to `0` for the validation icon

_Before:_

<img width="393" alt="Screen Shot 2021-03-12 at 23 44 35" src="https://user-images.githubusercontent.com/11017722/111006347-f2607580-838c-11eb-8379-a39e4cdd3759.png">

_After:_

<img width="395" alt="Screen Shot 2021-03-12 at 23 44 18" src="https://user-images.githubusercontent.com/11017722/111006361-f8eeed00-838c-11eb-8d13-898cac10ef6f.png">

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
