### PR TITLE
Fix the Plus icon's fill to inherit the currentColor

### DIFF
--- a/.changeset/beige-lies-mix.md
+++ b/.changeset/beige-lies-mix.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': patch
+---
+
+Fixed the Plus icon's fill to inherit the currentColor.

--- a/packages/icons/web/v1/plus_large.svg
+++ b/packages/icons/web/v1/plus_large.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 4a1 1 0 0 1 1 1v6h6a1 1 0 1 1 0 2h-6v6a1 1 0 1 1-2 0v-6H5a1 1 0 1 1 0-2h6V5a1 1 0 0 1 1-1z" fill="#000"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M12 4a1 1 0 0 1 1 1v6h6a1 1 0 1 1 0 2h-6v6a1 1 0 1 1-2 0v-6H5a1 1 0 1 1 0-2h6V5a1 1 0 0 1 1-1z" fill="currentColor"/>
 </svg>

--- a/packages/icons/web/v1/plus_small.svg
+++ b/packages/icons/web/v1/plus_small.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M8 0a1 1 0 0 1 1 1v6h6a1 1 0 1 1 0 2H9v6a1 1 0 1 1-2 0V9H1a1 1 0 1 1 0-2h6V1a1 1 0 0 1 1-1z" fill="#000"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M8 0a1 1 0 0 1 1 1v6h6a1 1 0 1 1 0 2H9v6a1 1 0 1 1-2 0V9H1a1 1 0 1 1 0-2h6V1a1 1 0 0 1 1-1z" fill="currentColor"/>
 </svg>


### PR DESCRIPTION
## Purpose

Although this was fixed on `next`, the change wasn't published in `@sumup/icons@1.8.1` (latest version) and no prerelease version was released.

## Approach and changes

Fix the icon's currentColor on `main` to release a new minor.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~[ ] Unit and integration tests~
* ~[ ] Meets minimum browser support~
* ~[ ] Meets accessibility requirements~
