### PR TITLE
Show focus styles only when needed

### DIFF
--- a/.changeset/real-dolphins-build.md
+++ b/.changeset/real-dolphins-build.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added the `focusVisible` style mixin that shows a focus outline only when the user agent determines via heuristics that the focus should be made evident on the element (see [`:focus-visible`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible)).

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -25,7 +25,7 @@ import { css } from '@emotion/core';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 import { Theme } from '@sumup/design-tokens';
 
-import { focusOutline } from '../../styles/style-mixins';
+import { focusVisible } from '../../styles/style-mixins';
 import { ReturnType } from '../../types/return-type';
 import { Body, BodyProps } from '../Body/Body';
 import { useComponents } from '../ComponentsContext';
@@ -51,7 +51,7 @@ type ButtonElProps = Omit<HTMLProps<HTMLButtonElement>, 'size' | 'onClick'>;
 
 export type AnchorProps = BaseProps & LinkElProps & ButtonElProps;
 
-const baseStyles = (theme: Theme) => css`
+const anchorStyles = (theme: Theme) => css`
   display: inline-block;
   text-decoration: underline;
   text-decoration-skip-ink: auto;
@@ -63,6 +63,7 @@ const baseStyles = (theme: Theme) => css`
   margin-left: 0;
   margin-right: 0;
   color: ${theme.colors.p500};
+  border-radius: ${theme.borderRadius.byte};
   transition: opacity ${theme.transitions.default},
     color ${theme.transitions.default},
     background-color ${theme.transitions.default},
@@ -86,10 +87,7 @@ const baseStyles = (theme: Theme) => css`
     }
   }
 
-  &:focus {
-    ${focusOutline({ theme })};
-    border-radius: ${theme.borderRadius.byte};
-  }
+  ${focusVisible(theme)};
 `;
 
 /**
@@ -119,7 +117,7 @@ export const Anchor = forwardRef(
       return (
         <Body
           {...props}
-          css={baseStyles}
+          css={anchorStyles}
           as={Link}
           ref={ref}
           onClick={handleClick}
@@ -131,7 +129,7 @@ export const Anchor = forwardRef(
       <Body
         as="button"
         {...props}
-        css={baseStyles}
+        css={anchorStyles}
         ref={ref}
         onClick={handleClick}
       />

--- a/packages/circuit-ui/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
+++ b/packages/circuit-ui/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
@@ -18,6 +18,7 @@ exports[`Anchor styles should render with custom styles 1`] = `
   margin-left: 0;
   margin-right: 0;
   color: #3063E9;
+  border-radius: 8px;
   -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
   color: rebeccapurple;
@@ -44,11 +45,14 @@ exports[`Anchor styles should render with custom styles 1`] = `
 .circuit-0:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
-  border-radius: 8px;
 }
 
 .circuit-0:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 <a
@@ -77,6 +81,7 @@ exports[`Anchor styles should render with default styles 1`] = `
   margin-left: 0;
   margin-right: 0;
   color: #3063E9;
+  border-radius: 8px;
   -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
 }
@@ -102,11 +107,14 @@ exports[`Anchor styles should render with default styles 1`] = `
 .circuit-0:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
-  border-radius: 8px;
 }
 
 .circuit-0:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 <a

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -32,7 +32,7 @@ import styled, { StyleProps } from '../../styles/styled';
 import {
   typography,
   disableVisually,
-  focusOutline,
+  focusVisible,
 } from '../../styles/style-mixins';
 import { ReturnType } from '../../types/return-type';
 import { useComponents } from '../ComponentsContext';
@@ -138,10 +138,6 @@ const baseStyles = ({ theme }: StyleProps) => css`
     color ${theme.transitions.default},
     background-color ${theme.transitions.default},
     border-color ${theme.transitions.default};
-
-  &:focus {
-    ${focusOutline({ theme })};
-  }
 
   &:disabled,
   &[disabled] {
@@ -271,6 +267,7 @@ const StyledButton = styled('button', {
   shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
 })<ButtonProps>(
   typography('one'),
+  focusVisible,
   baseStyles,
   primaryStyles,
   secondaryStyles,

--- a/packages/circuit-ui/components/Button/__snapshots__/Button.spec.tsx.snap
+++ b/packages/circuit-ui/components/Button/__snapshots__/Button.spec.tsx.snap
@@ -44,6 +44,10 @@ exports[`Button styles should render a button with icon 1`] = `
   border: 0;
 }
 
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-1:disabled,
 .circuit-1[disabled] {
   opacity: 0.5;
@@ -137,6 +141,10 @@ exports[`Button styles should render a disabled button 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0:disabled,
 .circuit-0[disabled] {
   opacity: 0.5;
@@ -204,6 +212,10 @@ exports[`Button styles should render a giga button 1`] = `
 
 .circuit-0:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-0:disabled,
@@ -274,6 +286,10 @@ exports[`Button styles should render a kilo button 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0:disabled,
 .circuit-0[disabled] {
   opacity: 0.5;
@@ -342,6 +358,10 @@ exports[`Button styles should render a primary button by default 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0:disabled,
 .circuit-0[disabled] {
   opacity: 0.5;
@@ -408,6 +428,10 @@ exports[`Button styles should render a secondary button 1`] = `
 
 .circuit-0:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-0:disabled,
@@ -479,6 +503,10 @@ exports[`Button styles should render a stretched button 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0:disabled,
 .circuit-0[disabled] {
   opacity: 0.5;
@@ -547,6 +575,10 @@ exports[`Button styles should render a tertiary button 1`] = `
 
 .circuit-0:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-0:disabled,

--- a/packages/circuit-ui/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -44,6 +44,10 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0:disabled,
 .circuit-0[disabled] {
   opacity: 0.5;
@@ -102,6 +106,10 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
 
 .circuit-1:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-1:disabled,
@@ -229,6 +237,10 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0:disabled,
 .circuit-0[disabled] {
   opacity: 0.5;
@@ -287,6 +299,10 @@ exports[`ButtonGroup Left aligment should render with left alignment styles 1`] 
 
 .circuit-1:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-1:disabled,
@@ -462,6 +478,10 @@ exports[`ButtonGroup should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0:disabled,
 .circuit-0[disabled] {
   opacity: 0.5;
@@ -520,6 +540,10 @@ exports[`ButtonGroup should render with default styles 1`] = `
 
 .circuit-1:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-1:disabled,

--- a/packages/circuit-ui/components/Calendar/__snapshots__/RangePicker.spec.js.snap
+++ b/packages/circuit-ui/components/Calendar/__snapshots__/RangePicker.spec.js.snap
@@ -1265,6 +1265,10 @@ exports[`RangePicker should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-2 .DayPickerNavigation_button__horizontal:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2 .DayPickerNavigation_button__horizontal:disabled,
 .circuit-2 .DayPickerNavigation_button__horizontal[disabled] {
   opacity: 0.5;

--- a/packages/circuit-ui/components/Calendar/__snapshots__/SingleDayPicker.spec.js.snap
+++ b/packages/circuit-ui/components/Calendar/__snapshots__/SingleDayPicker.spec.js.snap
@@ -1265,6 +1265,10 @@ exports[`SingleDayPicker should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-0 .DayPickerNavigation_button__horizontal:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0 .DayPickerNavigation_button__horizontal:disabled,
 .circuit-0 .DayPickerNavigation_button__horizontal[disabled] {
   opacity: 0.5;

--- a/packages/circuit-ui/components/Calendar/components/CalendarWrapper/CalendarWrapper.js
+++ b/packages/circuit-ui/components/Calendar/components/CalendarWrapper/CalendarWrapper.js
@@ -20,7 +20,7 @@ import { withTheme } from 'emotion-theming';
 import {
   typography,
   shadowTriple,
-  focusOutline,
+  focusVisible,
   disableVisually,
 } from '../../../../styles/style-mixins';
 
@@ -178,9 +178,7 @@ const navButtons = ({ theme }) => css`
       border-color: ${theme.colors.n800};
     }
 
-    &:focus {
-      ${focusOutline({ theme })};
-    }
+    ${focusVisible(theme)};
 
     &:disabled,
     &[disabled] {

--- a/packages/circuit-ui/components/Calendar/components/CalendarWrapper/__snapshots__/CalendarWrapper.spec.js.snap
+++ b/packages/circuit-ui/components/Calendar/components/CalendarWrapper/__snapshots__/CalendarWrapper.spec.js.snap
@@ -1265,6 +1265,10 @@ exports[`CalendarWrapper should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-0 .DayPickerNavigation_button__horizontal:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0 .DayPickerNavigation_button__horizontal:disabled,
 .circuit-0 .DayPickerNavigation_button__horizontal[disabled] {
   opacity: 0.5;

--- a/packages/circuit-ui/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
+++ b/packages/circuit-ui/components/CalendarTag/__snapshots__/CalendarTag.spec.js.snap
@@ -48,6 +48,10 @@ exports[`CalendarTag should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 <div>
   <div
     class="circuit-1"

--- a/packages/circuit-ui/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
+++ b/packages/circuit-ui/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.js.snap
@@ -48,6 +48,10 @@ exports[`CalendarTagTwoStep should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 <div>
   <div
     class="circuit-1"

--- a/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.js.snap
+++ b/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.js.snap
@@ -350,6 +350,10 @@ exports[`Carousel styles should render with children as a function 1`] = `
   border: 0;
 }
 
+.circuit-44:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-44:disabled,
 .circuit-44[disabled] {
   opacity: 0.5;
@@ -924,6 +928,10 @@ exports[`Carousel styles should render with children as a node 1`] = `
   border: 0;
 }
 
+.circuit-44:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-44:disabled,
 .circuit-44[disabled] {
   opacity: 0.5;
@@ -1454,6 +1462,10 @@ exports[`Carousel styles should render with default paused styles 1`] = `
 
 .circuit-44:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-44:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-44:disabled,
@@ -2043,6 +2055,10 @@ exports[`Carousel styles should render with default styles 1`] = `
 
 .circuit-44:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-44:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-44:disabled,

--- a/packages/circuit-ui/components/Carousel/components/Buttons/__snapshots__/Buttons.spec.js.snap
+++ b/packages/circuit-ui/components/Carousel/components/Buttons/__snapshots__/Buttons.spec.js.snap
@@ -61,6 +61,10 @@ exports[`Buttons styles should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2:disabled,
 .circuit-2[disabled] {
   opacity: 0.5;

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -140,7 +140,21 @@ const inputBaseStyles = ({ theme }: StyleProps) => css`
   }
 
   &:focus + label::before {
-    ${focusOutline({ theme })};
+    ${focusOutline(theme)};
+    border-color: ${theme.colors.p500};
+  }
+
+  &:focus:not(:focus-visible) + label::before {
+    box-shadow: none;
+    border-color: ${theme.colors.n500};
+  }
+
+  &:checked:focus:not(:focus-visible) + label::before {
+    border-color: ${theme.colors.p500};
+  }
+
+  &:focus-visible + label::before {
+    ${focusOutline(theme)};
     border-color: ${theme.colors.p500};
   }
 

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -153,11 +153,6 @@ const inputBaseStyles = ({ theme }: StyleProps) => css`
     border-color: ${theme.colors.p500};
   }
 
-  &:focus-visible + label::before {
-    ${focusOutline(theme)};
-    border-color: ${theme.colors.p500};
-  }
-
   &:checked + label > svg {
     transform: translateY(-50%) scale(1, 1);
     opacity: 1;

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -32,6 +32,25 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-0:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before::-moz-focus-inner {
+  border: 0;
+}
+
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -204,6 +223,25 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-0:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before::-moz-focus-inner {
+  border: 0;
+}
+
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -331,6 +369,25 @@ exports[`Checkbox should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-0:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before::-moz-focus-inner {
+  border: 0;
+}
+
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -454,6 +511,25 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 }
 
 .circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-0:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before::-moz-focus-inner {
   border: 0;
 }
 
@@ -593,6 +669,25 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 }
 
 .circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-0:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before::-moz-focus-inner {
   border: 0;
 }
 

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -41,16 +41,6 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   border-color: #3063E9;
 }
 
-.circuit-0:focus-visible + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before::-moz-focus-inner {
-  border: 0;
-}
-
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -232,16 +222,6 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   border-color: #3063E9;
 }
 
-.circuit-0:focus-visible + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before::-moz-focus-inner {
-  border: 0;
-}
-
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -378,16 +358,6 @@ exports[`Checkbox should render with default styles 1`] = `
   border-color: #3063E9;
 }
 
-.circuit-0:focus-visible + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before::-moz-focus-inner {
-  border: 0;
-}
-
 .circuit-0:checked + label > svg {
   -webkit-transform: translateY(-50%) scale(1,1);
   -ms-transform: translateY(-50%) scale(1,1);
@@ -521,16 +491,6 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
 
 .circuit-0:checked:focus:not(:focus-visible) + label::before {
   border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before::-moz-focus-inner {
-  border: 0;
 }
 
 .circuit-0:checked + label > svg {
@@ -679,16 +639,6 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
 
 .circuit-0:checked:focus:not(:focus-visible) + label::before {
   border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before::-moz-focus-inner {
-  border: 0;
 }
 
 .circuit-0:checked + label > svg {

--- a/packages/circuit-ui/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
@@ -46,6 +46,10 @@ exports[`CloseButton should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-1:disabled,
 .circuit-1[disabled] {
   opacity: 0.5;

--- a/packages/circuit-ui/components/Hamburger/__snapshots__/Hamburger.spec.tsx.snap
+++ b/packages/circuit-ui/components/Hamburger/__snapshots__/Hamburger.spec.tsx.snap
@@ -46,6 +46,10 @@ exports[`Hamburger should render with active styles when passed the isActive pro
   border: 0;
 }
 
+.circuit-3:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-3:disabled,
 .circuit-3[disabled] {
   opacity: 0.5;
@@ -221,6 +225,10 @@ exports[`Hamburger should render with default styles 1`] = `
 
 .circuit-3:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-3:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-3:disabled,

--- a/packages/circuit-ui/components/IconButton/__snapshots__/IconButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/IconButton/__snapshots__/IconButton.spec.tsx.snap
@@ -45,6 +45,10 @@ exports[`IconButton should render with the default styles 1`] = `
   border: 0;
 }
 
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-1:disabled,
 .circuit-1[disabled] {
   opacity: 0.5;

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -87,7 +87,11 @@ const HiddenInput = styled.input(
   ({ theme }) => css`
     ${hideVisually()};
     &:focus + label {
-      ${focusOutline({ theme })};
+      ${focusOutline(theme)};
+    }
+
+    &:focus:not(:focus-visible) + label {
+      box-shadow: none;
     }
   `,
 );

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -184,6 +184,10 @@ exports[`ImageInput styles should render a custom component 1`] = `
   border: 0;
 }
 
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-4:disabled,
 .circuit-4[disabled] {
   opacity: 0.5;
@@ -461,6 +465,10 @@ exports[`ImageInput styles should render with an existing image 1`] = `
   border: 0;
 }
 
+.circuit-5:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-5:disabled,
 .circuit-5[disabled] {
   opacity: 0.5;
@@ -701,6 +709,10 @@ exports[`ImageInput styles should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-5:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-5:disabled,
 .circuit-5[disabled] {
   opacity: 0.5;
@@ -934,6 +946,10 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
 
 .circuit-5:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-5:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-5:disabled,

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -43,6 +43,10 @@ exports[`ImageInput styles should render a custom component 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) + label {
+  box-shadow: none;
+}
+
 .circuit-2 {
   font-size: 14px;
   line-height: 20px;
@@ -311,6 +315,10 @@ exports[`ImageInput styles should render with an existing image 1`] = `
 
 .circuit-0:focus + label::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) + label {
+  box-shadow: none;
 }
 
 .circuit-3 {
@@ -594,6 +602,10 @@ exports[`ImageInput styles should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) + label {
+  box-shadow: none;
+}
+
 .circuit-3 {
   font-size: 14px;
   line-height: 20px;
@@ -874,6 +886,10 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
 
 .circuit-0:focus + label::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) + label {
+  box-shadow: none;
 }
 
 .circuit-1 {

--- a/packages/circuit-ui/components/LoadingButton/__snapshots__/LoadingButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/LoadingButton/__snapshots__/LoadingButton.spec.tsx.snap
@@ -60,6 +60,10 @@ exports[`LoadingButton styles should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-3:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-3:disabled,
 .circuit-3[disabled] {
   opacity: 0.5;
@@ -214,6 +218,10 @@ exports[`LoadingButton styles should render with loading styles 1`] = `
 
 .circuit-3:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-3:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-3:disabled,

--- a/packages/circuit-ui/components/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/packages/circuit-ui/components/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -138,6 +138,10 @@ exports[`Modal should match the snapshot 1`] = `
   border: 0;
 }
 
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-1:disabled,
 .circuit-1[disabled] {
   opacity: 0.5;

--- a/packages/circuit-ui/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
+++ b/packages/circuit-ui/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
@@ -68,6 +68,10 @@ exports[`Pagination with 2 to 5 pages should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-1:disabled,
 .circuit-1[disabled] {
   opacity: 0.5;
@@ -154,6 +158,10 @@ exports[`Pagination with 2 to 5 pages should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2:disabled,
 .circuit-2[disabled] {
   opacity: 0.5;
@@ -223,6 +231,10 @@ li:last-child .circuit-2 {
   border: 0;
 }
 
+.circuit-3:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-3:disabled,
 .circuit-3[disabled] {
   opacity: 0.5;
@@ -290,6 +302,10 @@ li:last-child .circuit-3 {
 
 .circuit-9:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-9:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-9:disabled,
@@ -491,6 +507,10 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
   border: 0;
 }
 
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-1:disabled,
 .circuit-1[disabled] {
   opacity: 0.5;
@@ -567,6 +587,10 @@ exports[`Pagination with more than 5 pages should render with default styles 1`]
 
 .circuit-10:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-10:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-10:disabled,

--- a/packages/circuit-ui/components/Pagination/components/PageList/__snapshots__/PageList.spec.tsx.snap
+++ b/packages/circuit-ui/components/Pagination/components/PageList/__snapshots__/PageList.spec.tsx.snap
@@ -59,6 +59,10 @@ exports[`PageList styles should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0:disabled,
 .circuit-0[disabled] {
   opacity: 0.5;
@@ -126,6 +130,10 @@ li:last-child .circuit-0 {
 
 .circuit-1:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-1:disabled,

--- a/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
+++ b/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
@@ -34,18 +34,22 @@ exports[`Popover styles should render popover on auto 1`] = `
 .circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
-  z-index: 1;
 }
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:disabled {
+.circuit-2:disabled,
+.circuit-2[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
@@ -209,18 +213,22 @@ exports[`Popover styles should render popover on bottom 1`] = `
 .circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
-  z-index: 1;
 }
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:disabled {
+.circuit-2:disabled,
+.circuit-2[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
@@ -384,18 +392,22 @@ exports[`Popover styles should render popover on left 1`] = `
 .circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
-  z-index: 1;
 }
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:disabled {
+.circuit-2:disabled,
+.circuit-2[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
@@ -559,18 +571,22 @@ exports[`Popover styles should render popover on right 1`] = `
 .circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
-  z-index: 1;
 }
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:disabled {
+.circuit-2:disabled,
+.circuit-2[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
@@ -734,18 +750,22 @@ exports[`Popover styles should render popover on top 1`] = `
 .circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
-  z-index: 1;
 }
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:disabled {
+.circuit-2:disabled,
+.circuit-2[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
@@ -909,18 +929,22 @@ exports[`Popover styles should render with default styles 1`] = `
 .circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
-  z-index: 1;
 }
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:disabled {
+.circuit-2:disabled,
+.circuit-2[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -135,7 +135,21 @@ const inputBaseStyles = ({ theme }: StyleProps) => css`
   }
 
   &:focus + label::before {
-    ${focusOutline({ theme })};
+    ${focusOutline(theme)};
+    border-color: ${theme.colors.p500};
+  }
+
+  &:focus:not(:focus-visible) + label::before {
+    box-shadow: none;
+    border-color: ${theme.colors.n500};
+  }
+
+  &:checked:focus:not(:focus-visible) + label::before {
+    border-color: ${theme.colors.p500};
+  }
+
+  &:focus-visible + label::before {
+    ${focusOutline(theme)};
     border-color: ${theme.colors.p500};
   }
 

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -148,11 +148,6 @@ const inputBaseStyles = ({ theme }: StyleProps) => css`
     border-color: ${theme.colors.p500};
   }
 
-  &:focus-visible + label::before {
-    ${focusOutline(theme)};
-    border-color: ${theme.colors.p500};
-  }
-
   &:checked + label {
     &::before {
       border-color: ${theme.colors.p500};

--- a/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
@@ -29,6 +29,25 @@ HTMLCollection [
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-0:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before::-moz-focus-inner {
+  border: 0;
+}
+
 .circuit-0:checked + label::before {
   border-color: #3063E9;
 }
@@ -131,6 +150,25 @@ HTMLCollection [
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-0:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before::-moz-focus-inner {
+  border: 0;
+}
+
 .circuit-0:checked + label::before {
   border-color: #3063E9;
 }
@@ -229,6 +267,25 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-0:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before::-moz-focus-inner {
   border: 0;
 }
 
@@ -350,6 +407,25 @@ HTMLCollection [
 }
 
 .circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-0:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus-visible + label::before::-moz-focus-inner {
   border: 0;
 }
 

--- a/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
@@ -38,16 +38,6 @@ HTMLCollection [
   border-color: #3063E9;
 }
 
-.circuit-0:focus-visible + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before::-moz-focus-inner {
-  border: 0;
-}
-
 .circuit-0:checked + label::before {
   border-color: #3063E9;
 }
@@ -159,16 +149,6 @@ HTMLCollection [
   border-color: #3063E9;
 }
 
-.circuit-0:focus-visible + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before::-moz-focus-inner {
-  border: 0;
-}
-
 .circuit-0:checked + label::before {
   border-color: #3063E9;
 }
@@ -277,16 +257,6 @@ HTMLCollection [
 
 .circuit-0:checked:focus:not(:focus-visible) + label::before {
   border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before::-moz-focus-inner {
-  border: 0;
 }
 
 .circuit-0:checked + label::before {
@@ -417,16 +387,6 @@ HTMLCollection [
 
 .circuit-0:checked:focus:not(:focus-visible) + label::before {
   border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-0:focus-visible + label::before::-moz-focus-inner {
-  border: 0;
 }
 
 .circuit-0:checked + label::before {

--- a/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
@@ -34,6 +34,25 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-1:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-1:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-1:focus-visible + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-1:focus-visible + label::before::-moz-focus-inner {
+  border: 0;
+}
+
 .circuit-1:checked + label::before {
   border-color: #3063E9;
 }

--- a/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
@@ -43,16 +43,6 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
   border-color: #3063E9;
 }
 
-.circuit-1:focus-visible + label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-1:focus-visible + label::before::-moz-focus-inner {
-  border: 0;
-}
-
 .circuit-1:checked + label::before {
   border-color: #3063E9;
 }

--- a/packages/circuit-ui/components/Selector/Selector.stories.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.stories.tsx
@@ -61,6 +61,7 @@ Disabled.args = {
   name: 'disabled',
   disabled: true,
 };
+
 export const Sizes = (args: SelectorProps) => (
   <Stack>
     <Selector {...args} size="kilo">

--- a/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -15,16 +15,25 @@ HTMLCollection [
   width: 1px;
 }
 
-.circuit-0:focus + label {
-  box-shadow: 0 0 0 2px #3063E9,0 0 0 5px #AFD0FE;
+.circuit-0:focus + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:focus + label:hover {
-  box-shadow: 0 0 0 2px #3063E9,0 0 0 5px #AFD0FE;
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
-.circuit-0:focus + label:active {
-  box-shadow: 0 0 0 2px #3063E9,0 0 0 5px #AFD0FE;
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+}
+
+.circuit-0:checked + label {
+  background-color: #F0F6FF;
+}
+
+.circuit-0:checked + label::before {
+  border: 2px solid #3063E9;
 }
 
 <input
@@ -38,26 +47,46 @@ HTMLCollection [
   .circuit-0 {
   display: inline-block;
   cursor: pointer;
-  padding: 16px 24px;
-  background-color: #F0F6FF;
+  background-color: #FFF;
   text-align: center;
   position: relative;
   border: none;
   border-radius: 8px;
-  -webkit-transition: box-shadow 0.1s ease-in-out;
-  transition: box-shadow 0.1s ease-in-out;
-  box-shadow: 0 0 0 2px #3063E9;
-  padding: calc(8px + 1px) 24px;
+  -webkit-transition: box-shadow 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out;
+  padding: calc(12px) 24px;
+}
+
+.circuit-0::before {
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  border: 1px solid #CCC;
+  -webkit-transition: border 120ms ease-in-out;
+  transition: border 120ms ease-in-out;
 }
 
 .circuit-0:hover {
   background-color: #F5F5F5;
-  box-shadow: 0 0 0 2px #3063E9;
+}
+
+.circuit-0:hover::before {
+  border-color: #999;
 }
 
 .circuit-0:active {
   background-color: #E6E6E6;
-  box-shadow: 0 0 0 2px #3063E9;
+}
+
+.circuit-0:active::before {
+  border-color: #666;
 }
 
 <label
@@ -84,16 +113,25 @@ HTMLCollection [
   width: 1px;
 }
 
-.circuit-0:focus + label {
-  box-shadow: 0 0 0 1px #CCC,0 0 0 4px #AFD0FE;
+.circuit-0:focus + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:focus + label:hover {
-  box-shadow: 0 0 0 1px #999,0 0 0 4px #AFD0FE;
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
-.circuit-0:focus + label:active {
-  box-shadow: 0 0 0 1px #666,0 0 0 4px #AFD0FE;
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+}
+
+.circuit-0:checked + label {
+  background-color: #F0F6FF;
+}
+
+.circuit-0:checked + label::before {
+  border: 2px solid #3063E9;
 }
 
 <input
@@ -106,26 +144,46 @@ HTMLCollection [
   .circuit-0 {
   display: inline-block;
   cursor: pointer;
-  padding: 16px 24px;
   background-color: #FFF;
   text-align: center;
   position: relative;
   border: none;
   border-radius: 8px;
-  -webkit-transition: box-shadow 0.1s ease-in-out;
-  transition: box-shadow 0.1s ease-in-out;
-  box-shadow: 0 0 0 1px #CCC;
-  padding: calc(8px + 1px) 24px;
+  -webkit-transition: box-shadow 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out;
+  padding: calc(12px) 24px;
+}
+
+.circuit-0::before {
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  border: 1px solid #CCC;
+  -webkit-transition: border 120ms ease-in-out;
+  transition: border 120ms ease-in-out;
 }
 
 .circuit-0:hover {
   background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-0:hover::before {
+  border-color: #999;
 }
 
 .circuit-0:active {
   background-color: #E6E6E6;
-  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-0:active::before {
+  border-color: #666;
 }
 
 <label
@@ -152,16 +210,25 @@ HTMLCollection [
   width: 1px;
 }
 
-.circuit-0:focus + label {
-  box-shadow: 0 0 0 1px #CCC,0 0 0 4px #AFD0FE;
+.circuit-0:focus + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:focus + label:hover {
-  box-shadow: 0 0 0 1px #999,0 0 0 4px #AFD0FE;
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
-.circuit-0:focus + label:active {
-  box-shadow: 0 0 0 1px #666,0 0 0 4px #AFD0FE;
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+}
+
+.circuit-0:checked + label {
+  background-color: #F0F6FF;
+}
+
+.circuit-0:checked + label::before {
+  border: 2px solid #3063E9;
 }
 
 <input
@@ -175,29 +242,49 @@ HTMLCollection [
   .circuit-0 {
   display: inline-block;
   cursor: pointer;
-  padding: 16px 24px;
   background-color: #FFF;
   text-align: center;
   position: relative;
   border: none;
   border-radius: 8px;
-  -webkit-transition: box-shadow 0.1s ease-in-out;
-  transition: box-shadow 0.1s ease-in-out;
-  box-shadow: 0 0 0 1px #CCC;
-  padding: calc(8px + 1px) 24px;
+  -webkit-transition: box-shadow 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out;
+  padding: calc(12px) 24px;
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
+.circuit-0::before {
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  border: 1px solid #CCC;
+  -webkit-transition: border 120ms ease-in-out;
+  transition: border 120ms ease-in-out;
+}
+
 .circuit-0:hover {
   background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-0:hover::before {
+  border-color: #999;
 }
 
 .circuit-0:active {
   background-color: #E6E6E6;
-  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-0:active::before {
+  border-color: #666;
 }
 
 <label

--- a/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -45,42 +45,71 @@ exports[`SelectorGroup should render with default styles 1`] = `
   width: 1px;
 }
 
-.circuit-0:focus + label {
-  box-shadow: 0 0 0 1px #CCC,0 0 0 4px #AFD0FE;
+.circuit-0:focus + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:focus + label:hover {
-  box-shadow: 0 0 0 1px #999,0 0 0 4px #AFD0FE;
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
-.circuit-0:focus + label:active {
-  box-shadow: 0 0 0 1px #666,0 0 0 4px #AFD0FE;
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+}
+
+.circuit-0:checked + label {
+  background-color: #F0F6FF;
+}
+
+.circuit-0:checked + label::before {
+  border: 2px solid #3063E9;
 }
 
 .circuit-1 {
   display: inline-block;
   cursor: pointer;
-  padding: 16px 24px;
   background-color: #FFF;
   text-align: center;
   position: relative;
   border: none;
   border-radius: 8px;
-  -webkit-transition: box-shadow 0.1s ease-in-out;
-  transition: box-shadow 0.1s ease-in-out;
-  box-shadow: 0 0 0 1px #CCC;
-  padding: calc(8px + 1px) 24px;
+  -webkit-transition: box-shadow 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out;
+  padding: calc(12px) 24px;
   width: 100%;
+}
+
+.circuit-1::before {
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  border: 1px solid #CCC;
+  -webkit-transition: border 120ms ease-in-out;
+  transition: border 120ms ease-in-out;
 }
 
 .circuit-1:hover {
   background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-1:hover::before {
+  border-color: #999;
 }
 
 .circuit-1:active {
   background-color: #E6E6E6;
-  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-1:active::before {
+  border-color: #666;
 }
 
 <div
@@ -187,42 +216,71 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
   width: 1px;
 }
 
-.circuit-0:focus + label {
-  box-shadow: 0 0 0 1px #CCC,0 0 0 4px #AFD0FE;
+.circuit-0:focus + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:focus + label:hover {
-  box-shadow: 0 0 0 1px #999,0 0 0 4px #AFD0FE;
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
 }
 
-.circuit-0:focus + label:active {
-  box-shadow: 0 0 0 1px #666,0 0 0 4px #AFD0FE;
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+}
+
+.circuit-0:checked + label {
+  background-color: #F0F6FF;
+}
+
+.circuit-0:checked + label::before {
+  border: 2px solid #3063E9;
 }
 
 .circuit-1 {
   display: inline-block;
   cursor: pointer;
-  padding: 16px 24px;
   background-color: #FFF;
   text-align: center;
   position: relative;
   border: none;
   border-radius: 8px;
-  -webkit-transition: box-shadow 0.1s ease-in-out;
-  transition: box-shadow 0.1s ease-in-out;
-  box-shadow: 0 0 0 1px #CCC;
-  padding: calc(8px + 1px) 24px;
+  -webkit-transition: box-shadow 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out;
+  padding: calc(12px) 24px;
   width: 100%;
+}
+
+.circuit-1::before {
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  border: 1px solid #CCC;
+  -webkit-transition: border 120ms ease-in-out;
+  transition: border 120ms ease-in-out;
 }
 
 .circuit-1:hover {
   background-color: #F5F5F5;
-  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-1:hover::before {
+  border-color: #999;
 }
 
 .circuit-1:active {
   background-color: #E6E6E6;
-  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-1:active::before {
+  border-color: #666;
 }
 
 <div

--- a/packages/circuit-ui/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
+++ b/packages/circuit-ui/components/Sidebar/__snapshots__/Sidebar.spec.js.snap
@@ -139,6 +139,10 @@ HTMLCollection [
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2:disabled,
 .circuit-2[disabled] {
   opacity: 0.5;
@@ -300,6 +304,10 @@ HTMLCollection [
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-2:disabled,

--- a/packages/circuit-ui/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
+++ b/packages/circuit-ui/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.js.snap
@@ -54,6 +54,10 @@ exports[`CloseButton styles should render and match snapshot when not visible 1`
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-2:disabled,
 .circuit-2[disabled] {
   opacity: 0.5;
@@ -185,6 +189,10 @@ exports[`CloseButton styles should render and match snapshot when visible 1`] = 
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-2:disabled,

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
@@ -53,17 +53,19 @@ const clickableStyles = ({ theme, onClick }: StyleProps & TableRowProps) =>
     &:focus {
       z-index: 1;
       transform: translate(0, 0);
-      ${focusOutline({ theme })};
+      ${focusOutline(theme)};
     }
 
-    tbody & {
-      &:focus,
-      &:hover {
-        td,
-        th {
-          color: ${theme.colors.p500};
-          background-color: ${theme.colors.n100};
-        }
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
+    }
+
+    tbody &:focus,
+    tbody &:hover {
+      td,
+      th {
+        color: ${theme.colors.p500};
+        background-color: ${theme.colors.n100};
       }
     }
   `;

--- a/packages/circuit-ui/components/Table/components/TableRow/__snapshots__/TableRow.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableRow/__snapshots__/TableRow.spec.tsx.snap
@@ -25,6 +25,10 @@ tbody .circuit-0:last-child td {
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 tbody .circuit-0:focus td,
 tbody .circuit-0:hover td,
 tbody .circuit-0:focus th,

--- a/packages/circuit-ui/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/packages/circuit-ui/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -78,14 +78,6 @@ exports[`Tabs styles should render with default styles 1`] = `
   outline: none;
 }
 
-.circuit-0:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-0:active {
-  background-color: #E6E6E6;
-}
-
 .circuit-0:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
@@ -93,6 +85,18 @@ exports[`Tabs styles should render with default styles 1`] = `
 
 .circuit-0:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-0:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-0:active {
+  background-color: #E6E6E6;
 }
 
 .circuit-2 {
@@ -128,14 +132,6 @@ exports[`Tabs styles should render with default styles 1`] = `
   color: #1A1A1A;
 }
 
-.circuit-2:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-2:active {
-  background-color: #E6E6E6;
-}
-
 .circuit-2:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
@@ -143,6 +139,18 @@ exports[`Tabs styles should render with default styles 1`] = `
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-2:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-2:active {
+  background-color: #E6E6E6;
 }
 
 .circuit-2::after {
@@ -234,14 +242,6 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   outline: none;
 }
 
-.circuit-0:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-0:active {
-  background-color: #E6E6E6;
-}
-
 .circuit-0:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
@@ -249,6 +249,18 @@ exports[`Tabs styles should render with stretched styles 1`] = `
 
 .circuit-0:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-0:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-0:active {
+  background-color: #E6E6E6;
 }
 
 .circuit-2 {
@@ -284,14 +296,6 @@ exports[`Tabs styles should render with stretched styles 1`] = `
   color: #1A1A1A;
 }
 
-.circuit-2:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-2:active {
-  background-color: #E6E6E6;
-}
-
 .circuit-2:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
@@ -299,6 +303,18 @@ exports[`Tabs styles should render with stretched styles 1`] = `
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-2:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-2:active {
+  background-color: #E6E6E6;
 }
 
 .circuit-2::after {

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.js
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
-import { typography, focusOutline } from '../../../../styles/style-mixins';
+import { typography, focusVisible } from '../../../../styles/style-mixins';
 
 const defaultTabStyles = ({ theme }) => css`
   label: tab;
@@ -43,10 +43,6 @@ const defaultTabStyles = ({ theme }) => css`
 
   &:active {
     background-color: ${theme.colors.n200};
-  }
-
-  &:focus {
-    ${focusOutline({ theme })};
   }
 `;
 
@@ -73,6 +69,7 @@ const tabIndex = (selected) => (selected ? undefined : '-1');
 
 const StyledTab = styled('button')(
   typography('one'),
+  focusVisible,
   defaultTabStyles,
   selectedTabStyles,
 );

--- a/packages/circuit-ui/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
+++ b/packages/circuit-ui/components/Tabs/components/Tab/__snapshots__/Tab.spec.js.snap
@@ -32,14 +32,6 @@ exports[`Tab styles should render with default styles 1`] = `
   outline: none;
 }
 
-.circuit-0:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-0:active {
-  background-color: #E6E6E6;
-}
-
 .circuit-0:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
@@ -47,6 +39,18 @@ exports[`Tab styles should render with default styles 1`] = `
 
 .circuit-0:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-0:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-0:active {
+  background-color: #E6E6E6;
 }
 
 <button
@@ -93,14 +97,6 @@ exports[`Tab styles should render with selected styles 1`] = `
   color: #1A1A1A;
 }
 
-.circuit-0:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-0:active {
-  background-color: #E6E6E6;
-}
-
 .circuit-0:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
@@ -108,6 +104,18 @@ exports[`Tab styles should render with selected styles 1`] = `
 
 .circuit-0:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-0:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-0:active {
+  background-color: #E6E6E6;
 }
 
 .circuit-0::after {

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -27,7 +27,7 @@ import { Dispatch as TrackingProps } from '@sumup/collector';
 import { Theme } from '@sumup/design-tokens';
 
 import styled, { StyleProps } from '../../styles/styled';
-import { typography, focusOutline } from '../../styles/style-mixins';
+import { typography, focusVisible } from '../../styles/style-mixins';
 import { useClickHandler } from '../../hooks/useClickHandler';
 import { CloseButton, CloseButtonProps } from '../CloseButton/CloseButton';
 
@@ -125,9 +125,7 @@ const tagClickableStyles = ({ theme, onClick }: StyleProps & TagElProps) =>
       border-color: ${theme.colors.n500};
     }
 
-    &:focus {
-      ${focusOutline({ theme })};
-    }
+    ${focusVisible(theme)};
   `;
 
 const tagSelectedStyles = ({ theme, selected }: StyleProps & TagElProps) =>

--- a/packages/circuit-ui/components/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/packages/circuit-ui/components/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -48,6 +48,10 @@ exports[`Tag when is clickable should render with clickable styles 1`] = `
   border: 0;
 }
 
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 <div
   class="circuit-1"
 >
@@ -179,6 +183,10 @@ exports[`Tag when is selected should change the close icon color 1`] = `
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-2:disabled,

--- a/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -55,6 +55,10 @@ exports[`Toggle should render with default styles 1`] = `
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0 {
   display: block;
   background-color: #FFF;

--- a/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
+++ b/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
@@ -18,7 +18,7 @@ import { css } from '@emotion/core';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import styled, { StyleProps } from '../../../../styles/styled';
-import { focusOutline, hideVisually } from '../../../../styles/style-mixins';
+import { focusVisible, hideVisually } from '../../../../styles/style-mixins';
 import { useClickHandler } from '../../../../hooks/useClickHandler';
 
 export interface SwitchProps
@@ -70,10 +70,6 @@ const trackBaseStyles = ({ theme }: StyleProps) => css`
   width: ${TRACK_WIDTH};
   overflow: visible;
   cursor: pointer;
-
-  &:focus {
-    ${focusOutline({ theme })};
-  }
 `;
 
 const trackOnStyles = ({ theme, checked }: StyleProps & TrackElProps) =>
@@ -84,6 +80,7 @@ const trackOnStyles = ({ theme, checked }: StyleProps & TrackElProps) =>
   `;
 
 const SwitchTrack = styled('button')<TrackElProps>(
+  focusVisible,
   trackBaseStyles,
   trackOnStyles,
 );

--- a/packages/circuit-ui/components/Toggle/components/Switch/__snapshots__/Switch.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/components/Switch/__snapshots__/Switch.spec.tsx.snap
@@ -32,6 +32,10 @@ exports[`Switch should have the correct default styles 1`] = `
   border: 0;
 }
 
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
 .circuit-0 {
   display: block;
   background-color: #FFF;
@@ -123,6 +127,10 @@ exports[`Switch should have the correct on styles 1`] = `
 
 .circuit-2:focus::-moz-focus-inner {
   border: 0;
+}
+
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
 }
 
 .circuit-0 {

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -159,6 +159,7 @@ export {
   disableVisually,
   hideVisually,
   focusOutline,
+  focusVisible,
   clearfix,
   hideScrollbar,
   inputOutline,

--- a/packages/circuit-ui/styles/style-mixins.docs.mdx
+++ b/packages/circuit-ui/styles/style-mixins.docs.mdx
@@ -95,16 +95,18 @@ clearfix(): SerializedStyles;
 
 <Story id="features-style-mixins--clearfix" />
 
-## `focusOutline`
+## `focusVisible`
 
 Visually communicates to the user that an element is focused.
 
 ```ts
-focusOutline(theme: Theme | { theme: Theme }): SerializedStyles;
-focusOutline('inset'): (theme: Theme | { theme: Theme }) => SerializedStyles;
+focusVisible(theme: Theme | { theme: Theme }): SerializedStyles;
+focusVisible('inset'): (theme: Theme | { theme: Theme }) => SerializedStyles;
 ```
 
-<Story id="features-style-mixins--focus-outline" />
+<Story id="features-style-mixins--focus-visible" />
+
+In cases where the focus outline is needed for conditions other than the focus state, use the `focusOutline` style mixin instead. It has the same API.
 
 ## `disableVisually`
 

--- a/packages/circuit-ui/styles/style-mixins.spec.tsx
+++ b/packages/circuit-ui/styles/style-mixins.spec.tsx
@@ -29,6 +29,7 @@ import {
   disableVisually,
   hideVisually,
   focusOutline,
+  focusVisible,
   clearfix,
   hideScrollbar,
   inputOutline,
@@ -202,6 +203,22 @@ describe('Style helpers', () => {
       const { styles } = focusOutline('inset')({ theme: light });
       expect(styles).toMatchInlineSnapshot(
         `"outline:0;box-shadow:inset 0 0 0 4px #AFD0FE;&::-moz-focus-inner{border:0;}"`,
+      );
+    });
+  });
+
+  describe('focusVisible', () => {
+    it('should match the snapshot', () => {
+      const { styles } = focusVisible({ theme: light });
+      expect(styles).toMatchInlineSnapshot(
+        `"&:focus{outline:0;box-shadow:0 0 0 4px #AFD0FE;&::-moz-focus-inner{border:0;}}&:focus:not(:focus-visible){box-shadow:none;}"`,
+      );
+    });
+
+    it('should match the snapshot with an inset outline', () => {
+      const { styles } = focusVisible('inset')({ theme: light });
+      expect(styles).toMatchInlineSnapshot(
+        `"&:focus{outline:0;box-shadow:inset 0 0 0 4px #AFD0FE;&::-moz-focus-inner{border:0;}}&:focus:not(:focus-visible){box-shadow:none;}"`,
       );
     });
   });

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -21,7 +21,7 @@ import Button from '../components/Button';
 import docs from './style-mixins.docs.mdx';
 import {
   spacing,
-  focusOutline,
+  focusVisible,
   disableVisually,
   clearfix,
   hideVisually,
@@ -127,10 +127,10 @@ const Focused = styled.div`
   background-color: white;
 `;
 
-export const FocusOutline = () => (
+export const FocusVisible = () => (
   <Stack>
-    <Focused css={focusOutline} />
-    <Focused css={focusOutline('inset')} />
+    <Focused css={focusVisible} />
+    <Focused css={focusVisible('inset')} />
   </Stack>
 );
 

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -233,6 +233,55 @@ export function focusOutline(
 }
 
 /**
+ * Visually communicates to the user that an element is focused when
+ * the user agent determines via heuristics that the focus should be
+ * made evident on the element.
+ */
+export function focusVisible(
+  options: 'inset',
+): (args: ThemeArgs) => SerializedStyles;
+export function focusVisible(args: ThemeArgs): SerializedStyles;
+export function focusVisible(
+  argsOrOptions: ThemeArgs | 'inset',
+): SerializedStyles | ((args: ThemeArgs) => SerializedStyles) {
+  if (typeof argsOrOptions === 'string') {
+    return (args: ThemeArgs): SerializedStyles => {
+      const theme = getTheme(args);
+      return css`
+        &:focus {
+          outline: 0;
+          box-shadow: inset 0 0 0 4px ${theme.colors.p300};
+
+          &::-moz-focus-inner {
+            border: 0;
+          }
+        }
+
+        &:focus:not(:focus-visible) {
+          box-shadow: none;
+        }
+      `;
+    };
+  }
+
+  const theme = getTheme(argsOrOptions);
+  return css`
+    &:focus {
+      outline: 0;
+      box-shadow: 0 0 0 4px ${theme.colors.p300};
+
+      &::-moz-focus-inner {
+        border: 0;
+      }
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
+    }
+  `;
+}
+
+/**
  * Forces an element to self-clear its floated children.
  * Taken from [CSS Tricks](https://css-tricks.com/clearfix-a-lesson-in-web-development-evolution/).
  */

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -413,15 +413,14 @@ export const listItem = (
       cursor: pointer;
     }
 
-    &:focus {
-      ${focusOutline('inset')({ theme })};
-      z-index: ${theme.zIndex.absolute};
-    }
+    ${focusVisible('inset')(theme)};
 
     &:active {
       background-color: ${theme.colors.n200};
     }
-    &:disabled {
+
+    &:disabled,
+    &[disabled] {
       ${disableVisually()};
     }
   `;


### PR DESCRIPTION
Partially addresses #808.

## Purpose

Currently, some browsers such as Firefox and Chrome apply focus styles to interactive elements after clicking them. This isn't intentional — ideally, focus styles should only be shown when necessary. The new [`:focus-visible` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) enables the user agent to determine via heuristics when the focus should be made evident on the element.

## Approach and changes

- Add a new `focusVisible` style mixin which shows focus styles only when needed and has a fallback for browsers that don't support the `:focus-visible` pseudo-class (looking at you, Safari 👀)
- Update Circuit UI components where appropriate

I've kept the `focusOutline` style mixin around since it's still helpful in situations where the focus outline should be applied based on different heuristics. 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
