### PR TITLE
Update Card component interface

### DIFF
--- a/.changeset/nice-camels-boil.md
+++ b/.changeset/nice-camels-boil.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Tweaked the Card component interface to extend an HTMLDivElement and support any optional ref.

--- a/.changeset/nice-camels-boil.md
+++ b/.changeset/nice-camels-boil.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Tweaked the Card component interface to extend an HTMLDivElement and support any optional ref.
+Tweaked the Card component interface to support any optional ref.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -42,7 +42,7 @@ export interface BaseProps extends BodyProps {
    */
   tracking?: TrackingProps;
   /**
-   * The ref to the html dom element, it can be a button an anchor or a span, typed as any for now because of complex js manipulation with styled components
+   * The ref to the HTML DOM element, it can be a button an anchor or a span, typed as any for now because of complex js manipulation with styled components
    */
   ref?: Ref<any>;
 }

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -78,7 +78,7 @@ export interface BaseProps {
    */
   'tracking'?: TrackingProps;
   /**
-   The ref to the html dom element, it can be an anchor or a button
+   The ref to the HTML DOM element
    */
   'ref'?: Ref<any>;
   'data-testid'?: string;

--- a/packages/circuit-ui/components/Card/Card.tsx
+++ b/packages/circuit-ui/components/Card/Card.tsx
@@ -24,7 +24,10 @@ export interface CardProps extends HTMLProps<HTMLDivElement> {
    * The padding of the Card.
    */
   spacing?: 'mega' | 'giga';
-  ref: Ref<HTMLDivElement>;
+  /**
+   * The ref to the HTML DOM element.
+   */
+  ref?: Ref<any>;
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -45,7 +45,7 @@ export interface CurrencyInputProps
    */
   placeholder?: string | number;
   /**
-   * The ref to the html dom element.
+   * The ref to the HTML DOM element.
    */
   ref?: Ref<NumberFormat>;
   /**

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -103,7 +103,7 @@ export interface InputProps extends Omit<HTMLProps<HTMLInputElement>, 'label'> {
    */
   labelStyles?: InterpolationWithTheme<Theme>;
   /**
-   * The ref to the html dom element
+   * The ref to the HTML DOM element
    */
   ref?: Ref<HTMLInputElement & HTMLTextAreaElement>;
 }

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -73,7 +73,7 @@ export interface BaseProps {
    */
   tracking?: TrackingProps;
   /**
-   * The ref to the HTML DOM element, can be a button or an anchor.
+   * The ref to the HTML DOM element
    */
   ref?: Ref<any>;
 }

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -32,7 +32,7 @@ export interface RadioButtonProps extends HTMLProps<HTMLInputElement> {
    */
   invalid?: boolean;
   /**
-   * The ref to the HTML Dom element
+   * The ref to the HTML DOM element
    */
   ref?: Ref<HTMLInputElement>;
   /**

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -42,7 +42,7 @@ export interface RadioButtonGroupProps
    */
   value?: RadioButtonProps['value'];
   /**
-   * The ref to the HTML Dom element
+   * The ref to the HTML DOM element
    */
   ref?: Ref<HTMLFieldSetElement>;
   /**

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -108,7 +108,7 @@ export interface SelectProps
    */
   id?: string;
   /**
-   * The ref to the html dom element
+   * The ref to the HTML DOM element
    */
   ref?: Ref<HTMLSelectElement>;
   /**

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -64,7 +64,7 @@ export interface SelectorProps
    */
   noMargin?: boolean;
   /**
-   * The ref to the html dom element
+   * The ref to the HTML DOM element
    */
   ref?: Ref<HTMLInputElement>;
   /**

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -61,7 +61,7 @@ export interface SelectorGroupProps {
    */
   stretch?: boolean;
   /**
-   * The ref to the HTML Dom element
+   * The ref to the HTML DOM element
    */
   ref?: Ref<HTMLDivElement>;
 }

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -38,7 +38,7 @@ export interface ToggleProps extends SwitchProps {
    */
   noMargin?: boolean;
   /**
-   * The ref to the html button dom element
+   * The ref to the HTML DOM button element
    */
   ref?: Ref<HTMLButtonElement>;
 }

--- a/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
+++ b/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
@@ -40,7 +40,7 @@ export interface SwitchProps
    */
   tracking?: TrackingProps;
   /**
-   * The ref to the html button dom element
+   * The ref to the HTML DOM button element
    */
   ref?: Ref<HTMLButtonElement>;
 }


### PR DESCRIPTION
## Purpose

I noticed a TS error when using the V3 `Card` component: the compiler asked for a required `ref`. I went into the component and updated its interface a bit.

## Approach and changes

- extend `HTMLDivElement` in the `CardProps` interface
- make the `ref` prop optional
- make the `ref` a `Ref<any>` to support the `<Card as=''>` use case (also aligned with recent changes in the typography components=

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~[ ] Unit and integration tests~
* ~[ ] Meets minimum browser support~
* ~[ ] Meets accessibility requirements~
