### PR TITLE
Replace Avatar identity variant picture to fix unstable stories

### DIFF
--- a/packages/circuit-ui/components/Avatar/Avatar.spec.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.spec.tsx
@@ -23,7 +23,7 @@ const sizes = ['giga', 'yotta'] as const;
 const variants = ['object', 'identity'] as const;
 const images = {
   object: 'https://source.unsplash.com/EcWFOYOpkpY/200x200',
-  identity: 'https://upload.wikimedia.org/wikipedia/en/8/86/Avatar_Aang.png',
+  identity: 'https://source.unsplash.com/ZDgrqccUn88/200x200',
 };
 
 describe('Avatar', () => {

--- a/packages/circuit-ui/components/Avatar/Avatar.stories.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.stories.tsx
@@ -33,6 +33,7 @@ Base.args = {
   src: 'https://source.unsplash.com/EcWFOYOpkpY/200x200',
   variant: 'object',
   size: 'yotta',
+  alt: 'A cup of coffee on a table',
 };
 
 export const ObjectVariant = (): JSX.Element => (
@@ -40,18 +41,20 @@ export const ObjectVariant = (): JSX.Element => (
     <Avatar
       src="https://source.unsplash.com/EcWFOYOpkpY/200x200"
       variant="object"
+      alt="A cup of coffee on a table"
     />
-    <Avatar variant="object" />
+    <Avatar variant="object" alt="A cup of coffee on a table" />
   </Stack>
 );
 
 export const IdentityVariant = (): JSX.Element => (
   <Stack>
     <Avatar
-      src="https://upload.wikimedia.org/wikipedia/en/8/86/Avatar_Aang.png"
+      src="https://source.unsplash.com/ZDgrqccUn88/200x200"
       variant="identity"
+      alt="A portrait of a grey cat"
     />
-    <Avatar variant="identity" />
+    <Avatar variant="identity" alt="" />
   </Stack>
 );
 
@@ -62,23 +65,27 @@ export const Sizes = (): JSX.Element => (
         src="https://source.unsplash.com/EcWFOYOpkpY/200x200"
         variant="object"
         size="yotta"
+        alt="A cup of coffee on a table"
       />
       <Avatar
         src="https://source.unsplash.com/EcWFOYOpkpY/200x200"
         variant="object"
         size="giga"
+        alt="A cup of coffee on a table"
       />
     </Stack>
     <Stack>
       <Avatar
-        src="https://upload.wikimedia.org/wikipedia/en/8/86/Avatar_Aang.png"
+        src="https://source.unsplash.com/ZDgrqccUn88/200x200"
         variant="identity"
         size="yotta"
+        alt="A portrait of a grey cat"
       />
       <Avatar
-        src="https://upload.wikimedia.org/wikipedia/en/8/86/Avatar_Aang.png"
+        src="https://source.unsplash.com/ZDgrqccUn88/200x200"
         variant="identity"
         size="giga"
+        alt="A portrait of a grey cat"
       />
     </Stack>
   </Stack>

--- a/packages/circuit-ui/components/Avatar/__snapshots__/Avatar.spec.tsx.snap
+++ b/packages/circuit-ui/components/Avatar/__snapshots__/Avatar.spec.tsx.snap
@@ -58,7 +58,7 @@ exports[`Avatar styles should render the identity variant with an image 1`] = `
   <img
     alt=""
     class="circuit-0"
-    src="https://upload.wikimedia.org/wikipedia/en/8/86/Avatar_Aang.png"
+    src="https://source.unsplash.com/ZDgrqccUn88/200x200"
   />
 </div>
 `;


### PR DESCRIPTION
## Purpose

Chromatic regularly reported changes to the stories with the image that the `Avatar` component's `identity` variant was using, although we weren't changing the URL. This is preventing a lot of automatic merges, especially in dependency upgrades PRs.

## Approach and changes

Sourced a different image from Unsplash. This should solve the issue since we never had this problem with other Unsplash images throughout the stories.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
