### PR TITLE
Fixed the contextual modal heights to match content height

### DIFF
--- a/.changeset/wise-lions-dream.md
+++ b/.changeset/wise-lions-dream.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the contextual modal heights to match content height instead of 90vh.

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -88,7 +88,6 @@ const contentStyles = ({ theme }: StyleProps) => css`
   ${theme.mq.untilKilo} {
     -webkit-overflow-scrolling: touch;
     padding: ${theme.spacings.mega};
-    height: 100vh;
     width: 100vw;
   }
 
@@ -111,7 +110,11 @@ const contentVariantStyles = ({
       }
     `;
   }
-  return null;
+  return css`
+    ${theme.mq.untilKilo} {
+      height: 100vh;
+    }
+  `;
 };
 
 const Content = styled.div<ContentProps>(contentStyles, contentVariantStyles);

--- a/packages/circuit-ui/components/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/packages/circuit-ui/components/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -102,7 +102,6 @@ exports[`Modal should match the snapshot 1`] = `
   .circuit-2 {
     -webkit-overflow-scrolling: touch;
     padding: 16px;
-    height: 100vh;
     width: 100vw;
   }
 }
@@ -113,6 +112,12 @@ exports[`Modal should match the snapshot 1`] = `
     max-height: 90vh;
     min-width: 480px;
     max-width: 90vw;
+  }
+}
+
+@media (max-width:479px) {
+  .circuit-2 {
+    height: 100vh;
   }
 }
 


### PR DESCRIPTION
## Purpose

In #1067 we mistakenly set all modal heights to be minimum `90vh`.

Contextual modals should match their content's height, which should generally be smaller than the viewport (otherwise, an immersive modal should be used).

## Approach and changes

Fixed the contextual modal heights to match content height, while retaining the scrolling behavior for taller modals.

Demo: (sorry for the quality, GitHub wants <10mb)

https://user-images.githubusercontent.com/35560568/127224123-a756edf5-3cb2-45f9-a4d1-7ca9c8b77fc4.mov

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~[ ] Unit and integration tests~
* ~[ ] Meets minimum browser support~
* ~[ ] Meets accessibility requirements~
