### PR TITLE
Document and export the inputOutline style mixin

### DIFF
--- a/.changeset/cold-beds-sort.md
+++ b/.changeset/cold-beds-sort.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Visually communicates to the user that an element is hovered, focused, or active; including for the disabled, invalid and warning states.

--- a/.changeset/cold-beds-sort.md
+++ b/.changeset/cold-beds-sort.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Visually communicates to the user that an element is hovered, focused, or active; including for the disabled, invalid and warning states.
+Added the `inputOutline` style mixin. It can be used to communicates to the user that an element is hovered, focused, or active; including for the disabled, invalid and warning states.

--- a/.changeset/cold-beds-sort.md
+++ b/.changeset/cold-beds-sort.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Added the `inputOutline` style mixin. It can be used to communicates to the user that an element is hovered, focused, or active; including for the disabled, invalid and warning states.
+Added the `inputOutline` style mixin. It can be used to communicate to the user that an element is hovered, focused, or active in the disabled, invalid, and warning states.

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -173,6 +173,7 @@ export {
   clearfix,
   hideScrollbar,
   shadow,
+  inputOutline,
 } from './styles/style-mixins';
 
 export { sharedPropTypes, styleHelpers };

--- a/packages/circuit-ui/styles/style-mixins.docs.mdx
+++ b/packages/circuit-ui/styles/style-mixins.docs.mdx
@@ -119,7 +119,7 @@ function focusOutline('inset'): (theme: Theme | { theme: Theme }) => SerializedS
 
 ## `inputOutline`
 
-Visually communicates to the user that an element is hovered, focused, or active; including for the disabled, invalid and warning states.
+Visually communicates to the user that an element is hovered, focused, or active in the disabled, invalid, and warning states.
 
 ```ts
 function inputOutline(

--- a/packages/circuit-ui/styles/style-mixins.docs.mdx
+++ b/packages/circuit-ui/styles/style-mixins.docs.mdx
@@ -119,7 +119,7 @@ function focusOutline('inset'): (theme: Theme | { theme: Theme }) => SerializedS
 
 ## `inputOutline`
 
-Visually communicates to the user that an element hovered, focused, or active; and optionally adds disabled, invalid or warning styles.
+Visually communicates to the user that an element is hovered, focused, or active; including for the disabled, invalid and warning states.
 
 ```ts
 function inputOutline(

--- a/packages/circuit-ui/styles/style-mixins.docs.mdx
+++ b/packages/circuit-ui/styles/style-mixins.docs.mdx
@@ -117,6 +117,25 @@ function focusOutline('inset'): (theme: Theme | { theme: Theme }) => SerializedS
 
 <Story id="features-style-mixins--focus-outline" />
 
+## `inputOutline`
+
+Visually communicates to the user that an element hovered, focused, or active; and optionally adds disabled, invalid or warning styles.
+
+```ts
+function inputOutline(
+  theme:
+    | Theme
+    | {
+        theme: Theme;
+        disabled?: boolean;
+        invalid?: boolean;
+        hasWarning?: boolean;
+      },
+): SerializedStyles;
+```
+
+<Story id="features-style-mixins--input-outline" />
+
 ## `disableVisually`
 
 Visually communicates to the user that an element is disabled and prevents user interactions.

--- a/packages/circuit-ui/styles/style-mixins.spec.tsx
+++ b/packages/circuit-ui/styles/style-mixins.spec.tsx
@@ -469,6 +469,18 @@ describe('Style helpers', () => {
       `);
     });
 
+    it('should match the snapshot when disabled', () => {
+      const { styles } = inputOutline({
+        theme: light,
+        disabled: true,
+      });
+      expect(styles).toMatchInlineSnapshot(`
+        "
+              box-shadow: 0 0 0 1px #999;
+            "
+      `);
+    });
+
     it('should match the snapshot when invalid', () => {
       const { styles } = inputOutline({
         theme: light,

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -17,6 +17,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import styled from '@emotion/styled';
+import { Theme } from '@sumup/design-tokens';
 
 import { Stack } from '../../../.storybook/components';
 import Button from '../components/Button';
@@ -26,6 +27,7 @@ import {
   spacing,
   shadow,
   focusOutline,
+  inputOutline,
   disableVisually,
   clearfix,
   hideVisually,
@@ -138,6 +140,15 @@ export const FocusOutline = () => (
   <Stack>
     <Box css={focusOutline} />
     <Box css={focusOutline('inset')} />
+  </Stack>
+);
+
+export const InputOutline = () => (
+  <Stack>
+    <Box css={inputOutline} />
+    <Box css={(theme: Theme) => inputOutline({ theme, disabled: true })} />
+    <Box css={(theme: Theme) => inputOutline({ theme, invalid: true })} />
+    <Box css={(theme: Theme) => inputOutline({ theme, hasWarning: true })} />
   </Stack>
 );
 

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -333,8 +333,8 @@ export const hideScrollbar = (): SerializedStyles => css`
 `;
 
 /**
- * Visually communicates to the user that an element hovered, focused, or
- * active; and optionally adds disabled, invalid or warning styles.
+ * Visually communicates to the user that an element is hovered, focused, or
+ * active; including for the disabled, invalid and warning states.
  */
 export const inputOutline = (
   args:

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -334,31 +334,18 @@ export const hideScrollbar = (): SerializedStyles => css`
 
 /**
  * Visually communicates to the user that an element is hovered, focused, or
- * active; including for the disabled, invalid and warning states.
+ * active in the disabled, invalid, and warning states.
  */
 export const inputOutline = (
   args:
     | Theme
     | {
-        /**
-         * The Theme object.
-         */
         theme: Theme;
-        /**
-         * Adds disabled styles.
-         */
         disabled?: boolean;
-        /**
-         * Adds invalid styles.
-         */
         invalid?: boolean;
-        /**
-         * Adds warning styles.
-         */
         hasWarning?: boolean;
         /**
          * @deprecated
-         * Has no effect, kept for legacy reasons.
          */
         showValid?: boolean;
       },

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -273,7 +273,6 @@ export const hideVisually = (): SerializedStyles => css`
 /**
  * Visually communicates to the user that an element is focused.
  */
-
 export function focusOutline(
   options: 'inset',
 ): (args: ThemeArgs) => SerializedStyles;
@@ -334,17 +333,33 @@ export const hideScrollbar = (): SerializedStyles => css`
 `;
 
 /**
- * Visually communicates to the user that an input is hovered, focused,
- * or active.
+ * Visually communicates to the user that an element hovered, focused, or
+ * active; and optionally adds disabled, invalid or warning styles.
  */
 export const inputOutline = (
   args:
     | Theme
     | {
+        /**
+         * The Theme object.
+         */
         theme: Theme;
+        /**
+         * Adds disabled styles.
+         */
         disabled?: boolean;
+        /**
+         * Adds invalid styles.
+         */
         invalid?: boolean;
+        /**
+         * Adds warning styles.
+         */
         hasWarning?: boolean;
+        /**
+         * @deprecated
+         * Has no effect, kept for legacy reasons.
+         */
         showValid?: boolean;
       },
 ): SerializedStyles => {


### PR DESCRIPTION
## Purpose

This exports the `inputOutline` externally and documents it properly in Storybook.

## Approach and changes

- export the mixin
- add documentation in Storybook
- add missing unit test for the disabled state
- add changeset
 
## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
