### PR TITLE
Removed the Modal's min-height

### DIFF
--- a/.changeset/gentle-pillows-build.md
+++ b/.changeset/gentle-pillows-build.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed the Modal's min-height to support modals with little content.

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -122,7 +122,6 @@ export const Modal: ModalComponent<ModalProps> = ({
               left: 50%;
               padding: ${theme.spacings.giga};
               transform: translate(-50%, -50%);
-              min-height: 320px;
               max-height: 90vh;
               min-width: 480px;
               max-width: 90vw;

--- a/packages/circuit-ui/components/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/packages/circuit-ui/components/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -33,7 +33,6 @@ exports[`Modal should match the snapshot 1`] = `
     -webkit-transform: translate(-50%,-50%);
     -ms-transform: translate(-50%,-50%);
     transform: translate(-50%,-50%);
-    min-height: 320px;
     max-height: 90vh;
     min-width: 480px;
     max-width: 90vw;


### PR DESCRIPTION
## Purpose

The `Modal` had a hardcoded `min-height` of 320px. This doesn't work well for modals with little content, closer to dialogs.

## Approach and changes

Removed the `min-height`.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
