### PR TITLE
feat(components): tweak spacing mixin

### DIFF
--- a/src/styles/style-helpers.spec.tsx
+++ b/src/styles/style-helpers.spec.tsx
@@ -88,48 +88,47 @@ describe('Style helpers', () => {
 
   describe('spacing', () => {
     it('should apply spacing to four sides when passing a string', () => {
-      const { styles } = spacing('mega', light);
+      const { styles } = spacing('mega')(light);
       expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
     });
 
     it('should apply individual spacing for one side when passing an object', () => {
-      const { styles } = spacing({ bottom: 'kilo' }, light);
+      const { styles } = spacing({ bottom: 'kilo' })(light);
       expect(styles).toMatchInlineSnapshot(`"margin-bottom:12px;"`);
     });
 
     it('should apply individual spacing to each sides when passing all four values in an object', () => {
-      const { styles } = spacing(
-        { top: 'kilo', right: 'mega', left: 'giga', bottom: 'kilo' },
-        light,
-      );
+      const { styles } = spacing({
+        top: 'kilo',
+        right: 'mega',
+        left: 'giga',
+        bottom: 'kilo',
+      })(light);
       expect(styles).toMatchInlineSnapshot(
         `"margin-top:12px;margin-right:16px;margin-bottom:12px;margin-left:24px;"`,
       );
     });
 
     it('should apply 0px spacing to one side when passing 0 value in an object', () => {
-      const { styles } = spacing(
-        { top: 0, right: 'mega', left: 'giga', bottom: 'kilo' },
-        light,
-      );
+      const { styles } = spacing({
+        top: 0,
+        right: 'mega',
+        left: 'giga',
+        bottom: 'kilo',
+      })(light);
       expect(styles).toMatchInlineSnapshot(
         `"margin-top:0;margin-right:16px;margin-bottom:12px;margin-left:24px;"`,
       );
     });
 
     it('should support `0` spacing value', () => {
-      const { styles } = spacing(0, light);
+      const { styles } = spacing(0)(light);
       expect(styles).toMatchInlineSnapshot(`"margin:0;"`);
     });
 
     it('should support the `auto` spacing value', () => {
-      const { styles } = spacing('auto', light);
+      const { styles } = spacing('auto')(light);
       expect(styles).toMatchInlineSnapshot(`"margin:auto;"`);
-    });
-
-    it('should apply correct margin for the currying behaviour', () => {
-      const { styles } = spacing('mega')(light);
-      expect(styles).toMatchInlineSnapshot(`"margin:16px;"`);
     });
   });
 

--- a/src/styles/style-helpers.spec.tsx
+++ b/src/styles/style-helpers.spec.tsx
@@ -103,7 +103,7 @@ describe('Style helpers', () => {
         light,
       );
       expect(styles).toMatchInlineSnapshot(
-        `"margin-top:12px;margin-bottom:12px;margin-right:16px;margin-left:24px;"`,
+        `"margin-top:12px;margin-right:16px;margin-bottom:12px;margin-left:24px;"`,
       );
     });
 
@@ -113,13 +113,18 @@ describe('Style helpers', () => {
         light,
       );
       expect(styles).toMatchInlineSnapshot(
-        `"margin-top:0px;margin-bottom:12px;margin-right:16px;margin-left:24px;"`,
+        `"margin-top:0;margin-right:16px;margin-bottom:12px;margin-left:24px;"`,
       );
     });
 
-    it('should apply 0px spacing to all sides when passing 0 value', () => {
+    it('should support `0` spacing value', () => {
       const { styles } = spacing(0, light);
-      expect(styles).toMatchInlineSnapshot(`"margin:0px;"`);
+      expect(styles).toMatchInlineSnapshot(`"margin:0;"`);
+    });
+
+    it('should support the `auto` spacing value', () => {
+      const { styles } = spacing('auto', light);
+      expect(styles).toMatchInlineSnapshot(`"margin:auto;"`);
     });
 
     it('should apply correct margin for the currying behaviour', () => {

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -36,33 +36,45 @@ type StyleFn =
 export const cx = (...styleFns: StyleFn[]) => (theme: Theme) =>
   styleFns.map((styleFn) => styleFn && styleFn(theme));
 
-type Spacing = keyof Theme['spacings'] | 0;
+type Spacing = keyof Theme['spacings'];
 
-const getSpacingValue = (theme: Theme, size: Spacing) => {
+type SpacingValue = Spacing | 'auto' | 0;
+
+const mapSpacingValue = (theme: Theme, value: SpacingValue) => {
   if (process.env.NODE_ENV !== 'production') {
-    if (typeof size === 'number' && size !== 0) {
+    if (typeof value === 'number' && value !== 0) {
       console.warn(
         [
-          `The number "${size as number}" was passed to the spacing mixin.`,
-          'This is not supported. Pass a spacing constant or 0 instead.',
+          `The number "${value as number}" was passed to the spacing mixin.`,
+          `This is not supported. Pass a spacing constant, 'auto', or 0 instead.`,
         ].join(' '),
       );
     }
   }
-  return typeof size === 'string' ? theme.spacings[size] : '0px';
+
+  if (value === 0 || value === 'auto') {
+    return String(value);
+  }
+
+  return theme.spacings[value];
 };
 
 export const spacing = curry(
   (
     size:
-      | Spacing
-      | { top?: Spacing; bottom?: Spacing; right?: Spacing; left?: Spacing },
+      | SpacingValue
+      | {
+          top?: SpacingValue;
+          bottom?: SpacingValue;
+          right?: SpacingValue;
+          left?: SpacingValue;
+        },
     args: ThemeArgs,
   ) => {
     const theme = getTheme(args);
 
     if (typeof size === 'string' || typeof size === 'number') {
-      return css({ margin: getSpacingValue(theme, size) });
+      return css({ margin: mapSpacingValue(theme, size) });
     }
 
     const margins: {
@@ -73,19 +85,19 @@ export const spacing = curry(
     } = {};
 
     if (typeof size.top !== 'undefined') {
-      margins.marginTop = getSpacingValue(theme, size.top);
-    }
-
-    if (typeof size.bottom !== 'undefined') {
-      margins.marginBottom = getSpacingValue(theme, size.bottom);
+      margins.marginTop = mapSpacingValue(theme, size.top);
     }
 
     if (typeof size.right !== 'undefined') {
-      margins.marginRight = getSpacingValue(theme, size.right);
+      margins.marginRight = mapSpacingValue(theme, size.right);
+    }
+
+    if (typeof size.bottom !== 'undefined') {
+      margins.marginBottom = mapSpacingValue(theme, size.bottom);
     }
 
     if (typeof size.left !== 'undefined') {
-      margins.marginLeft = getSpacingValue(theme, size.left);
+      margins.marginLeft = mapSpacingValue(theme, size.left);
     }
     return css(margins);
   },

--- a/src/styles/style-helpers.ts
+++ b/src/styles/style-helpers.ts
@@ -15,7 +15,6 @@
 
 import { css, SerializedStyles } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';
-import { curry } from 'lodash/fp';
 
 type ThemeArgs = Theme | { theme: Theme };
 
@@ -40,6 +39,13 @@ type Spacing = keyof Theme['spacings'];
 
 type SpacingValue = Spacing | 'auto' | 0;
 
+type SpacingObject = {
+  top?: SpacingValue;
+  bottom?: SpacingValue;
+  right?: SpacingValue;
+  left?: SpacingValue;
+};
+
 const mapSpacingValue = (theme: Theme, value: SpacingValue) => {
   if (process.env.NODE_ENV !== 'production') {
     if (typeof value === 'number' && value !== 0) {
@@ -59,30 +65,24 @@ const mapSpacingValue = (theme: Theme, value: SpacingValue) => {
   return theme.spacings[value];
 };
 
-export const spacing = curry(
-  (
-    size:
-      | SpacingValue
-      | {
-          top?: SpacingValue;
-          bottom?: SpacingValue;
-          right?: SpacingValue;
-          left?: SpacingValue;
-        },
-    args: ThemeArgs,
-  ) => {
-    const theme = getTheme(args);
+export const spacing = (size: SpacingValue | SpacingObject) => {
+  if (typeof size === 'string' || typeof size === 'number') {
+    return (args: ThemeArgs) => {
+      const theme = getTheme(args);
 
-    if (typeof size === 'string' || typeof size === 'number') {
       return css({ margin: mapSpacingValue(theme, size) });
-    }
+    };
+  }
 
-    const margins: {
-      marginTop?: string;
-      marginBottom?: string;
-      marginRight?: string;
-      marginLeft?: string;
-    } = {};
+  const margins: {
+    marginTop?: string;
+    marginBottom?: string;
+    marginRight?: string;
+    marginLeft?: string;
+  } = {};
+
+  return (args: ThemeArgs) => {
+    const theme = getTheme(args);
 
     if (typeof size.top !== 'undefined') {
       margins.marginTop = mapSpacingValue(theme, size.top);
@@ -100,8 +100,8 @@ export const spacing = curry(
       margins.marginLeft = mapSpacingValue(theme, size.left);
     }
     return css(margins);
-  },
-);
+  };
+};
 
 export const shadowSingle = (args: ThemeArgs): SerializedStyles => {
   const theme = getTheme(args);


### PR DESCRIPTION
Extracted from #848.

## Purpose

From @felixjung:

> I jumped on the canary branch in a TypeScript project and ran into some issues with the types provided by `curry`. I didn't try too much to make it work, TBH, feeling that `curry` was a bit too much for this specific use case (I've generally started regretting some of my heavy `lodash/fp` use from the past. 😅

## Approach and changes

- Drop support for calling the spacing mixin at once with all arguments (`spacing(size, theme)`) and enforce currying (`spacing(size)(theme)`)
- Add support for the `auto` value to allow resetting margins to default behavior

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
