### PR TITLE
Revert noMargin breaking change

### DIFF
--- a/.storybook/components/Swatch.js
+++ b/.storybook/components/Swatch.js
@@ -59,10 +59,10 @@ const Swatch = ({ colorName }) => (
     <ColorWrapper>
       <Color colorName={colorName} />
       <ColorName>
-        <Body variant="highlight" size="two">
+        <Body variant="highlight" size="two" noMargin>
           {colorName}
         </Body>
-        <ColorHex as="p" size="two">
+        <ColorHex as="p" size="two" noMargin>
           {light.colors[colorName]}
         </ColorHex>
       </ColorName>

--- a/packages/circuit-ui/CHANGELOG.md
+++ b/packages/circuit-ui/CHANGELOG.md
@@ -138,11 +138,6 @@
 
 * [#943](https://github.com/sumup-oss/circuit-ui/pull/943) [`0543719b`](https://github.com/sumup-oss/circuit-ui/commit/0543719bfceaf616829a223f9e4f306539fbcc15) Thanks [@mykolaharmash](https://github.com/mykolaharmash)! - `Selector` now has multiple `size` options. `SelectorGroup` is changed to horizontal layout and to be inline element by default with an option to stretch to full width.
 
-- [#995](https://github.com/sumup-oss/circuit-ui/pull/995) [`bd234296`](https://github.com/sumup-oss/circuit-ui/commit/bd23429679f2644ccfdc3fe3ebbad190e9948f09) Thanks [@robinmetral](https://github.com/robinmetral)! - Removed the deprecated `noMargin` prop from the components below. Use the `spacing` mixin to add spacing.
-
-  - **Typography**: `Body`, `Headline`, `SubHeadline`, `List`, `InlineMessage`
-  - **Forms**: `Input`, `Select`, `Selector`, `Toggle`, `Checkbox`
-
 * [#985](https://github.com/sumup-oss/circuit-ui/pull/985) [`61c15cf7`](https://github.com/sumup-oss/circuit-ui/commit/61c15cf7a5a23fb723a2d9a0b1434639bc8ae700) Thanks [@robinmetral](https://github.com/robinmetral)! - Removed the experimental static styles extraction feature.
 
 - [#995](https://github.com/sumup-oss/circuit-ui/pull/995) [`bd234296`](https://github.com/sumup-oss/circuit-ui/commit/bd23429679f2644ccfdc3fe3ebbad190e9948f09) Thanks [@robinmetral](https://github.com/robinmetral)! - Enforced the `Input` and `Select`'s built-in `label` prop. Do not use the `Label` component separately and pass the label as a prop instead.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -106,7 +106,7 @@ export const Anchor = forwardRef(
     const handleClick = useClickEvent(props.onClick, tracking, 'anchor');
 
     if (!props.href && !props.onClick) {
-      return <Body as="span" {...props} ref={ref} />;
+      return <Body as="span" {...props} ref={ref} noMargin />;
     }
 
     if (props.href) {
@@ -117,6 +117,7 @@ export const Anchor = forwardRef(
           as={Link}
           ref={ref}
           onClick={handleClick}
+          noMargin
         />
       );
     }
@@ -128,6 +129,7 @@ export const Anchor = forwardRef(
         css={anchorStyles}
         ref={ref}
         onClick={handleClick}
+        noMargin
       />
     );
   },

--- a/packages/circuit-ui/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
+++ b/packages/circuit-ui/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
@@ -3,8 +3,10 @@
 exports[`Anchor styles should render with custom styles 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 0;
   display: inline-block;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -66,8 +68,10 @@ exports[`Anchor styles should render with custom styles 1`] = `
 exports[`Anchor styles should render with default styles 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 0;
   display: inline-block;
   -webkit-text-decoration: underline;
   text-decoration: underline;

--- a/packages/circuit-ui/components/Body/Body.spec.tsx
+++ b/packages/circuit-ui/components/Body/Body.spec.tsx
@@ -41,6 +41,11 @@ describe('Body', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(<Body noMargin />);
+    expect(actual).toMatchSnapshot();
+  });
+
   /**
    * Accessibility tests.
    */

--- a/packages/circuit-ui/components/Body/Body.stories.tsx
+++ b/packages/circuit-ui/components/Body/Body.stories.tsx
@@ -29,13 +29,17 @@ export default {
   },
 };
 
-export const Base = (args: BodyProps) => <Body {...args}>{content}</Body>;
+export const Base = (args: BodyProps) => (
+  <Body {...args} noMargin>
+    {content}
+  </Body>
+);
 
 const sizes = ['one', 'two'] as const;
 
 export const Sizes = (args: BodyProps) =>
   sizes.map((s) => (
-    <Body key={s} {...args} size={s}>
+    <Body key={s} {...args} size={s} noMargin>
       This is a body {s}. {content}
     </Body>
   ));
@@ -44,7 +48,7 @@ const variants = ['highlight', 'quote', 'success', 'error', 'subtle'] as const;
 
 export const Variants = (args: BodyProps) =>
   variants.map((variant) => (
-    <Body key={variant} {...args} variant={variant}>
+    <Body key={variant} {...args} variant={variant} noMargin>
       This is a {variant} body
     </Body>
   ));

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -18,6 +18,7 @@ import { css } from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
+import { deprecate } from '../../util/logger';
 
 type Size = 'one' | 'two';
 type Variant = 'highlight' | 'quote' | 'success' | 'error' | 'subtle';
@@ -33,6 +34,11 @@ export interface BodyProps
    */
   variant?: Variant;
   /**
+   /**
+    * Remove the default margin below the text.
+    */
+  noMargin?: boolean;
+  /**
    * Render the text using any HTML element.
    */
   as?: string;
@@ -45,6 +51,7 @@ export interface BodyProps
 const baseStyles = ({ theme }: StyleProps) => css`
   label: body;
   font-weight: ${theme.fontWeight.regular};
+  margin-bottom: ${theme.spacings.mega};
 `;
 
 const sizeStyles = ({ theme, size = 'one' }: BodyProps & StyleProps) => {
@@ -99,9 +106,26 @@ const variantStyles = ({ theme, variant }: BodyProps & StyleProps) => {
   }
 };
 
+const marginStyles = ({ noMargin }: BodyProps & StyleProps) => {
+  if (!noMargin) {
+    deprecate(
+      'Body',
+      'The default outer spacing in the Body component is deprecated.',
+      'Use the `noMargin` prop to silence this warning.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+    );
+    return null;
+  }
+
+  return css`
+    label: text--no-margin;
+    margin-bottom: 0;
+  `;
+};
+
 const StyledBody = styled('p', {
   shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
-})<BodyProps>(baseStyles, sizeStyles, variantStyles);
+})<BodyProps>(baseStyles, sizeStyles, marginStyles, variantStyles);
 
 function getHTMLElement(variant?: Variant): string {
   if (variant === 'highlight') {

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -34,9 +34,8 @@ export interface BodyProps
    */
   variant?: Variant;
   /**
-   /**
-    * Remove the default margin below the text.
-    */
+   * Remove the default margin below the text.
+   */
   noMargin?: boolean;
   /**
    * Render the text using any HTML element.

--- a/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
+++ b/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Body should render with default styles 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
 }
@@ -14,9 +15,24 @@ exports[`Body should render with default styles 1`] = `
 </p>
 `;
 
+exports[`Body should render with no margin styles when passed the noMargin prop 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+<p
+  class="circuit-0"
+/>
+`;
+
 exports[`Body should render with size one 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
 }
@@ -31,6 +47,7 @@ exports[`Body should render with size one 1`] = `
 exports[`Body should render with size two 1`] = `
 .circuit-0 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
 }

--- a/packages/circuit-ui/components/Card/Card.stories.tsx
+++ b/packages/circuit-ui/components/Card/Card.stories.tsx
@@ -58,9 +58,15 @@ const contentStyles = (theme: Theme) => css`
   height: 118px;
 `;
 
-const Header = () => <Headline size="four">Card heading</Headline>;
+const Header = () => (
+  <Headline size="four" noMargin>
+    Card heading
+  </Headline>
+);
 
-const Content = () => <Body>This is some text showing in my card</Body>;
+const Content = () => (
+  <Body noMargin>This is some text showing in my card</Body>
+);
 
 export const Base = () => <Card css={cardStyles} />;
 

--- a/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.js.snap
+++ b/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.js.snap
@@ -199,6 +199,7 @@ exports[`Carousel styles should render with children as a function 1`] = `
 
 .circuit-37 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
   font-weight: 700;
@@ -777,6 +778,7 @@ exports[`Carousel styles should render with children as a node 1`] = `
 
 .circuit-37 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
   font-weight: 700;
@@ -1354,6 +1356,7 @@ exports[`Carousel styles should render with default paused styles 1`] = `
 
 .circuit-37 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
   font-weight: 700;
@@ -1906,6 +1909,7 @@ exports[`Carousel styles should render with default styles 1`] = `
 
 .circuit-37 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
   font-weight: 700;

--- a/packages/circuit-ui/components/Carousel/components/Status/__snapshots__/Status.spec.js.snap
+++ b/packages/circuit-ui/components/Carousel/components/Status/__snapshots__/Status.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`Status styles should render with default styles 1`] = `
 .circuit-1 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
   font-weight: 700;

--- a/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
@@ -55,6 +55,11 @@ describe('Checkbox', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render with noMargin styles when passed the noMargin prop', () => {
+    const actual = create(<Checkbox noMargin {...defaultProps} />);
+    expect(actual).toMatchSnapshot();
+  });
+
   it('should render with a tooltip when passed a validation hint', () => {
     const actual = create(
       <Checkbox validationHint="This field is required." {...defaultProps} />,

--- a/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
@@ -66,7 +66,7 @@ const CheckboxWithState = ({
     setChecked((prev) => !prev);
   };
   return (
-    <Checkbox {...props} checked={checked} onChange={handleChange}>
+    <Checkbox {...props} checked={checked} onChange={handleChange} noMargin>
       {children || (checked ? 'Checked' : 'Unchecked')}
     </Checkbox>
   );

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
 import { useClickEvent } from '../../hooks/useClickEvent';
+import { deprecate } from '../../util/logger';
 import Tooltip from '../Tooltip';
 
 export interface CheckboxProps extends HTMLProps<HTMLInputElement> {
@@ -37,6 +38,10 @@ export interface CheckboxProps extends HTMLProps<HTMLInputElement> {
    * Warning or error message, displayed in a tooltip.
    */
   validationHint?: string;
+  /**
+   * Removes the default bottom margin from the input.
+   */
+  noMargin?: boolean;
   /**
    * Additional data that is dispatched with the tracking event.
    */
@@ -122,12 +127,40 @@ const CheckboxLabel = styled('label')<LabelElProps>(
   labelInvalidStyles,
 );
 
-const wrapperBaseStyles = () => css`
+type WrapperElProps = Pick<CheckboxProps, 'noMargin'>;
+
+const wrapperBaseStyles = ({ theme }: StyleProps) => css`
   label: checkbox;
   position: relative;
+
+  &:last-of-type {
+    margin-bottom: ${theme.spacings.mega};
+  }
 `;
 
-const CheckboxWrapper = styled('div')(wrapperBaseStyles);
+const wrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
+  if (!noMargin) {
+    deprecate(
+      'Checkbox',
+      'The default outer spacing in the Checkbox component is deprecated.',
+      'Use the `noMargin` prop to silence this warning.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+    );
+
+    return null;
+  }
+  return css`
+    label: checkbox--no-margin;
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  `;
+};
+
+const CheckboxWrapper = styled('div')<WrapperElProps>(
+  wrapperBaseStyles,
+  wrapperNoMarginStyles,
+);
 
 type InputElProps = Omit<CheckboxProps, 'tracking'>;
 
@@ -208,6 +241,7 @@ export const Checkbox = forwardRef(
       className,
       style,
       invalid,
+      noMargin,
       tracking,
       ...props
     }: CheckboxProps,
@@ -217,7 +251,7 @@ export const Checkbox = forwardRef(
     const handleChange = useClickEvent(onChange, tracking, 'checkbox');
 
     return (
-      <CheckboxWrapper className={className} style={style}>
+      <CheckboxWrapper className={className} style={style} noMargin={noMargin}>
         <CheckboxInput
           {...props}
           id={id}

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -39,7 +39,7 @@ export interface CheckboxProps extends HTMLProps<HTMLInputElement> {
    */
   validationHint?: string;
   /**
-   * Removes the default bottom margin from the input.
+   * Removes the default bottom margin from the Checkbox.
    */
   noMargin?: boolean;
   /**

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -5,6 +5,10 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   position: relative;
 }
 
+.circuit-3:last-of-type {
+  margin-bottom: 16px;
+}
+
 .circuit-0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -147,14 +151,14 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 >
   <input
     class="circuit-0"
-    id="checkbox_5"
+    id="checkbox_6"
     name="name"
     type="checkbox"
     value=""
   />
   <label
     class="circuit-1"
-    for="checkbox_5"
+    for="checkbox_6"
   >
     <svg
       aria-hidden="true"
@@ -184,6 +188,10 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
 exports[`Checkbox should render with checked styles when passed the checked prop 1`] = `
 .circuit-2 {
   position: relative;
+}
+
+.circuit-2:last-of-type {
+  margin-bottom: 16px;
 }
 
 .circuit-0 {
@@ -322,6 +330,10 @@ exports[`Checkbox should render with default styles 1`] = `
   position: relative;
 }
 
+.circuit-2:last-of-type {
+  margin-bottom: 16px;
+}
+
 .circuit-0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -455,6 +467,10 @@ exports[`Checkbox should render with default styles 1`] = `
 exports[`Checkbox should render with disabled styles when passed the disabled prop 1`] = `
 .circuit-2 {
   position: relative;
+}
+
+.circuit-2:last-of-type {
+  margin-bottom: 16px;
 }
 
 .circuit-0 {
@@ -605,6 +621,10 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   position: relative;
 }
 
+.circuit-2:last-of-type {
+  margin-bottom: 16px;
+}
+
 .circuit-0 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
@@ -729,6 +749,149 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   <label
     class="circuit-1"
     for="checkbox_4"
+  >
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M2 8.79L6 13l8-9"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`Checkbox should render with noMargin styles when passed the noMargin prop 1`] = `
+.circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-0:hover + label::before {
+  border-color: #666;
+}
+
+.circuit-0:focus + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-0:checked:focus:not(:focus-visible) + label::before {
+  border-color: #3063E9;
+}
+
+.circuit-0:checked + label > svg {
+  -webkit-transform: translateY(-50%) scale(1,1);
+  -ms-transform: translateY(-50%) scale(1,1);
+  transform: translateY(-50%) scale(1,1);
+  opacity: 1;
+}
+
+.circuit-0:checked + label::before {
+  border-color: #3063E9;
+  background-color: #3063E9;
+}
+
+.circuit-1 {
+  color: #1A1A1A;
+  display: inline-block;
+  padding-left: 26px;
+  position: relative;
+  cursor: pointer;
+}
+
+.circuit-1::before {
+  height: 18px;
+  width: 18px;
+  box-sizing: border-box;
+  box-shadow: 0;
+  background-color: #FFF;
+  border: 1px solid #999;
+  border-radius: 3px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+}
+
+.circuit-1 svg {
+  height: 18px;
+  width: 18px;
+  padding: 2px;
+  box-sizing: border-box;
+  color: #FFF;
+  display: block;
+  line-height: 0;
+  opacity: 0;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%) scale(0,0);
+  -ms-transform: translateY(-50%) scale(0,0);
+  transform: translateY(-50%) scale(0,0);
+  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
+  -webkit-transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
+  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
+}
+
+.circuit-2 {
+  position: relative;
+}
+
+.circuit-2:last-of-type {
+  margin-bottom: 16px;
+}
+
+.circuit-2:last-of-type {
+  margin-bottom: 0;
+}
+
+<div
+  class="circuit-2"
+>
+  <input
+    class="circuit-0"
+    id="checkbox_5"
+    name="name"
+    type="checkbox"
+    value=""
+  />
+  <label
+    class="circuit-1"
+    for="checkbox_5"
   >
     <svg
       aria-hidden="true"

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.stories.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.stories.tsx
@@ -38,6 +38,7 @@ const baseArgs = {
   validationHint: 'Excluding VAT',
   currency: 'EUR',
   locale: 'de-DE',
+  noMargin: true,
 };
 
 export const Base = (args: CurrencyInputProps) => (

--- a/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -8,11 +8,6 @@ exports[`CurrencyInput should adjust input padding and suffix width to match cur
   margin-bottom: 16px;
 }
 
-label .circuit-4:not(label),
-label + .circuit-4:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-0 {
   display: inline-block;
   margin-bottom: 4px;
@@ -133,11 +128,6 @@ exports[`CurrencyInput should render with default styles 1`] = `
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-4:not(label),
-label + .circuit-4:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {

--- a/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -5,6 +5,12 @@ exports[`CurrencyInput should adjust input padding and suffix width to match cur
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -126,6 +132,12 @@ exports[`CurrencyInput should render with default styles 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {

--- a/packages/circuit-ui/components/Headline/Headline.spec.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.spec.tsx
@@ -37,6 +37,11 @@ describe('Headline', () => {
     expect(headline).toMatchSnapshot();
   });
 
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(<Headline noMargin />);
+    expect(actual).toMatchSnapshot();
+  });
+
   /**
    * Accessibility tests.
    */

--- a/packages/circuit-ui/components/Headline/Headline.stories.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.stories.tsx
@@ -25,14 +25,16 @@ export default {
 };
 
 export const Base = (args: HeadlineProps) => (
-  <Headline {...args}>This is a headline</Headline>
+  <Headline {...args} noMargin>
+    This is a headline
+  </Headline>
 );
 
 const sizes = ['one', 'two', 'three', 'four'] as const;
 
 export const Sizes = (args: HeadlineProps) =>
   sizes.map((s) => (
-    <Headline key={s} {...args} size={s}>
+    <Headline key={s} {...args} size={s} noMargin>
       This is a headline {s}
     </Headline>
   ));

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -18,6 +18,7 @@ import { css } from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
+import { deprecate } from '../../util/logger';
 
 type Size = 'one' | 'two' | 'three' | 'four';
 
@@ -27,6 +28,10 @@ export interface HeadlineProps
    * A Circuit UI headline size.
    */
   size?: Size;
+  /**
+   * Removes the default bottom margin from the headline.
+   */
+  noMargin?: boolean;
   /**
    * The HTML heading element to render. Headings should be nested sequentially
    * without skipping any levels. Learn more at
@@ -38,6 +43,7 @@ export interface HeadlineProps
 const baseStyles = ({ theme }: StyleProps) => css`
   label: headline;
   font-weight: ${theme.fontWeight.bold};
+  margin-bottom: ${theme.spacings.giga};
   color: ${theme.colors.black};
 `;
 
@@ -52,10 +58,26 @@ const sizeStyles = ({ theme, size = 'one' }: StyleProps & HeadlineProps) => {
     line-height: ${theme.typography.headline[size].lineHeight};
   `;
 };
+const noMarginStyles = ({ noMargin }: HeadlineProps) => {
+  if (!noMargin) {
+    deprecate(
+      'Headline',
+      'The default outer spacing in the Headline component is deprecated.',
+      'Use the `noMargin` prop to silence this warning.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+    );
+    return null;
+  }
+
+  return css`
+    label: headline--no-margin;
+    margin-bottom: 0;
+  `;
+};
 
 /**
  * A flexible headline component capable of rendering using any HTML headline tag.
  */
 export const Headline: FC<HeadlineProps> = styled('h2', {
   shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
-})<HeadlineProps>(baseStyles, sizeStyles);
+})<HeadlineProps>(baseStyles, sizeStyles, noMarginStyles);

--- a/packages/circuit-ui/components/Headline/__snapshots__/Headline.spec.tsx.snap
+++ b/packages/circuit-ui/components/Headline/__snapshots__/Headline.spec.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Headline should render as h1 element 1`] = `
 .circuit-0 {
   font-weight: 700;
+  margin-bottom: 24px;
   color: #000;
   font-size: 32px;
   line-height: 36px;
@@ -18,6 +19,7 @@ exports[`Headline should render as h1 element 1`] = `
 exports[`Headline should render as h2 element 1`] = `
 .circuit-0 {
   font-weight: 700;
+  margin-bottom: 24px;
   color: #000;
   font-size: 32px;
   line-height: 36px;
@@ -33,6 +35,7 @@ exports[`Headline should render as h2 element 1`] = `
 exports[`Headline should render as h3 element 1`] = `
 .circuit-0 {
   font-weight: 700;
+  margin-bottom: 24px;
   color: #000;
   font-size: 32px;
   line-height: 36px;
@@ -48,6 +51,7 @@ exports[`Headline should render as h3 element 1`] = `
 exports[`Headline should render as h4 element 1`] = `
 .circuit-0 {
   font-weight: 700;
+  margin-bottom: 24px;
   color: #000;
   font-size: 32px;
   line-height: 36px;
@@ -63,6 +67,7 @@ exports[`Headline should render as h4 element 1`] = `
 exports[`Headline should render as h5 element 1`] = `
 .circuit-0 {
   font-weight: 700;
+  margin-bottom: 24px;
   color: #000;
   font-size: 32px;
   line-height: 36px;
@@ -78,6 +83,7 @@ exports[`Headline should render as h5 element 1`] = `
 exports[`Headline should render as h6 element 1`] = `
 .circuit-0 {
   font-weight: 700;
+  margin-bottom: 24px;
   color: #000;
   font-size: 32px;
   line-height: 36px;
@@ -90,9 +96,25 @@ exports[`Headline should render as h6 element 1`] = `
 </h6>
 `;
 
+exports[`Headline should render with no margin styles when passed the noMargin prop 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  margin-bottom: 24px;
+  color: #000;
+  font-size: 32px;
+  line-height: 36px;
+  margin-bottom: 0;
+}
+
+<h2
+  class="circuit-0"
+/>
+`;
+
 exports[`Headline should render with size four 1`] = `
 .circuit-0 {
   font-weight: 700;
+  margin-bottom: 24px;
   color: #000;
   font-size: 18px;
   line-height: 24px;
@@ -108,6 +130,7 @@ exports[`Headline should render with size four 1`] = `
 exports[`Headline should render with size one 1`] = `
 .circuit-0 {
   font-weight: 700;
+  margin-bottom: 24px;
   color: #000;
   font-size: 32px;
   line-height: 36px;
@@ -123,6 +146,7 @@ exports[`Headline should render with size one 1`] = `
 exports[`Headline should render with size three 1`] = `
 .circuit-0 {
   font-weight: 700;
+  margin-bottom: 24px;
   color: #000;
   font-size: 20px;
   line-height: 24px;
@@ -138,6 +162,7 @@ exports[`Headline should render with size three 1`] = `
 exports[`Headline should render with size two 1`] = `
 .circuit-0 {
   font-weight: 700;
+  margin-bottom: 24px;
   color: #000;
   font-size: 24px;
   line-height: 28px;

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.spec.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.spec.tsx
@@ -41,6 +41,11 @@ describe('InlineMessage', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(<InlineMessage variant="danger" noMargin />);
+    expect(actual).toMatchSnapshot();
+  });
+
   /**
    * Accessibility tests.
    */

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.stories.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.stories.tsx
@@ -35,19 +35,20 @@ export const Base = (args: InlineMessageProps) => (
 
 Base.args = {
   variant: 'warning',
+  noMargin: true,
 };
 
 export const Variants = (args: InlineMessageProps) => (
   <Card spacing={args.size}>
-    <InlineMessage {...args} variant="success">
+    <InlineMessage {...args} variant="success" noMargin>
       Something has gone wonderfully right.
     </InlineMessage>
 
-    <InlineMessage {...args} variant="warning">
+    <InlineMessage {...args} variant="warning" noMargin>
       Something might go sideways.
     </InlineMessage>
 
-    <InlineMessage {...args} variant="danger">
+    <InlineMessage {...args} variant="danger" noMargin>
       Something has gone terribly wrong.
     </InlineMessage>
   </Card>
@@ -56,12 +57,12 @@ export const Variants = (args: InlineMessageProps) => (
 export const Sizes = (args: InlineMessageProps) => (
   <Stack>
     <Card spacing="mega">
-      <InlineMessage {...args} variant="success" size="mega">
+      <InlineMessage {...args} variant="success" size="mega" noMargin>
         Something has gone wonderfully right with a smaller card.
       </InlineMessage>
     </Card>
     <Card>
-      <InlineMessage {...args} variant="success" size="giga">
+      <InlineMessage {...args} variant="success" size="giga" noMargin>
         Something has gone wonderfully right with a larger card.
       </InlineMessage>
     </Card>

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
@@ -16,6 +16,7 @@
 import { css } from '@emotion/core';
 
 import styled, { StyleProps } from '../../styles/styled';
+import { deprecate } from '../../util/logger';
 
 type Variant = 'danger' | 'success' | 'warning';
 
@@ -28,11 +29,32 @@ export interface InlineMessageProps {
    * Should correspond to the size provided to the surrounding Card component.
    */
   size?: 'mega' | 'giga';
+  /**
+   * Removes the default bottom margin from the text.
+   */
+  noMargin?: boolean;
 }
 
 const baseStyles = css`
   label: inline-message;
 `;
+
+const marginStyles = ({ noMargin }: InlineMessageProps) => {
+  if (!noMargin) {
+    deprecate(
+      'InlineMessage',
+      'The default outer spacing in the InlineMessage component is deprecated.',
+      'Use the `noMargin` prop to silence this warning.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+    );
+    return null;
+  }
+
+  return css`
+    label: text--no-margin;
+    margin-bottom: 0;
+  `;
+};
 
 const createLeftBorderStyles = (variantName: Variant) => ({
   theme,
@@ -57,6 +79,7 @@ const createLeftBorderStyles = (variantName: Variant) => ({
       label: ${`inline-message--${variant}`};
       color: ${textColors[variant]};
       position: relative;
+      margin-bottom: ${theme.spacings.mega};
 
       &:before {
         display: inline-block;
@@ -86,4 +109,5 @@ export const InlineMessage = styled('p')<InlineMessageProps>(
   dangerStyles,
   successStyles,
   warningStyles,
+  marginStyles,
 );

--- a/packages/circuit-ui/components/InlineMessage/__snapshots__/InlineMessage.spec.tsx.snap
+++ b/packages/circuit-ui/components/InlineMessage/__snapshots__/InlineMessage.spec.tsx.snap
@@ -4,6 +4,7 @@ exports[`InlineMessage should render with danger styles 1`] = `
 .circuit-0 {
   color: #D23F47;
   position: relative;
+  margin-bottom: 16px;
 }
 
 .circuit-0:before {
@@ -28,6 +29,7 @@ exports[`InlineMessage should render with giga spacing 1`] = `
 .circuit-0 {
   color: #D23F47;
   position: relative;
+  margin-bottom: 16px;
 }
 
 .circuit-0:before {
@@ -48,10 +50,37 @@ exports[`InlineMessage should render with giga spacing 1`] = `
 />
 `;
 
+exports[`InlineMessage should render with no margin styles when passed the noMargin prop 1`] = `
+.circuit-0 {
+  color: #D23F47;
+  position: relative;
+  margin-bottom: 16px;
+  margin-bottom: 0;
+}
+
+.circuit-0:before {
+  display: inline-block;
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  content: '';
+  position: absolute;
+  left: -24px;
+  top: 0;
+  height: 100%;
+  background-color: #D23F47;
+  width: 3px;
+}
+
+<p
+  class="circuit-0"
+/>
+`;
+
 exports[`InlineMessage should render with success styles 1`] = `
 .circuit-0 {
   color: #000;
   position: relative;
+  margin-bottom: 16px;
 }
 
 .circuit-0:before {
@@ -76,6 +105,7 @@ exports[`InlineMessage should render with warning styles 1`] = `
 .circuit-0 {
   color: #000;
   position: relative;
+  margin-bottom: 16px;
 }
 
 .circuit-0:before {

--- a/packages/circuit-ui/components/Input/Input.spec.tsx
+++ b/packages/circuit-ui/components/Input/Input.spec.tsx
@@ -105,6 +105,11 @@ describe('Input', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(<Input noMargin />);
+    expect(actual).toMatchSnapshot();
+  });
+
   it('should render with custom styles', () => {
     const actual = create(
       <Input

--- a/packages/circuit-ui/components/Input/Input.stories.tsx
+++ b/packages/circuit-ui/components/Input/Input.stories.tsx
@@ -43,6 +43,7 @@ const baseArgs = {
   label: 'First name',
   placeholder: 'Jane',
   validationHint: 'Maximum 100 characters',
+  noMargin: true,
 };
 
 export const Base = (args: InputProps) => <Input {...args} css={inputStyles} />;
@@ -58,6 +59,7 @@ Valid.args = {
   placeholder: 'jane123',
   validationHint: 'Yay! That username is available.',
   showValid: true,
+  noMargin: true,
 };
 
 export const Invalid = (args: InputProps) => (

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -27,6 +27,7 @@ import { uniqueId } from '../../util/id';
 import Label from '../Label';
 import ValidationHint from '../ValidationHint';
 import { ReturnType } from '../../types/return-type';
+import { deprecate } from '../../util/logger';
 
 export interface InputProps extends Omit<HTMLProps<HTMLInputElement>, 'label'> {
   /**
@@ -81,6 +82,10 @@ export interface InputProps extends Omit<HTMLProps<HTMLInputElement>, 'label'> {
    */
   inline?: boolean;
   /**
+   * Removes the default bottom margin from the input.
+   */
+  noMargin?: boolean;
+  /**
    * Aligns text in the input
    */
   textAlign?: 'left' | 'right';
@@ -109,6 +114,42 @@ const containerStyles = () => css`
 `;
 
 const InputContainer = styled('div')(containerStyles);
+
+type LabelElProps = Pick<InputProps, 'noMargin'>;
+
+const labelCustomStyles = ({ theme }: StyleProps) => css`
+  label: input__label;
+
+  label &:not(label),
+  label + &:not(label) {
+    margin-top: ${theme.spacings.bit};
+  }
+`;
+
+const labelNoMarginStyles = ({
+  theme,
+  noMargin,
+}: StyleProps & LabelElProps) => {
+  if (!noMargin) {
+    deprecate(
+      'Input',
+      'The default outer spacing in the Input component is deprecated.',
+      'Use the `noMargin` prop to silence this warning.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+    );
+
+    return css`
+      label: input__label--margin;
+      margin-bottom: ${theme.spacings.mega};
+    `;
+  }
+  return null;
+};
+
+const InputLabel = styled(Label)<LabelElProps>(
+  labelCustomStyles,
+  labelNoMarginStyles,
+);
 
 type InputElProps = Omit<InputProps, 'label'> & {
   hasPrefix: boolean;
@@ -282,6 +323,7 @@ export const Input = forwardRef(
       invalid,
       hasWarning,
       showValid,
+      noMargin,
       inline,
       disabled,
       labelStyles,
@@ -303,7 +345,13 @@ export const Input = forwardRef(
     const hasSuffix = Boolean(suffix);
 
     return (
-      <Label htmlFor={id} inline={inline} disabled={disabled} css={labelStyles}>
+      <InputLabel
+        htmlFor={id}
+        inline={inline}
+        disabled={disabled}
+        noMargin={noMargin}
+        css={labelStyles}
+      >
         <LabelText hideLabel={hideLabel}>
           {label}
           {optionalLabel && !required ? (
@@ -336,7 +384,7 @@ export const Input = forwardRef(
           showValid={showValid}
           validationHint={validationHint}
         />
-      </Label>
+      </InputLabel>
     );
   },
 );

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -117,15 +117,6 @@ const InputContainer = styled('div')(containerStyles);
 
 type LabelElProps = Pick<InputProps, 'noMargin'>;
 
-const labelCustomStyles = ({ theme }: StyleProps) => css`
-  label: input__label;
-
-  label &:not(label),
-  label + &:not(label) {
-    margin-top: ${theme.spacings.bit};
-  }
-`;
-
 const labelNoMarginStyles = ({
   theme,
   noMargin,
@@ -146,10 +137,7 @@ const labelNoMarginStyles = ({
   return null;
 };
 
-const InputLabel = styled(Label)<LabelElProps>(
-  labelCustomStyles,
-  labelNoMarginStyles,
-);
+const InputLabel = styled(Label)<LabelElProps>(labelNoMarginStyles);
 
 type InputElProps = Omit<InputProps, 'label'> & {
   hasPrefix: boolean;

--- a/packages/circuit-ui/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/packages/circuit-ui/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -20,11 +20,6 @@ exports[`Input should prioritize disabled over error styles 1`] = `
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-1 {
   font-size: 16px;
   line-height: 24px;
@@ -110,11 +105,6 @@ exports[`Input should prioritize disabled over warning styles 1`] = `
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-1 {
   font-size: 16px;
   line-height: 24px;
@@ -185,11 +175,6 @@ exports[`Input should render with a Tooltip when passed the validationHint prop 
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-4:not(label),
-label + .circuit-4:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -304,11 +289,6 @@ exports[`Input should render with a prefix when passed the prefix prop 1`] = `
   margin-bottom: 16px;
 }
 
-label .circuit-4:not(label),
-label + .circuit-4:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-0 {
   display: inline-block;
   margin-bottom: 4px;
@@ -411,11 +391,6 @@ exports[`Input should render with a suffix when passed the suffix prop 1`] = `
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-4:not(label),
-label + .circuit-4:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -536,11 +511,6 @@ exports[`Input should render with custom styles 1`] = `
   border: 1px solid red;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-1 {
   font-size: 16px;
   line-height: 24px;
@@ -621,11 +591,6 @@ exports[`Input should render with default styles 1`] = `
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -728,11 +693,6 @@ exports[`Input should render with disabled styles when passed the disabled prop 
   pointer-events: none;
   box-shadow: none;
   margin-bottom: 16px;
-}
-
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-1 {
@@ -870,11 +830,6 @@ exports[`Input should render with inline styles when passed the inline prop 1`] 
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 <label
   class="circuit-3"
   for="input_13"
@@ -902,11 +857,6 @@ exports[`Input should render with invalid styles when passed the invalid prop 1`
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -1080,11 +1030,6 @@ exports[`Input should render with no margin styles when passed the noMargin prop
   display: block;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 <label
   class="circuit-3"
   for="input_14"
@@ -1110,11 +1055,6 @@ exports[`Input should render with readonly styles when passed the readOnly prop 
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -1209,11 +1149,6 @@ exports[`Input should render with right aligned text 1`] = `
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-0 {
   display: inline-block;
   margin-bottom: 4px;
@@ -1305,11 +1240,6 @@ exports[`Input should render with valid styles when passed the showValid prop 1`
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-0 {
   display: inline-block;
   margin-bottom: 4px;
@@ -1398,11 +1328,6 @@ exports[`Input should render with warning styles when passed the hasWarning prop
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {

--- a/packages/circuit-ui/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/packages/circuit-ui/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -17,6 +17,12 @@ exports[`Input should prioritize disabled over error styles 1`] = `
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-1 {
@@ -101,6 +107,12 @@ exports[`Input should prioritize disabled over warning styles 1`] = `
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-1 {
@@ -172,6 +184,12 @@ exports[`Input should render with a Tooltip when passed the validationHint prop 
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -283,6 +301,12 @@ exports[`Input should render with a prefix when passed the prefix prop 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -386,6 +410,12 @@ exports[`Input should render with a suffix when passed the suffix prop 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -502,7 +532,13 @@ exports[`Input should render with custom styles 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
   border: 1px solid red;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-1 {
@@ -560,7 +596,7 @@ exports[`Input should render with custom styles 1`] = `
 
 <label
   class="circuit-3"
-  for="input_14"
+  for="input_15"
 >
   <span
     class="circuit-0"
@@ -572,7 +608,7 @@ exports[`Input should render with custom styles 1`] = `
   >
     <input
       class="circuit-1"
-      id="input_14"
+      id="input_15"
       value=""
     />
   </div>
@@ -584,6 +620,12 @@ exports[`Input should render with default styles 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -685,6 +727,12 @@ exports[`Input should render with disabled styles when passed the disabled prop 
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-1 {
@@ -819,6 +867,12 @@ exports[`Input should render with inline styles when passed the inline prop 1`] 
   display: block;
   display: inline-block;
   margin-right: 16px;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 <label
@@ -847,6 +901,12 @@ exports[`Input should render with invalid styles when passed the invalid prop 1`
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -952,11 +1012,109 @@ exports[`Input should render with invalid styles when passed the invalid prop 1`
 </label>
 `;
 
+exports[`Input should render with no margin styles when passed the noMargin prop 1`] = `
+.circuit-0 {
+  display: inline-block;
+  margin-bottom: 4px;
+}
+
+.circuit-2 {
+  position: relative;
+}
+
+.circuit-1 {
+  font-size: 16px;
+  line-height: 24px;
+  -webkit-appearance: none;
+  background-color: #FFF;
+  border: none;
+  outline: 0;
+  border-radius: 8px;
+  padding: 12px 16px;
+  -webkit-transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
+  width: 100%;
+  margin: 0;
+  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-1::-webkit-input-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-1::-moz-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-1:-ms-input-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-1::placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-1:hover {
+  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-1:focus {
+  box-shadow: 0 0 0 2px #3063E9;
+}
+
+.circuit-1:active {
+  box-shadow: 0 0 0 1px #3063E9;
+}
+
+.circuit-3 {
+  font-size: 14px;
+  line-height: 20px;
+  display: block;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
+}
+
+<label
+  class="circuit-3"
+  for="input_14"
+>
+  <span
+    class="circuit-0"
+  />
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-1"
+      id="input_14"
+      value=""
+    />
+  </div>
+</label>
+`;
+
 exports[`Input should render with readonly styles when passed the readOnly prop 1`] = `
 .circuit-3 {
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -1048,6 +1206,12 @@ exports[`Input should render with right aligned text 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -1138,6 +1302,12 @@ exports[`Input should render with valid styles when passed the showValid prop 1`
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -1227,6 +1397,12 @@ exports[`Input should render with warning styles when passed the hasWarning prop
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {

--- a/packages/circuit-ui/components/List/List.spec.tsx
+++ b/packages/circuit-ui/components/List/List.spec.tsx
@@ -62,6 +62,15 @@ describe('List', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(
+      <List noMargin>
+        <li>no margin</li>
+      </List>,
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
   /**
    * Accessibility tests.
    */

--- a/packages/circuit-ui/components/List/List.stories.tsx
+++ b/packages/circuit-ui/components/List/List.stories.tsx
@@ -15,6 +15,8 @@
 
 import { Fragment } from 'react';
 
+import { spacing } from '../../styles/style-mixins';
+
 import docs from './List.docs.mdx';
 import { List, ListProps } from './List';
 
@@ -43,7 +45,13 @@ const variants: ListProps['variant'][] = ['unordered', 'ordered'];
 
 export const Variants = (args: ListProps) =>
   variants.map((variant) => (
-    <List key={variant} {...args} variant={variant} noMargin>
+    <List
+      key={variant}
+      {...args}
+      variant={variant}
+      noMargin
+      css={spacing({ bottom: 'giga' })}
+    >
       <ListItems />
     </List>
   ));
@@ -52,7 +60,13 @@ const sizes: ListProps['size'][] = ['one', 'two'];
 
 export const Sizes = (args: ListProps) =>
   sizes.map((size) => (
-    <List key={size} {...args} size={size} noMargin>
+    <List
+      key={size}
+      {...args}
+      size={size}
+      noMargin
+      css={spacing({ bottom: 'giga' })}
+    >
       <ListItems />
     </List>
   ));

--- a/packages/circuit-ui/components/List/List.stories.tsx
+++ b/packages/circuit-ui/components/List/List.stories.tsx
@@ -34,7 +34,7 @@ const ListItems = () => (
 );
 
 export const Base = (args: ListProps) => (
-  <List {...args}>
+  <List {...args} noMargin>
     <ListItems />
   </List>
 );
@@ -43,7 +43,7 @@ const variants: ListProps['variant'][] = ['unordered', 'ordered'];
 
 export const Variants = (args: ListProps) =>
   variants.map((variant) => (
-    <List key={variant} {...args} variant={variant}>
+    <List key={variant} {...args} variant={variant} noMargin>
       <ListItems />
     </List>
   ));
@@ -52,13 +52,13 @@ const sizes: ListProps['size'][] = ['one', 'two'];
 
 export const Sizes = (args: ListProps) =>
   sizes.map((size) => (
-    <List key={size} {...args} size={size}>
+    <List key={size} {...args} size={size} noMargin>
       <ListItems />
     </List>
   ));
 
 export const Nested = (args: ListProps) => (
-  <List {...args}>
+  <List {...args} noMargin>
     <ListItems />
     <List {...args}>
       <li>Sometimes a nested list</li>

--- a/packages/circuit-ui/components/List/List.stories.tsx
+++ b/packages/circuit-ui/components/List/List.stories.tsx
@@ -74,8 +74,9 @@ export const Sizes = (args: ListProps) =>
 export const Nested = (args: ListProps) => (
   <List {...args} noMargin>
     <ListItems />
-    <List {...args}>
+    <List {...args} noMargin>
       <li>Sometimes a nested list</li>
     </List>
+    <li>And the list goes on</li>
   </List>
 );

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -96,6 +96,9 @@ const marginStyles = ({ noMargin }: ListProps) => {
   return css`
     label: list--no-margin;
     margin-bottom: 0;
+    li:last-child {
+      margin-bottom: 0;
+    }
   `;
 };
 

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -31,7 +31,7 @@ export interface ListProps
    */
   size?: Size;
   /**
-   * Whether the list should be presented as an <ol>
+   * Whether the list should be presented as an <ol> or <ul>. Defaults to <ul>.
    */
   variant?: Variant;
   /**

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -80,6 +80,9 @@ const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
     ol {
       margin-bottom: ${marginBottom};
       margin-left: ${marginLeft};
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
   `;
 };

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -78,6 +78,7 @@ const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
 
     ul,
     ol {
+      margin-bottom: ${marginBottom};
       margin-left: ${marginLeft};
     }
   `;

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -19,6 +19,7 @@ import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { typography } from '../../styles/style-mixins';
+import { deprecate } from '../../util/logger';
 
 type Size = 'one' | 'two';
 type Variant = 'ordered' | 'unordered';
@@ -30,11 +31,15 @@ export interface ListProps
    */
   size?: Size;
   /**
-   * Whether the list should be presented as an <ol> or <ul>. Defaults to <ul>.
+   * Whether the list should be presented as an <ol>
    */
   variant?: Variant;
   /**
-   The ref to the HTML DOM element.
+   * Removes the default bottom margin from the list.
+   */
+  noMargin?: boolean;
+  /**
+   The ref to the HTML DOM element
    */
   ref?: Ref<HTMLOListElement & HTMLUListElement>;
 }
@@ -48,23 +53,26 @@ const baseStyles = ({ theme }: StyleProps) => css`
 const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
   const sizeMap = {
     one: {
+      marginBottom: theme.spacings.byte,
       paddingLeft: theme.spacings.kilo,
       marginLeft: theme.spacings.kilo,
       type: typography('one')(theme),
     },
     two: {
+      marginBottom: theme.spacings.kilo,
       paddingLeft: theme.spacings.kilo,
       marginLeft: theme.spacings.bit,
       type: typography('two')(theme),
     },
   };
-  const { paddingLeft, marginLeft, type } = sizeMap[size];
+  const { marginBottom, paddingLeft, marginLeft, type } = sizeMap[size];
   return css`
     label: ${`list--${size}`};
     padding-left: ${paddingLeft};
     ${type};
 
     li {
+      margin-bottom: ${marginBottom};
       margin-left: ${marginLeft};
     }
 
@@ -75,9 +83,25 @@ const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
   `;
 };
 
+const marginStyles = ({ noMargin }: ListProps) => {
+  if (!noMargin) {
+    deprecate(
+      'List',
+      'The default outer spacing in the List component is deprecated.',
+      'Use the `noMargin` prop to silence this warning.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+    );
+    return null;
+  }
+  return css`
+    label: list--no-margin;
+    margin-bottom: 0;
+  `;
+};
+
 const BaseList = styled('ol', {
   shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
-})<ListProps>(baseStyles, sizeStyles);
+})<ListProps>(baseStyles, sizeStyles, marginStyles);
 
 /**
  * A list, which can be ordered or unordered.

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -80,9 +80,6 @@ const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
     ol {
       margin-bottom: ${marginBottom};
       margin-left: ${marginLeft};
-      &:last-child {
-        margin-bottom: 0;
-      }
     }
   `;
 };
@@ -101,6 +98,10 @@ const marginStyles = ({ noMargin }: ListProps) => {
     label: list--no-margin;
     margin-bottom: 0;
     li:last-child {
+      margin-bottom: 0;
+    }
+    ul:last-child,
+    ol:last-child {
       margin-bottom: 0;
     }
   `;

--- a/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
+++ b/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
@@ -139,6 +139,10 @@ exports[`List should render with no margin styles when passed the noMargin prop 
   margin-left: 12px;
 }
 
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
 <ul
   class="circuit-0"
 >

--- a/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
+++ b/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`List should render a nested list 1`] = `
 }
 
 .circuit-0 li {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
@@ -44,6 +45,7 @@ exports[`List should render the ordered variant 1`] = `
 }
 
 .circuit-0 li {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
@@ -71,6 +73,7 @@ exports[`List should render the unordered variant 1`] = `
 }
 
 .circuit-0 li {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
@@ -98,6 +101,7 @@ exports[`List should render with default styles 1`] = `
 }
 
 .circuit-0 li {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
@@ -115,6 +119,35 @@ exports[`List should render with default styles 1`] = `
 </ul>
 `;
 
+exports[`List should render with no margin styles when passed the noMargin prop 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  padding-left: 12px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-0 li {
+  margin-bottom: 8px;
+  margin-left: 12px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-left: 12px;
+}
+
+<ul
+  class="circuit-0"
+>
+  <li>
+    no margin
+  </li>
+</ul>
+`;
+
 exports[`List should render with size one 1`] = `
 .circuit-0 {
   font-weight: 400;
@@ -125,6 +158,7 @@ exports[`List should render with size one 1`] = `
 }
 
 .circuit-0 li {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
@@ -152,6 +186,7 @@ exports[`List should render with size two 1`] = `
 }
 
 .circuit-0 li {
+  margin-bottom: 12px;
   margin-left: 4px;
 }
 

--- a/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
+++ b/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
@@ -16,6 +16,7 @@ exports[`List should render a nested list 1`] = `
 
 .circuit-0 ul,
 .circuit-0 ol {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
@@ -51,6 +52,7 @@ exports[`List should render the ordered variant 1`] = `
 
 .circuit-0 ul,
 .circuit-0 ol {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
@@ -79,6 +81,7 @@ exports[`List should render the unordered variant 1`] = `
 
 .circuit-0 ul,
 .circuit-0 ol {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
@@ -107,6 +110,7 @@ exports[`List should render with default styles 1`] = `
 
 .circuit-0 ul,
 .circuit-0 ol {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
@@ -136,10 +140,16 @@ exports[`List should render with no margin styles when passed the noMargin prop 
 
 .circuit-0 ul,
 .circuit-0 ol {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
 .circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
+.circuit-0 ul:last-child,
+.circuit-0 ol:last-child {
   margin-bottom: 0;
 }
 
@@ -168,6 +178,7 @@ exports[`List should render with size one 1`] = `
 
 .circuit-0 ul,
 .circuit-0 ol {
+  margin-bottom: 8px;
   margin-left: 12px;
 }
 
@@ -196,6 +207,7 @@ exports[`List should render with size two 1`] = `
 
 .circuit-0 ul,
 .circuit-0 ol {
+  margin-bottom: 12px;
   margin-left: 4px;
 }
 

--- a/packages/circuit-ui/components/Notification/Notification.stories.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.stories.tsx
@@ -23,6 +23,7 @@ import Body from '../Body';
 import Button from '../Button';
 import NotificationList from '../NotificationList';
 import NotificationCard from '../NotificationCard';
+import { spacing, cx } from '../../styles/style-mixins';
 
 import docs from './Notification.docs.mdx';
 import { Notification, NotificationProps } from './Notification';
@@ -53,7 +54,7 @@ export const Base = (args: NotificationProps) => (
     <Headline as="h4" size="four" noMargin>
       New Feature — Intelligent Reporting
     </Headline>
-    <Body>
+    <Body noMargin css={spacing({ bottom: 'mega' })}>
       Get automatic insights into your business statistics with one click.
     </Body>
     <Button size="kilo" onClick={action('Action clicked')}>
@@ -79,7 +80,7 @@ export const Variants = () => (
       <Headline size="four" as="h4" noMargin>
         You need to verify your account
       </Headline>
-      <Body>
+      <Body noMargin css={spacing({ bottom: 'mega' })}>
         We need to verify your identity before you can continue transacting.
       </Body>
       <Button size="kilo" onClick={action('Button clicked')}>
@@ -87,7 +88,11 @@ export const Variants = () => (
       </Button>
     </Notification>
     <Notification variant="error" css={notificationStyles}>
-      <Headline size="four" as="h4" css={headingStyles}>
+      <Headline
+        size="four"
+        as="h4"
+        css={cx(headingStyles, spacing({ bottom: 'mega' }))}
+      >
         We failed to process your transaction
       </Headline>
       <Button size="kilo" onClick={action('Button clicked')}>

--- a/packages/circuit-ui/components/Notification/Notification.stories.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.stories.tsx
@@ -50,7 +50,7 @@ const headingStyles = (theme: Theme) =>
 
 export const Base = (args: NotificationProps) => (
   <Notification {...args}>
-    <Headline as="h4" size="four">
+    <Headline as="h4" size="four" noMargin>
       New Feature — Intelligent Reporting
     </Headline>
     <Body>
@@ -71,12 +71,12 @@ Base.args = {
 export const Variants = () => (
   <Fragment>
     <Notification variant="success" css={notificationStyles}>
-      <Headline size="four" as="h4">
+      <Headline size="four" as="h4" noMargin>
         Transaction successfully refunded
       </Headline>
     </Notification>
     <Notification variant="warning" css={notificationStyles}>
-      <Headline size="four" as="h4">
+      <Headline size="four" as="h4" noMargin>
         You need to verify your account
       </Headline>
       <Body>

--- a/packages/circuit-ui/components/NotificationCard/NotificationCard.stories.tsx
+++ b/packages/circuit-ui/components/NotificationCard/NotificationCard.stories.tsx
@@ -30,7 +30,7 @@ export default {
 export const Base = (args: NotificationCardProps) => (
   <NotificationCard {...args}>
     <Notification variant="success">
-      <Headline as="h4" size="four">
+      <Headline as="h4" size="four" noMargin>
         New Feature — Intelligent Reporting
       </Headline>
       <Body>

--- a/packages/circuit-ui/components/NotificationCard/NotificationCard.stories.tsx
+++ b/packages/circuit-ui/components/NotificationCard/NotificationCard.stories.tsx
@@ -19,6 +19,7 @@ import Notification from '../Notification';
 import Headline from '../Headline';
 import Body from '../Body';
 import Button from '../Button';
+import { spacing } from '../../styles/style-mixins';
 
 import { NotificationCard, NotificationCardProps } from './NotificationCard';
 
@@ -33,7 +34,7 @@ export const Base = (args: NotificationCardProps) => (
       <Headline as="h4" size="four" noMargin>
         New Feature — Intelligent Reporting
       </Headline>
-      <Body>
+      <Body noMargin css={spacing({ bottom: 'mega' })}>
         Get automatic insights into your business statistics with one click.
       </Body>
       <Button size="kilo" onClick={action('Action clicked')}>

--- a/packages/circuit-ui/components/NotificationList/NotificationList.stories.tsx
+++ b/packages/circuit-ui/components/NotificationList/NotificationList.stories.tsx
@@ -30,7 +30,7 @@ export default {
 export const Base = (args: NotificationListProps) => (
   <NotificationList {...args}>
     <Notification variant="success">
-      <Headline as="h4" size="four">
+      <Headline as="h4" size="four" noMargin>
         New Feature — Intelligent Reporting
       </Headline>
       <Body>
@@ -45,7 +45,7 @@ export const Base = (args: NotificationListProps) => (
       onClose={action('Notification dismissed')}
       closeLabel="Close"
     >
-      <Headline as="h4" size="four">
+      <Headline as="h4" size="four" noMargin>
         We failed to process your transaction
       </Headline>
     </Notification>

--- a/packages/circuit-ui/components/NotificationList/NotificationList.stories.tsx
+++ b/packages/circuit-ui/components/NotificationList/NotificationList.stories.tsx
@@ -19,6 +19,7 @@ import Headline from '../Headline';
 import Body from '../Body';
 import Button from '../Button';
 import Notification from '../Notification';
+import { spacing } from '../../styles/style-mixins';
 
 import { NotificationList, NotificationListProps } from './NotificationList';
 
@@ -33,7 +34,7 @@ export const Base = (args: NotificationListProps) => (
       <Headline as="h4" size="four" noMargin>
         New Feature — Intelligent Reporting
       </Headline>
-      <Body>
+      <Body noMargin css={spacing({ bottom: 'mega' })}>
         Get automatic insights into your business statistics with one click.
       </Body>
       <Button size="kilo" onClick={action('Action clicked')}>

--- a/packages/circuit-ui/components/Pagination/components/PageSelect/PageSelect.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageSelect/PageSelect.tsx
@@ -57,6 +57,7 @@ export const PageSelect: FunctionComponent<PageSelectProps> = ({
         options={pageOptions}
         onChange={handleChange}
         hideLabel
+        noMargin
       />
       {totalLabel && <TotalPages>{totalLabel(totalPages)}</TotalPages>}
     </Fragment>

--- a/packages/circuit-ui/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
@@ -26,6 +26,12 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+  margin-bottom: 16px;
+}
+
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-2 {
@@ -115,6 +121,12 @@ exports[`SearchInput should render with default styles 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {

--- a/packages/circuit-ui/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
@@ -29,11 +29,6 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
   margin-bottom: 16px;
 }
 
-label .circuit-4:not(label),
-label + .circuit-4:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-2 {
   font-size: 16px;
   line-height: 24px;
@@ -122,11 +117,6 @@ exports[`SearchInput should render with default styles 1`] = `
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-4:not(label),
-label + .circuit-4:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {

--- a/packages/circuit-ui/components/Select/Select.spec.tsx
+++ b/packages/circuit-ui/components/Select/Select.spec.tsx
@@ -65,6 +65,11 @@ describe('Select', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(<Select {...{ options }} noMargin />);
+    expect(actual).toMatchSnapshot();
+  });
+
   it('should render with a tooltip when passed a validation hint', () => {
     const actual = create(
       <Select

--- a/packages/circuit-ui/components/Select/Select.stories.tsx
+++ b/packages/circuit-ui/components/Select/Select.stories.tsx
@@ -44,6 +44,7 @@ const baseArgs = {
       value: 'FR',
     },
   ],
+  noMargin: true,
 };
 
 const flagIconMap: { [key: string]: FC<{ className?: string }> } = {

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -30,6 +30,7 @@ import { ReturnType } from '../../types/return-type';
 import { useClickEvent } from '../../hooks/useClickEvent';
 import Label from '../Label';
 import ValidationHint from '../ValidationHint';
+import { deprecate } from '../../util/logger';
 
 export type SelectOption = {
   value: string | number;
@@ -79,6 +80,10 @@ export interface SelectProps
    * Trigger inline styles on the component.
    */
   inline?: boolean;
+  /**
+   * Removes the default bottom margin from the select.
+   */
+  noMargin?: boolean;
   /**
    * Render prop that should render a left-aligned overlay icon or element.
    * Receives a className prop.
@@ -140,7 +145,23 @@ const SelectContainer = styled('div')<ContainerElProps>(
   containerHideLabelStyles,
 );
 
-type LabelElProps = Pick<SelectProps, 'inline'>;
+type LabelElProps = Pick<SelectProps, 'noMargin' | 'inline'>;
+
+const labelMarginStyles = ({ theme, noMargin }: StyleProps & LabelElProps) => {
+  if (!noMargin) {
+    deprecate(
+      'Select',
+      'The default outer spacing in the Select component is deprecated.',
+      'Use the `noMargin` prop to silence this warning.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+    );
+    return css`
+      label: input__label--margin;
+      margin-bottom: ${theme.spacings.mega};
+    `;
+  }
+  return null;
+};
 
 const labelInlineStyles = ({ inline }: LabelElProps) =>
   inline &&
@@ -149,7 +170,10 @@ const labelInlineStyles = ({ inline }: LabelElProps) =>
     display: inline-block;
   `;
 
-const SelectLabel = styled(Label)<LabelElProps>(labelInlineStyles);
+const SelectLabel = styled(Label)<LabelElProps>(
+  labelMarginStyles,
+  labelInlineStyles,
+);
 
 type SelectElProps = Omit<SelectProps, 'options' | 'label'> & {
   hasPrefix: boolean;
@@ -290,6 +314,7 @@ export const Select = forwardRef(
       defaultValue,
       placeholder = 'Select an option',
       disabled,
+      noMargin,
       inline,
       invalid,
       required,
@@ -325,6 +350,7 @@ export const Select = forwardRef(
         htmlFor={id}
         inline={inline}
         disabled={disabled}
+        noMargin={noMargin}
       >
         <LabelText hideLabel={hideLabel}>
           {label}

--- a/packages/circuit-ui/components/Select/__snapshots__/Select.spec.tsx.snap
+++ b/packages/circuit-ui/components/Select/__snapshots__/Select.spec.tsx.snap
@@ -53,6 +53,7 @@ select:not(:active) ~ .circuit-3 {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -174,6 +175,7 @@ exports[`Select should render with a prefix when passed the prefix prop 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
 }
 
 .circuit-5 {
@@ -284,7 +286,7 @@ select:not(:active) ~ .circuit-4 {
 
 <label
   class="circuit-6"
-  for="select_8"
+  for="select_9"
 >
   <span
     class="circuit-0"
@@ -300,7 +302,7 @@ select:not(:active) ~ .circuit-4 {
     />
     <select
       class="circuit-2"
-      id="select_8"
+      id="select_9"
     >
       <option
         value=""
@@ -364,6 +366,7 @@ exports[`Select should render with a tooltip when passed a validation hint 1`] =
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
 }
 
 .circuit-4 {
@@ -480,7 +483,7 @@ select:not(:active) ~ .circuit-3 {
 
 <label
   class="circuit-6"
-  for="select_7"
+  for="select_8"
 >
   <span
     class="circuit-0"
@@ -492,7 +495,7 @@ select:not(:active) ~ .circuit-3 {
   >
     <select
       class="circuit-1"
-      id="select_7"
+      id="select_8"
     >
       <option
         value=""
@@ -561,6 +564,7 @@ exports[`Select should render with a visually-hidden label 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -744,6 +748,7 @@ exports[`Select should render with default styles 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
 }
 
 .circuit-4 {
@@ -967,6 +972,7 @@ select:not(:active) ~ .circuit-3 {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -1184,6 +1190,7 @@ select:not(:active) ~ .circuit-3 {
   display: block;
   display: inline-block;
   margin-right: 16px;
+  margin-bottom: 16px;
   display: inline-block;
 }
 
@@ -1265,6 +1272,7 @@ exports[`Select should render with invalid styles when passed the invalid prop 1
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
 }
 
 .circuit-4 {
@@ -1379,6 +1387,179 @@ select:not(:active) ~ .circuit-3 {
       aria-invalid="true"
       class="circuit-1"
       id="select_4"
+    >
+      <option
+        value=""
+      >
+        Select an option
+      </option>
+      <option
+        value="1"
+      >
+        Option 1
+      </option>
+      <option
+        value="2"
+      >
+        Option 2
+      </option>
+      <option
+        value="3"
+      >
+        Option 3
+      </option>
+    </select>
+    <svg
+      class="circuit-2"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4 6l4 4 4-4"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+    <svg
+      class="circuit-3"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4 10l4-4 4 4"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+  </div>
+</label>
+`;
+
+exports[`Select should render with no margin styles when passed the noMargin prop 1`] = `
+.circuit-4 {
+  color: #1A1A1A;
+  display: block;
+  position: relative;
+}
+
+label .circuit-4,
+label + .circuit-4 {
+  margin-top: 4px;
+}
+
+.circuit-1 {
+  font-size: 16px;
+  line-height: 24px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  cursor: pointer;
+  background-color: #FFF;
+  outline: none;
+  border: 0;
+  border-radius: 8px;
+  box-shadow: none;
+  color: #1A1A1A;
+  margin: 0;
+  padding-top: 12px;
+  padding-right: 48px;
+  padding-bottom: 12px;
+  padding-left: 16px;
+  position: relative;
+  width: 100%;
+  z-index: 20;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  -webkit-transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
+  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-1:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 #000;
+}
+
+.circuit-1::-ms-expand {
+  display: none;
+}
+
+.circuit-1:hover {
+  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-1:focus {
+  box-shadow: 0 0 0 2px #3063E9;
+}
+
+.circuit-1:active {
+  box-shadow: 0 0 0 1px #3063E9;
+}
+
+.circuit-2 {
+  color: #666;
+  display: block;
+  z-index: 21;
+  pointer-events: none;
+  position: absolute;
+  height: 48px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  padding: 16px;
+}
+
+select:active ~ .circuit-2 {
+  display: none;
+}
+
+.circuit-3 {
+  color: #666;
+  display: block;
+  z-index: 21;
+  pointer-events: none;
+  position: absolute;
+  height: 48px;
+  width: 48px;
+  top: 0;
+  right: 0;
+  padding: 16px;
+}
+
+select:not(:active) ~ .circuit-3 {
+  display: none;
+}
+
+.circuit-5 {
+  font-size: 14px;
+  line-height: 20px;
+  display: block;
+}
+
+<label
+  class="circuit-5"
+  for="select_7"
+>
+  <span
+    class="circuit-0"
+  />
+  <div
+    class="circuit-4"
+  >
+    <select
+      class="circuit-1"
+      id="select_7"
     >
       <option
         value=""

--- a/packages/circuit-ui/components/Selector/Selector.spec.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.spec.tsx
@@ -57,6 +57,15 @@ describe('Selector', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render a noMargin selector', () => {
+    const actual = create(
+      <Selector {...defaultProps} noMargin>
+        Label
+      </Selector>,
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
   it('should render a radio input by default', () => {
     const { getByLabelText } = render(
       <Selector {...defaultProps}>Label</Selector>,

--- a/packages/circuit-ui/components/Selector/Selector.stories.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.stories.tsx
@@ -31,6 +31,7 @@ export default {
 
 const baseArgs = {
   value: 'default',
+  noMargin: true,
 };
 
 export const Base = (args: SelectorProps) => (
@@ -71,8 +72,10 @@ export const Sizes = (args: SelectorProps) => (
       Mega
     </Selector>
     <Selector {...args} size="flexible">
-      <Body variant="highlight">Flexible</Body>
-      <Body>Hello World!</Body>
+      <Body variant="highlight" noMargin>
+        Flexible
+      </Body>
+      <Body noMargin>Hello World!</Body>
     </Selector>
   </Stack>
 );

--- a/packages/circuit-ui/components/Selector/Selector.stories.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.stories.tsx
@@ -80,4 +80,4 @@ export const Sizes = (args: SelectorProps) => (
   </Stack>
 );
 
-Disabled.args = { ...baseArgs, disabled: true };
+Sizes.args = { ...baseArgs, name: 'sizes' };

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
 import { useClickEvent } from '../../hooks/useClickEvent';
+import { deprecate } from '../../util/logger';
 
 export type SelectorSize = 'kilo' | 'mega' | 'flexible';
 
@@ -59,6 +60,10 @@ export interface SelectorProps
    */
   multiple?: boolean;
   /**
+   * Removes the default bottom margin from the input.
+   */
+  noMargin?: boolean;
+  /**
    * The ref to the html dom element
    */
   ref?: Ref<HTMLInputElement>;
@@ -68,7 +73,7 @@ export interface SelectorProps
   tracking?: TrackingProps;
 }
 
-type LabelElProps = Pick<SelectorProps, 'disabled' | 'size'>;
+type LabelElProps = Pick<SelectorProps, 'disabled' | 'size' | 'noMargin'>;
 
 const baseStyles = ({ theme }: StyleProps) => css`
   display: inline-block;
@@ -115,6 +120,22 @@ const baseStyles = ({ theme }: StyleProps) => css`
 const disabledStyles = ({ disabled }: LabelElProps) =>
   disabled && css(disableVisually());
 
+const noMarginStyles = ({ noMargin }: LabelElProps) => {
+  if (!noMargin) {
+    deprecate(
+      'Selector',
+      'The default outer spacing in the Selector component is deprecated.',
+      'Use the `noMargin` prop to silence this warning.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+    );
+    return null;
+  }
+  return css`
+    label: selector__label--no-margin;
+    margin-bottom: 0;
+  `;
+};
+
 const sizeStyles = ({ theme, size = 'mega' }: LabelElProps & StyleProps) => {
   const sizeMap = {
     kilo: {
@@ -135,6 +156,7 @@ const SelectorLabel = styled('label')<LabelElProps>(
   baseStyles,
   sizeStyles,
   disabledStyles,
+  noMarginStyles,
 );
 
 const inputStyles = ({ theme }: StyleProps) => css`
@@ -176,6 +198,7 @@ export const Selector = forwardRef(
       tracking,
       className,
       style,
+      noMargin,
       size,
       ...props
     }: SelectorProps,
@@ -211,6 +234,7 @@ export const Selector = forwardRef(
           size={size}
           className={className}
           style={style}
+          noMargin={noMargin}
         >
           {children}
         </SelectorLabel>

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -60,7 +60,7 @@ export interface SelectorProps
    */
   multiple?: boolean;
   /**
-   * Removes the default bottom margin from the input.
+   * Removes the default bottom margin from the Selector.
    */
   noMargin?: boolean;
   /**
@@ -84,6 +84,7 @@ const baseStyles = ({ theme }: StyleProps) => css`
   border: none;
   border-radius: ${theme.borderRadius.byte};
   transition: box-shadow ${theme.transitions.default};
+  margin-bottom: ${theme.spacings.mega};
 
   &::before {
     display: block;

--- a/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -296,3 +296,101 @@ HTMLCollection [
   </label>,
 ]
 `;
+
+exports[`Selector should render a noMargin selector 1`] = `
+HTMLCollection [
+  .circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-0:focus + label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus + label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) + label::before {
+  box-shadow: none;
+}
+
+.circuit-0:checked + label {
+  background-color: #F0F6FF;
+}
+
+.circuit-0:checked + label::before {
+  border: 2px solid #3063E9;
+}
+
+<input
+    class="circuit-0"
+    id="selector_4"
+    name="name"
+    type="radio"
+    value="value"
+  />,
+  .circuit-0 {
+  display: inline-block;
+  cursor: pointer;
+  background-color: #FFF;
+  text-align: center;
+  position: relative;
+  border: none;
+  border-radius: 8px;
+  -webkit-transition: box-shadow 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out;
+  padding: calc(12px) 24px;
+  margin-bottom: 0;
+}
+
+.circuit-0::before {
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  border: 1px solid #CCC;
+  -webkit-transition: border 120ms ease-in-out;
+  transition: border 120ms ease-in-out;
+}
+
+.circuit-0:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-0:hover::before {
+  border-color: #999;
+}
+
+.circuit-0:active {
+  background-color: #E6E6E6;
+}
+
+.circuit-0:active::before {
+  border-color: #666;
+}
+
+<label
+    class="circuit-0"
+    for="selector_4"
+  >
+    Label
+  </label>,
+]
+`;

--- a/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -54,6 +54,7 @@ HTMLCollection [
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
+  margin-bottom: 16px;
   padding: calc(12px) 24px;
 }
 
@@ -151,6 +152,7 @@ HTMLCollection [
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
+  margin-bottom: 16px;
   padding: calc(12px) 24px;
 }
 
@@ -249,6 +251,7 @@ HTMLCollection [
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
+  margin-bottom: 16px;
   padding: calc(12px) 24px;
   opacity: 0.5;
   pointer-events: none;
@@ -350,6 +353,7 @@ HTMLCollection [
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
+  margin-bottom: 16px;
   padding: calc(12px) 24px;
   margin-bottom: 0;
 }

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
@@ -26,9 +26,9 @@ const baseArgs = {
   name: 'selector-group',
   label: 'Choose your favourite fruit',
   options: [
-    { children: 'Apple', value: 'apple' },
-    { children: 'Banana', value: 'banana' },
-    { children: 'Mango', value: 'mango' },
+    { children: 'Apple', value: 'apple', noMargin: true },
+    { children: 'Banana', value: 'banana', noMargin: true },
+    { children: 'Mango', value: 'mango', noMargin: true },
   ],
 };
 

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -145,6 +145,7 @@ export const SelectorGroup = forwardRef(
                 multiple={multiple}
                 value={value}
                 size={size}
+                noMargin
                 checked={
                   multiple
                     ? includes(value, activeValue)

--- a/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -76,6 +76,7 @@ exports[`SelectorGroup should render with default styles 1`] = `
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
+  margin-bottom: 16px;
   padding: calc(12px) 24px;
   margin-bottom: 0;
   width: 100%;
@@ -248,6 +249,7 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
+  margin-bottom: 16px;
   padding: calc(12px) 24px;
   margin-bottom: 0;
   width: 100%;

--- a/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -77,6 +77,7 @@ exports[`SelectorGroup should render with default styles 1`] = `
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
   padding: calc(12px) 24px;
+  margin-bottom: 0;
   width: 100%;
 }
 
@@ -248,6 +249,7 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
   padding: calc(12px) 24px;
+  margin-bottom: 0;
   width: 100%;
 }
 

--- a/packages/circuit-ui/components/Step/examples/MultiStepForm.js
+++ b/packages/circuit-ui/components/Step/examples/MultiStepForm.js
@@ -34,11 +34,13 @@ const FormOne = ({ onNextClick }) => (
       label="First Name"
       placeholder="John"
       css={spacing({ bottom: 'mega' })}
+      noMargin
     />
     <Input
       label="Second Name"
       placeholder="Doe"
       css={spacing({ bottom: 'mega' })}
+      noMargin
     />
     <Button variant="primary" onClick={() => onNextClick()}>
       Next
@@ -55,8 +57,9 @@ const FormTwo = ({ onNextClick, onBackClick }) => (
       label="Street"
       placeholder="Madison Ave 5"
       css={spacing({ bottom: 'mega' })}
+      noMargin
     />
-    <Select label="State" css={spacing({ bottom: 'mega' })}>
+    <Select label="State" css={spacing({ bottom: 'mega' })} noMargin>
       <option>CA</option>
       <option>TX</option>
       <option>NY</option>
@@ -65,6 +68,7 @@ const FormTwo = ({ onNextClick, onBackClick }) => (
       label="Postal Code"
       placeholder="10179"
       css={spacing({ bottom: 'mega' })}
+      noMargin
     />
     <ButtonGroup align="left">
       <Button variant="primary" onClick={() => onNextClick()}>
@@ -81,7 +85,7 @@ FormTwo.propTypes = {
 
 const Thanks = () => (
   <section>
-    <Headline>Thanks!</Headline>
+    <Headline noMargin>Thanks!</Headline>
   </section>
 );
 
@@ -104,7 +108,7 @@ const MultiStepForm = () => {
 
         return (
           <Container>
-            <Headline size="three" css={spacing({ bottom: 'giga' })}>
+            <Headline size="three" noMargin css={spacing({ bottom: 'giga' })}>
               Step {stepNumber} of {totalSteps}
             </Headline>
             <ProgressBar

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.spec.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.spec.tsx
@@ -21,7 +21,7 @@ describe('SubHeadline', () => {
   /**
    * Style tests.
    */
-  const elements = ['h2', 'h3', 'h4', 'h5', 'h6'];
+  const elements = ['h2', 'h3', 'h4', 'h5', 'h6'] as const;
   it.each(elements)(`should render as %s element`, (element) => {
     const subheading = create(
       <SubHeadline as={element}>{`${element} subheading`}</SubHeadline>,
@@ -29,8 +29,8 @@ describe('SubHeadline', () => {
     expect(subheading).toMatchSnapshot();
   });
 
-  it('should render with no margin styles when passed the prop', () => {
-    const actual = create(<SubHeadline as="h3" />);
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(<SubHeadline as="h3" noMargin />);
     expect(actual).toMatchSnapshot();
   });
 

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.stories.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.stories.tsx
@@ -25,5 +25,7 @@ export default {
 };
 
 export const Base = (args: SubHeadlineProps) => (
-  <SubHeadline {...args}>This is a subheadline</SubHeadline>
+  <SubHeadline {...args} noMargin>
+    This is a subheadline
+  </SubHeadline>
 );

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -18,9 +18,14 @@ import { css } from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
+import { deprecate } from '../../util/logger';
 
 export interface SubHeadlineProps
   extends Omit<HTMLProps<HTMLHeadingElement>, 'size'> {
+  /**
+   * Removes the default bottom margin from the subheading.
+   */
+  noMargin?: boolean;
   /**
    * The HTML heading element to render. Headings should be nested sequentially
    * without skipping any levels. Learn more at
@@ -35,13 +40,30 @@ const baseStyles = ({ theme }: StyleProps) => css`
   font-weight: ${theme.fontWeight.bold};
   font-size: ${theme.typography.subHeadline.fontSize};
   line-height: ${theme.typography.subHeadline.lineHeight};
+  margin-bottom: ${theme.spacings.kilo};
   color: ${theme.colors.black};
 `;
 
+const noMarginStyles = ({ noMargin }: SubHeadlineProps) => {
+  if (!noMargin) {
+    deprecate(
+      'SubHeadline',
+      'The default outer spacing in the SubHeadline component is deprecated.',
+      'Use the `noMargin` prop to silence this warning.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+    );
+    return null;
+  }
+  return css`
+    label: sub-heading--no-margin;
+    margin-bottom: 0;
+  `;
+};
+
 /**
- * A flexible subheading component capable of rendering using any HTML heading
- * tag, except h1.
+ * A flexible SubHeadline component capable of rendering using any HTML heading
+ * element, except h1.
  */
 export const SubHeadline: FC<SubHeadlineProps> = styled('h3', {
   shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
-})<SubHeadlineProps>(baseStyles);
+})<SubHeadlineProps>(baseStyles, noMarginStyles);

--- a/packages/circuit-ui/components/SubHeadline/__snapshots__/SubHeadline.spec.tsx.snap
+++ b/packages/circuit-ui/components/SubHeadline/__snapshots__/SubHeadline.spec.tsx.snap
@@ -6,6 +6,7 @@ exports[`SubHeadline should render as h2 element 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 12px;
   color: #000;
 }
 
@@ -22,6 +23,7 @@ exports[`SubHeadline should render as h3 element 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 12px;
   color: #000;
 }
 
@@ -38,6 +40,7 @@ exports[`SubHeadline should render as h4 element 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 12px;
   color: #000;
 }
 
@@ -54,6 +57,7 @@ exports[`SubHeadline should render as h5 element 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 12px;
   color: #000;
 }
 
@@ -70,6 +74,7 @@ exports[`SubHeadline should render as h6 element 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 12px;
   color: #000;
 }
 
@@ -80,13 +85,15 @@ exports[`SubHeadline should render as h6 element 1`] = `
 </h6>
 `;
 
-exports[`SubHeadline should render with no margin styles when passed the prop 1`] = `
+exports[`SubHeadline should render with no margin styles when passed the noMargin prop 1`] = `
 .circuit-0 {
   text-transform: uppercase;
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 12px;
   color: #000;
+  margin-bottom: 0;
 }
 
 <h3

--- a/packages/circuit-ui/components/TextArea/TextArea.spec.tsx
+++ b/packages/circuit-ui/components/TextArea/TextArea.spec.tsx
@@ -95,6 +95,11 @@ describe('TextArea', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(<TextArea noMargin />);
+    expect(actual).toMatchSnapshot();
+  });
+
   describe('business logic', () => {
     /**
      * Should accept a working ref

--- a/packages/circuit-ui/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
+++ b/packages/circuit-ui/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
@@ -20,11 +20,6 @@ exports[`TextArea should prioritize disabled over error styles 1`] = `
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-1 {
   font-size: 16px;
   line-height: 24px;
@@ -109,11 +104,6 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-1 {
   font-size: 16px;
   line-height: 24px;
@@ -183,11 +173,6 @@ exports[`TextArea should render with a Tooltip when passed the validationHint pr
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-4:not(label),
-label + .circuit-4:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -301,11 +286,6 @@ exports[`TextArea should render with a prefix when passed the prefix prop 1`] = 
   margin-bottom: 16px;
 }
 
-label .circuit-4:not(label),
-label + .circuit-4:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-0 {
   display: inline-block;
   margin-bottom: 4px;
@@ -407,11 +387,6 @@ exports[`TextArea should render with a suffix when passed the suffix prop 1`] = 
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-4:not(label),
-label + .circuit-4:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -521,11 +496,6 @@ exports[`TextArea should render with default styles 1`] = `
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-0 {
   display: inline-block;
   margin-bottom: 4px;
@@ -625,11 +595,6 @@ exports[`TextArea should render with disabled styled when passed the disabled pr
   pointer-events: none;
   box-shadow: none;
   margin-bottom: 16px;
-}
-
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-1 {
@@ -768,11 +733,6 @@ exports[`TextArea should render with inline styles when passed the inline prop 1
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 <label
   class="circuit-3"
   for="input_12"
@@ -797,11 +757,6 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -976,11 +931,6 @@ exports[`TextArea should render with no margin styles when passed the noMargin p
   display: block;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 <label
   class="circuit-3"
   for="input_13"
@@ -1005,11 +955,6 @@ exports[`TextArea should render with readonly styles when passed the readonly pr
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -1103,11 +1048,6 @@ exports[`TextArea should render with valid styles when passed the showValid prop
   margin-bottom: 16px;
 }
 
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
-}
-
 .circuit-0 {
   display: inline-block;
   margin-bottom: 4px;
@@ -1195,11 +1135,6 @@ exports[`TextArea should render with warning styles when passed the hasWarning p
   line-height: 20px;
   display: block;
   margin-bottom: 16px;
-}
-
-label .circuit-3:not(label),
-label + .circuit-3:not(label) {
-  margin-top: 4px;
 }
 
 .circuit-0 {

--- a/packages/circuit-ui/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
+++ b/packages/circuit-ui/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
@@ -17,6 +17,12 @@ exports[`TextArea should prioritize disabled over error styles 1`] = `
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-1 {
@@ -100,6 +106,12 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-1 {
@@ -170,6 +182,12 @@ exports[`TextArea should render with a Tooltip when passed the validationHint pr
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -280,6 +298,12 @@ exports[`TextArea should render with a prefix when passed the prefix prop 1`] = 
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -382,6 +406,12 @@ exports[`TextArea should render with a suffix when passed the suffix prop 1`] = 
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-4:not(label),
+label + .circuit-4:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -488,6 +518,12 @@ exports[`TextArea should render with default styles 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -588,6 +624,12 @@ exports[`TextArea should render with disabled styled when passed the disabled pr
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-1 {
@@ -723,6 +765,12 @@ exports[`TextArea should render with inline styles when passed the inline prop 1
   display: block;
   display: inline-block;
   margin-right: 16px;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 <label
@@ -748,6 +796,12 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -852,11 +906,110 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
 </label>
 `;
 
+exports[`TextArea should render with no margin styles when passed the noMargin prop 1`] = `
+.circuit-0 {
+  display: inline-block;
+  margin-bottom: 4px;
+}
+
+.circuit-2 {
+  position: relative;
+}
+
+.circuit-1 {
+  font-size: 16px;
+  line-height: 24px;
+  -webkit-appearance: none;
+  background-color: #FFF;
+  border: none;
+  outline: 0;
+  border-radius: 8px;
+  padding: 12px 16px;
+  -webkit-transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
+  width: 100%;
+  margin: 0;
+  box-shadow: 0 0 0 1px #999;
+  overflow: auto;
+  resize: vertical;
+}
+
+.circuit-1::-webkit-input-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-1::-moz-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-1:-ms-input-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-1::placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-1:hover {
+  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-1:focus {
+  box-shadow: 0 0 0 2px #3063E9;
+}
+
+.circuit-1:active {
+  box-shadow: 0 0 0 1px #3063E9;
+}
+
+.circuit-3 {
+  font-size: 14px;
+  line-height: 20px;
+  display: block;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
+}
+
+<label
+  class="circuit-3"
+  for="input_13"
+>
+  <span
+    class="circuit-0"
+  />
+  <div
+    class="circuit-2"
+  >
+    <textarea
+      class="circuit-1"
+      id="input_13"
+    />
+  </div>
+</label>
+`;
+
 exports[`TextArea should render with readonly styles when passed the readonly prop 1`] = `
 .circuit-3 {
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -947,6 +1100,12 @@ exports[`TextArea should render with valid styles when passed the showValid prop
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {
@@ -1035,6 +1194,12 @@ exports[`TextArea should render with warning styles when passed the hasWarning p
   font-size: 14px;
   line-height: 20px;
   display: block;
+  margin-bottom: 16px;
+}
+
+label .circuit-3:not(label),
+label + .circuit-3:not(label) {
+  margin-top: 4px;
 }
 
 .circuit-0 {

--- a/packages/circuit-ui/components/Toggle/Toggle.spec.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.spec.tsx
@@ -35,6 +35,11 @@ describe('Toggle', () => {
     expect(actual).toMatchSnapshot();
   });
 
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(<Toggle {...defaultProps} noMargin />);
+    expect(actual).toMatchSnapshot();
+  });
+
   describe('business logic', () => {
     /**
      * Should accept a working ref

--- a/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
@@ -30,6 +30,7 @@ const baseArgs = {
   label: 'Short label',
   checkedLabel: 'on',
   uncheckedLabel: 'off',
+  noMargin: true,
 };
 
 export const Base = (args: ToggleProps) => {

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -19,6 +19,7 @@ import { css } from '@emotion/core';
 import styled, { NoTheme, StyleProps } from '../../styles/styled';
 import { disableVisually } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
+import { deprecate } from '../../util/logger';
 import { Body, BodyProps } from '../Body/Body';
 
 import { Switch, SwitchProps } from './components/Switch/Switch';
@@ -32,6 +33,10 @@ export interface ToggleProps extends SwitchProps {
    * Further explanation of the toggle. Can change depending on the state.
    */
   explanation?: string;
+  /**
+   * Removes the default bottom margin from the input.
+   */
+  noMargin?: boolean;
   /**
    * The ref to the html button dom element
    */
@@ -59,12 +64,13 @@ const explanationStyles = ({ theme }: StyleProps) => css`
 
 const ToggleExplanation = styled(Body)<BodyProps>(explanationStyles);
 
-type WrapperElProps = Pick<ToggleProps, 'disabled'>;
+type WrapperElProps = Pick<ToggleProps, 'noMargin' | 'disabled'>;
 
 const toggleWrapperStyles = ({ theme }: StyleProps) => css`
   label: toggle;
   display: flex;
   align-items: flex-start;
+  margin-bottom: ${theme.spacings.mega};
 
   ${theme.mq.untilKilo} {
     flex-direction: row-reverse;
@@ -79,26 +85,52 @@ const toggleWrapperDisabledStyles = ({ disabled }: WrapperElProps) =>
     ${disableVisually()};
   `;
 
+const toggleWrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
+  if (!noMargin) {
+    deprecate(
+      'Toggle',
+      'The default outer spacing in the Toggle component is deprecated.',
+      'Use the `noMargin` prop to silence this warning.',
+      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+    );
+    return null;
+  }
+  return css`
+    label: toggle--no-margin;
+    margin-bottom: 0;
+  `;
+};
+
 const ToggleWrapper = styled('div')<WrapperElProps>(
   toggleWrapperStyles,
   toggleWrapperDisabledStyles,
+  toggleWrapperNoMarginStyles,
 );
 
 /**
  * A toggle component with support for labels and additional explanations.
  */
 export const Toggle = forwardRef(
-  ({ label, explanation, ...props }: ToggleProps, ref: ToggleProps['ref']) => {
+  (
+    { label, explanation, noMargin, ...props }: ToggleProps,
+    ref: ToggleProps['ref'],
+  ) => {
     const switchId = uniqueId('toggle-switch_');
     const labelId = uniqueId('toggle-label_');
     return (
-      <ToggleWrapper disabled={props.disabled}>
+      <ToggleWrapper noMargin={noMargin} disabled={props.disabled}>
         <Switch {...props} aria-labelledby={labelId} id={switchId} ref={ref} />
         {(label || explanation) && (
           <ToggleTextWrapper id={labelId} htmlFor={switchId}>
-            {label && <Body size="one">{label}</Body>}
+            {label && (
+              <Body size="one" noMargin>
+                {label}
+              </Body>
+            )}
             {explanation && (
-              <ToggleExplanation size="two">{explanation}</ToggleExplanation>
+              <ToggleExplanation size="two" noMargin>
+                {explanation}
+              </ToggleExplanation>
             )}
           </ToggleTextWrapper>
         )}

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -34,7 +34,7 @@ export interface ToggleProps extends SwitchProps {
    */
   explanation?: string;
   /**
-   * Removes the default bottom margin from the input.
+   * Removes the default bottom margin from the Toggle.
    */
   noMargin?: boolean;
   /**

--- a/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`Toggle should render with default styles 1`] = `
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
+  margin-bottom: 16px;
 }
 
 @media (max-width:479px) {
@@ -104,14 +105,18 @@ exports[`Toggle should render with default styles 1`] = `
 
 .circuit-3 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 0;
 }
 
 .circuit-4 {
   font-weight: 400;
+  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 0;
   color: #666;
 }
 
@@ -139,6 +144,166 @@ exports[`Toggle should render with default styles 1`] = `
     class="circuit-5"
     for="toggle-switch_1"
     id="toggle-label_2"
+  >
+    <p
+      class="circuit-3"
+    >
+      Label
+    </p>
+    <p
+      class="circuit-4"
+    >
+      A longer explanation
+    </p>
+  </label>
+</div>
+`;
+
+exports[`Toggle should render with no margin styles when passed the noMargin prop 1`] = `
+.circuit-2 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-flex: 0 0 40px;
+  -ms-flex: 0 0 40px;
+  flex: 0 0 40px;
+  background-color: #CCC;
+  border-radius: 24px;
+  position: relative;
+  -webkit-transition: background-color 200ms ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  height: 24px;
+  width: 40px;
+  overflow: visible;
+  cursor: pointer;
+}
+
+.circuit-2:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-2:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-2:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-0 {
+  display: block;
+  background-color: #FFF;
+  box-shadow: 0 2px 0 0 #999;
+  position: absolute;
+  top: 50%;
+  -webkit-transform: translate3d(4px,-50%,0);
+  -ms-transform: translate3d(4px,-50%,0);
+  transform: translate3d(4px,-50%,0);
+  -webkit-transition: box-shadow 200ms ease-in-out,-webkit-transform 200ms ease-in-out;
+  -webkit-transition: box-shadow 200ms ease-in-out,transform 200ms ease-in-out;
+  transition: box-shadow 200ms ease-in-out,transform 200ms ease-in-out;
+  height: 16px;
+  width: 16px;
+  border-radius: 16px;
+}
+
+.circuit-1 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-5 {
+  display: block;
+  margin-left: 12px;
+  cursor: pointer;
+}
+
+@media (max-width:479px) {
+  .circuit-5 {
+    margin-left: 0;
+    margin-right: 12px;
+  }
+}
+
+.circuit-3 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-4 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 0;
+  color: #666;
+}
+
+.circuit-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  margin-bottom: 16px;
+  margin-bottom: 0;
+}
+
+@media (max-width:479px) {
+  .circuit-6 {
+    -webkit-flex-direction: row-reverse;
+    -ms-flex-direction: row-reverse;
+    flex-direction: row-reverse;
+    -webkit-box-pack: justify;
+    -webkit-justify-content: space-between;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
+  }
+}
+
+<div
+  class="circuit-6"
+>
+  <button
+    aria-checked="false"
+    aria-labelledby="toggle-label_4"
+    class="circuit-2"
+    id="toggle-switch_3"
+    role="switch"
+    type="button"
+  >
+    <span
+      class="circuit-0"
+    />
+    <span
+      class="circuit-1"
+    >
+      off
+    </span>
+  </button>
+  <label
+    class="circuit-5"
+    for="toggle-switch_3"
+    id="toggle-label_4"
   >
     <p
       class="circuit-3"


### PR DESCRIPTION
## Purpose

We decided to remove the noMargin prop in the next major version to keep the scope of V3 smaller.

## Approach and changes

- revert the commit that removed the noMargin
  - addressed merge conflicts (new logger util and more) so this. is unfortunately not a clean revert, please review as any normal PR
- remove relevant changelog entry
 
## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
