### PR TITLE
Improve semantics of the SelectorGroup

### DIFF
--- a/.changeset/silent-ladybugs-scream.md
+++ b/.changeset/silent-ladybugs-scream.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a `hideLabel` prop to the RadioButtonGroup to visually hide the label. This should only be used in rare cases and only if the purpose of the field can be inferred from context.

--- a/.changeset/three-moons-kick.md
+++ b/.changeset/three-moons-kick.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Made the label of the SelectorGroup visible by default. It can be hidden with the `hideLabel` prop, but this should only be done in rare cases and only if the purpose of the field can be inferred from context.

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -17,7 +17,7 @@ import { HTMLProps, Ref, forwardRef } from 'react';
 import { css } from '@emotion/core';
 
 import styled, { StyleProps } from '../../styles/styled';
-import { typography } from '../../styles/style-mixins';
+import { hideVisually, typography } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
 import { RadioButton, RadioButtonProps } from '../RadioButton/RadioButton';
 import ValidationHint from '../ValidationHint';
@@ -61,14 +61,27 @@ export interface RadioButtonGroupProps
    * Triggers valid message below the radio buttons.
    */
   showValid?: boolean;
+  /**
+   * Visually hide the label. This should only be used in rare cases and only if the
+   * purpose of the field can be inferred from other context.
+   */
+  hideLabel?: boolean;
 }
 
+type LegendProps = Pick<RadioButtonGroupProps, 'hideLabel'>;
+
 const legendStyles = ({ theme }: StyleProps) => css`
-  label: radio-button-group__legend;
   margin-bottom: ${theme.spacings.bit};
 `;
 
-const Legend = styled('legend')(legendStyles, typography('two'));
+const legendHiddenStyles = ({ hideLabel }: LegendProps) =>
+  hideLabel && hideVisually();
+
+const Legend = styled('legend')<LegendProps>(
+  typography('two'),
+  legendStyles,
+  legendHiddenStyles,
+);
 
 /**
  * A group of RadioButtons.
@@ -86,6 +99,7 @@ export const RadioButtonGroup = forwardRef(
       showValid,
       disabled,
       hasWarning,
+      hideLabel,
       ...props
     }: RadioButtonGroupProps,
     ref: RadioButtonGroupProps['ref'],
@@ -93,7 +107,7 @@ export const RadioButtonGroup = forwardRef(
     const name = customName || uniqueId('radio-button-group_');
     return (
       <fieldset name={name} ref={ref} {...props}>
-        {label && <Legend>{label}</Legend>}
+        {label && <Legend hideLabel={hideLabel}>{label}</Legend>}
         {options &&
           options.map(({ children, value, className, style, ...rest }) => (
             <div

--- a/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`RadioButtonGroup should render with default styles 1`] = `
 .circuit-0 {
-  margin-bottom: 4px;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 4px;
 }
 
 .circuit-1 {

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
@@ -72,12 +72,12 @@ describe('SelectorGroup', () => {
   });
 
   it('should accept a working ref', () => {
-    const tref = createRef<HTMLDivElement>();
+    const tref = createRef<HTMLFieldSetElement>();
     const { container } = render(
       <SelectorGroup {...defaultProps} ref={tref} />,
     );
-    const div = container.querySelector('div');
-    expect(tref.current).toBe(div);
+    const fieldset = container.querySelector('fieldset');
+    expect(tref.current).toBe(fieldset);
   });
 
   it('should render with horizontal layout by default', () => {

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
@@ -65,7 +65,6 @@ export const Multiple = (args: SelectorGroupProps) => {
       {...args}
       value={value}
       onChange={handleChange}
-      orientation="horizontal"
       stretch={false}
     />
   );

--- a/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SelectorGroup should render with default styles 1`] = `
-.circuit-9 {
+.circuit-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -21,18 +21,23 @@ exports[`SelectorGroup should render with default styles 1`] = `
   width: auto;
 }
 
-.circuit-9 > div:not(:last-child) {
+.circuit-10 > div:not(:last-child) {
   margin-right: 16px;
 }
 
-.circuit-2 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
+.circuit-0 {
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 4px;
 }
 
-.circuit-0 {
+.circuit-3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.circuit-1 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -45,28 +50,28 @@ exports[`SelectorGroup should render with default styles 1`] = `
   width: 1px;
 }
 
-.circuit-0:focus + label::before {
+.circuit-1:focus + label::before {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:focus + label::before::-moz-focus-inner {
+.circuit-1:focus + label::before::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-0:focus:not(:focus-visible) + label::before {
+.circuit-1:focus:not(:focus-visible) + label::before {
   box-shadow: none;
 }
 
-.circuit-0:checked + label {
+.circuit-1:checked + label {
   background-color: #F0F6FF;
 }
 
-.circuit-0:checked + label::before {
+.circuit-1:checked + label::before {
   border: 2px solid #3063E9;
 }
 
-.circuit-1 {
+.circuit-2 {
   display: inline-block;
   cursor: pointer;
   background-color: #FFF;
@@ -82,7 +87,7 @@ exports[`SelectorGroup should render with default styles 1`] = `
   width: 100%;
 }
 
-.circuit-1::before {
+.circuit-2::before {
   display: block;
   content: '';
   position: absolute;
@@ -98,83 +103,86 @@ exports[`SelectorGroup should render with default styles 1`] = `
   transition: border 120ms ease-in-out;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-1:hover::before {
+.circuit-2:hover::before {
   border-color: #999;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-1:active::before {
+.circuit-2:active::before {
   border-color: #666;
 }
 
-<div
-  aria-label="Choose an option"
-  class="circuit-9"
-  role="group"
+<fieldset
+  class="circuit-10"
 >
+  <legend
+    class="circuit-0"
+  >
+    Choose an option
+  </legend>
   <div
-    class="circuit-2"
+    class="circuit-3"
   >
     <input
-      class="circuit-0"
+      class="circuit-1"
       id="selector_2"
       name="selector-group_1"
       type="radio"
       value="first"
     />
     <label
-      class="circuit-1"
+      class="circuit-2"
       for="selector_2"
     >
       Option 1
     </label>
   </div>
   <div
-    class="circuit-2"
+    class="circuit-3"
   >
     <input
-      class="circuit-0"
+      class="circuit-1"
       id="selector_3"
       name="selector-group_1"
       type="radio"
       value="second"
     />
     <label
-      class="circuit-1"
+      class="circuit-2"
       for="selector_3"
     >
       Option 2
     </label>
   </div>
   <div
-    class="circuit-2"
+    class="circuit-3"
   >
     <input
-      class="circuit-0"
+      class="circuit-1"
       id="selector_4"
       name="selector-group_1"
       type="radio"
       value="third"
     />
     <label
-      class="circuit-1"
+      class="circuit-2"
       for="selector_4"
     >
       Option 3
     </label>
   </div>
-</div>
+</fieldset>
 `;
 
 exports[`SelectorGroup should render with horizontal layout by default 1`] = `
-.circuit-9 {
+.circuit-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -194,18 +202,23 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
   width: auto;
 }
 
-.circuit-9 > div:not(:last-child) {
+.circuit-10 > div:not(:last-child) {
   margin-right: 16px;
 }
 
-.circuit-2 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
+.circuit-0 {
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 4px;
 }
 
-.circuit-0 {
+.circuit-3 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.circuit-1 {
   border: 0;
   -webkit-clip: rect(0 0 0 0);
   clip: rect(0 0 0 0);
@@ -218,28 +231,28 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
   width: 1px;
 }
 
-.circuit-0:focus + label::before {
+.circuit-1:focus + label::before {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-0:focus + label::before::-moz-focus-inner {
+.circuit-1:focus + label::before::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-0:focus:not(:focus-visible) + label::before {
+.circuit-1:focus:not(:focus-visible) + label::before {
   box-shadow: none;
 }
 
-.circuit-0:checked + label {
+.circuit-1:checked + label {
   background-color: #F0F6FF;
 }
 
-.circuit-0:checked + label::before {
+.circuit-1:checked + label::before {
   border: 2px solid #3063E9;
 }
 
-.circuit-1 {
+.circuit-2 {
   display: inline-block;
   cursor: pointer;
   background-color: #FFF;
@@ -255,7 +268,7 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
   width: 100%;
 }
 
-.circuit-1::before {
+.circuit-2::before {
   display: block;
   content: '';
   position: absolute;
@@ -271,77 +284,80 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
   transition: border 120ms ease-in-out;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-1:hover::before {
+.circuit-2:hover::before {
   border-color: #999;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-1:active::before {
+.circuit-2:active::before {
   border-color: #666;
 }
 
-<div
-  aria-label="Choose an option"
-  class="circuit-9"
-  role="group"
+<fieldset
+  class="circuit-10"
 >
+  <legend
+    class="circuit-0"
+  >
+    Choose an option
+  </legend>
   <div
-    class="circuit-2"
+    class="circuit-3"
   >
     <input
-      class="circuit-0"
+      class="circuit-1"
       id="selector_18"
       name="selector-group_17"
       type="radio"
       value="first"
     />
     <label
-      class="circuit-1"
+      class="circuit-2"
       for="selector_18"
     >
       Option 1
     </label>
   </div>
   <div
-    class="circuit-2"
+    class="circuit-3"
   >
     <input
-      class="circuit-0"
+      class="circuit-1"
       id="selector_19"
       name="selector-group_17"
       type="radio"
       value="second"
     />
     <label
-      class="circuit-1"
+      class="circuit-2"
       for="selector_19"
     >
       Option 2
     </label>
   </div>
   <div
-    class="circuit-2"
+    class="circuit-3"
   >
     <input
-      class="circuit-0"
+      class="circuit-1"
       id="selector_20"
       name="selector-group_17"
       type="radio"
       value="third"
     />
     <label
-      class="circuit-1"
+      class="circuit-2"
       for="selector_20"
     >
       Option 3
     </label>
   </div>
-</div>
+</fieldset>
 `;


### PR DESCRIPTION
## Approach and changes

- Changed the SelectorGroup to render as a `fieldset` with a `legend`. This makes the label visible by default. It can be hidden with the `hideLabel` prop, but this should only be done in rare cases and only if the purpose of the field can be inferred from context. 
- Added a `hideLabel` prop to the RadioButtonGroup to visually hide the label. This should only be used in rare cases and only if the purpose of the field can be inferred from context.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
