### PR TITLE
Consistently track modal events

### DIFF
--- a/.changeset/blue-hounds-notice.md
+++ b/.changeset/blue-hounds-notice.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Refactored the modal components to consistently dispatch tracking events.

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -20,6 +20,7 @@ import { Theme } from '@sumup/design-tokens';
 
 import { Stack } from '../../../../.storybook/components';
 import Button from '../Button';
+import Headline from '../Headline';
 import Body from '../Body';
 import Image from '../Image';
 import { ModalProvider } from '../ModalContext';
@@ -56,7 +57,11 @@ export const Base = (modal: ModalProps): JSX.Element => {
 };
 
 Base.args = {
-  children: 'Hello World!',
+  children: (
+    <Headline as="h2" size="three">
+      Hello World!
+    </Headline>
+  ),
   variant: 'contextual',
   closeButtonLabel: 'Close modal',
 };
@@ -82,7 +87,11 @@ export const Variants = (modal: ModalProps): JSX.Element => {
 };
 
 Variants.args = {
-  children: 'Hello World!',
+  children: (
+    <Headline as="h2" size="three">
+      Hello World!
+    </Headline>
+  ),
   closeButtonLabel: 'Close modal',
 };
 
@@ -106,6 +115,9 @@ export const PreventClose = (modal: ModalProps): JSX.Element => {
 PreventClose.args = {
   children: ({ onClose }: { onClose: ModalProps['onClose'] }) => (
     <Fragment>
+      <Headline as="h2" size="three">
+        Complete the action
+      </Headline>
       <Body>
         Users have to complete the action inside the modal to close it. The
         close button is hidden and clicking outside the modal or pressing the
@@ -166,6 +178,9 @@ CustomStyles.args = {
   children: (
     <Fragment>
       <Image src="https://source.unsplash.com/TpHmEoVSmfQ/1600x900" alt="" />
+      <Headline as="h2" size="three">
+        Custom styles
+      </Headline>
       <Body css={spacing('mega')}>
         Custom styles can be applied using the <code>css</code> prop.
       </Body>

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -19,8 +19,7 @@ import ReactModal from 'react-modal';
 import { Theme } from '@sumup/design-tokens';
 
 import { isFunction } from '../../util/type-check';
-import { useClickHandler } from '../../hooks/useClickHandler';
-import { ModalComponent, BaseModalProps } from '../ModalContext/ModalContext';
+import { ModalComponent, BaseModalProps } from '../ModalContext';
 import CloseButton from '../CloseButton';
 
 const TRANSITION_DURATION_MOBILE = 120;
@@ -91,146 +90,140 @@ export const Modal: ModalComponent<ModalProps> = ({
   variant,
   preventClose = false,
   closeButtonLabel,
-  tracking = {},
   className,
   ...props
-}) => {
-  const handleClose = useClickHandler(onClose, tracking, 'modal-close');
-  return (
-    <ClassNames<Theme> key={variant}>
-      {({ css: cssString, cx, theme }) => {
-        // React Modal styles
-        // https://reactcommunity.org/react-modal/styles/classes/
+}) => (
+  <ClassNames<Theme> key={variant}>
+    {({ css: cssString, cx, theme }) => {
+      // React Modal styles
+      // https://reactcommunity.org/react-modal/styles/classes/
 
-        const styles = {
-          base: cx(
+      const styles = {
+        base: cx(
+          cssString`
+            position: fixed;
+            outline: none;
+            background-color: ${theme.colors.white};
+
+            ${theme.mq.untilKilo} {
+              right: 0;
+              bottom: 0;
+              left: 0;
+              -webkit-overflow-scrolling: touch;
+              overflow-y: auto;
+              width: 100vw;
+              transform: translateY(100%);
+              transition: transform ${TRANSITION_DURATION_MOBILE}ms ease-in-out;
+              padding: ${theme.spacings.mega};
+            }
+
+            ${theme.mq.kilo} {
+              top: 50%;
+              left: 50%;
+              padding: ${theme.spacings.giga};
+              transform: translate(-50%, -50%);
+              min-height: 320px;
+              max-height: 90vh;
+              min-width: 480px;
+              max-width: 90vw;
+              opacity: 0;
+              transition: opacity ${TRANSITION_DURATION_DESKTOP}ms ease-in-out;
+              border-radius: ${theme.borderRadius.mega};
+            }
+          `,
+          variant === 'immersive' &&
             cssString`
-              position: fixed;
-              outline: none;
-              background-color: ${theme.colors.white};
-
-              ${theme.mq.untilKilo} {
-                right: 0;
-                bottom: 0;
-                left: 0;
-                -webkit-overflow-scrolling: touch;
-                overflow-y: auto;
-                width: 100vw;
-                transform: translateY(100%);
-                transition: transform ${TRANSITION_DURATION_MOBILE}ms ease-in-out;
-                padding: ${theme.spacings.mega};
-              }
-
-              ${theme.mq.kilo} {
-                top: 50%;
-                left: 50%;
-                padding: ${theme.spacings.giga};
-                transform: translate(-50%, -50%);
-                min-height: 320px;
-                max-height: 90vh;
-                min-width: 480px;
-                max-width: 90vw;
-                opacity: 0;
-                transition: opacity ${TRANSITION_DURATION_DESKTOP}ms ease-in-out;
-                border-radius: ${theme.borderRadius.mega};
-              }
-            `,
-            variant === 'immersive' &&
-              cssString`
               ${theme.mq.untilKilo} {
                 height: 100vh;
               }
             `,
-            variant === 'contextual' &&
-              cssString`
+          variant === 'contextual' &&
+            cssString`
               ${theme.mq.untilKilo} {
                 max-height: calc(100vh - ${theme.spacings.mega});
                 border-top-left-radius: ${theme.borderRadius.mega};
                 border-top-right-radius: ${theme.borderRadius.mega};
               }
             `,
-            className,
-          ),
-          // The !important below is necessary because of some weird
-          // style specificity issues in Emotion.
-          afterOpen: cssString`
-            label: modal--after-open;
+          className,
+        ),
+        // The !important below is necessary because of some weird
+        // style specificity issues in Emotion.
+        afterOpen: cssString`
+          label: modal--after-open;
 
-            ${theme.mq.untilKilo} {
-              transform: translateY(0) !important;
-            }
+          ${theme.mq.untilKilo} {
+            transform: translateY(0) !important;
+          }
 
-            ${theme.mq.kilo} {
-              opacity: 1 !important;
-            }
-          `,
-          beforeClose: cssString`
-            label: modal--before-close;
+          ${theme.mq.kilo} {
+            opacity: 1 !important;
+          }
+        `,
+        beforeClose: cssString`
+          label: modal--before-close;
 
-            ${theme.mq.untilKilo} {
-              transform: translateY(100%);
-            }
+          ${theme.mq.untilKilo} {
+            transform: translateY(100%);
+          }
 
-            ${theme.mq.kilo} {
-              opacity: 0;
-            }
-          `,
-        };
-
-        const overlayStyles = {
-          base: cssString`
-            position: fixed;
-            top: 0;
-            left: 0;
-            bottom: 0;
-            right: 0;
+          ${theme.mq.kilo} {
             opacity: 0;
-            transition: opacity ${TRANSITION_DURATION_MOBILE}ms ease-in-out;
-            background: ${theme.colors.overlay};
-            z-index: ${theme.zIndex.modal};
+          }
+        `,
+      };
 
-            ${theme.mq.kilo} {
-              -webkit-overflow-scrolling: touch;
-              overflow-y: auto;
-              transition: opacity ${TRANSITION_DURATION_DESKTOP}ms ease-in-out;
-            }
-          `,
-          afterOpen: cssString`
-            opacity: 1;
-          `,
-          beforeClose: cssString`
-            opacity: 0;
-          `,
-        };
+      const overlayStyles = {
+        base: cssString`
+          position: fixed;
+          top: 0;
+          left: 0;
+          bottom: 0;
+          right: 0;
+          opacity: 0;
+          transition: opacity ${TRANSITION_DURATION_MOBILE}ms ease-in-out;
+          background: ${theme.colors.overlay};
+          z-index: ${theme.zIndex.modal};
 
-        const reactModalProps = {
-          className: styles,
-          overlayClassName: overlayStyles,
-          onRequestClose: handleClose,
-          closeTimeoutMS: TRANSITION_DURATION,
-          shouldCloseOnOverlayClick: !preventClose,
-          shouldCloseOnEsc: !preventClose,
-          ...props,
-        };
+          ${theme.mq.kilo} {
+            -webkit-overflow-scrolling: touch;
+            overflow-y: auto;
+            transition: opacity ${TRANSITION_DURATION_DESKTOP}ms ease-in-out;
+          }
+        `,
+        afterOpen: cssString`
+          opacity: 1;
+        `,
+        beforeClose: cssString`
+          opacity: 0;
+        `,
+      };
 
-        return (
-          <ReactModal {...reactModalProps}>
-            {!preventClose && closeButtonLabel && (
-              <CloseButton
-                onClick={onClose}
-                label={closeButtonLabel}
-                css={closeButtonStyles}
-              />
-            )}
+      const reactModalProps = {
+        className: styles,
+        overlayClassName: overlayStyles,
+        onRequestClose: onClose,
+        closeTimeoutMS: TRANSITION_DURATION,
+        shouldCloseOnOverlayClick: !preventClose,
+        shouldCloseOnEsc: !preventClose,
+        ...props,
+      };
 
-            {isFunction(children)
-              ? children({ onClose: handleClose })
-              : children}
-          </ReactModal>
-        );
-      }}
-    </ClassNames>
-  );
-};
+      return (
+        <ReactModal {...reactModalProps}>
+          {!preventClose && closeButtonLabel && (
+            <CloseButton
+              onClick={onClose}
+              label={closeButtonLabel}
+              css={closeButtonStyles}
+            />
+          )}
+
+          {isFunction(children) ? children({ onClose }) : children}
+        </ReactModal>
+      );
+    }}
+  </ClassNames>
+);
 
 Modal.TIMEOUT = TRANSITION_DURATION;

--- a/packages/circuit-ui/components/ModalContext/ModalContext.spec.tsx
+++ b/packages/circuit-ui/components/ModalContext/ModalContext.spec.tsx
@@ -16,21 +16,10 @@
 /* eslint-disable react/display-name */
 import React from 'react';
 
-import {
-  render,
-  renderHook,
-  act,
-  actHook,
-  userEvent,
-  fireEvent,
-} from '../../util/test-utils';
+import { render, act, userEvent, fireEvent } from '../../util/test-utils';
 
-import {
-  ModalProvider,
-  createUseModal,
-  ModalContext,
-  ModalComponent,
-} from './ModalContext';
+import { ModalProvider } from './ModalContext';
+import type { ModalComponent } from './types';
 
 const Modal: ModalComponent = ({ onClose }) => (
   <div role="dialog">
@@ -94,65 +83,6 @@ describe('ModalContext', () => {
 
       expect(queryByRole('dialog')).toBeNull();
       expect(onClose).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('createUseModal', () => {
-    const useModal = createUseModal(Modal);
-
-    const onClose = jest.fn();
-    const dispatch = jest.fn();
-    const state = [1, 2, 3, 4].map((id) => ({
-      id: id.toString(),
-      component: Modal,
-      onClose,
-    }));
-    const wrapper = ({ children }) => (
-      <ModalContext.Provider value={[state, dispatch]}>
-        {children}
-      </ModalContext.Provider>
-    );
-
-    it('should dispatch an action when setModal is called', () => {
-      const { result } = renderHook(() => useModal(), { wrapper });
-
-      actHook(() => {
-        result.current.setModal({});
-      });
-
-      const expected = expect.objectContaining({
-        type: 'push',
-        item: expect.objectContaining({
-          component: expect.any(Function),
-          id: expect.any(String),
-        }),
-      });
-      expect(dispatch).toHaveBeenCalledWith(expected);
-    });
-
-    it('should call the onClose callback when removeModal is called', () => {
-      const { result } = renderHook(() => useModal(), { wrapper });
-
-      actHook(() => {
-        result.current.removeModal();
-      });
-
-      expect(onClose).toHaveBeenCalledTimes(1);
-    });
-
-    it('should dispatch an action when removeModal is called', () => {
-      const { result } = renderHook(() => useModal(), { wrapper });
-
-      actHook(() => {
-        result.current.removeModal();
-      });
-
-      const expected = expect.objectContaining({
-        type: 'remove',
-        id: expect.any(String),
-        timeout: 200,
-      });
-      expect(dispatch).toHaveBeenCalledWith(expected);
     });
   });
 });

--- a/packages/circuit-ui/components/ModalContext/createUseModal.spec.tsx
+++ b/packages/circuit-ui/components/ModalContext/createUseModal.spec.tsx
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable react/display-name */
+import React from 'react';
+
+import { renderHook, actHook } from '../../util/test-utils';
+
+import { createUseModal } from './createUseModal';
+import { ModalContext } from './ModalContext';
+import type { ModalComponent } from './types';
+
+const Modal: ModalComponent = ({ onClose }) => (
+  <div role="dialog">
+    <button onClick={onClose}>Close</button>
+  </div>
+);
+Modal.TIMEOUT = 200;
+
+describe('createUseModal', () => {
+  const useModal = createUseModal(Modal);
+
+  const onClose = jest.fn();
+  const dispatch = jest.fn();
+  const state = [1, 2, 3, 4].map((id) => ({
+    id: id.toString(),
+    component: Modal,
+    onClose,
+  }));
+  const wrapper = ({ children }) => (
+    <ModalContext.Provider value={[state, dispatch]}>
+      {children}
+    </ModalContext.Provider>
+  );
+
+  it('should dispatch an action when setModal is called', () => {
+    const { result } = renderHook(() => useModal(), { wrapper });
+
+    actHook(() => {
+      result.current.setModal({});
+    });
+
+    const expected = expect.objectContaining({
+      type: 'push',
+      item: expect.objectContaining({
+        component: expect.any(Function),
+
+        id: expect.any(String),
+      }),
+    });
+    expect(dispatch).toHaveBeenCalledWith(expected);
+  });
+
+  it('should call the onClose callback when removeModal is called', () => {
+    const { result } = renderHook(() => useModal(), { wrapper });
+
+    actHook(() => {
+      result.current.removeModal();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should dispatch an action when removeModal is called', () => {
+    const { result } = renderHook(() => useModal(), { wrapper });
+
+    actHook(() => {
+      result.current.removeModal();
+    });
+
+    const expected = expect.objectContaining({
+      type: 'remove',
+      id: expect.any(String),
+      timeout: 200,
+    });
+    expect(dispatch).toHaveBeenCalledWith(expected);
+  });
+});

--- a/packages/circuit-ui/components/ModalContext/createUseModal.spec.tsx
+++ b/packages/circuit-ui/components/ModalContext/createUseModal.spec.tsx
@@ -32,20 +32,16 @@ Modal.TIMEOUT = 200;
 describe('createUseModal', () => {
   const useModal = createUseModal(Modal);
 
-  const onClose = jest.fn();
-  const dispatch = jest.fn();
-  const state = [1, 2, 3, 4].map((id) => ({
-    id: id.toString(),
-    component: Modal,
-    onClose,
-  }));
+  const setModal = jest.fn();
+  const removeModal = jest.fn();
+
   const wrapper = ({ children }) => (
-    <ModalContext.Provider value={[state, dispatch]}>
+    <ModalContext.Provider value={{ setModal, removeModal }}>
       {children}
     </ModalContext.Provider>
   );
 
-  it('should dispatch an action when setModal is called', () => {
+  it('should add the modal when setModal is called', () => {
     const { result } = renderHook(() => useModal(), { wrapper });
 
     actHook(() => {
@@ -53,38 +49,20 @@ describe('createUseModal', () => {
     });
 
     const expected = expect.objectContaining({
-      type: 'push',
-      item: expect.objectContaining({
-        component: expect.any(Function),
-
-        id: expect.any(String),
-      }),
-    });
-    expect(dispatch).toHaveBeenCalledWith(expected);
-  });
-
-  it('should call the onClose callback when removeModal is called', () => {
-    const { result } = renderHook(() => useModal(), { wrapper });
-
-    actHook(() => {
-      result.current.removeModal();
-    });
-
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('should dispatch an action when removeModal is called', () => {
-    const { result } = renderHook(() => useModal(), { wrapper });
-
-    actHook(() => {
-      result.current.removeModal();
-    });
-
-    const expected = expect.objectContaining({
-      type: 'remove',
+      component: expect.any(Function),
       id: expect.any(String),
-      timeout: 200,
     });
-    expect(dispatch).toHaveBeenCalledWith(expected);
+    expect(setModal).toHaveBeenCalledWith(expected);
+  });
+
+  it('should remove the modal when removeModal is called', () => {
+    const { result } = renderHook(() => useModal(), { wrapper });
+
+    actHook(() => {
+      result.current.removeModal();
+    });
+
+    const expected = expect.any(String);
+    expect(removeModal).toHaveBeenCalledWith(expected);
   });
 });

--- a/packages/circuit-ui/components/ModalContext/createUseModal.ts
+++ b/packages/circuit-ui/components/ModalContext/createUseModal.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { useContext, useMemo, useCallback, useDebugValue } from 'react';
+import { useContext, useMemo, useCallback } from 'react';
 
 import { uniqueId } from '../../util/id';
 
@@ -28,28 +28,18 @@ export function createUseModal<T extends BaseModalProps>(
     removeModal: () => void;
   } => {
     const id = useMemo(uniqueId, []);
-    const [modals, dispatch] = useContext(ModalContext);
-
-    const modal = useMemo<T | undefined>(
-      () => modals.find((m) => m.id === id),
-      [id, modals],
-    );
-
-    useDebugValue(modal);
+    const context = useContext(ModalContext);
 
     const setModal = useCallback(
       (props: Omit<T, 'isOpen'>): void => {
-        dispatch({ type: 'push', item: { ...props, id, component } });
+        context.setModal({ ...props, id, component });
       },
-      [dispatch, id],
+      [context, id],
     );
 
     const removeModal = useCallback((): void => {
-      if (modal && modal.onClose) {
-        modal.onClose();
-      }
-      dispatch({ type: 'remove', id, timeout: component.TIMEOUT });
-    }, [dispatch, id, modal]);
+      context.removeModal(id);
+    }, [context, id]);
 
     return { setModal, removeModal };
   };

--- a/packages/circuit-ui/components/ModalContext/createUseModal.ts
+++ b/packages/circuit-ui/components/ModalContext/createUseModal.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useContext, useMemo, useCallback, useDebugValue } from 'react';
+
+import { uniqueId } from '../../util/id';
+
+import { ModalContext } from './ModalContext';
+import type { BaseModalProps, ModalComponent } from './types';
+
+export function createUseModal<T extends BaseModalProps>(
+  component: ModalComponent<T>,
+) {
+  return (): {
+    setModal: (props: Omit<T, 'isOpen'>) => void;
+    removeModal: () => void;
+  } => {
+    const id = useMemo(uniqueId, []);
+    const [modals, dispatch] = useContext(ModalContext);
+
+    const modal = useMemo<T | undefined>(
+      () => modals.find((m) => m.id === id),
+      [id, modals],
+    );
+
+    useDebugValue(modal);
+
+    const setModal = useCallback(
+      (props: Omit<T, 'isOpen'>): void => {
+        dispatch({ type: 'push', item: { ...props, id, component } });
+      },
+      [dispatch, id],
+    );
+
+    const removeModal = useCallback((): void => {
+      if (modal && modal.onClose) {
+        modal.onClose();
+      }
+      dispatch({ type: 'remove', id, timeout: component.TIMEOUT });
+    }, [dispatch, id, modal]);
+
+    return { setModal, removeModal };
+  };
+}

--- a/packages/circuit-ui/components/ModalContext/index.ts
+++ b/packages/circuit-ui/components/ModalContext/index.ts
@@ -13,10 +13,9 @@
  * limitations under the License.
  */
 
-export { ModalProvider, createUseModal } from './ModalContext';
+export { ModalProvider } from './ModalContext';
+export { createUseModal } from './createUseModal';
 
-export type {
-  ModalProviderProps,
-  BaseModalProps,
-  ModalComponent,
-} from './ModalContext';
+export type { ModalProviderProps } from './ModalContext';
+
+export type { BaseModalProps, ModalComponent } from './types';

--- a/packages/circuit-ui/components/ModalContext/types.ts
+++ b/packages/circuit-ui/components/ModalContext/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MouseEvent, KeyboardEvent } from 'react';
+import { Props as ReactModalProps } from 'react-modal';
+import { Dispatch as TrackingProps } from '@sumup/collector';
+
+type OnClose = (event?: MouseEvent | KeyboardEvent) => void;
+
+export interface BaseModalProps
+  extends Omit<
+    ReactModalProps,
+    'shouldCloseOnOverlayClick' | 'shouldCloseOnEsc'
+  > {
+  /**
+   * Callback function that is called when the modal is closed.
+   */
+  onClose?: OnClose;
+  /**
+   * Additional data that is dispatched with the tracking event.
+   */
+  tracking?: TrackingProps;
+}
+
+export type ModalComponent<TProps extends BaseModalProps = BaseModalProps> = ((
+  props: TProps,
+) => JSX.Element) & { TIMEOUT?: number };


### PR DESCRIPTION
## Purpose

While migrating the dashboard to the new Modal API (#949), I realized that modal events aren't tracked consistently depending on how a modal is opened or closed. The logic is duplicated in several places which allowed for inconsistencies.

## Approach and changes

- Moved all the logic related to opening and closing a modal from the `useModal` hook into the `ModalProvider` component. Added tests to verify that tracking events are dispatched no matter how the model is triggered.
- Split the code into separate files to improve tree-shaking and code readability.
- Bonus: Added headlines to the modal stories as a best practice.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
