### PR TITLE
Add shadow style mixin

### DIFF
--- a/.changeset/pretty-scissors-press.md
+++ b/.changeset/pretty-scissors-press.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added the `shadow` style mixin which can be used to visually elevate an element above the surrounding content.

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -172,6 +172,7 @@ export {
   focusOutline,
   clearfix,
   hideScrollbar,
+  shadow,
 } from './styles/style-mixins';
 
 export { sharedPropTypes, styleHelpers };

--- a/packages/circuit-ui/styles/style-helpers.ts
+++ b/packages/circuit-ui/styles/style-helpers.ts
@@ -22,6 +22,7 @@ type StyleMixins = typeof styleMixins;
 const PUBLIC_STYLE_MIXINS: { [key: string]: boolean } = {
   cx: true,
   spacing: true,
+  shadow: true,
   disableVisually: true,
   hideVisually: true,
   focusOutline: true,
@@ -49,6 +50,7 @@ export const styleHelpers: StyleMixins =
           }
           // @ts-expect-error TypeScript isn't smart enough to infer the types here
           // and I'm too lazy to explicitly define them. — @connor-baer
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return fn(...args);
         };
         return acc;

--- a/packages/circuit-ui/styles/style-mixins.docs.mdx
+++ b/packages/circuit-ui/styles/style-mixins.docs.mdx
@@ -53,12 +53,12 @@ const Conditional = ({ disabled }) => (
 
 ## `spacing`
 
-Applies consistent outer spacing to an element. For the supported values have a look at the "Spacing" section on the [Theme](Features/Theme) page.
+Adds margin to one or more sides of an element. For an overview of the supported values, have a look at the "Spacing" section on the [Theme](Features/Theme) page.
 
 ```ts
 type Spacing = 0 | 'auto' | keyof Theme['spacings'];
 
-spacing(
+function spacing(
   size:
     | Spacing
     | { top?: Spacing; left?: Spacing; bottom?: Spacing; right?: Spacing },
@@ -85,12 +85,22 @@ const HorizontallyCentered = () => (
 
 <Story id="features-style-mixins--spacing" />
 
+## `shadow`
+
+Adds a drop shadow to an element to visually elevate it above the surrounding content.
+
+```ts
+function shadow(theme: Theme | { theme: Theme }): SerializedStyles;
+```
+
+<Story id="features-style-mixins--shadow" />
+
 ## `clearfix`
 
 Forces an element to self-clear its floated children. Taken from [CSS Tricks](https://css-tricks.com/clearfix-a-lesson-in-web-development-evolution/).
 
 ```ts
-clearfix(): SerializedStyles;
+function clearfix(): SerializedStyles;
 ```
 
 <Story id="features-style-mixins--clearfix" />
@@ -100,8 +110,9 @@ clearfix(): SerializedStyles;
 Visually communicates to the user that an element is focused.
 
 ```ts
-focusOutline(theme: Theme | { theme: Theme }): SerializedStyles;
-focusOutline('inset'): (theme: Theme | { theme: Theme }) => SerializedStyles;
+function focusOutline(theme: Theme | { theme: Theme }): SerializedStyles;
+// or
+function focusOutline('inset'): (theme: Theme | { theme: Theme }) => SerializedStyles;
 ```
 
 <Story id="features-style-mixins--focus-outline" />
@@ -111,7 +122,7 @@ focusOutline('inset'): (theme: Theme | { theme: Theme }) => SerializedStyles;
 Visually communicates to the user that an element is disabled and prevents user interactions.
 
 ```ts
-disableVisually(): SerializedStyles;
+function disableVisually(): SerializedStyles;
 ```
 
 <Story id="features-style-mixins--disable-visually" />
@@ -121,17 +132,17 @@ disableVisually(): SerializedStyles;
 Visually hides an element while keeping it accessible to users who rely on a screen reader.
 
 ```ts
-hideVisually(): SerializedStyles;
+function hideVisually(): SerializedStyles;
 ```
 
 <Story id="features-style-mixins--hide-visually" />
 
 ## `hideScrollbar`
 
-Hides the browser scrollbar on a scrollable element, e.g. with overflow.
+Hides the browser scrollbar on a scrollable element, e.g. one with overflow.
 
 ```ts
-hideScrollbar(): SerializedStyles;
+function hideScrollbar(): SerializedStyles;
 ```
 
 <Story id="features-style-mixins--hide-scrollbar" />

--- a/packages/circuit-ui/styles/style-mixins.spec.tsx
+++ b/packages/circuit-ui/styles/style-mixins.spec.tsx
@@ -153,11 +153,20 @@ describe('Style helpers', () => {
 
   describe('shadow', () => {
     it('should match the snapshot', () => {
+      const { styles } = shadow({ theme: light });
+      expect(styles).toMatchInlineSnapshot(`
+        "
+            box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
+          "
+      `);
+    });
+
+    it('should match the snapshot with options', () => {
       const { styles } = shadow()({ theme: light });
       expect(styles).toMatchInlineSnapshot(`
         "
-          box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
-        "
+              box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
+            "
       `);
     });
   });

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -103,9 +103,10 @@ Spacing.argTypes = {
 
 const Box = styled.div`
   display: inline-block;
-  height: 96px;
-  width: 240px;
+  height: 5rem;
+  width: 15rem;
   max-width: 100%;
+  margin: 1rem;
   background-color: white;
 `;
 

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -24,6 +24,7 @@ import Button from '../components/Button';
 import docs from './style-mixins.docs.mdx';
 import {
   spacing,
+  shadow,
   focusOutline,
   disableVisually,
   clearfix,
@@ -100,6 +101,16 @@ Spacing.argTypes = {
   left: spaceOptions,
 };
 
+const Box = styled.div`
+  display: inline-block;
+  height: 96px;
+  width: 240px;
+  max-width: 100%;
+  background-color: white;
+`;
+
+export const Shadow = () => <Box css={shadow} />;
+
 const Parent = styled.div`
   width: 100%;
   padding: 0.5rem;
@@ -122,18 +133,10 @@ export const Clearfix = () => (
   </Parent>
 );
 
-const Focused = styled.div`
-  display: inline-block;
-  height: 48px;
-  width: 480px;
-  max-width: 100%;
-  background-color: white;
-`;
-
 export const FocusOutline = () => (
   <Stack>
-    <Focused css={focusOutline} />
-    <Focused css={focusOutline('inset')} />
+    <Box css={focusOutline} />
+    <Box css={focusOutline('inset')} />
   </Stack>
 );
 

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -122,14 +122,27 @@ export const spacing = (
 };
 
 /**
- * @private
+ * Adds a drop shadow to an element to visually elevate it above the
+ * surrounding content.
  */
-export const shadow = () => (_args: ThemeArgs): SerializedStyles => css`
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
-`;
+export function shadow(options?: never): (args: ThemeArgs) => SerializedStyles;
+export function shadow(args: ThemeArgs): SerializedStyles;
+export function shadow(
+  argsOrOptions?: ThemeArgs | never,
+): SerializedStyles | ((args: ThemeArgs) => SerializedStyles) {
+  if (!argsOrOptions) {
+    return (): SerializedStyles => css`
+      box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
+    `;
+  }
+
+  return css`
+    box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
+  `;
+}
 
 /**
- * @private
+ * @deprecated Use the `shadow` style mixin instead.
  */
 export const shadowSingle = (args: ThemeArgs): SerializedStyles => {
   const theme = getTheme(args);
@@ -140,7 +153,7 @@ export const shadowSingle = (args: ThemeArgs): SerializedStyles => {
 };
 
 /**
- * @private
+ * @deprecated Use the `shadow` style mixin instead.
  */
 export const shadowDouble = (args: ThemeArgs): SerializedStyles => {
   const theme = getTheme(args);
@@ -151,7 +164,7 @@ export const shadowDouble = (args: ThemeArgs): SerializedStyles => {
 };
 
 /**
- * @private
+ * @deprecated Use the `shadow` style mixin instead.
  */
 export const shadowTriple = (args: ThemeArgs): SerializedStyles => {
   const theme = getTheme(args);


### PR DESCRIPTION
## Purpose

The `shadowSingle`, `shadowDouble`, and `shadowTriple` style helpers were never supposed to be exported, are deprecated, and will be removed in Circuit UI v3. They are replaced by the `shadow` style mixin which will be available in v3. It's backward-compatible so I decided to backport it to v2 to make the migration easier.

## Approach and changes

- Export the `shadow` style mixin
- Add documentation for it 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
