### PR TITLE
Improve Popover interface and accessibility

### DIFF
--- a/.changeset/friendly-birds-fail.md
+++ b/.changeset/friendly-birds-fail.md
@@ -1,0 +1,8 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Improved keyboard and accessibility support.
+
+- Now the Popover can be closed using Escape key.
+- The trigger component now accepts the `aria-haspopup` and `aria-controls` props.

--- a/.changeset/wise-yaks-try.md
+++ b/.changeset/wise-yaks-try.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Extended the Popover list item state with disabled variant.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -44,7 +44,7 @@ export interface BaseProps extends BodyProps {
   /**
    * The ref to the html dom element, it can be a button an anchor or a span, typed as any for now because of complex js manipulation with styled components
    */
-  ref?: Ref<HTMLButtonElement & HTMLAnchorElement>;
+  ref?: Ref<any>;
 }
 type LinkElProps = Omit<HTMLProps<HTMLAnchorElement>, 'size' | 'onClick'>;
 type ButtonElProps = Omit<HTMLProps<HTMLButtonElement>, 'size' | 'onClick'>;

--- a/packages/circuit-ui/components/Button/Button.spec.tsx
+++ b/packages/circuit-ui/components/Button/Button.spec.tsx
@@ -116,7 +116,7 @@ describe('Button', () => {
      * Should accept a working ref for button
      */
     it('should accept a working ref for a button', () => {
-      const tref = createRef<HTMLButtonElement & HTMLAnchorElement>();
+      const tref = createRef<any>();
       const { container } = render(
         <Button ref={tref}>This is a button</Button>,
       );
@@ -128,7 +128,7 @@ describe('Button', () => {
      * Should accept a working ref for link
      */
     it('should accept a working ref for a link', () => {
-      const tref = createRef<HTMLButtonElement & HTMLAnchorElement>();
+      const tref = createRef<any>();
       const { container } = render(
         <Button href="http://sumup.com" ref={tref}>
           Link button

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -80,7 +80,7 @@ export interface BaseProps {
   /**
    The ref to the html dom element, it can be an anchor or a button
    */
-  'ref'?: Ref<HTMLButtonElement & HTMLAnchorElement>;
+  'ref'?: Ref<any>;
   'data-testid'?: string;
 }
 

--- a/packages/circuit-ui/components/CloseButton/CloseButton.spec.tsx
+++ b/packages/circuit-ui/components/CloseButton/CloseButton.spec.tsx
@@ -33,7 +33,7 @@ describe('CloseButton', () => {
      * Should accept a working ref
      */
     it('should accept a working ref', () => {
-      const tref = createRef<HTMLButtonElement & HTMLAnchorElement>();
+      const tref = createRef<any>();
       const { container } = render(<CloseButton label="Close" ref={tref} />);
       const button = container.querySelector('button');
       expect(tref.current).toBe(button);

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -54,10 +54,7 @@ const sizeStyles = (size: IconButtonProps['size'] = 'giga') => (
  * as its only child.
  */
 export const IconButton = forwardRef(
-  (
-    { children, label, size, ...props }: IconButtonProps,
-    ref?: Ref<HTMLButtonElement & HTMLAnchorElement>,
-  ) => {
+  ({ children, label, size, ...props }: IconButtonProps, ref?: Ref<any>) => {
     const child = Children.only(children);
     const icon = cloneElement(child, { role: 'presentation' });
     return (

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -235,7 +235,7 @@ export const ImageInput = ({
   ...props
 }: ImageInputProps): JSX.Element => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const id = customId || uniqueId('ImageInput_');
+  const id = customId || uniqueId('image-input_');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [previewImage, setPreviewImage] = useState<string>('');
 

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -209,12 +209,12 @@ exports[`ImageInput styles should render a custom component 1`] = `
       accept="image/*"
       aria-invalid="false"
       class="circuit-0"
-      id="ImageInput_4"
+      id="image-input_4"
       type="file"
     />
     <label
       class="circuit-2"
-      for="ImageInput_4"
+      for="image-input_4"
     >
       <span
         class="circuit-1"
@@ -486,12 +486,12 @@ exports[`ImageInput styles should render with an existing image 1`] = `
       accept="image/*"
       aria-invalid="false"
       class="circuit-0"
-      id="ImageInput_2"
+      id="image-input_2"
       type="file"
     />
     <label
       class="circuit-3"
-      for="ImageInput_2"
+      for="image-input_2"
     >
       <span
         class="circuit-1"
@@ -764,12 +764,12 @@ exports[`ImageInput styles should render with default styles 1`] = `
       accept="image/*"
       aria-invalid="false"
       class="circuit-0"
-      id="ImageInput_1"
+      id="image-input_1"
       type="file"
     />
     <label
       class="circuit-3"
-      for="ImageInput_1"
+      for="image-input_1"
     >
       <span
         class="circuit-1"
@@ -1086,12 +1086,12 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
       accept="image/*"
       aria-invalid="true"
       class="circuit-0"
-      id="ImageInput_3"
+      id="image-input_3"
       type="file"
     />
     <label
       class="circuit-3"
-      for="ImageInput_3"
+      for="image-input_3"
     >
       <span
         class="circuit-1"

--- a/packages/circuit-ui/components/Popover/Popover.docs.mdx
+++ b/packages/circuit-ui/components/Popover/Popover.docs.mdx
@@ -5,7 +5,7 @@ import { Popover } from '@sumup/circuit-ui';
 
 Popover menus are a common pattern to display a list of subsequent action options, when interacting with an actionable component.
 
-<Story id="popover-base" />
+<Story id="components-popover--base" />
 <Props of={Popover} />
 
 - Triggers of Popover can be primary, secondary, tertiary buttons, an overflow icon, or components with embedded buttons such as the [ImageInput component](Forms/ImageInput).
@@ -19,5 +19,4 @@ Popover menus are a common pattern to display a list of subsequent action option
 - **Do** use clear, concise and actionable labels for Popover items
 - **Do** always think about the priority of the action option to be taken and put the option order in logical order
 
-<Story id="popover-icon-trigger" />
-<Story id="popover-item-base" />
+<Story id="components-popover--with-icon" />

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -15,12 +15,11 @@
 
 /* eslint-disable react/display-name */
 
-import { forwardRef, Ref } from 'react';
 import { CirclePlus, Zap } from '@sumup/icons';
 import { Placement } from '@popperjs/core';
+import { forwardRef } from 'react';
 
 import {
-  renderToHtml,
   axe,
   RenderFn,
   render,
@@ -68,20 +67,6 @@ describe('PopoverItem', () => {
     });
   });
 
-  describe('accessibility', () => {
-    it('should meet accessibility guidelines', async () => {
-      const props = {
-        ...baseProps,
-        href: 'https://sumup.com',
-        onClick: jest.fn(),
-        icon: Zap,
-      };
-      const wrapper = renderPopoverItem(renderToHtml, props);
-      const actual = await axe(wrapper);
-      expect(actual).toHaveNoViolations();
-    });
-  });
-
   describe('business logic', () => {
     it('should call onClick when rendered as Link', () => {
       const props = {
@@ -104,29 +89,24 @@ describe('Popover', () => {
   const renderPopover = (props: Omit<PopoverProps, 'component'>) =>
     render(
       <Popover
-        // eslint-disable-next-line @typescript-eslint/no-shadow
-        component={forwardRef<HTMLElement>((props, ref) => {
-          const buttonRef = ref as Ref<HTMLButtonElement>;
-          return (
-            <button ref={buttonRef} {...props}>
-              Button
-            </button>
-          );
-        })}
+        component={forwardRef<HTMLButtonElement>((triggerProps, ref) => (
+          <button ref={ref} {...triggerProps}>
+            Button
+          </button>
+        ))}
         {...props}
       />,
     );
 
-  const baseProps = {
+  const baseProps: Omit<PopoverProps, 'component'> = {
     actions: [
       {
         onClick: () => alert('Added'),
         children: 'Add',
         icon: CirclePlus,
       },
+      { type: 'divider' },
     ],
-    isOpen: true,
-    onClose: jest.fn(),
   };
 
   describe('styles', () => {
@@ -160,38 +140,38 @@ describe('Popover', () => {
 
   describe('business logic', () => {
     it('should close the popover when clicking outside', async () => {
-      const { getByRole, queryByText } = renderPopover(baseProps);
+      const { getByRole, queryByRole } = renderPopover(baseProps);
 
       const popoverTrigger = getByRole('button');
 
       userEvent.click(popoverTrigger);
 
       await waitFor(() => {
-        expect(queryByText(baseProps.actions[0].children)).toBeVisible();
+        expect(queryByRole('menu')).toBeVisible();
       });
 
       userEvent.click(document.body);
 
       await waitFor(() => {
-        expect(queryByText(baseProps.actions[0].children)).toBeNull();
+        expect(queryByRole('menu')).toBeNull();
       });
     });
 
     it('should close popover when clicking the trigger element', async () => {
-      const { getByRole, queryByText } = renderPopover(baseProps);
+      const { getByRole, queryByRole } = renderPopover(baseProps);
 
       const popoverTrigger = getByRole('button');
 
       userEvent.click(popoverTrigger);
 
       await waitFor(() => {
-        expect(queryByText(baseProps.actions[0].children)).toBeVisible();
+        expect(queryByRole('menu')).toBeVisible();
       });
 
       userEvent.click(popoverTrigger);
 
       await waitFor(() => {
-        expect(queryByText(baseProps.actions[0].children)).toBeNull();
+        expect(queryByRole('menu')).toBeNull();
       });
     });
 
@@ -199,14 +179,14 @@ describe('Popover', () => {
      * Accessibility tests.
      */
     it('should meet accessibility guidelines', async () => {
-      const { container, getByRole, queryByText } = renderPopover(baseProps);
+      const { container, getByRole, queryByRole } = renderPopover(baseProps);
 
       const popoverTrigger = getByRole('button');
 
       userEvent.click(popoverTrigger);
 
       await waitFor(() => {
-        expect(queryByText(baseProps.actions[0].children)).toBeVisible();
+        expect(queryByRole('menu')).toBeVisible();
       });
 
       const actual = await axe(container);

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -25,6 +25,7 @@ import {
   render,
   userEvent,
   waitFor,
+  fireEvent,
 } from '../../util/test-utils';
 
 import {
@@ -169,6 +170,26 @@ describe('Popover', () => {
       });
 
       userEvent.click(popoverTrigger);
+
+      await waitFor(() => {
+        expect(queryByRole('menu')).toBeNull();
+      });
+    });
+
+    it('should close popover when clicking the ESC key', async () => {
+      const { getByRole, queryByRole } = renderPopover(baseProps);
+
+      const popoverTrigger = getByRole('button');
+
+      userEvent.click(popoverTrigger);
+
+      await waitFor(() => {
+        expect(queryByRole('menu')).toBeVisible();
+      });
+
+      fireEvent.keyDown(queryByRole('menu'), {
+        key: 'Escape',
+      });
 
       await waitFor(() => {
         expect(queryByRole('menu')).toBeNull();

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -13,17 +13,19 @@
  * limitations under the License.
  */
 
-import { useRef, Fragment } from 'react';
+/* eslint-disable react/display-name */
+
+import { forwardRef, Ref } from 'react';
 import { CirclePlus, Zap } from '@sumup/icons';
 import { Placement } from '@popperjs/core';
 
 import {
-  create,
   renderToHtml,
   axe,
   RenderFn,
   render,
   userEvent,
+  waitFor,
 } from '../../util/test-utils';
 
 import {
@@ -99,21 +101,26 @@ describe('PopoverItem', () => {
 });
 
 describe('Popover', () => {
-  const Default = (props: Omit<PopoverProps, 'triggerRef'>) => {
-    const triggerRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
-
-    return (
-      <Fragment>
-        <button ref={triggerRef}>Button</button>
-        <Popover triggerRef={triggerRef} {...props} />
-      </Fragment>
+  const renderPopover = (props: Omit<PopoverProps, 'component'>) =>
+    render(
+      <Popover
+        // eslint-disable-next-line @typescript-eslint/no-shadow
+        component={forwardRef<HTMLElement>((props, ref) => {
+          const buttonRef = ref as Ref<HTMLButtonElement>;
+          return (
+            <button ref={buttonRef} {...props}>
+              Button
+            </button>
+          );
+        })}
+        {...props}
+      />,
     );
-  };
 
   const baseProps = {
     actions: [
       {
-        onClick: () => alert('Hello'),
+        onClick: () => alert('Added'),
         children: 'Add',
         icon: CirclePlus,
       },
@@ -123,45 +130,87 @@ describe('Popover', () => {
   };
 
   describe('styles', () => {
-    it('should render with default styles', () => {
-      const actual = create(<Default {...baseProps} />);
-      expect(actual).toMatchSnapshot();
+    it('should render with default styles', async () => {
+      const { container, getByRole } = renderPopover(baseProps);
+
+      const popoverTrigger = getByRole('button');
+
+      userEvent.click(popoverTrigger);
+
+      await waitFor(() => {
+        expect(container).toMatchSnapshot();
+      });
     });
 
-    placements.forEach((placement) => {
-      it(`should render popover on ${placement}`, () => {
-        const actual = create(<Default placement={placement} {...baseProps} />);
-        expect(actual).toMatchSnapshot();
+    it.each(placements)(`should render popover on %s`, async (placement) => {
+      const { container, getByRole } = renderPopover({
+        ...baseProps,
+        placement,
+      });
+
+      const popoverTrigger = getByRole('button');
+
+      userEvent.click(popoverTrigger);
+
+      await waitFor(() => {
+        expect(container).toMatchSnapshot();
       });
     });
   });
 
   describe('business logic', () => {
-    it('should close popover when passing a click outside', () => {
-      const { queryByText } = render(<Default {...baseProps} />);
-      expect(queryByText('Add')).not.toBeNull();
+    it('should close the popover when clicking outside', async () => {
+      const { getByRole, queryByText } = renderPopover(baseProps);
+
+      const popoverTrigger = getByRole('button');
+
+      userEvent.click(popoverTrigger);
+
+      await waitFor(() => {
+        expect(queryByText(baseProps.actions[0].children)).toBeVisible();
+      });
 
       userEvent.click(document.body);
 
-      expect(baseProps.onClose).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(queryByText(baseProps.actions[0].children)).toBeNull();
+      });
     });
 
-    it('should close popover when passing a click to a reference element', () => {
-      const { queryByText, getAllByRole } = render(<Default {...baseProps} />);
-      expect(queryByText('Add')).not.toBeNull();
+    it('should close popover when clicking the trigger element', async () => {
+      const { getByRole, queryByText } = renderPopover(baseProps);
 
-      userEvent.click(getAllByRole('button')[0]);
+      const popoverTrigger = getByRole('button');
 
-      expect(baseProps.onClose).toHaveBeenCalledTimes(1);
+      userEvent.click(popoverTrigger);
+
+      await waitFor(() => {
+        expect(queryByText(baseProps.actions[0].children)).toBeVisible();
+      });
+
+      userEvent.click(popoverTrigger);
+
+      await waitFor(() => {
+        expect(queryByText(baseProps.actions[0].children)).toBeNull();
+      });
     });
-  });
 
-  /**
-   * Accessibility tests.
-   */
-  it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<Default {...baseProps} />);
-    const actual = await axe(wrapper);
-    expect(actual).toHaveNoViolations();
+    /**
+     * Accessibility tests.
+     */
+    it('should meet accessibility guidelines', async () => {
+      const { container, getByRole, queryByText } = renderPopover(baseProps);
+
+      const popoverTrigger = getByRole('button');
+
+      userEvent.click(popoverTrigger);
+
+      await waitFor(() => {
+        expect(queryByText(baseProps.actions[0].children)).toBeVisible();
+      });
+
+      const actual = await axe(container);
+      expect(actual).toHaveNoViolations();
+    });
   });
 });

--- a/packages/circuit-ui/components/Popover/Popover.stories.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.stories.tsx
@@ -13,22 +13,16 @@
  * limitations under the License.
  */
 
-import { useState, useRef, Fragment } from 'react';
+/* eslint-disable react/display-name */
+
+import { forwardRef, Ref } from 'react';
 import { action } from '@storybook/addon-actions';
-import {
-  More,
-  ThumbUp,
-  Zap,
-  CirclePlus,
-  PenStroke,
-  Share,
-  Bin,
-} from '@sumup/icons';
+import { More, CirclePlus, PenStroke, Bin } from '@sumup/icons';
 
 import Button from '../Button';
 import IconButton from '../IconButton';
 
-import { Popover, PopoverItem } from './Popover';
+import { Popover, PopoverProps } from './Popover';
 import docs from './Popover.docs.mdx';
 
 export default {
@@ -41,115 +35,57 @@ export default {
     children: { control: 'text' },
   },
 };
-export const PopoverBase = (args) => {
-  const triggerRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
 
-  return (
-    <Fragment>
-      <Button size="kilo" variant="primary" ref={triggerRef} icon={ThumbUp}>
-        Button
-      </Button>
-      <Popover {...args} isOpen={true} triggerRef={triggerRef} />
-    </Fragment>
-  );
+const actions = [
+  {
+    onClick: action('Button Click'),
+    children: 'Add',
+    icon: CirclePlus,
+  },
+  {
+    onClick: action('Button Click'),
+    children: 'Edit',
+    icon: PenStroke,
+  },
+  { type: 'divider' },
+  {
+    onClick: action('Button Click'),
+    children: 'Delete',
+    icon: Bin,
+    destructive: true,
+  },
+];
+
+export const Base = (args: PopoverProps): JSX.Element => (
+  <Popover
+    {...args}
+    component={forwardRef<HTMLElement>((props, ref) => {
+      const buttonRef = ref as Ref<HTMLButtonElement & HTMLAnchorElement>;
+      return (
+        <Button size="kilo" variant="primary" ref={buttonRef} {...props}>
+          Open popover
+        </Button>
+      );
+    })}
+  />
+);
+
+Base.args = {
+  actions,
 };
 
-PopoverBase.args = {
-  actions: [
-    {
-      onClick: action('Button Click'),
-      href: '',
-      children: 'Label',
-      icon: Zap,
-    },
-    {
-      onClick: action('Button Click'),
-      href: 'https://sumup.com/',
-      children: 'Label',
-      icon: Zap,
-    },
-    { type: 'divider' },
-    {
-      onClick: action('Button Click'),
-      children: 'Label',
-      icon: Zap,
-      destructive: true,
-    },
-  ],
-};
+export const WithIcon = (args: PopoverProps): JSX.Element => (
+  <Popover
+    {...args}
+    component={forwardRef<HTMLElement>((props, ref) => {
+      const buttonRef = ref as Ref<HTMLButtonElement & HTMLAnchorElement>;
+      return (
+        <IconButton size="kilo" label="Open popover" ref={buttonRef} {...props}>
+          <More />
+        </IconButton>
+      );
+    })}
+  />
+);
 
-// eslint-disable-next-line arrow-body-style
-export const PopoverInteractive = (args) => {
-  // const [isOpen, setOpen] = useState(false);
-  // const triggerRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
-
-  // const handleClick = () => {
-  //   setOpen((prev) => !prev);
-  // };
-
-  // const onClose = () => {
-  //   setOpen(false);
-  // };
-
-  return (
-    <Fragment>
-      <Popover
-        {...args}
-        // onClose={onClose}
-        // isOpen={isOpen}
-        // triggerRef={triggerRef}
-        id="custom-popoverid"
-        triggerid="custom-triggerid"
-        component={(props) => (
-          <IconButton
-            size="kilo"
-            // onClick={handleClick}
-            label="Open popover"
-            {...props}
-          >
-            <More />
-          </IconButton>
-        )}
-      />
-    </Fragment>
-  );
-};
-
-PopoverInteractive.args = {
-  actions: [
-    {
-      onClick: action('Button Click'),
-      href: '',
-      children: 'Add',
-      icon: CirclePlus,
-    },
-    {
-      onClick: action('Button Click'),
-      href: 'https://sumup.com/',
-      children: 'Edit',
-      icon: PenStroke,
-    },
-    {
-      onClick: action('Button Click'),
-      href: 'https://sumup.com/',
-      children: 'Upload',
-      icon: Share,
-    },
-    { type: 'divider' },
-    {
-      onClick: action('Button Click'),
-      children: 'Delete',
-      icon: Bin,
-      destructive: true,
-    },
-  ],
-};
-
-export const PopoverItemBase = (args) => <PopoverItem {...args} />;
-
-PopoverItemBase.args = {
-  onClick: action('Button Click'),
-  href: 'https://sumup.com/',
-  children: 'Label',
-  icon: Zap,
-};
+WithIcon.args = { actions };

--- a/packages/circuit-ui/components/Popover/Popover.stories.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.stories.tsx
@@ -78,33 +78,38 @@ PopoverBase.args = {
   ],
 };
 
+// eslint-disable-next-line arrow-body-style
 export const PopoverInteractive = (args) => {
-  const [isOpen, setOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
+  // const [isOpen, setOpen] = useState(false);
+  // const triggerRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
 
-  const handleClick = () => {
-    setOpen((prev) => !prev);
-  };
+  // const handleClick = () => {
+  //   setOpen((prev) => !prev);
+  // };
 
-  const onClose = () => {
-    setOpen(false);
-  };
+  // const onClose = () => {
+  //   setOpen(false);
+  // };
 
   return (
     <Fragment>
-      <IconButton
-        size="kilo"
-        onClick={handleClick}
-        label="IconButton"
-        ref={triggerRef}
-      >
-        <More />
-      </IconButton>
       <Popover
         {...args}
-        onClose={onClose}
-        isOpen={isOpen}
-        triggerRef={triggerRef}
+        // onClose={onClose}
+        // isOpen={isOpen}
+        // triggerRef={triggerRef}
+        id="custom-popoverid"
+        triggerid="custom-triggerid"
+        component={(props) => (
+          <IconButton
+            size="kilo"
+            // onClick={handleClick}
+            label="Open popover"
+            {...props}
+          >
+            <More />
+          </IconButton>
+        )}
       />
     </Fragment>
   );

--- a/packages/circuit-ui/components/Popover/Popover.stories.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.stories.tsx
@@ -15,12 +15,11 @@
 
 /* eslint-disable react/display-name */
 
-import { forwardRef, Ref } from 'react';
+import { forwardRef } from 'react';
 import { action } from '@storybook/addon-actions';
-import { More, CirclePlus, PenStroke, Bin } from '@sumup/icons';
+import { CirclePlus, PenStroke, Bin } from '@sumup/icons';
 
 import Button from '../Button';
-import IconButton from '../IconButton';
 
 import { Popover, PopoverProps } from './Popover';
 import docs from './Popover.docs.mdx';
@@ -59,33 +58,14 @@ const actions = [
 export const Base = (args: PopoverProps): JSX.Element => (
   <Popover
     {...args}
-    component={forwardRef<HTMLElement>((props, ref) => {
-      const buttonRef = ref as Ref<HTMLButtonElement & HTMLAnchorElement>;
-      return (
-        <Button size="kilo" variant="primary" ref={buttonRef} {...props}>
-          Open popover
-        </Button>
-      );
-    })}
+    component={forwardRef((props, ref) => (
+      <Button size="kilo" variant="primary" ref={ref} {...props}>
+        Open popover
+      </Button>
+    ))}
   />
 );
 
 Base.args = {
   actions,
 };
-
-export const WithIcon = (args: PopoverProps): JSX.Element => (
-  <Popover
-    {...args}
-    component={forwardRef<HTMLElement>((props, ref) => {
-      const buttonRef = ref as Ref<HTMLButtonElement & HTMLAnchorElement>;
-      return (
-        <IconButton size="kilo" label="Open popover" ref={buttonRef} {...props}>
-          <More />
-        </IconButton>
-      );
-    })}
-  />
-);
-
-WithIcon.args = { actions };

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -175,17 +175,9 @@ function isDivider(action: Action): action is Divider {
 
 export interface PopoverProps {
   /**
-   * Determine whether the Popover is opened or closed.
-   */
-  // isOpen: boolean;
-  /**
    * An array of PopoverItem or Divider.
    */
   actions: Action[];
-  /**
-   * The reference to the element that toggles the Popover.
-   */
-  // triggerRef: Ref<HTMLElement>;
   /**
    * One of the accepted placement values. Defaults to bottom.
    */
@@ -195,43 +187,32 @@ export interface PopoverProps {
    */
   fallbackPlacements?: Placement[];
   /**
-   * Function that is called when closing the Popover.
+   * The element that toggles the Popover when clicked.
    */
-  onClose: (event: Event) => void;
   component: ({
     onClick,
     ref,
     id,
   }: {
-    onClick: () => void;
-    ref?: Ref<HTMLButtonElement & HTMLAnchorElement>;
-    id?: string;
+    onClick: (event: MouseEvent | KeyboardEvent) => void;
+    ref: Ref<HTMLElement>;
+    id: string;
   }) => JSX.Element;
-  /**
-   * A unique identifier for the Popover element. If not defined, a generated id
-   * is used.
-   */
-  id?: string;
-  triggerid?: string;
 }
 
 export const Popover = ({
-  id: customId,
-  // isOpen,
-  onClose,
   actions,
-  // triggerRef,
   placement = 'bottom',
   fallbackPlacements = ['top', 'right', 'left'],
   component: Component,
-  triggerid: customTriggerId,
   ...props
 }: PopoverProps): JSX.Element | null => {
-  const theme: Theme = useTheme();
-  const id = customId || uniqueId('Popover_');
-  const triggerid = customTriggerId || uniqueId('Trigger_');
-  const triggerRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
   const [isOpen, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLElement>(null);
+  const theme: Theme = useTheme();
+  const id = uniqueId('popover_');
+  const triggerid = uniqueId('trigger_');
+
   // Popper custom modifier to apply bottom sheet for mobile.
   // The window.matchMedia() is a useful API for this, it allows you to change the styles based on a condition.
   // useMemo hook is used in order to prevent the render loop, more https://popper.js.org/react-popper/v2/faq/#why-i-get-render-loop-whenever-i-put-a-function-inside-the-popper-configuration
@@ -288,13 +269,8 @@ export const Popover = ({
     ) {
       return;
     }
-    // onClose(event);
     setOpen(false);
   });
-
-  if (!isOpen) {
-    return null;
-  }
 
   return (
     <Fragment>
@@ -303,25 +279,29 @@ export const Popover = ({
         id={triggerid}
         aria-haspopup={true}
         aria-controls={id}
-        onClick={() => setOpen(true)}
+        onClick={() => setOpen((prev) => !prev)}
       />
-      <Overlay />
-      <PopoverWrapper
-        id={id}
-        {...props}
-        ref={setPopperElement}
-        style={styles.popper}
-        aria-labelledby={triggerid}
-        {...attributes.popper}
-      >
-        {actions.map((action, index) =>
-          isDivider(action) ? (
-            <Hr css={dividerStyles} key={index} />
-          ) : (
-            <PopoverItem key={index} {...action} />
-          ),
-        )}
-      </PopoverWrapper>
+      {isOpen && (
+        <Fragment>
+          <Overlay />
+          <PopoverWrapper
+            id={id}
+            {...props}
+            ref={setPopperElement}
+            style={styles.popper}
+            aria-labelledby={triggerid}
+            {...attributes.popper}
+          >
+            {actions.map((action, index) =>
+              isDivider(action) ? (
+                <Hr css={dividerStyles} key={index} />
+              ) : (
+                <PopoverItem key={index} {...action} />
+              ),
+            )}
+          </PopoverWrapper>
+        </Fragment>
+      )}
     </Fragment>
   );
 };

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -32,13 +32,13 @@ import { Dispatch as TrackingProps } from '@sumup/collector';
 import { usePopper } from 'react-popper';
 import { Placement, State, Modifier } from '@popperjs/core';
 import { useTheme } from 'emotion-theming';
-import { uniqueId } from 'lodash';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { listItem, shadow, typography } from '../../styles/style-mixins';
 import { useComponents } from '../ComponentsContext';
 import { useClickHandler } from '../../hooks/useClickHandler';
 import Hr from '../Hr';
+import { uniqueId } from '../../util/id';
 
 export interface BaseProps {
   /**

--- a/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
+++ b/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
@@ -45,6 +45,12 @@ exports[`Popover styles should render popover on auto 1`] = `
   background-color: #E6E6E6;
 }
 
+.circuit-2:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
 .circuit-1 {
   margin-right: 8px;
 }
@@ -61,7 +67,7 @@ exports[`Popover styles should render popover on auto 1`] = `
   }
 }
 
-.circuit-3 {
+.circuit-4 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -71,10 +77,20 @@ exports[`Popover styles should render popover on auto 1`] = `
 }
 
 @media (max-width:479px) {
-  .circuit-3 {
+  .circuit-4 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
+}
+
+.circuit-3 {
+  display: block;
+  width: 100%;
+  border: 1px solid #CCC;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  margin: 8px 16px;
+  width: calc(100% - 16px*2);
 }
 
 <div>
@@ -90,12 +106,14 @@ exports[`Popover styles should render popover on auto 1`] = `
   />
   <div
     aria-labelledby="trigger_14"
-    class="circuit-3"
+    class="circuit-4"
     id="popover_13"
+    role="menu"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
       class="circuit-2"
+      role="menuitem"
     >
       <svg
         class="circuit-1"
@@ -116,6 +134,9 @@ exports[`Popover styles should render popover on auto 1`] = `
       </svg>
       Add
     </button>
+    <hr
+      class="circuit-3"
+    />
   </div>
 </div>
 `;
@@ -165,6 +186,12 @@ exports[`Popover styles should render popover on bottom 1`] = `
   background-color: #E6E6E6;
 }
 
+.circuit-2:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
 .circuit-1 {
   margin-right: 8px;
 }
@@ -181,7 +208,7 @@ exports[`Popover styles should render popover on bottom 1`] = `
   }
 }
 
-.circuit-3 {
+.circuit-4 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -191,10 +218,20 @@ exports[`Popover styles should render popover on bottom 1`] = `
 }
 
 @media (max-width:479px) {
-  .circuit-3 {
+  .circuit-4 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
+}
+
+.circuit-3 {
+  display: block;
+  width: 100%;
+  border: 1px solid #CCC;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  margin: 8px 16px;
+  width: calc(100% - 16px*2);
 }
 
 <div>
@@ -210,12 +247,14 @@ exports[`Popover styles should render popover on bottom 1`] = `
   />
   <div
     aria-labelledby="trigger_30"
-    class="circuit-3"
+    class="circuit-4"
     id="popover_29"
+    role="menu"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
       class="circuit-2"
+      role="menuitem"
     >
       <svg
         class="circuit-1"
@@ -236,6 +275,9 @@ exports[`Popover styles should render popover on bottom 1`] = `
       </svg>
       Add
     </button>
+    <hr
+      class="circuit-3"
+    />
   </div>
 </div>
 `;
@@ -285,6 +327,12 @@ exports[`Popover styles should render popover on left 1`] = `
   background-color: #E6E6E6;
 }
 
+.circuit-2:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
 .circuit-1 {
   margin-right: 8px;
 }
@@ -301,7 +349,7 @@ exports[`Popover styles should render popover on left 1`] = `
   }
 }
 
-.circuit-3 {
+.circuit-4 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -311,10 +359,20 @@ exports[`Popover styles should render popover on left 1`] = `
 }
 
 @media (max-width:479px) {
-  .circuit-3 {
+  .circuit-4 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
+}
+
+.circuit-3 {
+  display: block;
+  width: 100%;
+  border: 1px solid #CCC;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  margin: 8px 16px;
+  width: calc(100% - 16px*2);
 }
 
 <div>
@@ -330,12 +388,14 @@ exports[`Popover styles should render popover on left 1`] = `
   />
   <div
     aria-labelledby="trigger_38"
-    class="circuit-3"
+    class="circuit-4"
     id="popover_37"
+    role="menu"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
       class="circuit-2"
+      role="menuitem"
     >
       <svg
         class="circuit-1"
@@ -356,6 +416,9 @@ exports[`Popover styles should render popover on left 1`] = `
       </svg>
       Add
     </button>
+    <hr
+      class="circuit-3"
+    />
   </div>
 </div>
 `;
@@ -405,6 +468,12 @@ exports[`Popover styles should render popover on right 1`] = `
   background-color: #E6E6E6;
 }
 
+.circuit-2:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
 .circuit-1 {
   margin-right: 8px;
 }
@@ -421,7 +490,7 @@ exports[`Popover styles should render popover on right 1`] = `
   }
 }
 
-.circuit-3 {
+.circuit-4 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -431,10 +500,20 @@ exports[`Popover styles should render popover on right 1`] = `
 }
 
 @media (max-width:479px) {
-  .circuit-3 {
+  .circuit-4 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
+}
+
+.circuit-3 {
+  display: block;
+  width: 100%;
+  border: 1px solid #CCC;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  margin: 8px 16px;
+  width: calc(100% - 16px*2);
 }
 
 <div>
@@ -450,12 +529,14 @@ exports[`Popover styles should render popover on right 1`] = `
   />
   <div
     aria-labelledby="trigger_46"
-    class="circuit-3"
+    class="circuit-4"
     id="popover_45"
+    role="menu"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
       class="circuit-2"
+      role="menuitem"
     >
       <svg
         class="circuit-1"
@@ -476,6 +557,9 @@ exports[`Popover styles should render popover on right 1`] = `
       </svg>
       Add
     </button>
+    <hr
+      class="circuit-3"
+    />
   </div>
 </div>
 `;
@@ -525,6 +609,12 @@ exports[`Popover styles should render popover on top 1`] = `
   background-color: #E6E6E6;
 }
 
+.circuit-2:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
 .circuit-1 {
   margin-right: 8px;
 }
@@ -541,7 +631,7 @@ exports[`Popover styles should render popover on top 1`] = `
   }
 }
 
-.circuit-3 {
+.circuit-4 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -551,10 +641,20 @@ exports[`Popover styles should render popover on top 1`] = `
 }
 
 @media (max-width:479px) {
-  .circuit-3 {
+  .circuit-4 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
+}
+
+.circuit-3 {
+  display: block;
+  width: 100%;
+  border: 1px solid #CCC;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  margin: 8px 16px;
+  width: calc(100% - 16px*2);
 }
 
 <div>
@@ -570,12 +670,14 @@ exports[`Popover styles should render popover on top 1`] = `
   />
   <div
     aria-labelledby="trigger_22"
-    class="circuit-3"
+    class="circuit-4"
     id="popover_21"
+    role="menu"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
       class="circuit-2"
+      role="menuitem"
     >
       <svg
         class="circuit-1"
@@ -596,6 +698,9 @@ exports[`Popover styles should render popover on top 1`] = `
       </svg>
       Add
     </button>
+    <hr
+      class="circuit-3"
+    />
   </div>
 </div>
 `;
@@ -645,6 +750,12 @@ exports[`Popover styles should render with default styles 1`] = `
   background-color: #E6E6E6;
 }
 
+.circuit-2:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
 .circuit-1 {
   margin-right: 8px;
 }
@@ -661,7 +772,7 @@ exports[`Popover styles should render with default styles 1`] = `
   }
 }
 
-.circuit-3 {
+.circuit-4 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -671,10 +782,20 @@ exports[`Popover styles should render with default styles 1`] = `
 }
 
 @media (max-width:479px) {
-  .circuit-3 {
+  .circuit-4 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
+}
+
+.circuit-3 {
+  display: block;
+  width: 100%;
+  border: 1px solid #CCC;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  margin: 8px 16px;
+  width: calc(100% - 16px*2);
 }
 
 <div>
@@ -690,12 +811,14 @@ exports[`Popover styles should render with default styles 1`] = `
   />
   <div
     aria-labelledby="trigger_6"
-    class="circuit-3"
+    class="circuit-4"
     id="popover_5"
+    role="menu"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
       class="circuit-2"
+      role="menuitem"
     >
       <svg
         class="circuit-1"
@@ -716,6 +839,9 @@ exports[`Popover styles should render with default styles 1`] = `
       </svg>
       Add
     </button>
+    <hr
+      class="circuit-3"
+    />
   </div>
 </div>
 `;

--- a/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
+++ b/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
@@ -1,26 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Popover styles should render popover on auto 1`] = `
-HTMLCollection [
-  <button>
-    Button
-  </button>,
-  @media (max-width:479px) {
-  .circuit-0 {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
-  }
-}
-
-<div
-    class="circuit-0"
-  />,
-  .circuit-1 {
+.circuit-2 {
   background-color: #FFF;
   padding: 12px 32px 12px 16px;
   border: 0;
@@ -45,30 +26,42 @@ HTMLCollection [
   line-height: 24px;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   background-color: #F5F5F5;
   cursor: pointer;
 }
 
-.circuit-1:focus {
+.circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
   z-index: 1;
 }
 
-.circuit-1:focus::-moz-focus-inner {
+.circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-0 {
+.circuit-1 {
   margin-right: 8px;
 }
 
-.circuit-2 {
+@media (max-width:479px) {
+  .circuit-0 {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(0,0,0,0.4);
+    pointer-events: none;
+  }
+}
+
+.circuit-3 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -78,21 +71,34 @@ HTMLCollection [
 }
 
 @media (max-width:479px) {
-  .circuit-2 {
+  .circuit-3 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
 }
 
-<div
-    class="circuit-2"
+<div>
+  <button
+    aria-controls="popover_13"
+    aria-haspopup="true"
+    id="trigger_14"
+  >
+    Button
+  </button>
+  <div
+    class="circuit-0"
+  />
+  <div
+    aria-labelledby="trigger_14"
+    class="circuit-3"
+    id="popover_13"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
-      class="circuit-1"
+      class="circuit-2"
     >
       <svg
-        class="circuit-0"
+        class="circuit-1"
         fill="none"
         height="16"
         viewBox="0 0 16 16"
@@ -110,31 +116,12 @@ HTMLCollection [
       </svg>
       Add
     </button>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`Popover styles should render popover on bottom 1`] = `
-HTMLCollection [
-  <button>
-    Button
-  </button>,
-  @media (max-width:479px) {
-  .circuit-0 {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
-  }
-}
-
-<div
-    class="circuit-0"
-  />,
-  .circuit-1 {
+.circuit-2 {
   background-color: #FFF;
   padding: 12px 32px 12px 16px;
   border: 0;
@@ -159,30 +146,42 @@ HTMLCollection [
   line-height: 24px;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   background-color: #F5F5F5;
   cursor: pointer;
 }
 
-.circuit-1:focus {
+.circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
   z-index: 1;
 }
 
-.circuit-1:focus::-moz-focus-inner {
+.circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-0 {
+.circuit-1 {
   margin-right: 8px;
 }
 
-.circuit-2 {
+@media (max-width:479px) {
+  .circuit-0 {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(0,0,0,0.4);
+    pointer-events: none;
+  }
+}
+
+.circuit-3 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -192,21 +191,34 @@ HTMLCollection [
 }
 
 @media (max-width:479px) {
-  .circuit-2 {
+  .circuit-3 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
 }
 
-<div
-    class="circuit-2"
+<div>
+  <button
+    aria-controls="popover_29"
+    aria-haspopup="true"
+    id="trigger_30"
+  >
+    Button
+  </button>
+  <div
+    class="circuit-0"
+  />
+  <div
+    aria-labelledby="trigger_30"
+    class="circuit-3"
+    id="popover_29"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
-      class="circuit-1"
+      class="circuit-2"
     >
       <svg
-        class="circuit-0"
+        class="circuit-1"
         fill="none"
         height="16"
         viewBox="0 0 16 16"
@@ -224,31 +236,12 @@ HTMLCollection [
       </svg>
       Add
     </button>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`Popover styles should render popover on left 1`] = `
-HTMLCollection [
-  <button>
-    Button
-  </button>,
-  @media (max-width:479px) {
-  .circuit-0 {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
-  }
-}
-
-<div
-    class="circuit-0"
-  />,
-  .circuit-1 {
+.circuit-2 {
   background-color: #FFF;
   padding: 12px 32px 12px 16px;
   border: 0;
@@ -273,30 +266,42 @@ HTMLCollection [
   line-height: 24px;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   background-color: #F5F5F5;
   cursor: pointer;
 }
 
-.circuit-1:focus {
+.circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
   z-index: 1;
 }
 
-.circuit-1:focus::-moz-focus-inner {
+.circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-0 {
+.circuit-1 {
   margin-right: 8px;
 }
 
-.circuit-2 {
+@media (max-width:479px) {
+  .circuit-0 {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(0,0,0,0.4);
+    pointer-events: none;
+  }
+}
+
+.circuit-3 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -306,21 +311,34 @@ HTMLCollection [
 }
 
 @media (max-width:479px) {
-  .circuit-2 {
+  .circuit-3 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
 }
 
-<div
-    class="circuit-2"
+<div>
+  <button
+    aria-controls="popover_37"
+    aria-haspopup="true"
+    id="trigger_38"
+  >
+    Button
+  </button>
+  <div
+    class="circuit-0"
+  />
+  <div
+    aria-labelledby="trigger_38"
+    class="circuit-3"
+    id="popover_37"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
-      class="circuit-1"
+      class="circuit-2"
     >
       <svg
-        class="circuit-0"
+        class="circuit-1"
         fill="none"
         height="16"
         viewBox="0 0 16 16"
@@ -338,31 +356,12 @@ HTMLCollection [
       </svg>
       Add
     </button>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`Popover styles should render popover on right 1`] = `
-HTMLCollection [
-  <button>
-    Button
-  </button>,
-  @media (max-width:479px) {
-  .circuit-0 {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
-  }
-}
-
-<div
-    class="circuit-0"
-  />,
-  .circuit-1 {
+.circuit-2 {
   background-color: #FFF;
   padding: 12px 32px 12px 16px;
   border: 0;
@@ -387,30 +386,42 @@ HTMLCollection [
   line-height: 24px;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   background-color: #F5F5F5;
   cursor: pointer;
 }
 
-.circuit-1:focus {
+.circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
   z-index: 1;
 }
 
-.circuit-1:focus::-moz-focus-inner {
+.circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-0 {
+.circuit-1 {
   margin-right: 8px;
 }
 
-.circuit-2 {
+@media (max-width:479px) {
+  .circuit-0 {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(0,0,0,0.4);
+    pointer-events: none;
+  }
+}
+
+.circuit-3 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -420,21 +431,34 @@ HTMLCollection [
 }
 
 @media (max-width:479px) {
-  .circuit-2 {
+  .circuit-3 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
 }
 
-<div
-    class="circuit-2"
+<div>
+  <button
+    aria-controls="popover_45"
+    aria-haspopup="true"
+    id="trigger_46"
+  >
+    Button
+  </button>
+  <div
+    class="circuit-0"
+  />
+  <div
+    aria-labelledby="trigger_46"
+    class="circuit-3"
+    id="popover_45"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
-      class="circuit-1"
+      class="circuit-2"
     >
       <svg
-        class="circuit-0"
+        class="circuit-1"
         fill="none"
         height="16"
         viewBox="0 0 16 16"
@@ -452,31 +476,12 @@ HTMLCollection [
       </svg>
       Add
     </button>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`Popover styles should render popover on top 1`] = `
-HTMLCollection [
-  <button>
-    Button
-  </button>,
-  @media (max-width:479px) {
-  .circuit-0 {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
-  }
-}
-
-<div
-    class="circuit-0"
-  />,
-  .circuit-1 {
+.circuit-2 {
   background-color: #FFF;
   padding: 12px 32px 12px 16px;
   border: 0;
@@ -501,30 +506,42 @@ HTMLCollection [
   line-height: 24px;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   background-color: #F5F5F5;
   cursor: pointer;
 }
 
-.circuit-1:focus {
+.circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
   z-index: 1;
 }
 
-.circuit-1:focus::-moz-focus-inner {
+.circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-0 {
+.circuit-1 {
   margin-right: 8px;
 }
 
-.circuit-2 {
+@media (max-width:479px) {
+  .circuit-0 {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(0,0,0,0.4);
+    pointer-events: none;
+  }
+}
+
+.circuit-3 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -534,21 +551,34 @@ HTMLCollection [
 }
 
 @media (max-width:479px) {
-  .circuit-2 {
+  .circuit-3 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
 }
 
-<div
-    class="circuit-2"
+<div>
+  <button
+    aria-controls="popover_21"
+    aria-haspopup="true"
+    id="trigger_22"
+  >
+    Button
+  </button>
+  <div
+    class="circuit-0"
+  />
+  <div
+    aria-labelledby="trigger_22"
+    class="circuit-3"
+    id="popover_21"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
-      class="circuit-1"
+      class="circuit-2"
     >
       <svg
-        class="circuit-0"
+        class="circuit-1"
         fill="none"
         height="16"
         viewBox="0 0 16 16"
@@ -566,31 +596,12 @@ HTMLCollection [
       </svg>
       Add
     </button>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`Popover styles should render with default styles 1`] = `
-HTMLCollection [
-  <button>
-    Button
-  </button>,
-  @media (max-width:479px) {
-  .circuit-0 {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
-  }
-}
-
-<div
-    class="circuit-0"
-  />,
-  .circuit-1 {
+.circuit-2 {
   background-color: #FFF;
   padding: 12px 32px 12px 16px;
   border: 0;
@@ -615,30 +626,42 @@ HTMLCollection [
   line-height: 24px;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   background-color: #F5F5F5;
   cursor: pointer;
 }
 
-.circuit-1:focus {
+.circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
   z-index: 1;
 }
 
-.circuit-1:focus::-moz-focus-inner {
+.circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-0 {
+.circuit-1 {
   margin-right: 8px;
 }
 
-.circuit-2 {
+@media (max-width:479px) {
+  .circuit-0 {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(0,0,0,0.4);
+    pointer-events: none;
+  }
+}
+
+.circuit-3 {
   padding: 8px 0px;
   border: 1px solid #E6E6E6;
   box-sizing: border-box;
@@ -648,21 +671,34 @@ HTMLCollection [
 }
 
 @media (max-width:479px) {
-  .circuit-2 {
+  .circuit-3 {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
 }
 
-<div
-    class="circuit-2"
+<div>
+  <button
+    aria-controls="popover_5"
+    aria-haspopup="true"
+    id="trigger_6"
+  >
+    Button
+  </button>
+  <div
+    class="circuit-0"
+  />
+  <div
+    aria-labelledby="trigger_6"
+    class="circuit-3"
+    id="popover_5"
     style="position: absolute; left: 0px; top: 0px;"
   >
     <button
-      class="circuit-1"
+      class="circuit-2"
     >
       <svg
-        class="circuit-0"
+        class="circuit-1"
         fill="none"
         height="16"
         viewBox="0 0 16 16"
@@ -680,6 +716,6 @@ HTMLCollection [
       </svg>
       Add
     </button>
-  </div>,
-]
+  </div>
+</div>
 `;

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -372,5 +372,8 @@ export const listItem = (
     &:active {
       background-color: ${theme.colors.n200};
     }
+    &:disabled {
+      ${disableVisually()};
+    }
   `;
 };

--- a/packages/circuit-ui/util/key-codes.js
+++ b/packages/circuit-ui/util/key-codes.js
@@ -25,8 +25,14 @@ export const isSpacebar = (event) =>
 export const isArrowLeft = (event) =>
   'key' in event ? event.key === 'ArrowLeft' : event.keyCode === 37;
 
+export const isArrowUp = (event) =>
+  'key' in event ? event.key === 'ArrowUp' : event.keyCode === 38;
+
 export const isArrowRight = (event) =>
   'key' in event ? event.key === 'ArrowRight' : event.keyCode === 39;
 
 export const isArrowDown = (event) =>
   'key' in event ? event.key === 'ArrowDown' : event.keyCode === 40;
+
+export const isEscape = (event) =>
+  'key' in event ? event.key === 'Escape' : event.keyCode === 27;


### PR DESCRIPTION
Addresses #723.

## Purpose

Some things have been left out of the initial PR's scope and are addressed now.

## Approach and changes

- Added disabled variant to the Popover list item.
- Add useEffect to handle the closing of Popover when using Escape key to improve the keyboard support.
- Added the Component prop to Popover that triggers it with 'aria-haspopup' and 'aria-controls' props to improve accessibility features.
- Improved stories for Popover.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
