### PR TITLE
Add minus icon to manifest

### DIFF
--- a/.changeset/witty-gorillas-rule.md
+++ b/.changeset/witty-gorillas-rule.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': patch
+---
+
+Added the minus icon to the icons manifest.

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -821,6 +821,11 @@
       "size": "small"
     },
     {
+      "name": "minus",
+      "category": "Action",
+      "size": "small"
+    },
+    {
       "name": "refresh",
       "category": "Action",
       "size": "small"


### PR DESCRIPTION
## Purpose

We forgot to add the minus icon to the icon manifest in #1045 which prevented it from being exported.

## Approach and changes

- Add minus icon to manifest

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
