### PR TITLE
Add Plus icons to @sumup/icons

### DIFF
--- a/.changeset/orange-seahorses-complain.md
+++ b/.changeset/orange-seahorses-complain.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': minor
+---
+
+Add new Plus icons in the small and large sizes.

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -36,6 +36,11 @@
       "size": "large"
     },
     {
+      "name": "plus",
+      "category": "Action",
+      "size": "large"
+    },
+    {
       "name": "refresh",
       "category": "Action",
       "size": "large"
@@ -807,6 +812,11 @@
     },
     {
       "name": "play",
+      "category": "Action",
+      "size": "small"
+    },
+    {
+      "name": "plus",
       "category": "Action",
       "size": "small"
     },

--- a/packages/icons/web/v1/plus_large.svg
+++ b/packages/icons/web/v1/plus_large.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 4a1 1 0 0 1 1 1v6h6a1 1 0 1 1 0 2h-6v6a1 1 0 1 1-2 0v-6H5a1 1 0 1 1 0-2h6V5a1 1 0 0 1 1-1z" fill="#000"/>
+</svg>

--- a/packages/icons/web/v1/plus_small.svg
+++ b/packages/icons/web/v1/plus_small.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M8 0a1 1 0 0 1 1 1v6h6a1 1 0 1 1 0 2H9v6a1 1 0 1 1-2 0V9H1a1 1 0 1 1 0-2h6V1a1 1 0 0 1 1-1z" fill="#000"/>
+</svg>


### PR DESCRIPTION
## Purpose

Add Plus icons to the icons library.

The reason behind this is that we want to import the SVG from there instead of hardcoding it in the ImageInput. The change in the ImageInput will be done in a separate PR targeting `next` and Circuit v3 (it will bump the `@sumup/icons` peerDependency).

## Approach and changes

Add the SVGs and add the new icon entries to manifest.json.

I kept SVG optimization consistent with other icons in `@sumup/icons`.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
