### PR TITLE
Add Selector size variations and switch SelectorGroup to horizontal orientation

### DIFF
--- a/.changeset/hot-cheetahs-press.md
+++ b/.changeset/hot-cheetahs-press.md
@@ -1,0 +1,11 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+- Add `size` prop to `Selector`
+- Refactor styling of the `Selector` to make sure its height matches other controls like `Input` and `Select`
+- Switch `SelectorGroup` to a horizontal orientation on a big screen and vertical on mobile
+- Add `inlineMobile` prop to `SelectorGroup` to force horizontal orientation on mobile
+- Add `size` prop to `SelectorGroup` which changes size of a `Selector` within the group
+- Add `gapSize` prop to `SelectorGroup` to control the spacing between `Selectors`
+- Add `stretch` prop to `SelectorGroup` to make it fill all available width

--- a/.changeset/hot-cheetahs-press.md
+++ b/.changeset/hot-cheetahs-press.md
@@ -2,9 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-- Add `size` prop to `Selector`
-- Refactor styling of the `Selector` to make sure its height matches other controls like `Input` and `Select`
-- Add orientation prop to `SelectorGroup` to choose between horizontal and vertical layout.
-- Add `size` prop to `SelectorGroup` which changes size of a `Selector` within the group
-- Add `gapSize` prop to `SelectorGroup` to control the spacing between `Selectors`
-- Add `stretch` prop to `SelectorGroup` to make it fill all available width
+`Selector` now has multiple `size` options. `SelectorGroup` is changed to horizontal layout and to be inline element by default with an option to stretch to full width.

--- a/.changeset/hot-cheetahs-press.md
+++ b/.changeset/hot-cheetahs-press.md
@@ -1,11 +1,10 @@
 ---
-'@sumup/circuit-ui': minor
+'@sumup/circuit-ui': major
 ---
 
 - Add `size` prop to `Selector`
 - Refactor styling of the `Selector` to make sure its height matches other controls like `Input` and `Select`
-- Switch `SelectorGroup` to a horizontal orientation on a big screen and vertical on mobile
-- Add `inlineMobile` prop to `SelectorGroup` to force horizontal orientation on mobile
+- Add orientation prop to `SelectorGroup` to choose between horizontal and vertical layout.
 - Add `size` prop to `SelectorGroup` which changes size of a `Selector` within the group
 - Add `gapSize` prop to `SelectorGroup` to control the spacing between `Selectors`
 - Add `stretch` prop to `SelectorGroup` to make it fill all available width

--- a/packages/circuit-ui/components/Selector/Selector.docs.mdx
+++ b/packages/circuit-ui/components/Selector/Selector.docs.mdx
@@ -31,6 +31,16 @@ same screen that they are currently in. For example, choosing a payment method o
 
 <Story id="forms-selector--disabled" />
 
+### Sizes
+
+Selector component supports 3 different sizes:
+
+- **mega**, the default size
+- **kilo**, used when there are sizing constraints
+- **flexible**, used for more complex content within selector which may define it's own margins. **flexible** just adds a minimal equal margin on all sides.
+
+<Story id="forms-selector--sizes" />
+
 ## SelectorGroup
 
 <Story id="forms-selector-selectorgroup--base" />

--- a/packages/circuit-ui/components/Selector/Selector.docs.mdx
+++ b/packages/circuit-ui/components/Selector/Selector.docs.mdx
@@ -37,7 +37,7 @@ Selector component supports 3 different sizes:
 
 - **mega**, the default size
 - **kilo**, used when there are sizing constraints
-- **flexible**, used for more complex content within selector which may define it's own margins. **flexible** just adds a minimal equal margin on all sides.
+- **flexible**, used for more complex content within selector which may define its own margins. **flexible** just adds a minimal equal margin on all sides.
 
 <Story id="forms-selector--sizes" />
 

--- a/packages/circuit-ui/components/Selector/Selector.stories.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.stories.tsx
@@ -15,7 +15,9 @@
 
 import React from 'react';
 
+import { Stack } from '../../../../.storybook/components';
 import SelectorGroup from '../SelectorGroup';
+import Text from '../Text';
 
 import docs from './Selector.docs.mdx';
 import { Selector, SelectorProps } from './Selector';
@@ -62,3 +64,21 @@ Disabled.args = {
   name: 'disabled',
   disabled: true,
 };
+export const Sizes = (args: SelectorProps) => (
+  <Stack>
+    <Selector {...args} size="kilo">
+      Kilo
+    </Selector>
+    <Selector {...args} size="mega">
+      Mega
+    </Selector>
+    <Selector {...args} size="flexible">
+      <Text bold noMargin>
+        Flexible
+      </Text>
+      <Text noMargin>Hello World!</Text>
+    </Selector>
+  </Stack>
+);
+
+Disabled.args = { ...baseArgs, disabled: true };

--- a/packages/circuit-ui/components/Selector/Selector.stories.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.stories.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 
 import { Stack } from '../../../../.storybook/components';
 import SelectorGroup from '../SelectorGroup';
-import Text from '../Text';
+import Body from '../Body';
 
 import docs from './Selector.docs.mdx';
 import { Selector, SelectorProps } from './Selector';
@@ -73,10 +73,10 @@ export const Sizes = (args: SelectorProps) => (
       Mega
     </Selector>
     <Selector {...args} size="flexible">
-      <Text bold noMargin>
+      <Body variant="highlight" noMargin>
         Flexible
-      </Text>
-      <Text noMargin>Hello World!</Text>
+      </Body>
+      <Body noMargin>Hello World!</Body>
     </Selector>
   </Stack>
 );

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -77,32 +77,6 @@ type LabelElProps = Pick<
   'disabled' | 'noMargin' | 'size' | 'checked'
 >;
 
-// const outlineStyles = ({
-//   theme,
-//   checked,
-//   hasFocus,
-// }: StyleProps & LabelElProps) => {
-//   const defaultBorder = `0 0 0 ${theme.borderWidth.kilo} ${theme.colors.n300}`;
-//   const hoverBorder = `0 0 0 ${theme.borderWidth.kilo} ${theme.colors.n500}`;
-//   const activeBorder = `0 0 0 ${theme.borderWidth.kilo} ${theme.colors.n700}`;
-//   const checkedBorder = `0 0 0 ${theme.borderWidth.mega} ${theme.colors.p500}`;
-//   const focusOutline = hasFocus
-//     ? `, 0 0 0 ${checked ? '5px' : '4px'} ${theme.colors.p300}`
-//     : '';
-
-//   return css`
-//     box-shadow: ${`${checked ? checkedBorder : defaultBorder}${focusOutline}`};
-
-//     &:hover {
-//       box-shadow: ${`${checked ? checkedBorder : hoverBorder}${focusOutline}`};
-//     }
-
-//     &:active {
-//       box-shadow: ${`${checked ? checkedBorder : activeBorder}${focusOutline}`};
-//     }
-//   `;
-// };
-
 interface OutlineStyles {
   default: string;
   hover: string;
@@ -135,7 +109,7 @@ const baseStyles = ({ theme, checked }: StyleProps & LabelElProps) => {
     position: relative;
     margin-bottom: ${theme.spacings.mega};
     border: none;
-    border-radius: ${theme.borderRadius.tera};
+    border-radius: ${theme.borderRadius.byte};
     transition: box-shadow 0.1s ease-in-out;
     box-shadow: ${borderStyles.default};
 

--- a/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -15,13 +15,16 @@ HTMLCollection [
   width: 1px;
 }
 
-.circuit-0:focus + label::before {
-  display: block;
+.circuit-0:focus + label {
+  box-shadow: 0 0 0 2px #3063E9,0 0 0 5px #AFD0FE;
 }
 
-.circuit-0:checked + label {
-  background-color: #F0F6FF;
-  box-shadow: 0 0 0 2px #3063E9;
+.circuit-0:focus + label:hover {
+  box-shadow: 0 0 0 2px #3063E9,0 0 0 5px #AFD0FE;
+}
+
+.circuit-0:focus + label:active {
+  box-shadow: 0 0 0 2px #3063E9,0 0 0 5px #AFD0FE;
 }
 
 <input
@@ -36,46 +39,26 @@ HTMLCollection [
   display: inline-block;
   cursor: pointer;
   padding: 16px 24px;
-  background-color: #FFF;
-  font-size: 16px;
-  line-height: 24px;
+  background-color: #F0F6FF;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
   border: none;
   border-radius: 8px;
-  box-shadow: 0 0 0 1px #CCC;
   -webkit-transition: box-shadow 0.1s ease-in-out;
   transition: box-shadow 0.1s ease-in-out;
+  box-shadow: 0 0 0 2px #3063E9;
   padding: calc(8px + 1px) 24px;
 }
 
 .circuit-0:hover {
   background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-0:active {
   background-color: #E6E6E6;
-  box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-0::before {
-  display: none;
-  content: '';
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  width: calc(100% + 2px * 2);
-  height: calc(100% + 2px * 2);
-  border: 2px solid transparent;
-  border-radius: calc(8px + 2px);
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0::before::-moz-focus-inner {
-  border: 0;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 <label
@@ -102,13 +85,16 @@ HTMLCollection [
   width: 1px;
 }
 
-.circuit-0:focus + label::before {
-  display: block;
+.circuit-0:focus + label {
+  box-shadow: 0 0 0 1px #CCC,0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:checked + label {
-  background-color: #F0F6FF;
-  box-shadow: 0 0 0 2px #3063E9;
+.circuit-0:focus + label:hover {
+  box-shadow: 0 0 0 1px #999,0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label:active {
+  box-shadow: 0 0 0 1px #666,0 0 0 4px #AFD0FE;
 }
 
 <input
@@ -123,16 +109,14 @@ HTMLCollection [
   cursor: pointer;
   padding: 16px 24px;
   background-color: #FFF;
-  font-size: 16px;
-  line-height: 24px;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
   border: none;
   border-radius: 8px;
-  box-shadow: 0 0 0 1px #CCC;
   -webkit-transition: box-shadow 0.1s ease-in-out;
   transition: box-shadow 0.1s ease-in-out;
+  box-shadow: 0 0 0 1px #CCC;
   padding: calc(8px + 1px) 24px;
 }
 
@@ -144,24 +128,6 @@ HTMLCollection [
 .circuit-0:active {
   background-color: #E6E6E6;
   box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-0::before {
-  display: none;
-  content: '';
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  width: calc(100% + 2px * 2);
-  height: calc(100% + 2px * 2);
-  border: 2px solid transparent;
-  border-radius: calc(8px + 2px);
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0::before::-moz-focus-inner {
-  border: 0;
 }
 
 <label
@@ -188,13 +154,16 @@ HTMLCollection [
   width: 1px;
 }
 
-.circuit-0:focus + label::before {
-  display: block;
+.circuit-0:focus + label {
+  box-shadow: 0 0 0 1px #CCC,0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:checked + label {
-  background-color: #F0F6FF;
-  box-shadow: 0 0 0 2px #3063E9;
+.circuit-0:focus + label:hover {
+  box-shadow: 0 0 0 1px #999,0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label:active {
+  box-shadow: 0 0 0 1px #666,0 0 0 4px #AFD0FE;
 }
 
 <input
@@ -210,16 +179,14 @@ HTMLCollection [
   cursor: pointer;
   padding: 16px 24px;
   background-color: #FFF;
-  font-size: 16px;
-  line-height: 24px;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
   border: none;
   border-radius: 8px;
-  box-shadow: 0 0 0 1px #CCC;
   -webkit-transition: box-shadow 0.1s ease-in-out;
   transition: box-shadow 0.1s ease-in-out;
+  box-shadow: 0 0 0 1px #CCC;
   padding: calc(8px + 1px) 24px;
   opacity: 0.5;
   pointer-events: none;
@@ -234,24 +201,6 @@ HTMLCollection [
 .circuit-0:active {
   background-color: #E6E6E6;
   box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-0::before {
-  display: none;
-  content: '';
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  width: calc(100% + 2px * 2);
-  height: calc(100% + 2px * 2);
-  border: 2px solid transparent;
-  border-radius: calc(8px + 2px);
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0::before::-moz-focus-inner {
-  border: 0;
 }
 
 <label
@@ -279,13 +228,16 @@ HTMLCollection [
   width: 1px;
 }
 
-.circuit-0:focus + label::before {
-  display: block;
+.circuit-0:focus + label {
+  box-shadow: 0 0 0 1px #CCC,0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:checked + label {
-  background-color: #F0F6FF;
-  box-shadow: 0 0 0 2px #3063E9;
+.circuit-0:focus + label:hover {
+  box-shadow: 0 0 0 1px #999,0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label:active {
+  box-shadow: 0 0 0 1px #666,0 0 0 4px #AFD0FE;
 }
 
 <input
@@ -300,16 +252,14 @@ HTMLCollection [
   cursor: pointer;
   padding: 16px 24px;
   background-color: #FFF;
-  font-size: 16px;
-  line-height: 24px;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
   border: none;
   border-radius: 8px;
-  box-shadow: 0 0 0 1px #CCC;
   -webkit-transition: box-shadow 0.1s ease-in-out;
   transition: box-shadow 0.1s ease-in-out;
+  box-shadow: 0 0 0 1px #CCC;
   padding: calc(8px + 1px) 24px;
   margin-bottom: 0;
 }
@@ -322,24 +272,6 @@ HTMLCollection [
 .circuit-0:active {
   background-color: #E6E6E6;
   box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-0::before {
-  display: none;
-  content: '';
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  width: calc(100% + 2px * 2);
-  height: calc(100% + 2px * 2);
-  border: 2px solid transparent;
-  border-radius: calc(8px + 2px);
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0::before::-moz-focus-inner {
-  border: 0;
 }
 
 <label

--- a/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -16,20 +16,12 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0:focus + label::before::-moz-focus-inner {
-  border: 0;
+  display: block;
 }
 
 .circuit-0:checked + label {
   background-color: #F0F6FF;
-}
-
-.circuit-0:checked + label::before {
-  border: 2px solid #3063E9;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 <input
@@ -41,46 +33,49 @@ HTMLCollection [
     value="value"
   />,
   .circuit-0 {
-  display: block;
+  display: inline-block;
   cursor: pointer;
   padding: 16px 24px;
-  border-radius: 8px;
   background-color: #FFF;
+  font-size: 16px;
+  line-height: 24px;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
-}
-
-.circuit-0::before {
-  display: block;
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  border: none;
   border-radius: 8px;
-  border: 1px solid #CCC;
-  -webkit-transition: border 0.1s ease-in-out;
-  transition: border 0.1s ease-in-out;
+  box-shadow: 0 0 0 1px #CCC;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  padding: calc(8px + 1px) 24px;
 }
 
 .circuit-0:hover {
   background-color: #F5F5F5;
-}
-
-.circuit-0:hover::before {
-  border-color: #999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0:active {
   background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #666;
 }
 
-.circuit-0:active::before {
-  border-color: #666;
+.circuit-0::before {
+  display: none;
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  width: calc(100% + 2px * 2);
+  height: calc(100% + 2px * 2);
+  border: 2px solid transparent;
+  border-radius: calc(8px + 2px);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0::before::-moz-focus-inner {
+  border: 0;
 }
 
 <label
@@ -108,20 +103,12 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0:focus + label::before::-moz-focus-inner {
-  border: 0;
+  display: block;
 }
 
 .circuit-0:checked + label {
   background-color: #F0F6FF;
-}
-
-.circuit-0:checked + label::before {
-  border: 2px solid #3063E9;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 <input
@@ -132,46 +119,49 @@ HTMLCollection [
     value="value"
   />,
   .circuit-0 {
-  display: block;
+  display: inline-block;
   cursor: pointer;
   padding: 16px 24px;
-  border-radius: 8px;
   background-color: #FFF;
+  font-size: 16px;
+  line-height: 24px;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
-}
-
-.circuit-0::before {
-  display: block;
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  border: none;
   border-radius: 8px;
-  border: 1px solid #CCC;
-  -webkit-transition: border 0.1s ease-in-out;
-  transition: border 0.1s ease-in-out;
+  box-shadow: 0 0 0 1px #CCC;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  padding: calc(8px + 1px) 24px;
 }
 
 .circuit-0:hover {
   background-color: #F5F5F5;
-}
-
-.circuit-0:hover::before {
-  border-color: #999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0:active {
   background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #666;
 }
 
-.circuit-0:active::before {
-  border-color: #666;
+.circuit-0::before {
+  display: none;
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  width: calc(100% + 2px * 2);
+  height: calc(100% + 2px * 2);
+  border: 2px solid transparent;
+  border-radius: calc(8px + 2px);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0::before::-moz-focus-inner {
+  border: 0;
 }
 
 <label
@@ -199,20 +189,12 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0:focus + label::before::-moz-focus-inner {
-  border: 0;
+  display: block;
 }
 
 .circuit-0:checked + label {
   background-color: #F0F6FF;
-}
-
-.circuit-0:checked + label::before {
-  border: 2px solid #3063E9;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 <input
@@ -224,49 +206,52 @@ HTMLCollection [
     value="value"
   />,
   .circuit-0 {
-  display: block;
+  display: inline-block;
   cursor: pointer;
   padding: 16px 24px;
-  border-radius: 8px;
   background-color: #FFF;
+  font-size: 16px;
+  line-height: 24px;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0 0 0 1px #CCC;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  padding: calc(8px + 1px) 24px;
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
-.circuit-0::before {
-  display: block;
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border-radius: 8px;
-  border: 1px solid #CCC;
-  -webkit-transition: border 0.1s ease-in-out;
-  transition: border 0.1s ease-in-out;
-}
-
 .circuit-0:hover {
   background-color: #F5F5F5;
-}
-
-.circuit-0:hover::before {
-  border-color: #999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0:active {
   background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #666;
 }
 
-.circuit-0:active::before {
-  border-color: #666;
+.circuit-0::before {
+  display: none;
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  width: calc(100% + 2px * 2);
+  height: calc(100% + 2px * 2);
+  border: 2px solid transparent;
+  border-radius: calc(8px + 2px);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0::before::-moz-focus-inner {
+  border: 0;
 }
 
 <label
@@ -295,20 +280,12 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0:focus + label::before::-moz-focus-inner {
-  border: 0;
+  display: block;
 }
 
 .circuit-0:checked + label {
   background-color: #F0F6FF;
-}
-
-.circuit-0:checked + label::before {
-  border: 2px solid #3063E9;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 <input
@@ -319,47 +296,50 @@ HTMLCollection [
     value="value"
   />,
   .circuit-0 {
-  display: block;
+  display: inline-block;
   cursor: pointer;
   padding: 16px 24px;
-  border-radius: 8px;
   background-color: #FFF;
+  font-size: 16px;
+  line-height: 24px;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
-  margin-bottom: 0;
-}
-
-.circuit-0::before {
-  display: block;
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  border: none;
   border-radius: 8px;
-  border: 1px solid #CCC;
-  -webkit-transition: border 0.1s ease-in-out;
-  transition: border 0.1s ease-in-out;
+  box-shadow: 0 0 0 1px #CCC;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  padding: calc(8px + 1px) 24px;
+  margin-bottom: 0;
 }
 
 .circuit-0:hover {
   background-color: #F5F5F5;
-}
-
-.circuit-0:hover::before {
-  border-color: #999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-0:active {
   background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #666;
 }
 
-.circuit-0:active::before {
-  border-color: #666;
+.circuit-0::before {
+  display: none;
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  width: calc(100% + 2px * 2);
+  height: calc(100% + 2px * 2);
+  border: 2px solid transparent;
+  border-radius: calc(8px + 2px);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0::before::-moz-focus-inner {
+  border: 0;
 }
 
 <label

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
@@ -80,6 +80,18 @@ describe('SelectorGroup', () => {
     expect(tref.current).toBe(div);
   });
 
+  describe('Orientation', () => {
+    it('should render with vertical layout by default', () => {
+      const actual = create(<SelectorGroup {...defaultProps} />);
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with horizontal layout', () => {
+      const actual = create(<SelectorGroup {...defaultProps} />);
+      expect(actual).toMatchSnapshot();
+    });
+  });
+
   /**
    * Accessibility tests.
    */

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
@@ -81,13 +81,15 @@ describe('SelectorGroup', () => {
   });
 
   describe('Orientation', () => {
-    it('should render with vertical layout by default', () => {
+    it('should render with horizontal layout by default', () => {
       const actual = create(<SelectorGroup {...defaultProps} />);
       expect(actual).toMatchSnapshot();
     });
 
-    it('should render with horizontal layout', () => {
-      const actual = create(<SelectorGroup {...defaultProps} />);
+    it('should render with vertical layout', () => {
+      const actual = create(
+        <SelectorGroup {...defaultProps} orientation="vertical" />,
+      );
       expect(actual).toMatchSnapshot();
     });
   });

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
@@ -80,18 +80,9 @@ describe('SelectorGroup', () => {
     expect(tref.current).toBe(div);
   });
 
-  describe('Orientation', () => {
-    it('should render with horizontal layout by default', () => {
-      const actual = create(<SelectorGroup {...defaultProps} />);
-      expect(actual).toMatchSnapshot();
-    });
-
-    it('should render with vertical layout', () => {
-      const actual = create(
-        <SelectorGroup {...defaultProps} orientation="vertical" />,
-      );
-      expect(actual).toMatchSnapshot();
-    });
+  it('should render with horizontal layout by default', () => {
+    const actual = create(<SelectorGroup {...defaultProps} />);
+    expect(actual).toMatchSnapshot();
   });
 
   /**

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
@@ -60,7 +60,15 @@ export const Multiple = (args: SelectorGroupProps) => {
     );
   };
 
-  return <SelectorGroup {...args} value={value} onChange={handleChange} />;
+  return (
+    <SelectorGroup
+      {...args}
+      value={value}
+      onChange={handleChange}
+      orientation="horizontal"
+      stretch={false}
+    />
+  );
 };
 
 Multiple.args = { ...baseArgs, multiple: true };

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -24,8 +24,6 @@ import { uniqueId } from '../../util/id';
 import Selector from '../Selector';
 import { SelectorSize } from '../Selector/Selector';
 
-type GapSize = 'kilo' | 'mega';
-
 export interface SelectorGroupProps {
   /**
    * A collection of available options. Each option must have at least
@@ -57,17 +55,9 @@ export interface SelectorGroupProps {
    */
   multiple?: boolean;
   /**
-   * Whether to layout Selectors in a row or a column. Default: 'horizontal'.
-   */
-  orientation?: 'vertical' | 'horizontal';
-  /**
    * Size of the Selectors within the group. Default: 'mega'.
    */
   size?: SelectorSize;
-  /**
-   * Spacing between selectors in a group. Default: 'kilo'.
-   */
-  gapSize?: GapSize;
   /**
    * Whether the group should take the whole width available. Default: true.
    */
@@ -78,48 +68,38 @@ export interface SelectorGroupProps {
   ref?: Ref<HTMLDivElement>;
 }
 
-type ContainerProps = Pick<
-  SelectorGroupProps,
-  'orientation' | 'gapSize' | 'stretch'
->;
+type ContainerProps = Pick<SelectorGroupProps, 'stretch'>;
 
-const stretchStyles = ({ stretch = false }: StyleProps & ContainerProps) => css`
-  display: ${stretch ? 'flex' : 'inline-flex'};
-  align-items: ${stretch ? 'stretch' : 'flex-start'};
-  width: ${stretch ? '100%' : 'auto'};
-`;
+const stretchStyles = ({ stretch = false }: StyleProps & ContainerProps) => {
+  if (stretch) {
+    return css`
+      display: flex;
+      align-items: stretch;
+      width: 100%;
+    `;
+  }
 
-const orientationStyles = ({
-  theme,
-  gapSize = 'mega',
-  orientation = 'horizontal',
-}: StyleProps & ContainerProps) => css`
-  flex-direction: ${orientation === 'vertical' ? 'column' : 'row'};
+  return css`
+    display: inline-flex;
+    align-items: flex-start;
+    width: auto;
+  `;
+};
+
+const baseStyles = ({ theme }: StyleProps) => css`
+  label: selector-group;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
 
   > div {
     &:not(:last-child) {
-      margin-right: ${orientation === 'horizontal'
-        ? theme.spacings[gapSize]
-        : 0};
-      margin-bottom: ${orientation === 'vertical'
-        ? theme.spacings[gapSize]
-        : 0};
+      margin-right: ${theme.spacings.mega};
     }
   }
 `;
 
-const baseStyles = () => css`
-  label: selector-group;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-`;
-
-const StyledSelectorGroup = styled.div(
-  baseStyles,
-  stretchStyles,
-  orientationStyles,
-);
+const StyledSelectorGroup = styled.div(baseStyles, stretchStyles);
 
 const OptionItem = styled.div`
   label: selector-group__option-item;
@@ -143,7 +123,6 @@ export const SelectorGroup = React.forwardRef(
       label,
       multiple,
       size,
-      gapSize,
       stretch,
       ...rest
     }: SelectorGroupProps,
@@ -156,7 +135,6 @@ export const SelectorGroup = React.forwardRef(
         role="group"
         aria-label={label}
         ref={ref}
-        gapSize={gapSize}
         stretch={stretch}
         {...rest}
       >

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -57,7 +57,7 @@ export interface SelectorGroupProps {
    */
   multiple?: boolean;
   /**
-   * Whether to layout Selectors in a row or a column. Default: 'vertical'.
+   * Whether to layout Selectors in a row or a column. Default: 'horizontal'.
    */
   orientation?: 'vertical' | 'horizontal';
   /**
@@ -83,7 +83,7 @@ type ContainerProps = Pick<
   'orientation' | 'gapSize' | 'stretch'
 >;
 
-const stretchStyles = ({ stretch = true }: StyleProps & ContainerProps) => css`
+const stretchStyles = ({ stretch = false }: StyleProps & ContainerProps) => css`
   display: ${stretch ? 'flex' : 'inline-flex'};
   align-items: ${stretch ? 'stretch' : 'flex-start'};
   width: ${stretch ? '100%' : 'auto'};
@@ -92,7 +92,7 @@ const stretchStyles = ({ stretch = true }: StyleProps & ContainerProps) => css`
 const orientationStyles = ({
   theme,
   gapSize = 'mega',
-  orientation = 'vertical',
+  orientation = 'horizontal',
 }: StyleProps & ContainerProps) => css`
   flex-direction: ${orientation === 'vertical' ? 'column' : 'row'};
 

--- a/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SelectorGroup Orientation should render with horizontal layout 1`] = `
+exports[`SelectorGroup Orientation should render with horizontal layout by default 1`] = `
 .circuit-9 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -10,23 +10,23 @@ exports[`SelectorGroup Orientation should render with horizontal layout 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  width: 100%;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  width: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
 }
 
 .circuit-9 > div:not(:last-child) {
-  margin-right: 0;
-  margin-bottom: 16px;
+  margin-right: 16px;
+  margin-bottom: 0;
 }
 
 .circuit-2 {
@@ -49,226 +49,40 @@ exports[`SelectorGroup Orientation should render with horizontal layout 1`] = `
   width: 1px;
 }
 
-.circuit-0:focus + label::before {
-  display: block;
-}
-
-.circuit-0:checked + label {
-  background-color: #F0F6FF;
-  box-shadow: 0 0 0 2px #3063E9;
-}
-
 .circuit-1 {
   display: inline-block;
   cursor: pointer;
   padding: 16px 24px;
   background-color: #FFF;
-  font-size: 16px;
-  line-height: 24px;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
   border: none;
   border-radius: 8px;
-  box-shadow: 0 0 0 1px #CCC;
   -webkit-transition: box-shadow 0.1s ease-in-out;
   transition: box-shadow 0.1s ease-in-out;
+  font-size: 16px;
+  line-height: 24px;
   padding: calc(8px + 1px) 24px;
+  box-shadow: 0 0 0 1px #CCC;
   margin-bottom: 0;
   width: 100%;
 }
 
 .circuit-1:hover {
   background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1:active {
   background-color: #E6E6E6;
-  box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-1::before {
-  display: none;
-  content: '';
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  width: calc(100% + 2px * 2);
-  height: calc(100% + 2px * 2);
-  border: 2px solid transparent;
-  border-radius: calc(8px + 2px);
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-1::before::-moz-focus-inner {
-  border: 0;
-}
-
-<div
-  aria-label="Choose an option"
-  class="circuit-9"
-  role="group"
->
-  <div
-    class="circuit-2"
-  >
-    <input
-      class="circuit-0"
-      id="selector_22"
-      name="selector-group_21"
-      type="radio"
-      value="first"
-    />
-    <label
-      class="circuit-1"
-      for="selector_22"
-    >
-      Option 1
-    </label>
-  </div>
-  <div
-    class="circuit-2"
-  >
-    <input
-      class="circuit-0"
-      id="selector_23"
-      name="selector-group_21"
-      type="radio"
-      value="second"
-    />
-    <label
-      class="circuit-1"
-      for="selector_23"
-    >
-      Option 2
-    </label>
-  </div>
-  <div
-    class="circuit-2"
-  >
-    <input
-      class="circuit-0"
-      id="selector_24"
-      name="selector-group_21"
-      type="radio"
-      value="third"
-    />
-    <label
-      class="circuit-1"
-      for="selector_24"
-    >
-      Option 3
-    </label>
-  </div>
-</div>
-`;
-
-exports[`SelectorGroup Orientation should render with vertical layout by default 1`] = `
-.circuit-9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  width: 100%;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.circuit-9 > div:not(:last-child) {
-  margin-right: 0;
-  margin-bottom: 16px;
-}
-
-.circuit-2 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.circuit-0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-0:focus + label::before {
-  display: block;
-}
-
-.circuit-0:checked + label {
-  background-color: #F0F6FF;
-  box-shadow: 0 0 0 2px #3063E9;
-}
-
-.circuit-1 {
-  display: inline-block;
-  cursor: pointer;
-  padding: 16px 24px;
-  background-color: #FFF;
-  font-size: 16px;
-  line-height: 24px;
-  text-align: center;
-  position: relative;
-  margin-bottom: 16px;
-  border: none;
-  border-radius: 8px;
-  box-shadow: 0 0 0 1px #CCC;
-  -webkit-transition: box-shadow 0.1s ease-in-out;
-  transition: box-shadow 0.1s ease-in-out;
-  padding: calc(8px + 1px) 24px;
-  margin-bottom: 0;
-  width: 100%;
 }
 
 .circuit-1:hover {
-  background-color: #F5F5F5;
   box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1:active {
-  background-color: #E6E6E6;
   box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-1::before {
-  display: none;
-  content: '';
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  width: calc(100% + 2px * 2);
-  height: calc(100% + 2px * 2);
-  border: 2px solid transparent;
-  border-radius: calc(8px + 2px);
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-1::before::-moz-focus-inner {
-  border: 0;
 }
 
 <div
@@ -330,6 +144,151 @@ exports[`SelectorGroup Orientation should render with vertical layout by default
 </div>
 `;
 
+exports[`SelectorGroup Orientation should render with vertical layout 1`] = `
+.circuit-2 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-1 {
+  display: inline-block;
+  cursor: pointer;
+  padding: 16px 24px;
+  background-color: #FFF;
+  text-align: center;
+  position: relative;
+  margin-bottom: 16px;
+  border: none;
+  border-radius: 8px;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  font-size: 16px;
+  line-height: 24px;
+  padding: calc(8px + 1px) 24px;
+  box-shadow: 0 0 0 1px #CCC;
+  margin-bottom: 0;
+  width: 100%;
+}
+
+.circuit-1:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-1:active {
+  background-color: #E6E6E6;
+}
+
+.circuit-1:hover {
+  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-1:active {
+  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  width: auto;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.circuit-9 > div:not(:last-child) {
+  margin-right: 0;
+  margin-bottom: 16px;
+}
+
+<div
+  aria-label="Choose an option"
+  class="circuit-9"
+  orientation="vertical"
+  role="group"
+>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_22"
+      name="selector-group_21"
+      type="radio"
+      value="first"
+    />
+    <label
+      class="circuit-1"
+      for="selector_22"
+    >
+      Option 1
+    </label>
+  </div>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_23"
+      name="selector-group_21"
+      type="radio"
+      value="second"
+    />
+    <label
+      class="circuit-1"
+      for="selector_23"
+    >
+      Option 2
+    </label>
+  </div>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_24"
+      name="selector-group_21"
+      type="radio"
+      value="third"
+    />
+    <label
+      class="circuit-1"
+      for="selector_24"
+    >
+      Option 3
+    </label>
+  </div>
+</div>
+`;
+
 exports[`SelectorGroup should render with default styles 1`] = `
 .circuit-9 {
   display: -webkit-box;
@@ -340,23 +299,23 @@ exports[`SelectorGroup should render with default styles 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  width: 100%;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  width: auto;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
 }
 
 .circuit-9 > div:not(:last-child) {
-  margin-right: 0;
-  margin-bottom: 16px;
+  margin-right: 16px;
+  margin-bottom: 0;
 }
 
 .circuit-2 {
@@ -379,61 +338,40 @@ exports[`SelectorGroup should render with default styles 1`] = `
   width: 1px;
 }
 
-.circuit-0:focus + label::before {
-  display: block;
-}
-
-.circuit-0:checked + label {
-  background-color: #F0F6FF;
-  box-shadow: 0 0 0 2px #3063E9;
-}
-
 .circuit-1 {
   display: inline-block;
   cursor: pointer;
   padding: 16px 24px;
   background-color: #FFF;
-  font-size: 16px;
-  line-height: 24px;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
   border: none;
   border-radius: 8px;
-  box-shadow: 0 0 0 1px #CCC;
   -webkit-transition: box-shadow 0.1s ease-in-out;
   transition: box-shadow 0.1s ease-in-out;
+  font-size: 16px;
+  line-height: 24px;
   padding: calc(8px + 1px) 24px;
+  box-shadow: 0 0 0 1px #CCC;
   margin-bottom: 0;
   width: 100%;
 }
 
 .circuit-1:hover {
   background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1:active {
   background-color: #E6E6E6;
+}
+
+.circuit-1:hover {
+  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-1:active {
   box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-1::before {
-  display: none;
-  content: '';
-  position: absolute;
-  top: -2px;
-  left: -2px;
-  width: calc(100% + 2px * 2);
-  height: calc(100% + 2px * 2);
-  border: 2px solid transparent;
-  border-radius: calc(8px + 2px);
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-1::before::-moz-focus-inner {
-  border: 0;
 }
 
 <div

--- a/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -1,303 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SelectorGroup Orientation should render with horizontal layout by default 1`] = `
-.circuit-9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  width: auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-}
-
-.circuit-9 > div:not(:last-child) {
-  margin-right: 16px;
-  margin-bottom: 0;
-}
-
-.circuit-2 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.circuit-0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-1 {
-  display: inline-block;
-  cursor: pointer;
-  padding: 16px 24px;
-  background-color: #FFF;
-  text-align: center;
-  position: relative;
-  margin-bottom: 16px;
-  border: none;
-  border-radius: 8px;
-  -webkit-transition: box-shadow 0.1s ease-in-out;
-  transition: box-shadow 0.1s ease-in-out;
-  font-size: 16px;
-  line-height: 24px;
-  padding: calc(8px + 1px) 24px;
-  box-shadow: 0 0 0 1px #CCC;
-  margin-bottom: 0;
-  width: 100%;
-}
-
-.circuit-1:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-1:active {
-  background-color: #E6E6E6;
-}
-
-.circuit-1:hover {
-  box-shadow: 0 0 0 1px #999;
-}
-
-.circuit-1:active {
-  box-shadow: 0 0 0 1px #666;
-}
-
-<div
-  aria-label="Choose an option"
-  class="circuit-9"
-  role="group"
->
-  <div
-    class="circuit-2"
-  >
-    <input
-      class="circuit-0"
-      id="selector_18"
-      name="selector-group_17"
-      type="radio"
-      value="first"
-    />
-    <label
-      class="circuit-1"
-      for="selector_18"
-    >
-      Option 1
-    </label>
-  </div>
-  <div
-    class="circuit-2"
-  >
-    <input
-      class="circuit-0"
-      id="selector_19"
-      name="selector-group_17"
-      type="radio"
-      value="second"
-    />
-    <label
-      class="circuit-1"
-      for="selector_19"
-    >
-      Option 2
-    </label>
-  </div>
-  <div
-    class="circuit-2"
-  >
-    <input
-      class="circuit-0"
-      id="selector_20"
-      name="selector-group_17"
-      type="radio"
-      value="third"
-    />
-    <label
-      class="circuit-1"
-      for="selector_20"
-    >
-      Option 3
-    </label>
-  </div>
-</div>
-`;
-
-exports[`SelectorGroup Orientation should render with vertical layout 1`] = `
-.circuit-2 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.circuit-0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-1 {
-  display: inline-block;
-  cursor: pointer;
-  padding: 16px 24px;
-  background-color: #FFF;
-  text-align: center;
-  position: relative;
-  margin-bottom: 16px;
-  border: none;
-  border-radius: 8px;
-  -webkit-transition: box-shadow 0.1s ease-in-out;
-  transition: box-shadow 0.1s ease-in-out;
-  font-size: 16px;
-  line-height: 24px;
-  padding: calc(8px + 1px) 24px;
-  box-shadow: 0 0 0 1px #CCC;
-  margin-bottom: 0;
-  width: 100%;
-}
-
-.circuit-1:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-1:active {
-  background-color: #E6E6E6;
-}
-
-.circuit-1:hover {
-  box-shadow: 0 0 0 1px #999;
-}
-
-.circuit-1:active {
-  box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  width: auto;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.circuit-9 > div:not(:last-child) {
-  margin-right: 0;
-  margin-bottom: 16px;
-}
-
-<div
-  aria-label="Choose an option"
-  class="circuit-9"
-  orientation="vertical"
-  role="group"
->
-  <div
-    class="circuit-2"
-  >
-    <input
-      class="circuit-0"
-      id="selector_22"
-      name="selector-group_21"
-      type="radio"
-      value="first"
-    />
-    <label
-      class="circuit-1"
-      for="selector_22"
-    >
-      Option 1
-    </label>
-  </div>
-  <div
-    class="circuit-2"
-  >
-    <input
-      class="circuit-0"
-      id="selector_23"
-      name="selector-group_21"
-      type="radio"
-      value="second"
-    />
-    <label
-      class="circuit-1"
-      for="selector_23"
-    >
-      Option 2
-    </label>
-  </div>
-  <div
-    class="circuit-2"
-  >
-    <input
-      class="circuit-0"
-      id="selector_24"
-      name="selector-group_21"
-      type="radio"
-      value="third"
-    />
-    <label
-      class="circuit-1"
-      for="selector_24"
-    >
-      Option 3
-    </label>
-  </div>
-</div>
-`;
-
 exports[`SelectorGroup should render with default styles 1`] = `
 .circuit-9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   width: 100%;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -308,14 +19,10 @@ exports[`SelectorGroup should render with default styles 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   width: auto;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .circuit-9 > div:not(:last-child) {
   margin-right: 16px;
-  margin-bottom: 0;
 }
 
 .circuit-2 {
@@ -338,6 +45,18 @@ exports[`SelectorGroup should render with default styles 1`] = `
   width: 1px;
 }
 
+.circuit-0:focus + label {
+  box-shadow: 0 0 0 1px #CCC,0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label:hover {
+  box-shadow: 0 0 0 1px #999,0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label:active {
+  box-shadow: 0 0 0 1px #666,0 0 0 4px #AFD0FE;
+}
+
 .circuit-1 {
   display: inline-block;
   cursor: pointer;
@@ -350,27 +69,19 @@ exports[`SelectorGroup should render with default styles 1`] = `
   border-radius: 8px;
   -webkit-transition: box-shadow 0.1s ease-in-out;
   transition: box-shadow 0.1s ease-in-out;
-  font-size: 16px;
-  line-height: 24px;
-  padding: calc(8px + 1px) 24px;
   box-shadow: 0 0 0 1px #CCC;
+  padding: calc(8px + 1px) 24px;
   margin-bottom: 0;
   width: 100%;
 }
 
 .circuit-1:hover {
   background-color: #F5F5F5;
-}
-
-.circuit-1:active {
-  background-color: #E6E6E6;
-}
-
-.circuit-1:hover {
   box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1:active {
+  background-color: #E6E6E6;
   box-shadow: 0 0 0 1px #666;
 }
 
@@ -426,6 +137,150 @@ exports[`SelectorGroup should render with default styles 1`] = `
     <label
       class="circuit-1"
       for="selector_4"
+    >
+      Option 3
+    </label>
+  </div>
+</div>
+`;
+
+exports[`SelectorGroup should render with horizontal layout by default 1`] = `
+.circuit-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  width: 100%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  width: auto;
+}
+
+.circuit-9 > div:not(:last-child) {
+  margin-right: 16px;
+}
+
+.circuit-2 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-0:focus + label {
+  box-shadow: 0 0 0 1px #CCC,0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label:hover {
+  box-shadow: 0 0 0 1px #999,0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label:active {
+  box-shadow: 0 0 0 1px #666,0 0 0 4px #AFD0FE;
+}
+
+.circuit-1 {
+  display: inline-block;
+  cursor: pointer;
+  padding: 16px 24px;
+  background-color: #FFF;
+  text-align: center;
+  position: relative;
+  margin-bottom: 16px;
+  border: none;
+  border-radius: 8px;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  box-shadow: 0 0 0 1px #CCC;
+  padding: calc(8px + 1px) 24px;
+  margin-bottom: 0;
+  width: 100%;
+}
+
+.circuit-1:hover {
+  background-color: #F5F5F5;
+  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-1:active {
+  background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #666;
+}
+
+<div
+  aria-label="Choose an option"
+  class="circuit-9"
+  role="group"
+>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_18"
+      name="selector-group_17"
+      type="radio"
+      value="first"
+    />
+    <label
+      class="circuit-1"
+      for="selector_18"
+    >
+      Option 1
+    </label>
+  </div>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_19"
+      name="selector-group_17"
+      type="radio"
+      value="second"
+    />
+    <label
+      class="circuit-1"
+      for="selector_19"
+    >
+      Option 2
+    </label>
+  </div>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_20"
+      name="selector-group_17"
+      type="radio"
+      value="third"
+    />
+    <label
+      class="circuit-1"
+      for="selector_20"
     >
       Option 3
     </label>

--- a/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -1,6 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SelectorGroup should render with default styles 1`] = `
+exports[`SelectorGroup Orientation should render with horizontal layout 1`] = `
+.circuit-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.circuit-9 > div:not(:last-child) {
+  margin-right: 0;
+  margin-bottom: 16px;
+}
+
+.circuit-2 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
 .circuit-0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -15,107 +50,447 @@ exports[`SelectorGroup should render with default styles 1`] = `
 }
 
 .circuit-0:focus + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0:focus + label::before::-moz-focus-inner {
-  border: 0;
+  display: block;
 }
 
 .circuit-0:checked + label {
   background-color: #F0F6FF;
-}
-
-.circuit-0:checked + label::before {
-  border: 2px solid #3063E9;
+  box-shadow: 0 0 0 2px #3063E9;
 }
 
 .circuit-1 {
-  display: block;
+  display: inline-block;
   cursor: pointer;
   padding: 16px 24px;
-  border-radius: 8px;
   background-color: #FFF;
+  font-size: 16px;
+  line-height: 24px;
   text-align: center;
   position: relative;
   margin-bottom: 16px;
-}
-
-.circuit-1::before {
-  display: block;
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  border: none;
   border-radius: 8px;
-  border: 1px solid #CCC;
-  -webkit-transition: border 0.1s ease-in-out;
-  transition: border 0.1s ease-in-out;
+  box-shadow: 0 0 0 1px #CCC;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  padding: calc(8px + 1px) 24px;
+  margin-bottom: 0;
+  width: 100%;
 }
 
 .circuit-1:hover {
   background-color: #F5F5F5;
-}
-
-.circuit-1:hover::before {
-  border-color: #999;
+  box-shadow: 0 0 0 1px #999;
 }
 
 .circuit-1:active {
   background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #666;
 }
 
-.circuit-1:active::before {
-  border-color: #666;
+.circuit-1::before {
+  display: none;
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  width: calc(100% + 2px * 2);
+  height: calc(100% + 2px * 2);
+  border: 2px solid transparent;
+  border-radius: calc(8px + 2px);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-1::before::-moz-focus-inner {
+  border: 0;
 }
 
 <div
   aria-label="Choose an option"
+  class="circuit-9"
   role="group"
 >
-  <input
-    class="circuit-0"
-    id="selector_2"
-    name="selector-group_1"
-    type="radio"
-    value="first"
-  />
-  <label
-    class="circuit-1"
-    for="selector_2"
+  <div
+    class="circuit-2"
   >
-    Option 1
-  </label>
-  <input
-    class="circuit-0"
-    id="selector_3"
-    name="selector-group_1"
-    type="radio"
-    value="second"
-  />
-  <label
-    class="circuit-1"
-    for="selector_3"
+    <input
+      class="circuit-0"
+      id="selector_22"
+      name="selector-group_21"
+      type="radio"
+      value="first"
+    />
+    <label
+      class="circuit-1"
+      for="selector_22"
+    >
+      Option 1
+    </label>
+  </div>
+  <div
+    class="circuit-2"
   >
-    Option 2
-  </label>
-  <input
-    class="circuit-0"
-    id="selector_4"
-    name="selector-group_1"
-    type="radio"
-    value="third"
-  />
-  <label
-    class="circuit-1"
-    for="selector_4"
+    <input
+      class="circuit-0"
+      id="selector_23"
+      name="selector-group_21"
+      type="radio"
+      value="second"
+    />
+    <label
+      class="circuit-1"
+      for="selector_23"
+    >
+      Option 2
+    </label>
+  </div>
+  <div
+    class="circuit-2"
   >
-    Option 3
-  </label>
+    <input
+      class="circuit-0"
+      id="selector_24"
+      name="selector-group_21"
+      type="radio"
+      value="third"
+    />
+    <label
+      class="circuit-1"
+      for="selector_24"
+    >
+      Option 3
+    </label>
+  </div>
+</div>
+`;
+
+exports[`SelectorGroup Orientation should render with vertical layout by default 1`] = `
+.circuit-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.circuit-9 > div:not(:last-child) {
+  margin-right: 0;
+  margin-bottom: 16px;
+}
+
+.circuit-2 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-0:focus + label::before {
+  display: block;
+}
+
+.circuit-0:checked + label {
+  background-color: #F0F6FF;
+  box-shadow: 0 0 0 2px #3063E9;
+}
+
+.circuit-1 {
+  display: inline-block;
+  cursor: pointer;
+  padding: 16px 24px;
+  background-color: #FFF;
+  font-size: 16px;
+  line-height: 24px;
+  text-align: center;
+  position: relative;
+  margin-bottom: 16px;
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0 0 0 1px #CCC;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  padding: calc(8px + 1px) 24px;
+  margin-bottom: 0;
+  width: 100%;
+}
+
+.circuit-1:hover {
+  background-color: #F5F5F5;
+  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-1:active {
+  background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-1::before {
+  display: none;
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  width: calc(100% + 2px * 2);
+  height: calc(100% + 2px * 2);
+  border: 2px solid transparent;
+  border-radius: calc(8px + 2px);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-1::before::-moz-focus-inner {
+  border: 0;
+}
+
+<div
+  aria-label="Choose an option"
+  class="circuit-9"
+  role="group"
+>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_18"
+      name="selector-group_17"
+      type="radio"
+      value="first"
+    />
+    <label
+      class="circuit-1"
+      for="selector_18"
+    >
+      Option 1
+    </label>
+  </div>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_19"
+      name="selector-group_17"
+      type="radio"
+      value="second"
+    />
+    <label
+      class="circuit-1"
+      for="selector_19"
+    >
+      Option 2
+    </label>
+  </div>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_20"
+      name="selector-group_17"
+      type="radio"
+      value="third"
+    />
+    <label
+      class="circuit-1"
+      for="selector_20"
+    >
+      Option 3
+    </label>
+  </div>
+</div>
+`;
+
+exports[`SelectorGroup should render with default styles 1`] = `
+.circuit-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  width: 100%;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.circuit-9 > div:not(:last-child) {
+  margin-right: 0;
+  margin-bottom: 16px;
+}
+
+.circuit-2 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-0:focus + label::before {
+  display: block;
+}
+
+.circuit-0:checked + label {
+  background-color: #F0F6FF;
+  box-shadow: 0 0 0 2px #3063E9;
+}
+
+.circuit-1 {
+  display: inline-block;
+  cursor: pointer;
+  padding: 16px 24px;
+  background-color: #FFF;
+  font-size: 16px;
+  line-height: 24px;
+  text-align: center;
+  position: relative;
+  margin-bottom: 16px;
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0 0 0 1px #CCC;
+  -webkit-transition: box-shadow 0.1s ease-in-out;
+  transition: box-shadow 0.1s ease-in-out;
+  padding: calc(8px + 1px) 24px;
+  margin-bottom: 0;
+  width: 100%;
+}
+
+.circuit-1:hover {
+  background-color: #F5F5F5;
+  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-1:active {
+  background-color: #E6E6E6;
+  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-1::before {
+  display: none;
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  width: calc(100% + 2px * 2);
+  height: calc(100% + 2px * 2);
+  border: 2px solid transparent;
+  border-radius: calc(8px + 2px);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-1::before::-moz-focus-inner {
+  border: 0;
+}
+
+<div
+  aria-label="Choose an option"
+  class="circuit-9"
+  role="group"
+>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_2"
+      name="selector-group_1"
+      type="radio"
+      value="first"
+    />
+    <label
+      class="circuit-1"
+      for="selector_2"
+    >
+      Option 1
+    </label>
+  </div>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_3"
+      name="selector-group_1"
+      type="radio"
+      value="second"
+    />
+    <label
+      class="circuit-1"
+      for="selector_3"
+    >
+      Option 2
+    </label>
+  </div>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-0"
+      id="selector_4"
+      name="selector-group_1"
+      type="radio"
+      value="third"
+    />
+    <label
+      class="circuit-1"
+      for="selector_4"
+    >
+      Option 3
+    </label>
+  </div>
 </div>
 `;


### PR DESCRIPTION
Addresses  #931.

## Purpose

Extending `Selector` and `SelectorGroup` features to support most common usecases.

## Approach and changes

* Add `size` prop to `Selector`
* Refactor styling of the `Selector` to make sure its height matches other controls like `Input` and `Select`
* Switch `SelectorGroup` to a horizontal orientation on a big screen and vertical on mobile
* Add `orientation` prop to `SelectorGroup` to choose between horizontal and vertical layout.
* Add `size` prop to `SelectorGroup` which changes size of a `Selector` within the group
* Add `gapSize` prop to `SelectorGroup` to control the spacing between `Selectors`
* Add `stretch` prop to `SelectorGroup` to make it fill all available width

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] ~~Unit and integration tests~~ Only updated snapshots as it's only styling changes, let me know if you think we need some new tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
