### PR TITLE
Ensure heading components use semantic elements

### DIFF
--- a/.changeset/strange-buckets-teach.md
+++ b/.changeset/strange-buckets-teach.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Restricted the `Headline`'s and `SubHeadline`'s `as` prop to heading elements.

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -32,7 +32,7 @@ export interface HeadlineProps
    * without skipping any levels. Learn more at
    * https://www.w3.org/WAI/tutorials/page-structure/headings/.
    */
-  as: string;
+  as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -26,7 +26,7 @@ export interface SubHeadlineProps
    * without skipping any levels. Learn more at
    * https://www.w3.org/WAI/tutorials/page-structure/headings/.
    */
-  as: string;
+  as: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`


### PR DESCRIPTION
## Purpose

Components that visually look like a heading should only use semantic heading HTML elements.

## Approach and changes

- Restrict the Headline's and SubHeadline's `as` prop to heading elements

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
