### PR TITLE
Add method to close a modal

### DIFF
--- a/.changeset/metal-bananas-drive.md
+++ b/.changeset/metal-bananas-drive.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added `removeModal` and `isModalOpen` properties to `useModal` hook and deprecated the `getModal` property.

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -25,10 +25,10 @@ import IS_IOS from '../../util/ios';
 import { isFunction } from '../../util/type-check';
 import useClickHandler from '../../hooks/use-click-handler';
 
-type OnClose = (event: MouseEvent | KeyboardEvent) => void;
+type OnClose = (event?: MouseEvent | KeyboardEvent) => void;
 
 export interface ModalProps extends Partial<Props> {
-  children: ReactNode | (({ onClose }: { onClose: OnClose }) => ReactNode);
+  children: ReactNode | (({ onClose }: { onClose?: OnClose }) => ReactNode);
   /**
    * Determines if the modal is visible or not.
    */
@@ -37,7 +37,7 @@ export interface ModalProps extends Partial<Props> {
    * Function to close the modal. Passed down to the children
    * render prop.
    */
-  onClose: OnClose;
+  onClose?: OnClose;
   /**
    * React Modal's accessibility string.
    */

--- a/packages/circuit-ui/components/Modal/ModalContext.tsx
+++ b/packages/circuit-ui/components/Modal/ModalContext.tsx
@@ -28,11 +28,21 @@ import { Modal, ModalProps } from './Modal';
 
 export type ModalContextValue = {
   setModal: (modal: ModalProps) => void;
+  removeModal: () => void;
+  isModalOpen: boolean;
+  /**
+   * @deprecated
+   *
+   * If you need access to the `onClose` method or `isOpen` state of the modal,
+   * use the `removeModal` and `isOpen` context properties instead.
+   */
   getModal: () => ModalProps | null;
 };
 
 export const ModalContext = createContext<ModalContextValue>({
   setModal: () => {},
+  removeModal: () => {},
+  isModalOpen: false,
   getModal: () => null,
 });
 
@@ -58,7 +68,7 @@ export const ModalProvider: FC<Pick<ModalProps, 'appElement'>> = (props) => {
   const { onClose, children, ...modalProps } = modal || {};
 
   const handleClose = useCallback(
-    (event: MouseEvent | KeyboardEvent): void => {
+    (event?: MouseEvent | KeyboardEvent): void => {
       if (onClose) {
         onClose(event);
       }
@@ -70,7 +80,14 @@ export const ModalProvider: FC<Pick<ModalProps, 'appElement'>> = (props) => {
   const getModal = useCallback(() => modal, [modal]);
 
   return (
-    <ModalContext.Provider value={{ setModal: openModal, getModal }}>
+    <ModalContext.Provider
+      value={{
+        setModal: openModal,
+        removeModal: handleClose,
+        isModalOpen: isOpen,
+        getModal,
+      }}
+    >
       {props.children}
 
       {modal && (


### PR DESCRIPTION
## Purpose

As reported by @jmaslate, there is currently no way to close a modal programmatically from the outside. 

## Approach and changes

- Add a `removeModal` method to the return value of `useModal`
- Add a `isModalOpen` boolean to the  return value of `useModal`
- Deprecate the `getModal` method as the modal configuration can be kept in state in userland code when needed.

**Note to reviewers:** I intend to rewrite the modal components for v3. I'll add comprehensive tests then, I promise 🙈

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
