### PR TITLE
Fix Popover story

### DIFF
--- a/packages/circuit-ui/components/Popover/Popover.stories.js
+++ b/packages/circuit-ui/components/Popover/Popover.stories.js
@@ -52,8 +52,8 @@ export const Base = (args) => {
 
   return (
     <Popover
-      isOpen={open}
       {...props}
+      isOpen={open}
       renderPopover={() => <Card>Popover Content</Card>}
       renderReference={() => (
         <Button


### PR DESCRIPTION
## Purpose

The story's isOpen prop was being overridden by Storybook, causing a render loop and breaking the story.

## Approach and changes

Pass isOpen after spreading props in the story.

## Definition of done

(n/a)

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
