### PR TITLE
Extend the borderRadius update codemod

### DIFF
--- a/packages/circuit-ui/cli/migrate/__testfixtures__/theme-border-radius.input.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/theme-border-radius.input.js
@@ -1,11 +1,11 @@
-import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 
 const elementStyles = ({ theme }) => css`
   border-top-left-radius: ${theme.borderRadius.mega};
   border-top-right-radius: ${theme.borderRadius.giga};
-  border-bottom-left-radius: ${theme.borderRadius.tera};
-  border-bottom-right-radius: ${theme.borderRadius.peta};
+  border-bottom-left-radius: ${(p) => p.theme.borderRadius.tera};
+  border-bottom-right-radius: ${(p) => p.theme.borderRadius.peta};
   border-radius: ${theme.borderRadius.kilo};
 `;
 

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/theme-border-radius.output.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/theme-border-radius.output.js
@@ -1,11 +1,11 @@
-import styled from '@emotion/styled';
 import { css } from '@emotion/core';
+import styled from '@emotion/styled';
 
 const elementStyles = ({ theme }) => css`
   border-top-left-radius: ${theme.borderRadius.bit};
   border-top-right-radius: ${theme.borderRadius.byte};
-  border-bottom-left-radius: ${theme.borderRadius.byte};
-  border-bottom-right-radius: ${theme.borderRadius.kilo};
+  border-bottom-left-radius: ${(p) => p.theme.borderRadius.byte};
+  border-bottom-right-radius: ${(p) => p.theme.borderRadius.kilo};
   border-radius: ${'1px'};
 `;
 

--- a/packages/circuit-ui/cli/migrate/theme-border-radius.ts
+++ b/packages/circuit-ui/cli/migrate/theme-border-radius.ts
@@ -13,32 +13,30 @@
  * limitations under the License.
  */
 
-import { Collection, JSCodeshift, Transform } from 'jscodeshift';
+import { Transform } from 'jscodeshift';
 
 import { findProperty } from './utils';
-
-function renameFactory(
-  j: JSCodeshift,
-  root: Collection,
-  prevValue: string,
-  nextValue: string,
-): void {
-  findProperty(j, root, `theme.borderRadius.${prevValue}`).replaceWith(
-    j.identifier(`theme.borderRadius.${nextValue}`),
-  );
-}
 
 const transform: Transform = (file, api) => {
   const j = api.jscodeshift;
   const root = j(file.source);
 
-  findProperty(j, root, `theme.borderRadius.kilo`).replaceWith(
-    j.identifier(`'1px'`),
+  const mappings = [
+    ['theme.borderRadius.mega', 'theme.borderRadius.bit'],
+    ['theme.borderRadius.giga', 'theme.borderRadius.byte'],
+    ['theme.borderRadius.tera', 'theme.borderRadius.byte'],
+    ['theme.borderRadius.peta', 'theme.borderRadius.kilo'],
+    ['theme.borderRadius.kilo', `'1px'`],
+    ['p.theme.borderRadius.mega', 'p.theme.borderRadius.bit'],
+    ['p.theme.borderRadius.giga', 'p.theme.borderRadius.byte'],
+    ['p.theme.borderRadius.tera', 'p.theme.borderRadius.byte'],
+    ['p.theme.borderRadius.peta', 'p.theme.borderRadius.kilo'],
+    ['p.theme.borderRadius.kilo', `'1px'`],
+  ];
+
+  mappings.forEach(([prevValue, nextValue]) =>
+    findProperty(j, root, prevValue).replaceWith(j.identifier(nextValue)),
   );
-  renameFactory(j, root, 'mega', 'bit');
-  renameFactory(j, root, 'giga', 'byte');
-  renameFactory(j, root, 'tera', 'byte');
-  renameFactory(j, root, 'peta', 'kilo');
 
   return root.toSource();
 };


### PR DESCRIPTION
## Purpose

The codemod will now transform two styled component patterns that are common in our apps, after the borderRadius update from #980:

- `${theme.borderRadius.mega}`
- `${(p) => p.theme.borderRadius.mega}`.

## Approach and changes

- Extend the codemod
- We decided not to. support further, less common patterns like `${(props) => props.theme.borderRadius.mega}`. Any occurrences of these will be manually migrated.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
