### PR TITLE
Add inset option to focusOutline style mixin

### DIFF
--- a/.changeset/thick-parents-wave.md
+++ b/.changeset/thick-parents-wave.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added `inset` option to the `focusOutline` style mixin. This should only be used when the outline cannot be shown outside the element, for example when the overflow is hidden.

--- a/packages/circuit-ui/styles/style-mixins.docs.mdx
+++ b/packages/circuit-ui/styles/style-mixins.docs.mdx
@@ -101,6 +101,7 @@ Visually communicates to the user that an element is focused.
 
 ```ts
 focusOutline(theme: Theme | { theme: Theme }): SerializedStyles;
+focusOutline('inset'): (theme: Theme | { theme: Theme }) => SerializedStyles;
 ```
 
 <Story id="features-style-mixins--focus-outline" />

--- a/packages/circuit-ui/styles/style-mixins.spec.tsx
+++ b/packages/circuit-ui/styles/style-mixins.spec.tsx
@@ -359,6 +359,20 @@ describe('Style helpers', () => {
           "
       `);
     });
+
+    it('should match the snapshot with an inset outline', () => {
+      const { styles } = focusOutline('inset')({ theme: light });
+      expect(styles).toMatchInlineSnapshot(`
+        "
+                outline: 0;
+                box-shadow: inset 0 0 0 4px #AFD0FE;
+
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+              "
+      `);
+    });
   });
 
   describe('clearfix', () => {

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -130,7 +130,12 @@ const Focused = styled.div`
   background-color: white;
 `;
 
-export const FocusOutline = () => <Focused css={focusOutline} />;
+export const FocusOutline = () => (
+  <Stack>
+    <Focused css={focusOutline} />
+    <Focused css={focusOutline('inset')} />
+  </Stack>
+);
 
 export const DisableVisually = () => (
   <div css={disableVisually}>This element is visually disabled.</div>


### PR DESCRIPTION
Addresses https://github.com/sumup/ze-dashboard/pull/4123/files#r632440773. 

## Purpose

Sometimes, it's not possible to show the focus outline outside an element, for example when the overflow is hidden.

## Approach and changes

- Add an `inset` option to the `focusOutline` style mixin. It can be called in two ways now:

```ts
focusOutline(theme)
// or
focusOutline('inset')(theme)
```

This change is backward compatible and favors the outside approach.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
