### PR TITLE
Add a new peta borderRadius size to @sumup/design-tokens

### DIFF
--- a/.changeset/smart-boats-camp.md
+++ b/.changeset/smart-boats-camp.md
@@ -1,0 +1,7 @@
+---
+'@sumup/design-tokens': minor
+---
+
+Add a new peta borderRadius size of 12px to `@sumup/design-tokens`.
+
+This size will be used in components including the `Avatar` and the `ImageInput` starting from circuit-ui@v3.

--- a/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
@@ -7,6 +7,7 @@ Object {
     "giga": "6px",
     "kilo": "1px",
     "mega": "4px",
+    "peta": "12px",
     "pill": "999999px",
     "tera": "8px",
   },

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -51,6 +51,7 @@ export const borderRadius: BorderRadius = {
   mega: '4px',
   giga: '6px',
   tera: '8px',
+  peta: '12px',
   circle: '100%',
   pill: '999999px', // HACK: By providing a very large absolute size, the browser picks the maximum size in one dimension.
 };

--- a/packages/design-tokens/types/index.ts
+++ b/packages/design-tokens/types/index.ts
@@ -108,6 +108,7 @@ export type BorderRadius = {
   mega: string;
   giga: string;
   tera: string;
+  peta: string;
   circle: string;
   pill: string;
 };


### PR DESCRIPTION
## Purpose

Add a new peta borderRadius size of 12px to `@sumup/design-tokens`.

This size will be used in components including the `Avatar` and the `ImageInput` starting from circuit-ui@v3.

## Approach and changes

Added the new size and updated the BorderRadius type. Tested locally.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
