### PR TITLE
Hide card overflow

### DIFF
--- a/.changeset/lucky-chicken-yell.md
+++ b/.changeset/lucky-chicken-yell.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Hide Card overflow. This is helpful when Card children have a background-color, for example.

--- a/packages/circuit-ui/components/Card/Card.tsx
+++ b/packages/circuit-ui/components/Card/Card.tsx
@@ -41,6 +41,7 @@ const baseStyles = ({ theme }: StyleProps) => css`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  overflow: hidden;
 `;
 
 const shadowStyles = ({ shadow }: CardProps) => {

--- a/packages/circuit-ui/components/Card/__snapshots__/Card.spec.tsx.snap
+++ b/packages/circuit-ui/components/Card/__snapshots__/Card.spec.tsx.snap
@@ -16,6 +16,7 @@ exports[`Card should render with default styles 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  overflow: hidden;
   padding: 16px 24px;
 }
 
@@ -40,6 +41,7 @@ exports[`Card should render with giga spacing styles 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  overflow: hidden;
   padding: 16px 24px;
 }
 
@@ -64,6 +66,7 @@ exports[`Card should render with mega spacing styles 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  overflow: hidden;
   padding: 16px 16px;
 }
 

--- a/packages/circuit-ui/components/CardList/__snapshots__/CardList.spec.js.snap
+++ b/packages/circuit-ui/components/CardList/__snapshots__/CardList.spec.js.snap
@@ -16,6 +16,7 @@ exports[`CardList should render with default styles 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  overflow: hidden;
   padding: 16px 24px;
   padding: 0;
   border-radius: 4px;

--- a/packages/circuit-ui/components/Modal/components/ModalWrapper/__snapshots__/ModalWrapper.spec.tsx.snap
+++ b/packages/circuit-ui/components/Modal/components/ModalWrapper/__snapshots__/ModalWrapper.spec.tsx.snap
@@ -16,6 +16,7 @@ exports[`ModalWrapper should render with default styles 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
+  overflow: hidden;
   padding: 16px 24px;
   width: 100%;
   border: none;


### PR DESCRIPTION
## Purpose

The new Card border-radius can cause UI bugs is Card children have a background color (it overflows in the corners).

| Before | After |
| --- | --- |
| <img width="435" alt="Screenshot 2021-06-07 at 10 51 30" src="https://user-images.githubusercontent.com/35560568/120988516-ef540600-c77e-11eb-99ed-63fb8a322f2d.png"> | <img width="435" alt="Screenshot 2021-06-07 at 10 51 41" src="https://user-images.githubusercontent.com/35560568/120988523-f11dc980-c77e-11eb-9bf7-980e2c3d1f68.png"> |

## Approach and changes

Add `overflow:hidden;` to the Card and update snapshots.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
