### PR TITLE
Fix alignment of multiline RadioButton labels

### DIFF
--- a/.changeset/ninety-jeans-drive.md
+++ b/.changeset/ninety-jeans-drive.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the alignment of long, multiline labels in the RadioButton component. Fixes #934.

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -47,6 +47,7 @@ type LabelElProps = Pick<RadioButtonProps, 'invalid' | 'disabled'>;
 const labelBaseStyles = ({ theme }: StyleProps) => css`
   label: radio-button__label;
   color: ${theme.colors.bodyColor};
+  display: inline-block;
   padding-left: 26px;
   position: relative;
   cursor: pointer;

--- a/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
@@ -49,6 +49,7 @@ HTMLCollection [
   />,
   .circuit-0 {
   color: #1A1A1A;
+  display: inline-block;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -149,6 +150,7 @@ HTMLCollection [
   />,
   .circuit-0 {
   color: #1A1A1A;
+  display: inline-block;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -250,6 +252,7 @@ HTMLCollection [
   />,
   .circuit-0 {
   color: #1A1A1A;
+  display: inline-block;
   padding-left: 26px;
   position: relative;
   cursor: pointer;
@@ -378,6 +381,7 @@ HTMLCollection [
   />,
   .circuit-0 {
   color: #1A1A1A;
+  display: inline-block;
   padding-left: 26px;
   position: relative;
   cursor: pointer;

--- a/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
@@ -47,6 +47,7 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
 
 .circuit-2 {
   color: #1A1A1A;
+  display: inline-block;
   padding-left: 26px;
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
Fixes #934.

## Approach and changes

- Added `display: inline-block;` to the label, same as in the Checkbox component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
