### PR TITLE
Add jsxImportSource to the Circuit UI tsconfig.json

### DIFF
--- a/.changeset/rare-news-check.md
+++ b/.changeset/rare-news-check.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the JSX runtime import source for Circuit UI package.

--- a/packages/circuit-ui/tsconfig.json
+++ b/packages/circuit-ui/tsconfig.json
@@ -8,6 +8,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "jsxImportSource": "@emotion/core",
     "module": "ES2020",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## Purpose

We were missing the `jsxImportSource: "@emotion/core"` in the Circuit UI `tsconfig.json` to import the JSX runtime from emotion. This caused some classNames to not be passed properly.

## Approach and changes

Added `jsxImportSource: "@emotion/core"`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~[ ] Unit and integration tests~
* ~[ ] Meets minimum browser support~
* ~[ ] Meets accessibility requirements~
