### PR TITLE
fix(components): improve grid component types

### DIFF
--- a/src/components/Col/Col.js
+++ b/src/components/Col/Col.js
@@ -20,7 +20,7 @@ import isPropValid from '@emotion/is-prop-valid';
 
 import { getSpanStyles, getSkipStyles, getBreakPointStyles } from './utils';
 
-const baseStyles = ({ theme, skip = '0', span = '0' }) => css`
+const baseStyles = ({ theme, span, skip }) => css`
   label: col;
 
   box-sizing: border-box;

--- a/src/components/Col/utils.js
+++ b/src/components/Col/utils.js
@@ -21,7 +21,6 @@ import {
   toPairs,
   head,
   compose,
-  curry,
   map,
   mapValues,
   values,
@@ -65,7 +64,7 @@ export const createSkipStyles = (grid, theme, skip) => {
   return wrapStyles(styles, breakpoint, theme);
 };
 
-const createBreakpointStyles = curry((theme, current) => {
+const createBreakpointStyles = (theme) => (current) => {
   const config = theme.grid[current.breakpoint];
 
   if (!config) {
@@ -78,7 +77,7 @@ const createBreakpointStyles = curry((theme, current) => {
   `;
 
   return wrapStyles(styles, current.breakpoint, theme);
-});
+};
 
 /**
  * Return the default styles for each breakpoint provided by the config
@@ -90,28 +89,25 @@ export const getBreakPointStyles = (theme) =>
  * Sort the key/value based on the breakpoint priority
  * defined on the grid config.
  */
-export const sortByPriority = curry((grid, iteratee) =>
-  iteratee.sort((a, b) => grid[head(a)].priority - grid[head(b)].priority),
-);
+export const sortByPriority = (grid) => (iteratee) =>
+  iteratee.sort((a, b) => grid[head(a)].priority - grid[head(b)].priority);
 
 /**
  * Map the provided key/value breakpoint into styles based on the grid/theme
  * config.
  */
-export const mapBreakpoint = curry((fn, grid, theme, [key, value]) =>
-  fn(grid[key], theme, value),
-);
+export const mapBreakpoint = (fn, grid, theme) => ([key, value]) =>
+  fn(grid[key], theme, value);
 
 /**
  * Compose the breakpoints object into an array of styles.
  */
-const composeBreakpoints = curry((fn, grid, theme, breakpoints) =>
+const composeBreakpoints = (fn, grid, theme, breakpoints) =>
   compose(
     map(mapBreakpoint(fn, grid, theme)),
     sortByPriority(grid),
     toPairs,
-  )(breakpoints),
-);
+  )(breakpoints);
 
 /**
  * Return the styles of the span based on the provided value. If it is a string

--- a/src/components/Col/utils.js
+++ b/src/components/Col/utils.js
@@ -118,7 +118,7 @@ const composeBreakpoints = curry((fn, grid, theme, breakpoints) =>
  * returns a single style, otherwise composes the breakpoints into an array of
  * styles
  */
-export const getSpanStyles = ({ grid, ...theme }, span) =>
+export const getSpanStyles = ({ grid, ...theme }, span = '0') =>
   isString(span)
     ? createSpanStyles(grid.default, theme, span)
     : composeBreakpoints(createSpanStyles, grid, theme, span);
@@ -128,7 +128,7 @@ export const getSpanStyles = ({ grid, ...theme }, span) =>
  * returns a single style, otherwise composes the breakpoints into an array of
  * styles
  */
-export const getSkipStyles = ({ grid, ...theme }, skip) =>
+export const getSkipStyles = ({ grid, ...theme }, skip = '0') =>
   isString(skip)
     ? createSkipStyles(grid.default, theme, skip)
     : composeBreakpoints(createSkipStyles, grid, theme, skip);

--- a/src/components/Col/utils.spec.js
+++ b/src/components/Col/utils.spec.js
@@ -58,7 +58,7 @@ describe('Col utils', () => {
       const breakpoints = [['last'], ['first'], ['default']];
 
       const expected = [['default'], ['first'], ['last']];
-      const actual = utils.sortByPriority(grid, breakpoints);
+      const actual = utils.sortByPriority(grid)(breakpoints);
 
       expect(actual).toEqual(expected);
     });
@@ -73,7 +73,7 @@ describe('Col utils', () => {
       const theme = 'default';
       const tuple = ['default', 0];
 
-      utils.mapBreakpoint(mock, grid, theme, tuple);
+      utils.mapBreakpoint(mock, grid, theme)(tuple);
 
       expect(mock).toHaveBeenCalledWith(grid[head(tuple)], theme, last(tuple));
     });

--- a/src/components/Table/utils.js
+++ b/src/components/Table/utils.js
@@ -14,7 +14,7 @@
  */
 
 import PropTypes from 'prop-types';
-import { isString, isNumber, isArray, curry } from 'lodash/fp';
+import { isString, isNumber, isArray } from 'lodash/fp';
 
 import { childrenPropType } from '../../util/shared-prop-types';
 
@@ -43,7 +43,7 @@ export const getSortDirection = (isActive, currentSort) => {
   return currentSort === ASCENDING ? DESCENDING : ASCENDING;
 };
 
-export const ascendingSort = curry((i, a, b) => {
+export const ascendingSort = (i) => (a, b) => {
   const firstRow = getRowCells(a);
   const secondRow = getRowCells(b);
   const first = getSortByValue(firstRow[i]);
@@ -57,9 +57,9 @@ export const ascendingSort = curry((i, a, b) => {
   }
 
   return 0;
-});
+};
 
-export const descendingSort = curry((i, a, b) => {
+export const descendingSort = (i) => (a, b) => {
   const firstRow = getRowCells(a);
   const secondRow = getRowCells(b);
   const first = getSortByValue(firstRow[i]);
@@ -73,7 +73,7 @@ export const descendingSort = curry((i, a, b) => {
   }
 
   return 0;
-});
+};
 
 export const RowPropType = PropTypes.oneOfType([
   PropTypes.string,


### PR DESCRIPTION
## Purpose

TypeScript inferred types for the Col component based on its default props that were too restrictive.

## Approach and changes

- Move the default values to the service file to fool TypeScript
- Remove unnecessary use of `curry` in all of Circuit UI

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
