### PR TITLE
Add support for style objects to the cx style mixin

### DIFF
--- a/.changeset/pretty-carpets-count.md
+++ b/.changeset/pretty-carpets-count.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added support for style objects to the `cx` style mixin.

--- a/packages/circuit-ui/styles/style-mixins.spec.tsx
+++ b/packages/circuit-ui/styles/style-mixins.spec.tsx
@@ -54,6 +54,9 @@ describe('Style helpers', () => {
   const green = (theme: Theme) => css`
     color: ${theme.colors.g500};
   `;
+  const purple = css`
+    color: rebeccapurple;
+  `;
 
   describe('cx', () => {
     it('should call each style function with the theme', () => {
@@ -63,6 +66,20 @@ describe('Style helpers', () => {
         .circuit-0 {
           color: #D23F47;
           color: #8CC13F;
+        }
+
+        <div
+          class="circuit-0"
+        />
+      `);
+    });
+
+    it('should support style objects', () => {
+      const actual = create(<div css={cx(purple)} />);
+
+      expect(actual).toMatchInlineSnapshot(`
+        .circuit-0 {
+          color: rebeccapurple;
         }
 
         <div

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -16,6 +16,8 @@
 import { css, SerializedStyles } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';
 
+import { isFunction } from '../util/type-check';
+
 type ThemeArgs = Theme | { theme: Theme };
 
 function isTheme(args: ThemeArgs): args is Theme {
@@ -31,6 +33,7 @@ const getTheme = (args: ThemeArgs): Theme =>
 type StyleFn =
   | ((theme: Theme) => SerializedStyles)
   | ((args: ThemeArgs) => SerializedStyles)
+  | SerializedStyles
   | false
   | null
   | undefined;
@@ -42,7 +45,7 @@ type StyleFn =
 export const cx = (...styleFns: StyleFn[]) => (
   theme: Theme,
 ): (SerializedStyles | false | null | undefined)[] =>
-  styleFns.map((styleFn) => styleFn && styleFn(theme));
+  styleFns.map((styleFn) => (isFunction(styleFn) ? styleFn(theme) : styleFn));
 
 type Spacing = keyof Theme['spacings'];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15614,12 +15614,12 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
 react-modal@^3.8.1:
-  version "3.14.3"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.14.3.tgz#7eb7c5ec85523e5843e2d4737cc17fc3f6aeb1c0"
-  integrity sha512-+C2KODVKyu20zHXPJxfOOcf571L1u/EpFlH+oS/3YDn8rgVE51QZuxuuIwabJ8ZFnOEHaD+r6XNjqwtxZnXO0g==
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.13.1.tgz#a02dce63bbfee7582936f1e9835d518ef8f56453"
+  integrity sha512-m6yXK7I4YKssQnsjHK7xITSXy2O81BSOHOsg0/uWAsdKtuT9HF2tdoYhRuxNNQg2V+LgepsoHUPJKS8m6no+eg==
   dependencies:
     exenv "^1.2.0"
-    prop-types "^15.7.2"
+    prop-types "^15.5.10"
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
 


### PR DESCRIPTION
Addresses https://github.com/sumup/ze-dashboard/pull/4461#discussion_r668069729.

## Purpose

Emotion's `css` prop supports style objects in addition to style functions, so the `cx` style mixin should do the same.

## Approach and changes

- Add support for style objects to the `cx` style mixin

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
