### PR TITLE
Update List component sizes

### DIFF
--- a/.changeset/fresh-days-fold.md
+++ b/.changeset/fresh-days-fold.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Replaced the `List` component sizes **_mega_** and **_kilo_** with new values **_one_** and **_two_** respectively (🤖 _typography-sizes_).

--- a/.changeset/fresh-days-fold.md
+++ b/.changeset/fresh-days-fold.md
@@ -1,5 +1,0 @@
----
-'@sumup/circuit-ui': major
----
-
-Replaced the `List` component sizes **_mega_** and **_kilo_** with new values **_one_** and **_two_** respectively (🤖 _typography-sizes_).

--- a/.changeset/healthy-stingrays-count.md
+++ b/.changeset/healthy-stingrays-count.md
@@ -46,3 +46,7 @@ The `Blockquote` component has been removed and replaced by the `Body` component
 Usage example:
 
 `<Body variant="quote">quote</Body>`
+
+#### List
+
+Replaced the `List` component sizes **_mega_** and **_kilo_** with new values **_one_** and **_two_** respectively (🤖 _typography-sizes_).

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/typography-sizes.input.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/typography-sizes.input.js
@@ -6,6 +6,7 @@ import {
   Headline,
   SubHeadline,
   Body,
+  List,
 } from '@sumup/circuit-ui';
 
 const HeadlineZetta = () => <Headline size="zetta">Headline</Headline>;
@@ -35,3 +36,6 @@ const BodyKilo = () => <Body size="kilo">Body 2</Body>;
 
 const TextMega = () => <Text size="mega">Body 1</Text>;
 const TextKilo = () => <Text size="kilo">Body 2</Text>;
+
+const ListMega = () => <List size="mega">Body 1</List>;
+const ListKilo = () => <List size="kilo">Body 2</List>;

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/typography-sizes.output.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/typography-sizes.output.js
@@ -6,6 +6,7 @@ import {
   Headline,
   SubHeadline,
   Body,
+  List,
 } from '@sumup/circuit-ui';
 
 const HeadlineZetta = () => <Headline size="zetta">Headline</Headline>;
@@ -35,3 +36,6 @@ const BodyKilo = () => <Body size="two">Body 2</Body>;
 
 const TextMega = () => <Text size="one">Body 1</Text>;
 const TextKilo = () => <Text size="two">Body 2</Text>;
+
+const ListMega = () => <List size="one">Body 1</List>;
+const ListKilo = () => <List size="two">Body 2</List>;

--- a/packages/circuit-ui/cli/migrate/typography-sizes.ts
+++ b/packages/circuit-ui/cli/migrate/typography-sizes.ts
@@ -110,6 +110,11 @@ const transform: Transform = (file, api) => {
     kilo: 'two',
   });
 
+  renameFactory(j, root, 'List', {
+    mega: 'one',
+    kilo: 'two',
+  });
+
   return root.toSource();
 };
 

--- a/packages/circuit-ui/components/List/List.spec.tsx
+++ b/packages/circuit-ui/components/List/List.spec.tsx
@@ -40,7 +40,7 @@ describe('List', () => {
     expect(actual).toMatchSnapshot();
   });
 
-  const sizes: ListProps['size'][] = ['kilo', 'mega'];
+  const sizes: ListProps['size'][] = ['one', 'two'];
   it.each(sizes)('should render with size %s', (size) => {
     const actual = create(
       <List size={size}>

--- a/packages/circuit-ui/components/List/List.stories.tsx
+++ b/packages/circuit-ui/components/List/List.stories.tsx
@@ -48,7 +48,7 @@ export const Variants = (args: ListProps) =>
     </List>
   ));
 
-const sizes: ListProps['size'][] = ['kilo', 'mega'];
+const sizes: ListProps['size'][] = ['one', 'two'];
 
 export const Sizes = (args: ListProps) =>
   sizes.map((size) => (

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -21,7 +21,7 @@ import styled, { StyleProps } from '../../styles/styled';
 import { typography } from '../../styles/style-mixins';
 import deprecate from '../../util/deprecate';
 
-type Size = 'kilo' | 'mega';
+type Size = 'one' | 'two';
 type Variant = 'ordered' | 'unordered';
 
 export interface ListProps
@@ -50,19 +50,19 @@ const baseStyles = ({ theme }: StyleProps) => css`
   margin-bottom: ${theme.spacings.mega};
 `;
 
-const sizeStyles = ({ theme, size = 'mega' }: ListProps & StyleProps) => {
+const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
   const sizeMap = {
-    kilo: {
-      marginBottom: theme.spacings.kilo,
-      paddingLeft: theme.spacings.kilo,
-      marginLeft: theme.spacings.bit,
-      type: typography('two')(theme),
-    },
-    mega: {
+    one: {
       marginBottom: theme.spacings.byte,
       paddingLeft: theme.spacings.kilo,
       marginLeft: theme.spacings.kilo,
       type: typography('one')(theme),
+    },
+    two: {
+      marginBottom: theme.spacings.kilo,
+      paddingLeft: theme.spacings.kilo,
+      marginLeft: theme.spacings.bit,
+      type: typography('two')(theme),
     },
   };
   const { marginBottom, paddingLeft, marginLeft, type } = sizeMap[size];

--- a/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
+++ b/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
@@ -148,35 +148,7 @@ exports[`List should render with no margin styles when passed the noMargin prop 
 </ul>
 `;
 
-exports[`List should render with size kilo 1`] = `
-.circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  padding-left: 12px;
-  font-size: 14px;
-  line-height: 20px;
-}
-
-.circuit-0 li {
-  margin-bottom: 12px;
-  margin-left: 4px;
-}
-
-.circuit-0 ul,
-.circuit-0 ol {
-  margin-left: 4px;
-}
-
-<ul
-  class="circuit-0"
->
-  <li>
-    kilo
-  </li>
-</ul>
-`;
-
-exports[`List should render with size mega 1`] = `
+exports[`List should render with size one 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
@@ -199,7 +171,35 @@ exports[`List should render with size mega 1`] = `
   class="circuit-0"
 >
   <li>
-    mega
+    one
+  </li>
+</ul>
+`;
+
+exports[`List should render with size two 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  padding-left: 12px;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.circuit-0 li {
+  margin-bottom: 12px;
+  margin-left: 4px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-left: 4px;
+}
+
+<ul
+  class="circuit-0"
+>
+  <li>
+    two
   </li>
 </ul>
 `;


### PR DESCRIPTION
Addresses #819.

## Purpose

When implementing the new semantic typography components in #884, we overlooked the List component sizes.

## Approach and changes

- Replace the `List` component sizes `mega` and `kilo` with new values `one` and `two` respectively.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
