### PR TITLE
Extend CardProps interface

### DIFF
--- a/.changeset/early-cherries-yawn.md
+++ b/.changeset/early-cherries-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Improved CardProps interface to allow all default HTML attributes.

--- a/packages/circuit-ui/components/Card/Card.tsx
+++ b/packages/circuit-ui/components/Card/Card.tsx
@@ -13,14 +13,14 @@
  * limitations under the License.
  */
 
-import { FC } from 'react';
+import { FC, HTMLProps } from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import { css } from '@emotion/core';
 
 import styled, { StyleProps } from '../../styles/styled';
 import deprecate from '../../util/deprecate';
 
-export interface CardProps {
+export interface CardProps extends HTMLProps<HTMLDivElement> {
   /**
    * @deprecated
    * The shadow variations have been replaced with a single outline.

--- a/packages/circuit-ui/components/Modal/components/ModalWrapper/ModalWrapper.tsx
+++ b/packages/circuit-ui/components/Modal/components/ModalWrapper/ModalWrapper.tsx
@@ -19,7 +19,7 @@ import { css } from '@emotion/core';
 import styled, { StyleProps } from '../../../../styles/styled';
 import { Card, CardProps } from '../../../Card/Card';
 
-export type ModalWrapperProps = CardProps;
+export type ModalWrapperProps = Omit<CardProps, 'ref'>;
 
 const baseStyles = ({ theme }: StyleProps) => css`
   width: 100%;


### PR DESCRIPTION
## Purpose

I was trying to assign a `onTouchStart` listener to the `ModalWrapper` which is based on the `Card` component and got a TypeScript error. 

## Approach and changes

- Update the CardProps to extend the default HTML attributes

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
