### PR TITLE
Continously test starter templates

### DIFF
--- a/.changeset/few-ducks-move.md
+++ b/.changeset/few-ducks-move.md
@@ -1,5 +1,5 @@
 ---
-'@sumup/cra-template': patch
+'@sumup/cna-template': patch
 ---
 
 Added default options when initializing Foundry.

--- a/.changeset/gentle-moles-collect.md
+++ b/.changeset/gentle-moles-collect.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Add support for `null` or `undefined` values in `<Table>` cells
+Added support for `null` or `undefined` values in `<Table>` cells.

--- a/.changeset/ninety-jeans-drive.md
+++ b/.changeset/ninety-jeans-drive.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Fixed the alignment of long, multiline labels in the RadioButton component. Fixes #934.
+Fixed the alignment of long, multiline labels in the RadioButton component (#934).

--- a/.changeset/shy-files-fix.md
+++ b/.changeset/shy-files-fix.md
@@ -1,0 +1,5 @@
+---
+'@sumup/cra-template': patch
+---
+
+Added default options to initialize Foundry.

--- a/.github/workflows/cna.yml
+++ b/.github/workflows/cna.yml
@@ -1,0 +1,23 @@
+name: Create SumUp Next App
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js v14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Bootstrap test app
+        run: yarn create next-app --example "https://github.com/sumup-oss/circuit-ui/tree/main/packages/create-sumup-next-app/template" test-app
+
+      - name: Build test app
+        run: cd test-app && yarn build

--- a/.github/workflows/cna.yml
+++ b/.github/workflows/cna.yml
@@ -3,6 +3,7 @@ name: Create SumUp Next App
 on:
   schedule:
     - cron: '0 3 * * 1'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -16,8 +17,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Bootstrap test app
+      - name: Bootstrap app
         run: yarn create next-app --example "https://github.com/sumup-oss/circuit-ui/tree/main/packages/create-sumup-next-app/template" test-app
 
-      - name: Build test app
-        run: cd test-app && yarn build
+      - name: Build app
+        working-directory: ./test-app
+        run: yarn build
+
+      - name: Install test dependencies
+        working-directory: ./test-app
+        run: yarn add puppeteer start-server-and-test
+
+      - name: Test app
+        working-directory: ./test-app
+        run: start-server-and-test start http://localhost:3000 "node ../scripts/verify-template.js"

--- a/.github/workflows/cra.yml
+++ b/.github/workflows/cra.yml
@@ -1,0 +1,23 @@
+name: Create SumUp React App
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js v14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Bootstrap test app
+        run: yarn create react-app test-app --template @sumup
+
+      - name: Build test app
+        run: cd test-app && yarn build

--- a/.github/workflows/cra.yml
+++ b/.github/workflows/cra.yml
@@ -1,8 +1,7 @@
-name: Create SumUp React App
-
 on:
   schedule:
     - cron: '0 3 * * 1'
+  workflow_dispatch:
 
 jobs:
   test:
@@ -16,8 +15,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Bootstrap test app
+      - name: Bootstrap app
         run: yarn create react-app test-app --template @sumup
 
-      - name: Build test app
-        run: cd test-app && yarn build
+      - name: Build app
+        working-directory: ./test-app
+        run: yarn build
+
+      - name: Install test dependencies
+        working-directory: ./test-app
+        run: yarn add puppeteer start-server-and-test
+
+      - name: Test app
+        working-directory: ./test-app
+        run: start-server-and-test start http://localhost:3000 "node ../scripts/verify-template.js"

--- a/packages/create-sumup-next-app/template/package.json
+++ b/packages/create-sumup-next-app/template/package.json
@@ -9,7 +9,7 @@
     "analyze": "ANALYZE=true yarn build",
     "test": "jest --watch",
     "test:ci": "mkdir -p __reports__ && jest --ci --coverage --runInBand --json --outputFile=__reports__/jest-results.json",
-    "postinstall": "yarn foundry init; echo \"Remove the postinstall script from the package.json file after setting up Foundry.\""
+    "postinstall": "yarn foundry init -p lint -l TypeScript -e Browser Node; echo \"Remove the postinstall script from the package.json file after setting up Foundry.\""
   },
   "dependencies": {
     "@emotion/core": "^10.0.0",

--- a/packages/create-sumup-react-app/template.json
+++ b/packages/create-sumup-react-app/template.json
@@ -20,7 +20,7 @@
       "@testing-library/jest-dom": "^5.11.6"
     },
     "scripts": {
-      "postinstall": "yarn run foundry init"
+      "postinstall": "yarn foundry init -p lint -l JavaScript -e Browser; echo \"Remove the postinstall script from the package.json file after setting up Foundry.\""
     },
     "eslintConfig": {
       "extends": ".eslintrc.js"

--- a/scripts/verify-template.js
+++ b/scripts/verify-template.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const puppeteer = require('puppeteer');
+
+/**
+ * This script is used to check for runtime errors in the starter templates
+ * create-sumup-next-app and create-sumup-react-app.
+ */
+(async () => {
+  const expected = 'Welcome to SumUp';
+
+  try {
+    const browser = await puppeteer.launch();
+    const page = await browser.newPage();
+
+    await page.goto('http://localhost:3000');
+    await page.screenshot({ path: 'example.png' });
+
+    const heading = await page.$eval('h1', (e) => e.textContent);
+    const assertion = heading.includes(expected);
+
+    if (!assertion) {
+      throw new Error(
+        [
+          `Expected page heading to contain '${expected}',`,
+          `instead got '${heading}'.`,
+        ].join(' '),
+      );
+    }
+
+    await browser.close();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/scripts/verify-template.js
+++ b/scripts/verify-template.js
@@ -27,7 +27,6 @@ const puppeteer = require('puppeteer');
     const page = await browser.newPage();
 
     await page.goto('http://localhost:3000');
-    await page.screenshot({ path: 'example.png' });
 
     const heading = await page.$eval('h1', (e) => e.textContent);
     const assertion = heading.includes(expected);


### PR DESCRIPTION
## Purpose

The starter templates can occasionally break when a dependency releases a breaking change in a minor release. Until now, we've found out about these issues from user reports. Having to fight with errors doesn't make for a good first impression of Circuit UI.

## Approach and changes

- Create and test both starter templates once a week in CI

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
