### PR TITLE
Add support for the new JSX transform

### DIFF
--- a/.changeset/popular-keys-fetch.md
+++ b/.changeset/popular-keys-fetch.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added compatibility with the new [JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.htmlhttps://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) which was introduced in React 17.

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import {
   forwardRef,

--- a/packages/circuit-ui/components/Card/Card.stories.tsx
+++ b/packages/circuit-ui/components/Card/Card.stories.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { Fragment } from 'react';
 import { action } from '@storybook/addon-actions';

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { HTMLProps, Ref } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/CloseButton/CloseButton.tsx
+++ b/packages/circuit-ui/components/CloseButton/CloseButton.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.stories.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.stories.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { Children, cloneElement, ReactElement } from 'react';
 import { css, jsx, SerializedStyles } from '@emotion/core';

--- a/packages/circuit-ui/components/InlineElements/InlineElements.stories.tsx
+++ b/packages/circuit-ui/components/InlineElements/InlineElements.stories.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import styled from '@emotion/styled';
 import { jsx, css } from '@emotion/core';

--- a/packages/circuit-ui/components/Input/Input.stories.tsx
+++ b/packages/circuit-ui/components/Input/Input.stories.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { forwardRef, Ref, FC, HTMLProps, ReactNode } from 'react';
 import { css, jsx, InterpolationWithTheme } from '@emotion/core';

--- a/packages/circuit-ui/components/LoadingButton/LoadingButton.tsx
+++ b/packages/circuit-ui/components/LoadingButton/LoadingButton.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { FC } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/Modal/Modal.embed.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.embed.stories.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import styled from '@emotion/styled';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { MouseEvent, KeyboardEvent } from 'react';
 import styled from '@emotion/styled';

--- a/packages/circuit-ui/components/Notification/Notification.stories.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.stories.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { Fragment } from 'react';
 import { action } from '@storybook/addon-actions';

--- a/packages/circuit-ui/components/Notification/Notification.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { FC, SVGProps, ReactNode, MouseEvent, KeyboardEvent } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.stories.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { Fragment } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { Fragment, HTMLProps, Ref } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { HTMLProps, Ref } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { FC, ReactNode, Ref, HTMLProps, ChangeEvent } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { Fragment, Ref, HTMLProps } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { ReactNode, ChangeEvent, Ref } from 'react';
 import { includes } from 'lodash/fp';

--- a/packages/circuit-ui/components/Sidebar/Sidebar.stories.js
+++ b/packages/circuit-ui/components/Sidebar/Sidebar.stories.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { useState } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
@@ -16,6 +16,7 @@
 // TODO: Improve types
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import {
   useState,

--- a/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.js
+++ b/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';

--- a/packages/circuit-ui/components/Sidebar/components/Separator/Separator.js
+++ b/packages/circuit-ui/components/Sidebar/components/Separator/Separator.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 

--- a/packages/circuit-ui/components/Spinner/Spinner.stories.tsx
+++ b/packages/circuit-ui/components/Spinner/Spinner.stories.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { css, jsx } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';

--- a/packages/circuit-ui/components/Step/examples/MultiStepForm.js
+++ b/packages/circuit-ui/components/Step/examples/MultiStepForm.js
@@ -15,6 +15,7 @@
 
 /* istanbul ignore file */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 import PropTypes from 'prop-types';

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { HTMLAttributes } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { FC, MouseEvent, KeyboardEvent } from 'react';
 import styled from '@emotion/styled';

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.js
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.js
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import React, { HTMLProps, Ref, FC, SVGProps, MouseEvent } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
+++ b/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { HTMLProps } from 'react';
 import { css, jsx } from '@emotion/core';

--- a/packages/circuit-ui/styles/style-mixins.spec.tsx
+++ b/packages/circuit-ui/styles/style-mixins.spec.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx, css } from '@emotion/core';
 import { light, Theme } from '@sumup/design-tokens';

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+/** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import styled from '@emotion/styled';


### PR DESCRIPTION
## Purpose

When using Circuit UI together with the new [JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) and the `runtime` set to `automatic`, an error would be thrown:

```sh
SyntaxError: [...]/node_modules/@sumup/circuit-ui/dist/es/components/Button/Button.js: pragma and pragmaFrag cannot be set when runtime is automatic.
> 1 | /**
    | ^
  2 |  * Copyright 2019, SumUp Ltd.
  3 |  * Licensed under the Apache License, Version 2.0 (the "License");
  4 |  * you may not use this file except in compliance with the License.
```

Thanks to @slavsan for reporting this issue!

## Approach and changes

- Add JSX runtime directive to force the classic runtime

In Circuit UI v3, we'll switch to using the [`importSource`](https://babeljs.io/docs/en/babel-preset-react#importsource) directive instead.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
