### PR TITLE
Extend the typography-sizes changeset to transform Anchors

### DIFF
--- a/.changeset/nice-kids-punch.md
+++ b/.changeset/nice-kids-punch.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Extended the typography-sizes codemod to transform the Anchor component and warn of any necessary manual migration.

--- a/packages/circuit-ui/CHANGELOG.md
+++ b/packages/circuit-ui/CHANGELOG.md
@@ -50,7 +50,9 @@
 
   Renamed the `Heading` component to `Headline` and mapped the styles to the new ones. These changes can be codemodded (🤖 _component-names-v3_).
 
-  The `size` prop has been adapted to accept the new size numbers. For the `Headline` component, **_zetta_**, **_exa_** and **_peta_** should be migrated to **_one_**, **_tera_** to **_two_**, **_giga_** to **_three_**, and **_mega_** and **_kilo_** to **_four_** (🤖 _typography-sizes_)
+  The `size` prop has been adapted to accept the new size numbers. For the `Headline` component, **_exa_** and **_peta_** should be migrated to **_one_**, **_tera_** to **_two_**, **_giga_** to **_three_**, and **_mega_** and **_kilo_** to **_four_** (🤖 _typography-sizes_).
+
+  The uncommonly used `zetta` size should be migrated manually, if possible to `one`, or alternatively to a `2.625rem` size (with `1rem` = `16px`).
 
   Usage example:
 
@@ -63,11 +65,13 @@
 
   Renamed the `SubHeading` component to `SubHeadline` and mapped the styles to the new ones (🤖 _component-names-v3_). The `SubHeadline` component now uses only one size value, so the `size` prop should be removed (🤖 _typography-sizes_).
 
-  #### Body (and Anchor)
+  #### Body, Anchor, List
 
   The `Text` component has been renamed to `Body` (🤖 _component-names-v3_).
 
-  The `size` prop has been adapted to accept the new size numbers. **_giga_** and **_mega_** should be migrated to **_one_**, and **_kilo_** to **_two_**. This also applies to `Anchor`, which uses `Body` under the hood (🤖 _typography-sizes_).
+  The `size` prop has been adapted to accept the new size numbers. For the `Body`, `Anchor` and `List` components, **_mega_** should be migrated to **_one_**, and **_kilo_** to **_two_** (🤖 _typography-sizes_).
+
+  The uncommonly used `giga` size should be migrated manually, if possible to `one`, or alternatively to a `1.125rem` size (with `1rem` = `16px`).
 
   Usage example:
 
@@ -76,25 +80,19 @@
   +  <Body size="one" />
   ```
 
-  The `Text` component's bold prop has been removed. Use the `Body` component's `variant="highlight"` instead. This also applies to `Anchor`, which uses `Body` under the hood (🤖 _body-variant-highlight_).
+  The `Text` and `Anchor` components' `bold` prop has been removed. Use the `variant="highlight"` prop instead (🤖 _body-variant-highlight_).
 
   Usage example:
 
   `<Body variant="highlight">bold</Body>`
 
-  The `Text` component's italic and strike props has been removed. Use the custom styles instead.
-
-  Additionally, the new `success`, `error` and `subtle` variants are added.
+  The `Text` and `Anchor` components' `italic` and `strike` props have been removed. Use custom styles instead.
 
   The `Blockquote` component has been removed and replaced by the `Body` component with `variant="quote"`. This should be migrated manually.
 
   Usage example:
 
   `<Body variant="quote">quote</Body>`
-
-  #### List
-
-  The `List`'s `size` prop has been adapted to accept the new size numbers. **_giga_** and **_mega_** should be migrated to **_one_**, and **_kilo_** to **_two_** (🤖 _typography-sizes_).
 
 - [#960](https://github.com/sumup-oss/circuit-ui/pull/960) [`1a1a3646`](https://github.com/sumup-oss/circuit-ui/commit/1a1a36466e096c20b0dd19dc468359d65341e0fe) Thanks [@robinmetral](https://github.com/robinmetral)! - Default `data-testid`s are no longer built into the `Table` component. They can still be passed manually. We also recommend [querying by role](https://testing-library.com/docs/queries/about/#priority) in tests, for them to resemble how users interact with the code. You can find examples in the component's specs.
 
@@ -154,6 +152,8 @@
 ### Minor Changes
 
 - [#984](https://github.com/sumup-oss/circuit-ui/pull/984) [`7879a990`](https://github.com/sumup-oss/circuit-ui/commit/7879a9901c06e389135e0d22697b97669c485949) Thanks [@amelako](https://github.com/amelako)! - Added a `size` prop to the Spinner component. The possible values are `byte`, `kilo` (default), and `giga`.
+
+* [#884](https://github.com/sumup-oss/circuit-ui/pull/884) [`eb9e0b47`](https://github.com/sumup-oss/circuit-ui/commit/eb9e0b474e675f13c9876e22857a170665e9a92f) Thanks [@amelako](https://github.com/amelako)! - Added new `success`, `error` and `subtle` variants to the `Body` and `Anchor` component.
 
 ### Patch Changes
 

--- a/packages/circuit-ui/CHANGELOG.md
+++ b/packages/circuit-ui/CHANGELOG.md
@@ -49,7 +49,8 @@
   #### Headline
 
   Renamed the `Heading` component to `Headline` and mapped the styles to the new ones. These changes can be codemodded (🤖 _component-names-v3_).
-  The size prop has been changed to accept the new size numbers. For `Headline` component **_exa_** and **_peta_** has been changed to **_one_** with new values, **_tera_** has been changed to **_two_**, **_giga_** to **_three_**, **_mega_** and **_kilo_** to **_four_** (🤖 _typography-sizes_)
+
+  The `size` prop has been adapted to accept the new size numbers. For the `Headline` component, **_zetta_**, **_exa_** and **_peta_** should be migrated to **_one_**, **_tera_** to **_two_**, **_giga_** to **_three_**, and **_mega_** and **_kilo_** to **_four_** (🤖 _typography-sizes_)
 
   Usage example:
 
@@ -60,11 +61,13 @@
 
   #### SubHeadline
 
-  Renamed the `SubHeading` component to `SubHeadline` and mapped the styles to the new ones (🤖 _component-names-v3_). The `SubHeadline` component now uses only one size value (🤖 _typography-sizes_).
+  Renamed the `SubHeading` component to `SubHeadline` and mapped the styles to the new ones (🤖 _component-names-v3_). The `SubHeadline` component now uses only one size value, so the `size` prop should be removed (🤖 _typography-sizes_).
 
-  #### Body
+  #### Body (and Anchor)
 
-  The `Text` component has been renamed to `Body` (🤖 _component-names-v3_). The size prop is adapted to accept the new size numbers and **_giga_** size has been removed, **_mega_** and **_kilo_** sizes have been changed to **_one_** and **_two_** respectively.
+  The `Text` component has been renamed to `Body` (🤖 _component-names-v3_).
+
+  The `size` prop has been adapted to accept the new size numbers. **_giga_** and **_mega_** should be migrated to **_one_**, and **_kilo_** to **_two_**. This also applies to `Anchor`, which uses `Body` under the hood (🤖 _typography-sizes_).
 
   Usage example:
 
@@ -73,7 +76,7 @@
   +  <Body size="one" />
   ```
 
-  The `Text` component's bold prop has been removed. Use the `Body` component `(variant="highlight")` instead (🤖 _body-variant-highlight_).
+  The `Text` component's bold prop has been removed. Use the `Body` component's `variant="highlight"` instead. This also applies to `Anchor`, which uses `Body` under the hood (🤖 _body-variant-highlight_).
 
   Usage example:
 
@@ -83,7 +86,7 @@
 
   Additionally, the new `success`, `error` and `subtle` variants are added.
 
-  The `Blockquote` component has been removed and replaced by the `Body` component with `variant="quote"`.
+  The `Blockquote` component has been removed and replaced by the `Body` component with `variant="quote"`. This should be migrated manually.
 
   Usage example:
 
@@ -91,7 +94,7 @@
 
   #### List
 
-  Replaced the `List` component sizes **_mega_** and **_kilo_** with new values **_one_** and **_two_** respectively (🤖 _typography-sizes_).
+  The `List`'s `size` prop has been adapted to accept the new size numbers. **_giga_** and **_mega_** should be migrated to **_one_**, and **_kilo_** to **_two_** (🤖 _typography-sizes_).
 
 - [#960](https://github.com/sumup-oss/circuit-ui/pull/960) [`1a1a3646`](https://github.com/sumup-oss/circuit-ui/commit/1a1a36466e096c20b0dd19dc468359d65341e0fe) Thanks [@robinmetral](https://github.com/robinmetral)! - Default `data-testid`s are no longer built into the `Table` component. They can still be passed manually. We also recommend [querying by role](https://testing-library.com/docs/queries/about/#priority) in tests, for them to resemble how users interact with the code. You can find examples in the component's specs.
 

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/body-variant-highlight.input.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/body-variant-highlight.input.js
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Body, Text } from '@sumup/circuit-ui';
+import { Body, Text, Anchor } from '@sumup/circuit-ui';
 
 const BoldBody = () => (
   <>
@@ -15,6 +15,13 @@ const BoldText = () => (
   </>
 );
 
+const BoldAnchor = () => (
+  <>
+    <Anchor bold>bold</Anchor>
+    <Anchor bold={!true}>bold</Anchor>
+  </>
+);
+
 const RedBody = styled(Body)`
   color: red;
 `;
@@ -23,9 +30,14 @@ const RedText = styled(Text)`
   color: red;
 `;
 
+const RedAnchor = styled(Anchor)`
+  color: red;
+`;
+
 const Styled = () => (
   <>
     <RedBody bold>bold body</RedBody>
     <RedText bold>bold text</RedText>
+    <RedAnchor bold>bold anchor</RedAnchor>
   </>
 );

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/body-variant-highlight.output.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/body-variant-highlight.output.js
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Body, Text } from '@sumup/circuit-ui';
+import { Body, Text, Anchor } from '@sumup/circuit-ui';
 
 const BoldBody = () => (
   <>
@@ -15,6 +15,13 @@ const BoldText = () => (
   </>
 );
 
+const BoldAnchor = () => (
+  <>
+    <Anchor variant="highlight">bold</Anchor>
+    <Anchor bold={!true}>bold</Anchor>
+  </>
+);
+
 const RedBody = styled(Body)`
   color: red;
 `;
@@ -23,9 +30,14 @@ const RedText = styled(Text)`
   color: red;
 `;
 
+const RedAnchor = styled(Anchor)`
+  color: red;
+`;
+
 const Styled = () => (
   <>
     <RedBody variant="highlight">bold body</RedBody>
     <RedText variant="highlight">bold text</RedText>
+    <RedAnchor variant="highlight">bold anchor</RedAnchor>
   </>
 );

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/typography-sizes.input.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/typography-sizes.input.js
@@ -7,9 +7,10 @@ import {
   SubHeadline,
   Body,
   List,
+  Anchor,
 } from '@sumup/circuit-ui';
 
-const HeadlineZetta = () => <Headline size="zetta">Headline</Headline>;
+const HeadlineZetta = () => <Headline size="zetta">Headline 1</Headline>;
 const HeadlineExa = () => <Headline size="exa">Headline 1</Headline>;
 const HeadlinePeta = () => <Headline size="peta">Headline 1</Headline>;
 const HeadlineTera = () => <Headline size="tera">Headline 2</Headline>;
@@ -31,11 +32,24 @@ const SubHeadlineKilo = () => <SubHeadline size="kilo">Test</SubHeadline>;
 const SubHeadingMega = () => <SubHeading size="mega">Test</SubHeading>;
 const SubHeadingKilo = () => <SubHeading size="kilo">Test</SubHeading>;
 
+const BodyGiga = () => <Body size="giga">Body 1</Body>;
 const BodyMega = () => <Body size="mega">Body 1</Body>;
 const BodyKilo = () => <Body size="kilo">Body 2</Body>;
 
+const TextGiga = () => <Text size="giga">Body 1</Text>;
 const TextMega = () => <Text size="mega">Body 1</Text>;
 const TextKilo = () => <Text size="kilo">Body 2</Text>;
 
+const ListGiga = () => <List size="giga">Body 1</List>;
 const ListMega = () => <List size="mega">Body 1</List>;
 const ListKilo = () => <List size="kilo">Body 2</List>;
+
+const AnchorGiga = () => <Anchor size="giga">Body 1</Anchor>;
+const AnchorMega = () => <Anchor size="mega">Body 1</Anchor>;
+const AnchorKilo = () => <Anchor size="kilo">Body 2</Anchor>;
+
+const RedHeadline = styled(Headline)`
+  color: red;
+`;
+
+const StyledComponent = () => <RedHeadline size="exa" />;

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/typography-sizes.output.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/typography-sizes.output.js
@@ -7,9 +7,10 @@ import {
   SubHeadline,
   Body,
   List,
+  Anchor,
 } from '@sumup/circuit-ui';
 
-const HeadlineZetta = () => <Headline size="zetta">Headline</Headline>;
+const HeadlineZetta = () => <Headline size="one">Headline 1</Headline>;
 const HeadlineExa = () => <Headline size="one">Headline 1</Headline>;
 const HeadlinePeta = () => <Headline size="one">Headline 1</Headline>;
 const HeadlineTera = () => <Headline size="two">Headline 2</Headline>;
@@ -17,7 +18,7 @@ const HeadlineGiga = () => <Headline size="three">Headline 3</Headline>;
 const HeadlineMega = () => <Headline size="four">Headline 4</Headline>;
 const HeadlineKilo = () => <Headline size="four">Headline 4</Headline>;
 
-const HeadingZetta = () => <Heading size="zetta">Headline 1</Heading>;
+const HeadingZetta = () => <Heading size="one">Headline 1</Heading>;
 const HeadingExa = () => <Heading size="one">Headline 1</Heading>;
 const HeadingPeta = () => <Heading size="one">Headline 1</Heading>;
 const HeadingTera = () => <Heading size="two">Headline 2</Heading>;
@@ -31,11 +32,24 @@ const SubHeadlineKilo = () => <SubHeadline>Test</SubHeadline>;
 const SubHeadingMega = () => <SubHeading>Test</SubHeading>;
 const SubHeadingKilo = () => <SubHeading>Test</SubHeading>;
 
+const BodyGiga = () => <Body size="one">Body 1</Body>;
 const BodyMega = () => <Body size="one">Body 1</Body>;
 const BodyKilo = () => <Body size="two">Body 2</Body>;
 
+const TextGiga = () => <Text size="one">Body 1</Text>;
 const TextMega = () => <Text size="one">Body 1</Text>;
 const TextKilo = () => <Text size="two">Body 2</Text>;
 
+const ListGiga = () => <List size="one">Body 1</List>;
 const ListMega = () => <List size="one">Body 1</List>;
 const ListKilo = () => <List size="two">Body 2</List>;
+
+const AnchorGiga = () => <Anchor size="one">Body 1</Anchor>;
+const AnchorMega = () => <Anchor size="one">Body 1</Anchor>;
+const AnchorKilo = () => <Anchor size="two">Body 2</Anchor>;
+
+const RedHeadline = styled(Headline)`
+  color: red;
+`;
+
+const StyledComponent = () => <RedHeadline size="one" />;

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/typography-sizes.output.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/typography-sizes.output.js
@@ -10,7 +10,7 @@ import {
   Anchor,
 } from '@sumup/circuit-ui';
 
-const HeadlineZetta = () => <Headline size="one">Headline 1</Headline>;
+const HeadlineZetta = () => <Headline size="zetta">Headline 1</Headline>;
 const HeadlineExa = () => <Headline size="one">Headline 1</Headline>;
 const HeadlinePeta = () => <Headline size="one">Headline 1</Headline>;
 const HeadlineTera = () => <Headline size="two">Headline 2</Headline>;
@@ -18,7 +18,7 @@ const HeadlineGiga = () => <Headline size="three">Headline 3</Headline>;
 const HeadlineMega = () => <Headline size="four">Headline 4</Headline>;
 const HeadlineKilo = () => <Headline size="four">Headline 4</Headline>;
 
-const HeadingZetta = () => <Heading size="one">Headline 1</Heading>;
+const HeadingZetta = () => <Heading size="zetta">Headline 1</Heading>;
 const HeadingExa = () => <Heading size="one">Headline 1</Heading>;
 const HeadingPeta = () => <Heading size="one">Headline 1</Heading>;
 const HeadingTera = () => <Heading size="two">Headline 2</Heading>;
@@ -32,19 +32,19 @@ const SubHeadlineKilo = () => <SubHeadline>Test</SubHeadline>;
 const SubHeadingMega = () => <SubHeading>Test</SubHeading>;
 const SubHeadingKilo = () => <SubHeading>Test</SubHeading>;
 
-const BodyGiga = () => <Body size="one">Body 1</Body>;
+const BodyGiga = () => <Body size="giga">Body 1</Body>;
 const BodyMega = () => <Body size="one">Body 1</Body>;
 const BodyKilo = () => <Body size="two">Body 2</Body>;
 
-const TextGiga = () => <Text size="one">Body 1</Text>;
+const TextGiga = () => <Text size="giga">Body 1</Text>;
 const TextMega = () => <Text size="one">Body 1</Text>;
 const TextKilo = () => <Text size="two">Body 2</Text>;
 
-const ListGiga = () => <List size="one">Body 1</List>;
+const ListGiga = () => <List size="giga">Body 1</List>;
 const ListMega = () => <List size="one">Body 1</List>;
 const ListKilo = () => <List size="two">Body 2</List>;
 
-const AnchorGiga = () => <Anchor size="one">Body 1</Anchor>;
+const AnchorGiga = () => <Anchor size="giga">Body 1</Anchor>;
 const AnchorMega = () => <Anchor size="one">Body 1</Anchor>;
 const AnchorKilo = () => <Anchor size="two">Body 2</Anchor>;
 

--- a/packages/circuit-ui/cli/migrate/body-variant-highlight.ts
+++ b/packages/circuit-ui/cli/migrate/body-variant-highlight.ts
@@ -66,6 +66,7 @@ const transform: Transform = (file, api) => {
 
   transformFactory(j, root, filePath, 'Body');
   transformFactory(j, root, filePath, 'Text');
+  transformFactory(j, root, filePath, 'Anchor');
 
   return root.toSource();
 };

--- a/packages/circuit-ui/cli/migrate/typography-sizes.ts
+++ b/packages/circuit-ui/cli/migrate/typography-sizes.ts
@@ -82,6 +82,7 @@ const transform: Transform = (file, api) => {
   const root = j(file.source);
 
   renameFactory(j, root, 'Headline', {
+    zetta: 'one',
     exa: 'one',
     peta: 'one',
     tera: 'two',
@@ -90,6 +91,7 @@ const transform: Transform = (file, api) => {
     kilo: 'four',
   });
   renameFactory(j, root, 'Heading', {
+    zetta: 'one',
     exa: 'one',
     peta: 'one',
     tera: 'two',
@@ -102,15 +104,22 @@ const transform: Transform = (file, api) => {
   removeFactory(j, root, 'SubHeading');
 
   renameFactory(j, root, 'Body', {
+    giga: 'one',
     mega: 'one',
     kilo: 'two',
   });
   renameFactory(j, root, 'Text', {
+    giga: 'one',
     mega: 'one',
     kilo: 'two',
   });
-
   renameFactory(j, root, 'List', {
+    giga: 'one',
+    mega: 'one',
+    kilo: 'two',
+  });
+  renameFactory(j, root, 'Anchor', {
+    giga: 'one',
     mega: 'one',
     kilo: 'two',
   });

--- a/packages/create-sumup-next-app/CHANGELOG.md
+++ b/packages/create-sumup-next-app/CHANGELOG.md
@@ -1,8 +1,7 @@
 # @sumup/cna-template
 
 ## 1.2.1
+
 ### Patch Changes
-
-
 
 - [#937](https://github.com/sumup-oss/circuit-ui/pull/937) [`5746ae28`](https://github.com/sumup-oss/circuit-ui/commit/5746ae285813fc4d712d9394927e6b680c1951d0) Thanks [@connor-baer](https://github.com/connor-baer)! - Added default options when initializing Foundry.


### PR DESCRIPTION
## Purpose

We overlooked the `Anchor` in the typography-sizes codemod for V3: it should be migrated just like `Body`, because it extends its props.

## Approach and changes

- Update the codemods and fixtures
  - Support Anchors
  - Warn for headline `zetta` sizes and body `giga` sizes that a manual migration is necessary
- Update the changelog

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
