### PR TITLE
feat(spacing): add spacing array support

### DIFF
--- a/src/styles/style-helpers.spec.tsx
+++ b/src/styles/style-helpers.spec.tsx
@@ -87,48 +87,109 @@ describe('Style helpers', () => {
   });
 
   describe('spacing', () => {
-    it('should apply spacing to four sides when passing a string', () => {
-      const { styles } = spacing('mega')(light);
-      expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
+    describe('when used with a spacings object', () => {
+      it('should apply spacing to four sides when passing a string', () => {
+        const { styles } = spacing('mega')(light);
+        expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
+      });
+
+      it('should apply individual spacing for one side when passing an object', () => {
+        const { styles } = spacing({ bottom: 'kilo' })(light);
+        expect(styles).toMatchInlineSnapshot(`"margin-bottom:12px;"`);
+      });
+
+      it('should apply individual spacing to each sides when passing all four values in an object', () => {
+        const { styles } = spacing({
+          top: 'kilo',
+          right: 'mega',
+          left: 'giga',
+          bottom: 'kilo',
+        })(light);
+        expect(styles).toMatchInlineSnapshot(
+          `"margin-top:12px;margin-right:16px;margin-bottom:12px;margin-left:24px;"`,
+        );
+      });
+
+      it('should apply 0px spacing to one side when passing 0 value in an object', () => {
+        const { styles } = spacing({
+          top: 0,
+          right: 'mega',
+          left: 'giga',
+          bottom: 'kilo',
+        })(light);
+        expect(styles).toMatchInlineSnapshot(
+          `"margin-top:0;margin-right:16px;margin-bottom:12px;margin-left:24px;"`,
+        );
+      });
+
+      it('should apply 0px spacing to all sides when passing 0 value', () => {
+        const { styles } = spacing(0)(light);
+        expect(styles).toMatchInlineSnapshot(`"margin:0;"`);
+      });
+
+      it('should apply correct margin for the currying behaviour', () => {
+        const { styles } = spacing('mega')(light);
+        expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
+      });
     });
 
-    it('should apply individual spacing for one side when passing an object', () => {
-      const { styles } = spacing({ bottom: 'kilo' })(light);
-      expect(styles).toMatchInlineSnapshot(`"margin-bottom:12px;"`);
-    });
+    describe('when called with an array', () => {
+      describe('when called with a single-value array', () => {
+        it('should apply the same margin on all sides for a single value array', () => {
+          const { styles } = spacing(['mega'])(light);
+          expect(styles).toMatchInlineSnapshot(
+            `"margin-top:16px;margin-right:16px;margin-bottom:16px;margin-left:16px;"`,
+          );
+        });
+      });
 
-    it('should apply individual spacing to each sides when passing all four values in an object', () => {
-      const { styles } = spacing({
-        top: 'kilo',
-        right: 'mega',
-        left: 'giga',
-        bottom: 'kilo',
-      })(light);
-      expect(styles).toMatchInlineSnapshot(
-        `"margin-top:12px;margin-bottom:12px;margin-right:16px;margin-left:24px;"`,
-      );
-    });
+      describe('when called with a two-element array', () => {
+        it('should apply vertical and horizontal margins for a two value array', () => {
+          const { styles } = spacing(['mega', 'kilo'])(light);
+          expect(styles).toMatchInlineSnapshot(
+            `"margin-top:16px;margin-right:12px;margin-bottom:16px;margin-left:12px;"`,
+          );
+        });
 
-    it('should apply 0px spacing to one side when passing 0 value in an object', () => {
-      const { styles } = spacing({
-        top: 0,
-        right: 'mega',
-        left: 'giga',
-        bottom: 'kilo',
-      })(light);
-      expect(styles).toMatchInlineSnapshot(
-        `"margin-top:0px;margin-bottom:12px;margin-right:16px;margin-left:24px;"`,
-      );
-    });
+        it('should ignore null values', () => {
+          const { styles } = spacing(['mega', null])(light);
+          expect(styles).toMatchInlineSnapshot(
+            `"margin-top:16px;margin-bottom:16px;"`,
+          );
+        });
+      });
 
-    it('should apply 0px spacing to all sides when passing 0 value', () => {
-      const { styles } = spacing(0)(light);
-      expect(styles).toMatchInlineSnapshot(`"margin:0px;"`);
-    });
+      describe('when called with a three-element array', () => {
+        it('should apply top, horizontal, and bottom styles', () => {
+          const { styles } = spacing(['mega', 'kilo', 'zetta'])(light);
+          expect(styles).toMatchInlineSnapshot(
+            `"margin-top:16px;margin-right:12px;margin-bottom:56px;margin-left:12px;"`,
+          );
+        });
 
-    it('should apply correct margin for the currying behaviour', () => {
-      const { styles } = spacing('mega')(light);
-      expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
+        it('should ignore null values', () => {
+          const { styles } = spacing(['mega', null, 'zetta'])(light);
+          expect(styles).toMatchInlineSnapshot(
+            `"margin-top:16px;margin-bottom:56px;"`,
+          );
+        });
+      });
+
+      describe('when called with a four-element array', () => {
+        it('should skip set all margin values individually', () => {
+          const { styles } = spacing(['bit', 'byte', 'kilo', 'mega'])(light);
+          expect(styles).toMatchInlineSnapshot(
+            `"margin-top:4px;margin-right:8px;margin-bottom:12px;margin-left:16px;"`,
+          );
+        });
+
+        it('should skip null values', () => {
+          const { styles } = spacing(['mega', null, null, 'kilo'])(light);
+          expect(styles).toMatchInlineSnapshot(
+            `"margin-top:16px;margin-left:12px;"`,
+          );
+        });
+      });
     });
   });
 

--- a/src/styles/style-helpers.spec.tsx
+++ b/src/styles/style-helpers.spec.tsx
@@ -88,37 +88,41 @@ describe('Style helpers', () => {
 
   describe('spacing', () => {
     it('should apply spacing to four sides when passing a string', () => {
-      const { styles } = spacing('mega', light);
+      const { styles } = spacing('mega')(light);
       expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
     });
 
     it('should apply individual spacing for one side when passing an object', () => {
-      const { styles } = spacing({ bottom: 'kilo' }, light);
+      const { styles } = spacing({ bottom: 'kilo' })(light);
       expect(styles).toMatchInlineSnapshot(`"margin-bottom:12px;"`);
     });
 
     it('should apply individual spacing to each sides when passing all four values in an object', () => {
-      const { styles } = spacing(
-        { top: 'kilo', right: 'mega', left: 'giga', bottom: 'kilo' },
-        light,
-      );
+      const { styles } = spacing({
+        top: 'kilo',
+        right: 'mega',
+        left: 'giga',
+        bottom: 'kilo',
+      })(light);
       expect(styles).toMatchInlineSnapshot(
         `"margin-top:12px;margin-bottom:12px;margin-right:16px;margin-left:24px;"`,
       );
     });
 
     it('should apply 0px spacing to one side when passing 0 value in an object', () => {
-      const { styles } = spacing(
-        { top: 0, right: 'mega', left: 'giga', bottom: 'kilo' },
-        light,
-      );
+      const { styles } = spacing({
+        top: 0,
+        right: 'mega',
+        left: 'giga',
+        bottom: 'kilo',
+      })(light);
       expect(styles).toMatchInlineSnapshot(
         `"margin-top:0px;margin-bottom:12px;margin-right:16px;margin-left:24px;"`,
       );
     });
 
     it('should apply 0px spacing to all sides when passing 0 value', () => {
-      const { styles } = spacing(0, light);
+      const { styles } = spacing(0)(light);
       expect(styles).toMatchInlineSnapshot(`"margin:0px;"`);
     });
 

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -35,20 +35,20 @@ type StyleFn =
 export const cx = (...styleFns: StyleFn[]) => (theme: Theme) =>
   styleFns.map((styleFn) => styleFn && styleFn(theme));
 
-type Spacing = keyof Theme['spacings'] | 0;
+type Spacing = keyof Theme['spacings'];
 
 type SpacingValue = Spacing | 'auto' | 0;
 
-type SpacingValueWithNull = SpacingValue & null;
+type SpacingValueWithNull = SpacingValue | null;
 
 type SpacingObject = {
-  top?: SpacingValue;
-  right?: SpacingValue;
-  bottom?: SpacingValue;
-  left?: SpacingValue;
+  top?: SpacingValueWithNull;
+  right?: SpacingValueWithNull;
+  bottom?: SpacingValueWithNull;
+  left?: SpacingValueWithNull;
 };
 
-function parseArrayValues(values: SpacingValue[]): SpacingObject {
+function parseArrayValues(values: SpacingValueWithNull[]): SpacingObject {
   const [
     firstValue,
     secondValue = firstValue,
@@ -99,8 +99,18 @@ type MarginCSSProps = {
 };
 
 export const spacing = (
-  values: SpacingValueWithNull[] | SpacingObject,
+  values: SpacingValueWithNull[] | SpacingObject | SpacingValue,
 ): CSSPropFunc => {
+  if (typeof values === 'string' || typeof values === 'number') {
+    return (args: ThemeArg) => {
+      const theme = getTheme(args);
+
+      const margin = mapSpacingValue(theme, values);
+
+      return css({ margin });
+    };
+  }
+
   const { top, right, bottom, left } = Array.isArray(values)
     ? parseArrayValues(values)
     : values;
@@ -122,7 +132,7 @@ export const spacing = (
     }
 
     if (left !== null && typeof left !== 'undefined') {
-      cssProps.marginBottom = mapSpacingValue(theme, left);
+      cssProps.marginLeft = mapSpacingValue(theme, left);
     }
 
     return css(cssProps);


### PR DESCRIPTION
## Purpose

I jumped on the canary branch in a TypeScript project and ran into some issues with the types provided by `curry`. I didn't try too much to make it work, TBH, feeling that `curry` was a bit too much for this specific use case (I've generally started regretting some of my heavy `lodash/fp` use from the past. 😅

I also missed the support for arrays with `null` values for skipping. I know there've been previous discussions around that on the original PR. Having missed those discussions I wanted to make a case for them nevertheless using the code I had written for the other project.

Please check out the changes. If you feel they don't work for Circuit, that's OK. I can continue to use my own mixin for this. 🤗 

## Approach and changes

- Add support for the `auto` value to allow resetting margins to default behavior.
- Add support for the array syntax using the same rules as CSS and providing `null` as a "don't touch" value. I feel this is quite important. Consider the case where you want to set three values values.

```js
// Object version
const margins = {
  top: 'bit',
  right: 'byte',
  bottom: 'kilo',
  left: 'mega',
}

// Array version
const margins = ['bit', 'byte', null, 'mega']
```

Personally, I find this much more ergonomic. Additionally, popular CSS-in-JS libraries like [polished](https://polished.js.org/docs/) and [facepaint](https://github.com/emotion-js/facepaint) also use `null` to skip.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [ ] Meets accessibility requirements
