### PR TITLE
Fix the typography sizes codemod warnings

### DIFF
--- a/packages/circuit-ui/cli/migrate/typography-sizes.ts
+++ b/packages/circuit-ui/cli/migrate/typography-sizes.ts
@@ -93,24 +93,28 @@ function warnFactory(
   components.forEach((component) => {
     const jsxElement = root.findJSXElements(component);
     ['Literal', 'StringLiteral'].forEach((type) => {
-      const element = jsxElement.find(j.JSXAttribute, {
-        name: {
-          type: 'JSXIdentifier',
-          name: 'size',
-        },
-        value: {
-          type,
-          value: propName,
-        },
-      });
-      if (element) {
-        console.error(
-          [
-            `Cannot migrate the ${componentName} "${propName}" size automatically,`,
-            `please refer to the migration guide to migrate manually.\n  in ${filePath}`,
-          ].join(' '),
-        );
-      }
+      jsxElement
+        .find(j.JSXAttribute, {
+          name: {
+            type: 'JSXIdentifier',
+            name: 'size',
+          },
+          value: {
+            type,
+            value: propName,
+          },
+        })
+        .forEach((nodePath) => {
+          const hasValue = Boolean(nodePath.value.value);
+          if (hasValue) {
+            console.error(
+              [
+                `Cannot migrate the ${componentName} "${propName}" size automatically,`,
+                `please refer to the migration guide to migrate manually.\n in ${filePath}`,
+              ].join(' '),
+            );
+          }
+        });
     });
   });
 }


### PR DESCRIPTION
## Purpose

The `typography-sizes` codemod was warning of the required manual migration (for `zetta` Headlines, etc.) for every typography component.

## Approach and changes

Use the JSCodeshift forEach to only print the warnings at the right time

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* ~[ ] Meets minimum browser support~
* ~[ ] Meets accessibility requirements~
