### PR TITLE
Fix Input ref prop type

### DIFF
--- a/.changeset/sharp-pans-cheat.md
+++ b/.changeset/sharp-pans-cheat.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fix the Input component's `ref` prop type to work with a ref to a single element.

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -108,7 +108,7 @@ export interface InputProps extends Omit<HTMLProps<HTMLInputElement>, 'label'> {
   /**
    * The ref to the html dom element
    */
-  ref?: Ref<HTMLInputElement & HTMLTextAreaElement>;
+  ref?: Ref<HTMLInputElement | HTMLTextAreaElement>;
 }
 
 const containerStyles = () => css`


### PR DESCRIPTION
When passing a ref to an element like an input, TypeScript gives an error because that ref will be incompatible with the prop type.

**Example**

```tsx
const input = useRef<HTMLInputelement>(null)

return (<Input
      ref={ref}
    />)
```

## Approach and changes

Change the `ref` prop's type.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
