### PR TITLE
Don't render empty children in Sidebar Aggregator

### DIFF
--- a/.changeset/serious-spies-itch.md
+++ b/.changeset/serious-spies-itch.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Prevent the Aggregator in the Sidebar from rendering its children when they're just an empty array, fixes #907.

--- a/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
@@ -28,6 +28,7 @@ import {
 } from 'react';
 import { css, jsx } from '@emotion/core';
 import { TrackingElement } from '@sumup/collector';
+import { isEmpty } from 'lodash/fp';
 
 import styled, { StyleProps } from '../../../../styles/styled';
 import SubNavList from '../SubNavList';
@@ -187,7 +188,7 @@ const Aggregator = ({
         {icon}
         <NavLabel secondary={false}>{label}</NavLabel>
       </AggregatorContainer>
-      {children && !disabled && (
+      {!isEmpty(children) && !disabled && (
         <TrackingElement name={TRACKING_ELEMENT}>
           <SubNavList visible={isOpen}>{children}</SubNavList>
         </TrackingElement>


### PR DESCRIPTION
Fixes #907.

## Approach and changes

- Prevent the Aggregator in the Sidebar from rendering its children when they're just an empty array

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
