### PR TITLE
Support defaultValue prop in Select

### DIFF
--- a/.changeset/gorgeous-chicken-smile.md
+++ b/.changeset/gorgeous-chicken-smile.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Do not render placeholder in Select when defaultValue is passed
+Do not render a placeholder in the `Select` component when a `defaultValue` is passed.

--- a/.changeset/gorgeous-chicken-smile.md
+++ b/.changeset/gorgeous-chicken-smile.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Do not render placeholder in Select when defaultValue is passed

--- a/packages/circuit-ui/components/Select/Select.spec.tsx
+++ b/packages/circuit-ui/components/Select/Select.spec.tsx
@@ -127,7 +127,7 @@ describe('Select', () => {
     expect(selectEl).toBeDisabled();
   });
 
-  it('should show the placeholder when no value is passed', () => {
+  it('should show the placeholder when no value or defaultValue is passed', () => {
     const placeholder = 'Placeholder';
     const { getByTestId } = render(
       <Select
@@ -138,6 +138,21 @@ describe('Select', () => {
     );
     const selectEl = getByTestId('select-element');
     expect(selectEl.firstChild).toHaveTextContent(placeholder);
+  });
+
+  it('should not show the placeholder when a defaultValue is set', () => {
+    const placeholder = 'Placeholder';
+    const defaultValue = 2;
+    const { getByTestId } = render(
+      <Select
+        options={options}
+        placeholder={placeholder}
+        defaultValue={defaultValue}
+        data-testid="select-element"
+      />,
+    );
+    const selectEl = getByTestId('select-element');
+    expect(selectEl.firstChild).not.toHaveTextContent(placeholder);
   });
 
   it('should not show the placeholder when a value is selected', () => {

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -388,6 +388,7 @@ export const Select = React.forwardRef(
             required={required}
             disabled={disabled}
             hasPrefix={hasPrefix}
+            defaultValue={defaultValue}
             {...props}
             onChange={handleChange}
           >

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -315,6 +315,7 @@ export const Select = React.forwardRef(
   (
     {
       value,
+      defaultValue,
       placeholder = 'Select an option',
       disabled,
       noMargin,
@@ -390,7 +391,7 @@ export const Select = React.forwardRef(
             {...props}
             onChange={handleChange}
           >
-            {!value && (
+            {!value && !defaultValue && (
               <option key="placeholder" value="">
                 {placeholder}
               </option>


### PR DESCRIPTION
Addresses #1009

## Purpose

Support the `defaultValue` prop on `Select` components so the unnecessary
placeholder option doesn't get rendered.

## Approach and changes

* Check whether the `defaultValue` prop is set when inserting the placeholder
  `option` element.
* Add tests.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
