### PR TITLE
Add support for drag'n'drop and paste to ImageInput

### DIFF
--- a/.changeset/dull-worms-exist.md
+++ b/.changeset/dull-worms-exist.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added support for drag'n'drop and paste to the ImageInput.

--- a/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
@@ -22,6 +22,7 @@ import {
   userEvent,
   fireEvent,
   waitFor,
+  createEvent,
 } from '../../util/test-utils';
 
 import { ImageInput, ImageInputProps } from './ImageInput';
@@ -149,11 +150,26 @@ describe('ImageInput', () => {
       });
     });
 
-    it('should support drag and drop', async () => {
+    it('should support dragging and dropping an image', async () => {
       const { getByText } = render(<StatefulInput />);
-      const inputEl = getByText(defaultProps.label) as HTMLInputElement;
+      const labelEl = getByText(defaultProps.label);
 
-      fireEvent.drop(inputEl, { dataTransfer: { files: [file] } });
+      fireEvent.drop(labelEl, { dataTransfer: { files: [file] } });
+
+      await waitFor(() => {
+        expect(mockUploadFn).toHaveBeenCalledWith(file);
+      });
+    });
+
+    it('should support pasting an image', async () => {
+      const { getByLabelText } = render(<StatefulInput />);
+      const inputEl = getByLabelText(defaultProps.label) as HTMLInputElement;
+
+      const paste = createEvent.paste(inputEl, {
+        clipboardData: { files: [file] },
+      });
+
+      fireEvent(inputEl, paste);
 
       await waitFor(() => {
         expect(mockUploadFn).toHaveBeenCalledWith(file);

--- a/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
@@ -16,7 +16,13 @@
 import React, { useState } from 'react';
 
 import Avatar from '../Avatar';
-import { render, axe, userEvent, waitFor } from '../../util/test-utils';
+import {
+  render,
+  axe,
+  userEvent,
+  fireEvent,
+  waitFor,
+} from '../../util/test-utils';
 
 import { ImageInput, ImageInputProps } from './ImageInput';
 
@@ -139,6 +145,17 @@ describe('ImageInput', () => {
       await waitFor(() => {
         expect(inputEl.files && inputEl.files[0]).toEqual(file);
         expect(inputEl.files).toHaveLength(1);
+        expect(mockUploadFn).toHaveBeenCalledWith(file);
+      });
+    });
+
+    it('should support drag and drop', async () => {
+      const { getByText } = render(<StatefulInput />);
+      const inputEl = getByText(defaultProps.label) as HTMLInputElement;
+
+      fireEvent.drop(inputEl, { dataTransfer: { files: [file] } });
+
+      await waitFor(() => {
         expect(mockUploadFn).toHaveBeenCalledWith(file);
       });
     });

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -354,7 +354,7 @@ export const ImageInput = ({
 
   const handleDrop = (event: DragEvent) => {
     handleDragLeave(event);
-    const files = event.dataTransfer?.files;
+    const files = event.dataTransfer && event.dataTransfer.files;
     handleChange(files);
 
     if (inputRef.current && files) {

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -53,7 +53,7 @@ export interface ImageInputProps
   /**
    * A callback function to call when the input is cleared.
    */
-  onClear: (event: MouseEvent | KeyboardEvent) => void;
+  onClear: (event: MouseEvent | KeyboardEvent) => void | Promise<void>;
   /**
    * An accessible label for the "clear" icon button.
    */
@@ -280,9 +280,15 @@ export const ImageInput = ({
   };
 
   const handleClear = (event: MouseEvent | KeyboardEvent) => {
-    clearInputElement();
-    setPreviewImage('');
-    onClear(event);
+    Promise.resolve(onClear(event))
+      .then(() => {
+        clearInputElement();
+        setPreviewImage('');
+      })
+      .catch(() => {
+        clearInputElement();
+        setPreviewImage('');
+      });
   };
 
   /**

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -20,6 +20,7 @@ import {
   useRef,
   InputHTMLAttributes,
   ChangeEvent,
+  ClipboardEvent,
   DragEvent,
   MouseEvent,
   KeyboardEvent,
@@ -325,6 +326,20 @@ export const ImageInput = ({
     clearInputElement();
   };
 
+  const handlePaste = (event: ClipboardEvent) => {
+    const { files } = event.clipboardData;
+    handleChange(files);
+
+    if (inputRef.current && files) {
+      // An error is thrown when trying to assign anything but a FileList here.
+      // For security reasons, it's not possible to simulate a FileList object.
+      // That's why this code has to be disabled during testing.
+      if (process.env.NODE_ENV !== 'test') {
+        inputRef.current.files = files;
+      }
+    }
+  };
+
   const handleDragging = (event: DragEvent) => {
     event.preventDefault();
     event.stopPropagation();
@@ -354,7 +369,7 @@ export const ImageInput = ({
 
   return (
     <Fragment>
-      <InputWrapper>
+      <InputWrapper onPaste={handlePaste}>
         <HiddenInput
           ref={inputRef}
           id={id}

--- a/packages/circuit-ui/util/test-utils.tsx
+++ b/packages/circuit-ui/util/test-utils.tsx
@@ -17,12 +17,7 @@ import React, { FunctionComponent } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import '@testing-library/jest-dom/extend-expect';
 import { configureAxe } from 'jest-axe';
-import {
-  render as renderTest,
-  waitFor,
-  act,
-  RenderResult,
-} from '@testing-library/react';
+import { render as renderTest, RenderResult } from '@testing-library/react';
 import { renderHook, act as actHook } from '@testing-library/react-hooks';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from 'emotion-theming';
@@ -32,6 +27,8 @@ import {
   ComponentsContext,
   defaultComponents,
 } from '../components/ComponentsContext';
+
+export * from '@testing-library/react';
 
 export type RenderFn<T = any> = (
   component: React.ReactElement,
@@ -62,14 +59,4 @@ const axe = configureAxe({
   },
 });
 
-export {
-  create,
-  render,
-  renderToHtml,
-  renderHook,
-  act,
-  actHook,
-  userEvent,
-  waitFor,
-  axe,
-};
+export { create, render, renderToHtml, renderHook, actHook, userEvent, axe };


### PR DESCRIPTION
## Purpose

It's a common feature for custom file inputs to support drag'n'drop. Pasting files is less common, but very helpful for keyboard users.

## Approach and changes

- Add support for drag'n'drop to the ImageInput
- Add support for paste to the ImageInput
- Handle asynchronous `onClear` prop on the ImageInput

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
