### PR TITLE
CurrencyInput hotfix for Chile

### DIFF
--- a/.changeset/popular-dodos-type.md
+++ b/.changeset/popular-dodos-type.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the CurrencyInput bug for Chile locale where shouldn’t be any fraction digits in the input.

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -67,6 +67,8 @@ const DEFAULT_FORMAT = {
   groupDelimiter: ',',
 };
 
+const DUMMY_DELIMITER = '?';
+
 const CurrencyIcon = styled('span')`
   label: simple-currency-input__symbol;
   line-height: ${({ theme }) => theme.spacings.mega};
@@ -120,7 +122,9 @@ export const CurrencyInput = forwardRef(
       <NumberFormat
         // NumberFormat props
         thousandSeparator={groupDelimiter}
-        decimalSeparator={decimalDelimiter}
+        decimalSeparator={
+          maximumFractionDigits > 0 ? decimalDelimiter : DUMMY_DELIMITER
+        }
         decimalScale={maximumFractionDigits}
         customInput={Input}
         getInputRef={ref}


### PR DESCRIPTION


## Purpose

 For Chilean pesos there shouldn’t be any fraction digits and the error decimalDelimiter: undefined was thrown.

## Approach and changes

Pass a dummy decimalSeparator to NumberFormat for a hot fix.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
