### PR TITLE
Minus Icon

### DIFF
--- a/.changeset/heavy-toys-thank.md
+++ b/.changeset/heavy-toys-thank.md
@@ -2,4 +2,4 @@
 '@sumup/icons': minor
 ---
 
-Added a new asset to the icons package. The 'minus_small' icon.
+Added a new minus icon in a small size.

--- a/.changeset/heavy-toys-thank.md
+++ b/.changeset/heavy-toys-thank.md
@@ -1,5 +1,5 @@
 ---
-'@sumup/icons': major
+'@sumup/icons': minor
 ---
 
 Added a new asset to the icons package. The 'minus_small' icon.

--- a/.changeset/heavy-toys-thank.md
+++ b/.changeset/heavy-toys-thank.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': major
+---
+
+Added a new asset to the icons package. The 'minus_small' icon.

--- a/packages/icons/web/v1/minus_small.svg
+++ b/packages/icons/web/v1/minus_small.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M9 7h6a1 1 0 1 1 0 2H1a1 1 0 0 1 0-2h8z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
## Purpose

In the [design](https://www.figma.com/file/PSltEJWi5fJCJjBEihXbad/4---MVP---Acquisition-Journey?node-id=5304%3A28141) we have the need for a new icon, to represent the (-) sign.

![image](https://user-images.githubusercontent.com/18490172/126156821-a07c70dc-ff2c-429c-940a-15feae6e7fbc.png)


## Approach and changes

Adding the new svg asset to the `icons` package.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
