### PR TITLE
Fix useClickOutside when the target element is removed

### DIFF
--- a/.changeset/spicy-knives-trade.md
+++ b/.changeset/spicy-knives-trade.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the `useClickOutside` hook when the clicked element is inside the container and removed from the DOM immediately after the click.

--- a/packages/circuit-ui/hooks/useClickOutside/useClickOutside.spec.tsx
+++ b/packages/circuit-ui/hooks/useClickOutside/useClickOutside.spec.tsx
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
-import { render, act, userEvent } from '../../util/test-utils';
+import { render, userEvent } from '../../util/test-utils';
 
 import { useClickOutside } from './useClickOutside';
 
@@ -31,10 +31,7 @@ describe('useClickOutside', () => {
   it('should call the callback when clicking outside the element', () => {
     const onClickOutside = jest.fn();
     render(<MockComponent onClickOutside={onClickOutside} />);
-
-    act(() => {
-      userEvent.click(document.body);
-    });
+    userEvent.click(document.body);
 
     expect(onClickOutside).toHaveBeenCalledTimes(1);
   });
@@ -45,9 +42,33 @@ describe('useClickOutside', () => {
       <MockComponent onClickOutside={onClickOutside} />,
     );
 
-    act(() => {
-      userEvent.click(getByRole('button'));
-    });
+    userEvent.click(getByRole('button'));
+
+    expect(onClickOutside).not.toHaveBeenCalled();
+  });
+
+  it('should not call the callback when clicking inside the element and the target element is removed', () => {
+    function MockRemoveComponent({ onClickOutside, isActive = true }) {
+      const ref = useRef<HTMLDivElement>(null);
+      const [open, setOpen] = useState(true);
+
+      useClickOutside(ref, onClickOutside, isActive);
+
+      return (
+        <div ref={ref}>
+          {open && (
+            <button onClick={() => setOpen(false)}>Click outside</button>
+          )}
+        </div>
+      );
+    }
+
+    const onClickOutside = jest.fn();
+    const { getByRole } = render(
+      <MockRemoveComponent onClickOutside={onClickOutside} />,
+    );
+
+    userEvent.click(getByRole('button'));
 
     expect(onClickOutside).not.toHaveBeenCalled();
   });
@@ -56,9 +77,7 @@ describe('useClickOutside', () => {
     const onClickOutside = jest.fn();
     render(<MockComponent onClickOutside={onClickOutside} isActive={false} />);
 
-    act(() => {
-      userEvent.click(document.body);
-    });
+    userEvent.click(document.body);
 
     expect(onClickOutside).not.toHaveBeenCalled();
   });

--- a/packages/circuit-ui/hooks/useClickOutside/useClickOutside.ts
+++ b/packages/circuit-ui/hooks/useClickOutside/useClickOutside.ts
@@ -13,26 +13,35 @@
  * limitations under the License.
  */
 
-import { RefObject, useEffect } from 'react';
+import { RefObject, useEffect, useRef } from 'react';
 
 export function useClickOutside(
   ref: RefObject<HTMLElement>,
   callback: (event: MouseEvent) => void,
   active = true,
 ): void {
+  const isOutsideClick = useRef(false);
   useEffect(() => {
     if (!active) {
       return undefined;
     }
 
+    const handleOutsideMousedown = (event: MouseEvent) => {
+      isOutsideClick.current = ref.current
+        ? !ref.current.contains(event.target as Node)
+        : false;
+    };
+
     const handleOutsideClick = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
+      if (isOutsideClick.current) {
         callback(event);
       }
     };
 
+    document.addEventListener('mousedown', handleOutsideMousedown);
     document.addEventListener('click', handleOutsideClick);
     return () => {
+      document.removeEventListener('mousedown', handleOutsideMousedown);
       document.removeEventListener('click', handleOutsideClick);
     };
   }, [ref, callback, active]);


### PR DESCRIPTION
## Purpose

When an element is clicked inside the container element and removed right after the click, `useClickOutside` would trigger because, at the time when the hook checks whether the container contains the clicked element, the element has already been detached from the DOM. 

_Thanks @hris27 for the report and suggested fix! 🙌🏻_

## Approach and changes

- Check if the container contains the clicked element on the `mousedown` event. The callback is still triggered on the `click` event because it can be intercepted, unlike the `mousedown` event.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements