### PR TITLE
Throw at missing labels

### DIFF
--- a/.changeset/gentle-frogs-build.md
+++ b/.changeset/gentle-frogs-build.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Added a development-only check for required label props that throws a runtime error if any is missing.

--- a/docs/features/icons.stories.mdx
+++ b/docs/features/icons.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Intro, Icons } from '../../.storybook/components';
 
 # Icons
 
-<Intro>
+<Intro as="div">
 
 The icons used throughout Circuit UI come from SumUp's icon library, [`@sumup/icons`](Packages/icons), which is a required peer dependency of `@sumup/circuit-ui`. Refer to its [documentation](Packages/icons) for usage instructions.
 

--- a/packages/circuit-ui/components/Badge/Badge.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.tsx
@@ -62,7 +62,6 @@ const COLOR_MAP = {
 } as const;
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: badge;
   border-radius: ${theme.borderRadius.pill};
   color: ${theme.colors.white};
   display: inline-block;
@@ -83,7 +82,6 @@ const variantStyles = ({
     return null;
   }
   return css`
-    label: ${`badge--${variant}`};
     background-color: ${theme.colors[currentColor.default]};
     color: ${theme.colors[currentColor.text]};
   `;
@@ -99,7 +97,6 @@ const isDynamicWidth = (children: BadgeProps['children']) => {
 const circleStyles = ({ circle = false, children }: BadgeProps) =>
   circle &&
   css`
-    label: badge--circle;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -48,7 +48,6 @@ export interface BodyProps
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: body;
   font-weight: ${theme.fontWeight.regular};
   margin-bottom: ${theme.spacings.mega};
 `;
@@ -59,7 +58,6 @@ const sizeStyles = ({ theme, size = 'one' }: BodyProps & StyleProps) => {
   }
 
   return css`
-    label: ${`body-${size}`};
     font-size: ${theme.typography.body[size].fontSize};
     line-height: ${theme.typography.body[size].lineHeight};
   `;
@@ -72,13 +70,11 @@ const variantStyles = ({ theme, variant }: BodyProps & StyleProps) => {
     }
     case 'highlight': {
       return css`
-        label: body--highlight;
         font-weight: ${theme.fontWeight.bold};
       `;
     }
     case 'quote': {
       return css`
-        label: body--quote;
         font-style: italic;
         padding-left: ${theme.spacings.kilo};
         border-left: ${theme.borderWidth.mega} solid ${theme.colors.p500};
@@ -86,19 +82,16 @@ const variantStyles = ({ theme, variant }: BodyProps & StyleProps) => {
     }
     case 'success': {
       return css`
-        label: body--success;
         color: ${theme.colors.success};
       `;
     }
     case 'error': {
       return css`
-        label: body--error;
         color: ${theme.colors.danger};
       `;
     }
     case 'subtle': {
       return css`
-        label: body--subtle;
         color: ${theme.colors.n700};
       `;
     }
@@ -117,7 +110,6 @@ const marginStyles = ({ noMargin }: BodyProps & StyleProps) => {
   }
 
   return css`
-    label: text--no-margin;
     margin-bottom: 0;
   `;
 };

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -120,7 +120,6 @@ const SECONDARY_COLOR_MAP = {
 } as const;
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: button;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -157,7 +156,6 @@ const primaryStyles = ({
   const colors = destructive ? COLOR_MAP.destructive : COLOR_MAP.default;
 
   return css`
-    label: button--primary;
     background-color: ${theme.colors[colors.default]};
     border-color: ${theme.colors[colors.default]};
     color: ${theme.colors.white};
@@ -190,7 +188,6 @@ const secondaryStyles = ({
     : SECONDARY_COLOR_MAP.default;
 
   return css`
-    label: button--secondary;
     background-color: ${theme.colors.white};
     border-color: ${theme.colors[colors.default]};
     color: ${theme.colors[colors.text]};
@@ -221,7 +218,6 @@ const tertiaryStyles = ({
   const colors = destructive ? COLOR_MAP.destructive : COLOR_MAP.default;
 
   return css`
-    label: button--tertiary;
     background-color: transparent;
     border-color: transparent;
     color: ${theme.colors[colors.default]};
@@ -251,7 +247,6 @@ const sizeStyles = ({ theme, size = 'giga' }: ButtonProps & StyleProps) => {
   };
 
   return css({
-    label: `button--${size}`,
     ...sizeMap[size],
   });
 };
@@ -259,12 +254,10 @@ const sizeStyles = ({ theme, size = 'giga' }: ButtonProps & StyleProps) => {
 const stretchStyles = ({ stretch }: ButtonProps) =>
   stretch &&
   css`
-    label: button--stretch;
     width: 100%;
   `;
 
 const iconStyles = (theme: Theme) => css`
-  label: button__icon;
   flex-shrink: 0;
   margin-right: ${theme.spacings.byte};
 `;

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
@@ -52,7 +52,6 @@ const getInlineStyles = ({ theme }: StyleProps) => css`
 `;
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: button-group;
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
@@ -78,14 +77,9 @@ const alignmentMap = {
   right: 'flex-end',
 } as const;
 
-const alignmentStyles = ({ align = 'right' }: ButtonGroupProps) => {
-  const label = `button-group--${align}`;
-
-  return css`
-    label: ${label};
-    justify-content: ${alignmentMap[align]};
-  `;
-};
+const alignmentStyles = ({ align = 'right' }: ButtonGroupProps) => css`
+  justify-content: ${alignmentMap[align]};
+`;
 
 const inlineMobileStyles = ({
   theme,
@@ -93,7 +87,6 @@ const inlineMobileStyles = ({
 }: StyleProps & ButtonGroupProps) =>
   inlineMobile &&
   css`
-    label: button-group--inline-mobile;
     ${getInlineStyles({ theme })}
   `;
 

--- a/packages/circuit-ui/components/Card/Card.tsx
+++ b/packages/circuit-ui/components/Card/Card.tsx
@@ -31,7 +31,6 @@ export interface CardProps extends HTMLProps<HTMLDivElement> {
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: card;
   background-color: ${theme.colors.white};
   border-radius: ${theme.borderRadius.mega};
   border: ${theme.borderWidth.mega} solid ${theme.colors.n200};
@@ -50,7 +49,6 @@ const spacingStyles = ({ theme, spacing = 'giga' }: StyleProps & CardProps) => {
     `,
   };
   return css`
-    label: ${`card--spacing-${spacing}`};
     padding: ${spacings[spacing]};
   `;
 };

--- a/packages/circuit-ui/components/Card/components/Footer/Footer.tsx
+++ b/packages/circuit-ui/components/Card/components/Footer/Footer.tsx
@@ -28,7 +28,6 @@ export interface CardFooterProps {
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: card__footer;
   display: block;
   width: 100%;
   margin-top: ${theme.spacings.giga};
@@ -46,7 +45,6 @@ const alignmentStyles = ({
 }: StyleProps & CardFooterProps) =>
   align === 'right' &&
   css`
-    label: card__footer--right;
     ${theme.mq.kilo} {
       justify-content: flex-end;
     }

--- a/packages/circuit-ui/components/Card/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Card/components/Header/Header.tsx
@@ -52,7 +52,6 @@ export type CardHeaderProps = {
 type ContainerElProps = Pick<CardHeaderProps, 'children'>;
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: card__header;
   align-items: center;
   display: flex;
   justify-content: space-between;
@@ -63,7 +62,6 @@ const noHeadlineStyles = ({ children }: ContainerElProps) =>
   Array.isArray(children) &&
   !children[0] &&
   css`
-    label: card__header--no-heading;
     justify-content: flex-end;
   `;
 

--- a/packages/circuit-ui/components/CardList/CardList.js
+++ b/packages/circuit-ui/components/CardList/CardList.js
@@ -21,8 +21,6 @@ import Card from '../Card';
  * Component that wraps a list of CardList.Item components
  */
 const Wrapper = styled(Card)`
-  label: cardlist__wrapper;
-
   padding: 0;
   border-radius: ${(p) => p.theme.borderRadius.bit};
   border: ${(p) => `${p.theme.borderWidth.kilo} solid ${p.theme.colors.n300}`};

--- a/packages/circuit-ui/components/CardList/components/Item/Item.js
+++ b/packages/circuit-ui/components/CardList/components/Item/Item.js
@@ -20,8 +20,6 @@ import { css } from '@emotion/core';
 import { isEnter, isSpacebar } from '../../../../util/key-codes';
 
 const baseStyles = ({ theme }) => css`
-  label: cardlist__item;
-
   align-items: center;
   position: relative;
   cursor: pointer;
@@ -63,8 +61,6 @@ const paddingStyles = ({ theme, padding }) =>
 const selectedStyles = ({ theme, selected }) =>
   selected &&
   css`
-    label: cardlist__item--selected;
-
     background: ${theme.colors.p100};
 
     ${getBorderStyles(theme)};

--- a/packages/circuit-ui/components/Carousel/components/Buttons/Buttons.js
+++ b/packages/circuit-ui/components/Carousel/components/Buttons/Buttons.js
@@ -21,7 +21,6 @@ import { ChevronLeft, ChevronRight, Pause, Play } from '@sumup/icons';
 import IconButton from '../../../IconButton';
 
 const buttonListStyles = css`
-  label: carousel__buttonlist;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -30,7 +29,6 @@ const buttonListStyles = css`
 export const ButtonList = styled('div')(buttonListStyles);
 
 const buttonStyles = ({ theme }) => css`
-  label: carousel__button;
   margin-left: ${theme.spacings.byte};
 
   &:first-of-type {

--- a/packages/circuit-ui/components/Carousel/components/Container/Container.js
+++ b/packages/circuit-ui/components/Carousel/components/Container/Container.js
@@ -17,7 +17,6 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 const baseStyles = css`
-  label: carousel__container;
   width: 100%;
   height: auto;
   position: relative;

--- a/packages/circuit-ui/components/Carousel/components/Controls/Controls.js
+++ b/packages/circuit-ui/components/Carousel/components/Controls/Controls.js
@@ -17,7 +17,6 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 const baseStyles = ({ theme }) => css`
-  label: carousel__controls;
   width: 100%;
   display: flex;
   align-items: center;

--- a/packages/circuit-ui/components/Carousel/components/Slide/Slide.js
+++ b/packages/circuit-ui/components/Carousel/components/Slide/Slide.js
@@ -23,7 +23,6 @@ import { ANIMATION_DURATION, SLIDE_DIRECTIONS } from '../../constants';
 import * as SlideService from './SlideService';
 
 const baseStyles = ({ index, stackOrder, width }) => css`
-  label: carousel__slide;
   width: 100%;
   flex-grow: 0;
   flex-shrink: 0;

--- a/packages/circuit-ui/components/Carousel/components/SlideImage/SlideImage.js
+++ b/packages/circuit-ui/components/Carousel/components/SlideImage/SlideImage.js
@@ -22,13 +22,11 @@ import AspectRatio from '../../../AspectRatio';
 import { ASPECT_RATIO } from '../../constants';
 
 const backgroundStyles = ({ theme }) => css`
-  label: carousel__slideimage;
   background: ${theme.colors.n100};
 `;
 const StyledAspectRatio = styled(AspectRatio)(backgroundStyles);
 
 const imageStyles = css`
-  label: carousel__image;
   img {
     object-fit: cover;
   }

--- a/packages/circuit-ui/components/Carousel/components/Slides/Slides.js
+++ b/packages/circuit-ui/components/Carousel/components/Slides/Slides.js
@@ -17,7 +17,6 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 const baseStyles = css`
-  label: carousel__slides;
   display: flex;
   align-items: center;
   overflow: hidden;

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -55,7 +55,6 @@ export interface CheckboxProps extends HTMLProps<HTMLInputElement> {
 type LabelElProps = Pick<CheckboxProps, 'invalid' | 'disabled'>;
 
 const labelBaseStyles = ({ theme }: StyleProps) => css`
-  label: checkbox__label;
   color: ${theme.colors.bodyColor};
   display: inline-block;
   padding-left: 26px;
@@ -101,7 +100,6 @@ const labelBaseStyles = ({ theme }: StyleProps) => css`
 const labelInvalidStyles = ({ theme, invalid }: StyleProps & LabelElProps) =>
   invalid &&
   css`
-    label: checkbox--error;
     &:not(:focus)::before {
       border-color: ${theme.colors.danger};
       background-color: ${theme.colors.r100};
@@ -111,7 +109,6 @@ const labelInvalidStyles = ({ theme, invalid }: StyleProps & LabelElProps) =>
 const labelDisabledStyles = ({ disabled, theme }: StyleProps & LabelElProps) =>
   disabled &&
   css`
-    label: checkbox--disabled;
     ${disableVisually()};
 
     &::before {
@@ -130,7 +127,6 @@ const CheckboxLabel = styled('label')<LabelElProps>(
 type WrapperElProps = Pick<CheckboxProps, 'noMargin'>;
 
 const wrapperBaseStyles = ({ theme }: StyleProps) => css`
-  label: checkbox;
   position: relative;
 
   &:last-of-type {
@@ -150,7 +146,6 @@ const wrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
     return null;
   }
   return css`
-    label: checkbox--no-margin;
     &:last-of-type {
       margin-bottom: 0;
     }
@@ -165,7 +160,6 @@ const CheckboxWrapper = styled('div')<WrapperElProps>(
 type InputElProps = Omit<CheckboxProps, 'tracking'>;
 
 const inputBaseStyles = ({ theme }: StyleProps) => css`
-  label: checkbox__input;
   ${hideVisually()};
 
   &:hover + label::before {
@@ -200,8 +194,6 @@ const inputBaseStyles = ({ theme }: StyleProps) => css`
 const inputInvalidStyles = ({ theme, invalid }: StyleProps & InputElProps) =>
   invalid &&
   css`
-    label: checkbox__input--invalid;
-
     &:hover + label::before,
     &:focus + label::before {
       border-color: ${theme.colors.r700};
@@ -219,7 +211,6 @@ const CheckboxInput = styled('input')<InputElProps>(
 );
 
 const tooltipStyles = ({ theme }: StyleProps) => css`
-  label: checkbox__tooltip;
   left: -${theme.spacings.kilo};
 `;
 

--- a/packages/circuit-ui/components/Col/Col.js
+++ b/packages/circuit-ui/components/Col/Col.js
@@ -21,8 +21,6 @@ import isPropValid from '@emotion/is-prop-valid';
 import { getSpanStyles, getSkipStyles, getBreakPointStyles } from './utils';
 
 const baseStyles = ({ theme, span, skip }) => css`
-  label: col;
-
   box-sizing: border-box;
   float: left;
 

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -68,7 +68,6 @@ const DEFAULT_FORMAT = {
 };
 
 const CurrencyIcon = styled('span')`
-  label: simple-currency-input__symbol;
   line-height: ${({ theme }) => theme.spacings.mega};
   display: flex;
   align-items: center;

--- a/packages/circuit-ui/components/Grid/Grid.js
+++ b/packages/circuit-ui/components/Grid/Grid.js
@@ -31,8 +31,6 @@ const getBreakPointStyles = (theme, breakpoint) => {
 };
 
 const baseStyles = ({ theme }) => css`
-  label: grid;
-
   margin: 0 auto;
   width: 100%;
 

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -46,14 +46,12 @@ const LAYER_HEIGHT = '2px';
 const HAMBURGER_WIDTH = '14px';
 
 const buttonStyles = () => css`
-  label: hamburger;
   border: 0;
 `;
 
 const Button = styled(IconButton)<IconButtonProps>(buttonStyles);
 
 const boxStyles = ({ theme }: StyleProps) => css`
-  label: hamburger__box;
   position: relative;
   display: flex;
   justify-content: center;
@@ -65,7 +63,6 @@ const boxStyles = ({ theme }: StyleProps) => css`
 const Box = styled.span<HTMLProps<HTMLSpanElement>>(boxStyles);
 
 const layersBaseStyles = () => css`
-  label: hamburger__layers;
   top: 50%;
   width: ${HAMBURGER_WIDTH};
 
@@ -101,7 +98,6 @@ const layersBaseStyles = () => css`
 const layersActiveStyles = ({ isActive }: { isActive?: boolean }) =>
   isActive &&
   css`
-    label: hamburger__layers--active;
     transform: rotate(225deg);
 
     &,

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -128,19 +128,31 @@ const Layers = styled('span')<{ isActive?: boolean }>(
  */
 export const Hamburger = ({
   isActive,
-  activeLabel = 'Close menu',
-  inactiveLabel = 'Open menu',
+  activeLabel,
+  inactiveLabel,
   tracking = {},
   ...props
-}: HamburgerProps): JSX.Element => (
-  <Button
-    label={isActive ? activeLabel : inactiveLabel}
-    {...props}
-    tracking={{ component: 'hamburger', ...tracking }}
-    type="button"
-  >
-    <Box>
-      <Layers isActive={isActive} />
-    </Box>
-  </Button>
-);
+}: HamburgerProps): JSX.Element => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    (!activeLabel || !inactiveLabel)
+  ) {
+    throw new Error(
+      'The Hamburger component is missing an `activeLabel` and/or an `inactiveLabel` prop. This is an accessibility requirement.',
+    );
+  }
+
+  return (
+    <Button
+      label={isActive ? activeLabel : inactiveLabel}
+      {...props}
+      tracking={{ component: 'hamburger', ...tracking }}
+      type="button"
+    >
+      <Box>
+        <Layers isActive={isActive} />
+      </Box>
+    </Button>
+  );
+};

--- a/packages/circuit-ui/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Header/Header.tsx
@@ -43,7 +43,6 @@ export interface HeaderProps extends HTMLProps<HTMLDivElement> {
 type HeaderElProps = Pick<HeaderProps, 'mobileOnly'>;
 
 const containerStyles = ({ theme }: StyleProps) => css`
-  label: header;
   width: 100%;
   display: flex;
   align-items: center;

--- a/packages/circuit-ui/components/Header/components/Title/Title.tsx
+++ b/packages/circuit-ui/components/Header/components/Title/Title.tsx
@@ -26,7 +26,6 @@ export interface TitleProps {
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: header__title;
   font-size: ${theme.typography.headline.four.fontSize};
   line-height: ${theme.typography.headline.four.lineHeight};
   font-weight: ${theme.fontWeight.bold};

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -41,7 +41,6 @@ export interface HeadlineProps
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: headline;
   font-weight: ${theme.fontWeight.bold};
   margin-bottom: ${theme.spacings.giga};
   color: ${theme.colors.black};
@@ -53,7 +52,6 @@ const sizeStyles = ({ theme, size = 'one' }: StyleProps & HeadlineProps) => {
   }
 
   return css`
-    label: ${`headline-${size}`};
     font-size: ${theme.typography.headline[size].fontSize};
     line-height: ${theme.typography.headline[size].lineHeight};
   `;
@@ -70,7 +68,6 @@ const noMarginStyles = ({ noMargin }: HeadlineProps) => {
   }
 
   return css`
-    label: headline--no-margin;
     margin-bottom: 0;
   `;
 };

--- a/packages/circuit-ui/components/Hr/Hr.tsx
+++ b/packages/circuit-ui/components/Hr/Hr.tsx
@@ -18,7 +18,6 @@ import { css } from '@emotion/core';
 import styled, { NoTheme, StyleProps } from '../../styles/styled';
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: hr;
   display: block;
   width: 100%;
   border: 0;

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -44,7 +44,6 @@ const sizeStyles = (size: IconButtonProps['size'] = 'giga') => (
   };
 
   return css({
-    label: `button--${size}`,
     padding: `calc(${sizeMap[size]} - 1px)`,
   });
 };

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -56,6 +56,15 @@ export const IconButton = forwardRef(
   ({ children, label, size, ...props }: IconButtonProps, ref?: Ref<any>) => {
     const child = Children.only(children);
     const icon = cloneElement(child, { role: 'presentation' });
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !label
+    ) {
+      throw new Error(
+        'The IconButton component is missing a `label` prop. This is an accessibility requirement.',
+      );
+    }
     return (
       <Button title={label} css={sizeStyles(size)} {...props} ref={ref}>
         {icon}

--- a/packages/circuit-ui/components/Image/Image.tsx
+++ b/packages/circuit-ui/components/Image/Image.tsx
@@ -33,7 +33,6 @@ export interface ImageProps
 }
 
 const baseStyles = () => css`
-  label: image;
   display: block;
   height: auto;
   max-height: 100%;

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -278,6 +278,16 @@ export const ImageInput = ({
   component: Component,
   ...props
 }: ImageInputProps): JSX.Element => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    (!label || !clearButtonLabel || !loadingLabel)
+  ) {
+    throw new Error(
+      'The ImageInput component is missing a `label`, a `clearButtonLabel` and/or a `loadingLabel` prop. This is an accessibility requirement.',
+    );
+  }
+
   const inputRef = useRef<HTMLInputElement>(null);
   const id = customId || uniqueId('image-input_');
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/packages/circuit-ui/components/InlineElements/InlineElements.tsx
+++ b/packages/circuit-ui/components/InlineElements/InlineElements.tsx
@@ -45,7 +45,6 @@ const fallbackBaseStyles = ({
   }) / ${childrenCount}`;
 
   return css`
-    label: inline-elements--fallback;
     > * {
       display: block;
       width: 100%;
@@ -79,7 +78,6 @@ const baseStyles = ({
     ).join('\n');
 
   return css`
-    label: inline-elements;
     display: flex;
     flex-direction: column;
     width: 100%;
@@ -125,7 +123,6 @@ const fallbackInlineMobileStyles = ({
   }) / ${childrenCount}`;
 
   return css`
-    label: inline-elements--inline-mobile-fallback;
     ${theme.mq.untilKilo} {
       > * {
         float: left;
@@ -143,8 +140,6 @@ const inlineMobileStyles = ({
 }: StyleProps & InlineElementsProps) =>
   inlineMobile &&
   css`
-    label: inline-elements--inline-mobile;
-
     ${theme.mq.untilKilo} {
       flex-direction: row;
       flex-grow: 1;

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
@@ -35,10 +35,6 @@ export interface InlineMessageProps {
   noMargin?: boolean;
 }
 
-const baseStyles = css`
-  label: inline-message;
-`;
-
 const marginStyles = ({ noMargin }: InlineMessageProps) => {
   if (!noMargin) {
     deprecate(
@@ -51,7 +47,6 @@ const marginStyles = ({ noMargin }: InlineMessageProps) => {
   }
 
   return css`
-    label: text--no-margin;
     margin-bottom: 0;
   `;
 };
@@ -76,7 +71,6 @@ const createLeftBorderStyles = (variantName: Variant) => ({
   return (
     variant === variantName &&
     css`
-      label: ${`inline-message--${variant}`};
       color: ${textColors[variant]};
       position: relative;
       margin-bottom: ${theme.spacings.mega};
@@ -105,7 +99,6 @@ const dangerStyles = createLeftBorderStyles('danger');
  * An inline message displayed inside a Card.
  */
 export const InlineMessage = styled('p')<InlineMessageProps>(
-  baseStyles,
   dangerStyles,
   successStyles,
   warningStyles,

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -324,6 +324,16 @@ export const Input = forwardRef(
     }: InputProps,
     ref: InputProps['ref'],
   ): ReturnType => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !label
+    ) {
+      throw new Error(
+        'The Input component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` to hide the label visually.',
+      );
+    }
+
     const id = customId || uniqueId('input_');
 
     const prefix = RenderPrefix && <RenderPrefix css={prefixStyles} />;

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -109,7 +109,6 @@ export interface InputProps extends Omit<HTMLProps<HTMLInputElement>, 'label'> {
 }
 
 const containerStyles = () => css`
-  label: input__container;
   position: relative;
 `;
 
@@ -130,7 +129,6 @@ const labelNoMarginStyles = ({
     );
 
     return css`
-      label: input__label--margin;
       margin-bottom: ${theme.spacings.mega};
     `;
   }
@@ -145,7 +143,6 @@ type InputElProps = Omit<InputProps, 'label'> & {
 };
 
 const inputBaseStyles = ({ theme }: StyleProps) => css`
-  label: input;
   -webkit-appearance: none;
   background-color: ${theme.colors.white};
   border: none;
@@ -171,7 +168,6 @@ const inputWarningStyles = ({
   !disabled &&
   hasWarning &&
   css`
-    label: input--warning;
     &:not(:focus)::placeholder {
       color: ${theme.colors.warning};
     }
@@ -185,7 +181,6 @@ const inputInvalidStyles = ({
   !disabled &&
   invalid &&
   css`
-    label: input--error;
     &:not(:focus)::placeholder {
       color: ${theme.colors.danger};
       opacity: 0.5;
@@ -195,35 +190,30 @@ const inputInvalidStyles = ({
 const inputReadonlyStyles = ({ theme, readOnly }: StyleProps & InputElProps) =>
   readOnly &&
   css`
-    label: input--readonly;
     background-color: ${theme.colors.n100};
   `;
 
 const inputDisabledStyles = ({ theme, disabled }: StyleProps & InputElProps) =>
   disabled &&
   css`
-    label: input--disabled;
     background-color: ${theme.colors.n200};
   `;
 
 const inputTextAlignRightStyles = ({ textAlign }: InputElProps) =>
   textAlign === 'right' &&
   css`
-    label: input--right;
     text-align: right;
   `;
 
 const inputPrefixStyles = ({ theme, hasPrefix }: StyleProps & InputElProps) =>
   hasPrefix &&
   css`
-    label: input--prefix;
     padding-left: ${theme.spacings.exa};
   `;
 
 const inputSuffixStyles = ({ theme, hasSuffix }: StyleProps & InputElProps) =>
   hasSuffix &&
   css`
-    label: input--suffix;
     padding-right: ${theme.spacings.exa};
   `;
 
@@ -245,7 +235,6 @@ const InputElement = styled('input')<InputElProps>(
  * destructuring.
  */
 const prefixStyles = (theme: Theme) => css`
-  label: input__prefix;
   position: absolute;
   pointer-events: none;
   color: ${theme.colors.n700};
@@ -259,7 +248,6 @@ const prefixStyles = (theme: Theme) => css`
  * destructuring.
  */
 const suffixStyles = (theme: Theme) => css`
-  label: input__suffix;
   position: absolute;
   top: 0;
   right: 0;
@@ -272,7 +260,6 @@ const suffixStyles = (theme: Theme) => css`
 `;
 
 const labelTextStyles = ({ theme }: StyleProps) => css`
-  label: input__label-text;
   display: inline-block;
   margin-bottom: ${theme.spacings.bit};
 `;
@@ -280,7 +267,6 @@ const labelTextStyles = ({ theme }: StyleProps) => css`
 const labelTextHiddenStyles = ({ hideLabel }: { hideLabel?: boolean }) =>
   hideLabel &&
   css`
-    label: input__label-text--hidden;
     ${hideVisually()};
   `;
 
@@ -290,7 +276,6 @@ const LabelText = styled('span')<{ hideLabel?: boolean }>(
 );
 
 const optionalLabelStyles = ({ theme }: StyleProps) => css`
-  label: input__optional-label;
   color: ${theme.colors.n700};
 `;
 

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -315,7 +315,7 @@ export const Input = forwardRef(
       !label
     ) {
       throw new Error(
-        'The Input component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` to hide the label visually.',
+        'The Input component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
 

--- a/packages/circuit-ui/components/Label/Label.tsx
+++ b/packages/circuit-ui/components/Label/Label.tsx
@@ -44,21 +44,18 @@ export interface LabelProps extends HTMLProps<HTMLLabelElement> {
 }
 
 const baseStyles = () => css`
-  label: label;
   display: block;
 `;
 
 const visuallyHiddenStyles = ({ visuallyHidden }: LabelProps) =>
   visuallyHidden &&
   css`
-    label: label--hidden;
     ${hideVisually()};
   `;
 
 const inlineStyles = ({ theme, inline }: StyleProps & LabelProps) =>
   inline &&
   css`
-    label: label--inline;
     display: inline-block;
     margin-right: ${theme.spacings.mega};
   `;
@@ -66,7 +63,6 @@ const inlineStyles = ({ theme, inline }: StyleProps & LabelProps) =>
 const disabledStyles = ({ disabled }: LabelProps) =>
   disabled &&
   css`
-    label: input__label--disabled;
     ${disableVisually()};
   `;
 

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -45,7 +45,6 @@ export interface ListProps
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: list;
   font-weight: ${theme.fontWeight.regular};
   margin-bottom: ${theme.spacings.mega};
 `;
@@ -67,7 +66,6 @@ const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
   };
   const { marginBottom, paddingLeft, marginLeft, type } = sizeMap[size];
   return css`
-    label: ${`list--${size}`};
     padding-left: ${paddingLeft};
     ${type};
 
@@ -95,7 +93,6 @@ const marginStyles = ({ noMargin }: ListProps) => {
     return null;
   }
   return css`
-    label: list--no-margin;
     margin-bottom: 0;
     li:last-child {
       margin-bottom: 0;

--- a/packages/circuit-ui/components/LoadingButton/LoadingButton.tsx
+++ b/packages/circuit-ui/components/LoadingButton/LoadingButton.tsx
@@ -86,19 +86,31 @@ const Children = styled.span<{ isLoading: boolean }>(
 export const LoadingButton: FC<LoadingButtonProps> = ({
   children,
   isLoading = false,
-  loadingLabel = 'Loading',
+  loadingLabel,
   ...props
-}) => (
-  <Button
-    css={buttonStyles}
-    disabled={isLoading}
-    aria-live="polite"
-    aria-busy={isLoading}
-    {...props}
-  >
-    <LoadingIcon isLoading={isLoading} size="byte">
-      <LoadingLabel>{loadingLabel}</LoadingLabel>
-    </LoadingIcon>
-    <Children isLoading={isLoading}>{children}</Children>
-  </Button>
-);
+}) => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !loadingLabel
+  ) {
+    throw new Error(
+      'The LoadingButton component is missing a `loadingLabel` prop. This is an accessibility requirement.',
+    );
+  }
+
+  return (
+    <Button
+      css={buttonStyles}
+      disabled={isLoading}
+      aria-live="polite"
+      aria-busy={isLoading}
+      {...props}
+    >
+      <LoadingIcon isLoading={isLoading} size="byte">
+        <LoadingLabel>{loadingLabel}</LoadingLabel>
+      </LoadingIcon>
+      <Children isLoading={isLoading}>{children}</Children>
+    </Button>
+  );
+};

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -151,15 +151,26 @@ export const Modal: ModalComponent<ModalProps> = ({
   closeButtonLabel,
   className,
   ...props
-}) => (
-  <ClassNames<Theme> key={variant}>
-    {({ css: cssString, cx, theme }) => {
-      // React Modal styles
-      // https://reactcommunity.org/react-modal/styles/classes/
+}) => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !preventClose &&
+    !closeButtonLabel
+  ) {
+    throw new Error(
+      'The Modal is missing a `closeButtonLabel` prop. This is an accessibility requirement. Pass `preventClose` to hide the close button.',
+    );
+  }
+  return (
+    <ClassNames<Theme> key={variant}>
+      {({ css: cssString, cx, theme }) => {
+        // React Modal styles
+        // https://reactcommunity.org/react-modal/styles/classes/
 
-      const styles = {
-        base: cx(
-          cssString`
+        const styles = {
+          base: cx(
+            cssString`
             position: fixed;
             outline: none;
             background-color: ${theme.colors.white};
@@ -205,15 +216,15 @@ export const Modal: ModalComponent<ModalProps> = ({
               }
             }
           `,
-          variant === 'contextual' &&
-            cssString`
+            variant === 'contextual' &&
+              cssString`
               ${theme.mq.untilKilo} {
                 border-top-left-radius: ${theme.borderRadius.mega};
                 border-top-right-radius: ${theme.borderRadius.mega};
               }
             `,
-          variant === 'immersive' &&
-            cssString`
+            variant === 'immersive' &&
+              cssString`
               /* iOS viewport bug fix */
               /* https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/ */
               @supports (max-height: -webkit-fill-available) {
@@ -223,10 +234,10 @@ export const Modal: ModalComponent<ModalProps> = ({
                 }
               }
             `,
-        ),
-        // The !important below is necessary because of some weird
-        // style specificity issues in Emotion.
-        afterOpen: cssString`
+          ),
+          // The !important below is necessary because of some weird
+          // style specificity issues in Emotion.
+          afterOpen: cssString`
           ${theme.mq.untilKilo} {
             transform: translateY(0) !important;
           }
@@ -235,7 +246,7 @@ export const Modal: ModalComponent<ModalProps> = ({
             opacity: 1 !important;
           }
         `,
-        beforeClose: cssString`
+          beforeClose: cssString`
           ${theme.mq.untilKilo} {
             transform: translateY(100%);
           }
@@ -244,10 +255,10 @@ export const Modal: ModalComponent<ModalProps> = ({
             opacity: 0;
           }
         `,
-      };
+        };
 
-      const overlayStyles = {
-        base: cssString`
+        const overlayStyles = {
+          base: cssString`
           position: fixed;
           top: 0;
           left: 0;
@@ -262,43 +273,44 @@ export const Modal: ModalComponent<ModalProps> = ({
             transition: opacity ${TRANSITION_DURATION_DESKTOP}ms ease-in-out;
           }
         `,
-        afterOpen: cssString`
+          afterOpen: cssString`
           opacity: 1;
         `,
-        beforeClose: cssString`
+          beforeClose: cssString`
           opacity: 0;
         `,
-      };
+        };
 
-      const reactModalProps = {
-        className: styles,
-        overlayClassName: overlayStyles,
-        onRequestClose: onClose,
-        closeTimeoutMS: TRANSITION_DURATION,
-        shouldCloseOnOverlayClick: !preventClose,
-        shouldCloseOnEsc: !preventClose,
-        ...props,
-      };
+        const reactModalProps = {
+          className: styles,
+          overlayClassName: overlayStyles,
+          onRequestClose: onClose,
+          closeTimeoutMS: TRANSITION_DURATION,
+          shouldCloseOnOverlayClick: !preventClose,
+          shouldCloseOnEsc: !preventClose,
+          ...props,
+        };
 
-      return (
-        <StackContext.Provider value={theme.zIndex.modal}>
-          <ReactModal {...reactModalProps}>
-            <Content variant={variant} className={className}>
-              {!preventClose && closeButtonLabel && (
-                <CloseButton
-                  onClick={onClose}
-                  label={closeButtonLabel}
-                  css={closeButtonStyles}
-                />
-              )}
+        return (
+          <StackContext.Provider value={theme.zIndex.modal}>
+            <ReactModal {...reactModalProps}>
+              <Content variant={variant} className={className}>
+                {!preventClose && closeButtonLabel && (
+                  <CloseButton
+                    onClick={onClose}
+                    label={closeButtonLabel}
+                    css={closeButtonStyles}
+                  />
+                )}
 
-              {isFunction(children) ? children({ onClose }) : children}
-            </Content>
-          </ReactModal>
-        </StackContext.Provider>
-      );
-    }}
-  </ClassNames>
-);
+                {isFunction(children) ? children({ onClose }) : children}
+              </Content>
+            </ReactModal>
+          </StackContext.Provider>
+        );
+      }}
+    </ClassNames>
+  );
+};
 
 Modal.TIMEOUT = TRANSITION_DURATION;

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -159,7 +159,7 @@ export const Modal: ModalComponent<ModalProps> = ({
     !closeButtonLabel
   ) {
     throw new Error(
-      'The Modal is missing a `closeButtonLabel` prop. This is an accessibility requirement. Pass `preventClose` to hide the close button.',
+      "The modal is missing a `closeButtonLabel` prop. This is an accessibility requirement. Pass it in `setModal`, or pass `preventClose` if you intend to hide the modal's close button.",
     );
   }
   return (

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -227,8 +227,6 @@ export const Modal: ModalComponent<ModalProps> = ({
         // The !important below is necessary because of some weird
         // style specificity issues in Emotion.
         afterOpen: cssString`
-          label: modal--after-open;
-
           ${theme.mq.untilKilo} {
             transform: translateY(0) !important;
           }
@@ -238,8 +236,6 @@ export const Modal: ModalComponent<ModalProps> = ({
           }
         `,
         beforeClose: cssString`
-          label: modal--before-close;
-
           ${theme.mq.untilKilo} {
             transform: translateY(100%);
           }

--- a/packages/circuit-ui/components/Notification/Notification.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.tsx
@@ -36,7 +36,6 @@ export interface NotificationProps {
 }
 
 const containerStyles = () => css`
-  label: notification;
   position: relative;
   display: flex;
   flex-direction: row;
@@ -47,7 +46,6 @@ const containerStyles = () => css`
 const Container = styled('div')<NoTheme>(containerStyles);
 
 const contentStyles = () => css`
-  label: notification__content;
   width: 100%;
 `;
 
@@ -67,7 +65,6 @@ const iconMap = {
 
 const iconStyles = (variant: Variant) => (theme: Theme) =>
   css`
-    label: notification__icon;
     display: block;
     margin-right: ${theme.spacings.kilo};
     flex-grow: 0;
@@ -77,7 +74,6 @@ const iconStyles = (variant: Variant) => (theme: Theme) =>
   `;
 
 const closeButtonStyles = ({ theme }: StyleProps) => css`
-  label: notification__close-button;
   flex-grow: 0;
   flex-shrink: 0;
   align-self: flex-start;
@@ -100,7 +96,7 @@ export const Notification = ({
   onClose,
   closeLabel,
   ...props
-}: NotificationProps) => {
+}: NotificationProps): JSX.Element => {
   const Icon = icon || iconMap[variant];
 
   return (

--- a/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
+++ b/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
@@ -27,7 +27,6 @@ export interface NotificationCardProps extends HTMLProps<HTMLDivElement> {
 }
 
 const outerStyles = ({ theme }: StyleProps) => css`
-  label: notification-banner;
   width: 100%;
   background-color: ${theme.colors.white};
   border-radius: ${theme.borderRadius.mega};
@@ -36,7 +35,6 @@ const outerStyles = ({ theme }: StyleProps) => css`
 const NotificationCardOuter = styled('div')<NoTheme>(outerStyles, shadow());
 
 const innerStyles = ({ theme }: StyleProps) => css`
-  label: notification-banner__inner;
   padding: ${theme.spacings.mega} ${theme.spacings.giga};
 `;
 
@@ -48,7 +46,7 @@ const NotificationCardInner = styled('div')<NoTheme>(innerStyles);
 export const NotificationCard = ({
   children,
   ...props
-}: NotificationCardProps) => (
+}: NotificationCardProps): JSX.Element => (
   <NotificationCardOuter {...props} aria-live="polite" role="status">
     <NotificationCardInner>{children}</NotificationCardInner>
   </NotificationCardOuter>

--- a/packages/circuit-ui/components/NotificationList/NotificationList.tsx
+++ b/packages/circuit-ui/components/NotificationList/NotificationList.tsx
@@ -29,7 +29,6 @@ export interface NotificationListProps extends HTMLProps<HTMLUListElement> {
 // The first max-width rule is a fallback for old versions of Android
 // that don't support calc()
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: notification-list;
   display: flex;
   flex-direction: column;
   width: 400px;
@@ -53,7 +52,6 @@ const baseStyles = ({ theme }: StyleProps) => css`
 const NotificationListWrapper = styled('ul')<NoTheme>(baseStyles);
 
 const cardStyles = ({ theme }: StyleProps) => css`
-  label: card;
   background-color: ${theme.colors.white};
   border-radius: ${theme.borderRadius.mega};
   border: ${theme.borderWidth.kilo} solid ${theme.colors.n200};
@@ -71,7 +69,7 @@ const NotificationListCard = styled('li')(cardStyles, shadow());
 export const NotificationList = ({
   children,
   ...props
-}: NotificationListProps) => (
+}: NotificationListProps): JSX.Element => (
   <NotificationListWrapper {...props} aria-live="polite">
     {Children.map(children, (child, i) => (
       <NotificationListCard key={i}>{child}</NotificationListCard>

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -94,14 +94,24 @@ export const Pagination = ({
   currentPage = 1,
   totalPages,
   onChange,
-  label = 'Pagination',
-  previousLabel = 'Previous page',
-  nextLabel = 'Next page',
+  label,
+  previousLabel,
+  nextLabel,
   pageLabel = (page) => `Go to page ${page}`,
   totalLabel,
   tracking = {},
   ...props
 }: PaginationProps): ReactNode => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    (!label || !previousLabel || !nextLabel)
+  ) {
+    throw new Error(
+      'The Pagination component is missing a `label`, a `previousLabel` and/or a `nextLabel` prop. This is an accessibility requirement.',
+    );
+  }
+
   // Can't use our custom useClickEvent here because it doesn't allow us
   // to add the page number as label. So we implement it from scratch:
   const dispatch = useClickTrigger();

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { ReactNode } from 'react';
 import { css } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';
 import { ChevronLeft, ChevronRight } from '@sumup/icons';
@@ -100,7 +101,7 @@ export const Pagination = ({
   totalLabel,
   tracking = {},
   ...props
-}: PaginationProps) => {
+}: PaginationProps): ReactNode => {
   // Can't use our custom useClickEvent here because it doesn't allow us
   // to add the page number as label. So we implement it from scratch:
   const dispatch = useClickTrigger();

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -30,11 +30,11 @@ interface BaseProps {
    */
   size?: 'byte' | 'kilo' | 'mega';
   /**
-   * A descriptive label that is used by screenreaders.
+   * A descriptive label that is used by screen readers.
    */
   label: string;
   /**
-   * Visually hide the label. It will remain accessible to screenreaders.
+   * Visually hide the label. It will remain accessible to screen readers.
    */
   hideLabel?: boolean;
 }
@@ -231,6 +231,15 @@ export function ProgressBar({
   hideLabel,
   ...props
 }: ProgressBarProps): JSX.Element {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !label
+  ) {
+    throw new Error(
+      'The ProgressBar component is missing a `label` prop. This is an accessibility requirement.',
+    );
+  }
   const ariaId = uniqueId('progress-bar_');
   const title = hideLabel ? label : undefined;
   return (

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -82,7 +82,6 @@ const wrapperStyles = () => css`
 const ProgressBarWrapper = styled('div')<NoTheme>(wrapperStyles);
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: progress-bar;
   background-color: ${theme.colors.n200};
   border-radius: ${theme.borderRadius.pill};
   position: relative;
@@ -164,8 +163,6 @@ const variantStyles = ({
     secondary: theme.colors.n900,
   };
   return css`
-    label: ${`progress-bar--${variant}`};
-
     &::after {
       background-color: ${variantMap[variant]};
     }
@@ -182,7 +179,6 @@ const sizeStyles = ({
     mega: theme.spacings.mega,
   };
   return css({
-    label: `progress-bar--${size}`,
     height: sizeMap[size],
   });
 };
@@ -202,14 +198,12 @@ const TimeProgress = styled('span')<TimeProgressElProps>(
 );
 
 const labelStyles = ({ theme }: StyleProps) => css`
-  label: progress-bar__label;
   margin-left: ${theme.spacings.byte};
 `;
 
 const labelHiddenStyles = ({ hideLabel }: LabelElProps) =>
   hideLabel &&
   css`
-    label: progress-bar__label--hidden;
     ${hideVisually()};
   `;
 

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -44,7 +44,6 @@ export interface RadioButtonProps extends HTMLProps<HTMLInputElement> {
 type LabelElProps = Pick<RadioButtonProps, 'invalid' | 'disabled'>;
 
 const labelBaseStyles = ({ theme }: StyleProps) => css`
-  label: radio-button__label;
   color: ${theme.colors.bodyColor};
   display: inline-block;
   padding-left: 26px;
@@ -89,7 +88,6 @@ const labelBaseStyles = ({ theme }: StyleProps) => css`
 const labelInvalidStyles = ({ theme, invalid }: StyleProps & LabelElProps) =>
   invalid &&
   css`
-    label: radio-button--error;
     &:not(:focus)::before {
       border-color: ${theme.colors.danger};
       background-color: ${theme.colors.r100};
@@ -103,7 +101,6 @@ const labelInvalidStyles = ({ theme, invalid }: StyleProps & LabelElProps) =>
 const labelDisabledStyles = ({ theme, disabled }: StyleProps & LabelElProps) =>
   disabled &&
   css`
-    label: radio-button--disabled;
     ${disableVisually()};
 
     &::before {
@@ -127,7 +124,6 @@ const RadioButtonLabel = styled('label')<LabelElProps>(
 type InputElProps = Omit<RadioButtonProps, 'tracking'>;
 
 const inputBaseStyles = ({ theme }: StyleProps) => css`
-  label: radio-button__input;
   ${hideVisually()};
 
   &:hover + label::before {
@@ -163,8 +159,6 @@ const inputBaseStyles = ({ theme }: StyleProps) => css`
 const inputInvalidStyles = ({ theme, invalid }: StyleProps & InputElProps) =>
   invalid &&
   css`
-    label: radio-button__input--invalid;
-
     &:hover + label::before,
     &:focus + label::before {
       border-color: ${theme.colors.r700};

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.stories.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.stories.tsx
@@ -49,23 +49,6 @@ Base.args = {
   ],
 };
 
-export const NoLabel = (args: RadioButtonGroupProps) => {
-  const [value, setValue] = useState<string>();
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setValue(event.target.value);
-  };
-  return <RadioButtonGroup {...args} value={value} onChange={handleChange} />;
-};
-
-NoLabel.args = {
-  name: 'radio-button-group',
-  options: [
-    { children: 'Apple', value: 'apple' },
-    { children: 'Banana', value: 'banana' },
-    { children: 'Mango', value: 'mango' },
-  ],
-};
-
 export const Invalid = (args: RadioButtonGroupProps) => {
   const [value, setValue] = useState<string>();
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -110,7 +110,7 @@ export const RadioButtonGroup = forwardRef(
       !label
     ) {
       throw new Error(
-        'The RadioButtonGroup component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` to hide the label visually.',
+        'The RadioButtonGroup component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
     const name = customName || uniqueId('radio-button-group_');

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -104,10 +104,19 @@ export const RadioButtonGroup = forwardRef(
     }: RadioButtonGroupProps,
     ref: RadioButtonGroupProps['ref'],
   ) => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !label
+    ) {
+      throw new Error(
+        'The RadioButtonGroup component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` to hide the label visually.',
+      );
+    }
     const name = customName || uniqueId('radio-button-group_');
     return (
       <fieldset name={name} ref={ref} {...props}>
-        {label && <Legend hideLabel={hideLabel}>{label}</Legend>}
+        <Legend hideLabel={hideLabel}>{label}</Legend>
         {options &&
           options.map(({ children, value, className, style, ...rest }) => (
             <div

--- a/packages/circuit-ui/components/Row/Row.js
+++ b/packages/circuit-ui/components/Row/Row.js
@@ -34,8 +34,6 @@ const getBreakPointStyles = (theme, breakpoint) => {
 };
 
 const baseStyles = ({ theme }) => css`
-  label: row;
-
   position: relative;
   ${clearfix()};
 

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -56,22 +56,34 @@ export const SearchInput = forwardRef(
   (
     { value, onClear, clearLabel, ...props }: SearchInputProps,
     ref: SearchInputProps['ref'],
-  ) => (
-    <Input
-      value={value}
-      type="text"
-      renderPrefix={(renderProps) => <Search {...renderProps} />}
-      renderSuffix={(renderProps) =>
-        value && onClear && clearLabel ? (
-          <ClearButton onClick={onClear} label={clearLabel} {...renderProps}>
-            <Cross />
-          </ClearButton>
-        ) : null
-      }
-      {...props}
-      ref={ref}
-    />
-  ),
+  ) => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      onClear &&
+      !clearLabel
+    ) {
+      throw new Error(
+        'The SearchInput component is missing a `clearLabel` prop. This is an accessibility requirement. Do not pass `onClear` to disable the clearing functionality.',
+      );
+    }
+    return (
+      <Input
+        value={value}
+        type="text"
+        renderPrefix={(renderProps) => <Search {...renderProps} />}
+        renderSuffix={(renderProps) =>
+          value && onClear && clearLabel ? (
+            <ClearButton onClick={onClear} label={clearLabel} {...renderProps}>
+              <Cross />
+            </ClearButton>
+          ) : null
+        }
+        {...props}
+        ref={ref}
+      />
+    );
+  },
 );
 
 SearchInput.displayName = 'SearchInput';

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -64,7 +64,7 @@ export const SearchInput = forwardRef(
       !clearLabel
     ) {
       throw new Error(
-        'The SearchInput component is missing a `clearLabel` prop. This is an accessibility requirement. Do not pass `onClear` to disable the clearing functionality.',
+        'The SearchInput component is missing a `clearLabel` prop. This is an accessibility requirement. Omit the `onClear` prop if you intend to disable the input clearing functionality.',
       );
     }
     return (

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -321,6 +321,15 @@ export const Select = forwardRef(
     }: SelectProps,
     ref?: SelectProps['ref'],
   ): ReturnType => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !label
+    ) {
+      throw new Error(
+        'The Select component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` to hide the label visually.',
+      );
+    }
     const id = customId || uniqueId('select_');
 
     const prefix = RenderPrefix && (

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -118,7 +118,6 @@ export interface SelectProps
 }
 
 const containerBaseStyles = ({ theme }: StyleProps) => css`
-  label: select__container;
   color: ${theme.colors.n900};
   display: block;
   position: relative;
@@ -132,8 +131,6 @@ const containerHideLabelStyles = ({
 }: StyleProps & ContainerElProps) =>
   !hideLabel &&
   css`
-    label: select__container--hide-label;
-
     label &,
     label + & {
       margin-top: ${theme.spacings.bit};
@@ -156,7 +153,6 @@ const labelMarginStyles = ({ theme, noMargin }: StyleProps & LabelElProps) => {
       'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
     );
     return css`
-      label: input__label--margin;
       margin-bottom: ${theme.spacings.mega};
     `;
   }
@@ -166,7 +162,6 @@ const labelMarginStyles = ({ theme, noMargin }: StyleProps & LabelElProps) => {
 const labelInlineStyles = ({ inline }: LabelElProps) =>
   inline &&
   css`
-    label: input__label--inline;
     display: inline-block;
   `;
 
@@ -180,7 +175,6 @@ type SelectElProps = Omit<SelectProps, 'options' | 'label'> & {
 };
 
 const selectBaseStyles = ({ theme }: StyleProps) => css`
-  label: select;
   appearance: none;
   cursor: pointer;
   background-color: ${theme.colors.white};
@@ -221,14 +215,12 @@ const selectInvalidStyles = ({
   invalid &&
   !disabled &&
   css`
-    label: select--invalid;
     padding-right: ${theme.spacings.zetta};
   `;
 
 const selectPrefixStyles = ({ theme, hasPrefix }: StyleProps & SelectElProps) =>
   hasPrefix &&
   css`
-    label: select--prefix;
     padding-left: ${theme.spacings.exa};
   `;
 
@@ -246,7 +238,6 @@ const labelTextStyles = ({ hideLabel }: { hideLabel?: boolean }) =>
 const LabelText = styled('span')(labelTextStyles);
 
 const optionalLabelStyles = ({ theme }: StyleProps) => css`
-  label: input__optional-label;
   color: ${theme.colors.n700};
 `;
 
@@ -257,7 +248,6 @@ const OptionalLabel = styled('span')(optionalLabelStyles);
  * destructuring.
  */
 const prefixStyles = (theme: Theme) => css`
-  label: select__prefix;
   display: block;
   position: absolute;
   z-index: ${theme.zIndex.input + 1};
@@ -268,7 +258,6 @@ const prefixStyles = (theme: Theme) => css`
 `;
 
 const iconBaseStyles = ({ theme }: StyleProps) => css`
-  label: select__icon;
   color: ${theme.colors.n700};
   display: block;
   z-index: ${theme.zIndex.input + 1};
@@ -282,14 +271,12 @@ const iconBaseStyles = ({ theme }: StyleProps) => css`
 `;
 
 const iconActiveStyles = () => css`
-  label: select__icon-active;
   select:active ~ & {
     display: none;
   }
 `;
 
 const iconInactiveStyles = () => css`
-  label: select__icon-inactive;
   select:not(:active) ~ & {
     display: none;
   }

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -327,7 +327,7 @@ export const Select = forwardRef(
       !label
     ) {
       throw new Error(
-        'The Select component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` to hide the label visually.',
+        'The Select component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
     const id = customId || uniqueId('select_');

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -132,7 +132,6 @@ const noMarginStyles = ({ noMargin }: LabelElProps) => {
     return null;
   }
   return css`
-    label: selector__label--no-margin;
     margin-bottom: 0;
   `;
 };

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -146,7 +146,7 @@ export const SelectorGroup = forwardRef(
       !label
     ) {
       throw new Error(
-        'The SelectorGroup component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` to hide the label visually.',
+        'The SelectorGroup component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
     const name = customName || uniqueId('selector-group_');

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -140,6 +140,15 @@ export const SelectorGroup = forwardRef(
     }: SelectorGroupProps,
     ref: SelectorGroupProps['ref'],
   ) => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !label
+    ) {
+      throw new Error(
+        'The SelectorGroup component is missing a `label` prop. This is an accessibility requirement. Pass `hideLabel` to hide the label visually.',
+      );
+    }
     const name = customName || uniqueId('selector-group_');
 
     if (!options) {
@@ -148,7 +157,7 @@ export const SelectorGroup = forwardRef(
 
     return (
       <Fieldset ref={ref} stretch={stretch} {...rest}>
-        {label && <Legend hideLabel={hideLabel}>{label}</Legend>}
+        <Legend hideLabel={hideLabel}>{label}</Legend>
         {options.map(({ children, value, ...optionRest }) => (
           <OptionItem key={value}>
             <Selector

--- a/packages/circuit-ui/components/Sidebar/Sidebar.js
+++ b/packages/circuit-ui/components/Sidebar/Sidebar.js
@@ -33,7 +33,6 @@ import Separator from './components/Separator';
 const SIDEBAR_WIDTH = 256;
 
 const baseStyles = ({ theme }) => css`
-  label: sidebar;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -52,7 +51,6 @@ const baseStyles = ({ theme }) => css`
 const openStyles = ({ theme, open }) =>
   open &&
   css`
-    label: sidebar--open;
     transform: translateX(0);
     ${theme.mq.giga} {
       transform: translateX(0);

--- a/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
@@ -141,6 +141,15 @@ const Aggregator = ({
   tracking,
   ...props
 }: AggregatorProps): JSX.Element => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !label
+  ) {
+    throw new Error(
+      'The Aggregator component is missing a `label` prop. This is an accessibility requirement.',
+    );
+  }
   const [isOpen, setIsOpen] = useState(false);
   const selectedChild = hasSelectedChild(children);
   const baseHandleClick = (event: MouseEvent | KeyboardEvent) => {

--- a/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
@@ -76,7 +76,6 @@ type Disabled = { disabled: boolean };
 type Selected = { selected: boolean };
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: nav-aggregator;
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
@@ -101,7 +100,6 @@ const hoverStyles = ({
   !disabled &&
   !selected &&
   css`
-    label: nav-aggregator--hover;
     &:hover,
     &:focus {
       color: ${theme.colors.n100};
@@ -111,14 +109,12 @@ const hoverStyles = ({
 const selectedStyles = ({ theme, selected }: StyleProps & Selected) =>
   selected &&
   css`
-    label: nav-aggregator--active;
     color: ${theme.colors.white};
   `;
 
 const disabledStyles = ({ theme, disabled }: StyleProps & Disabled) =>
   disabled &&
   css`
-    label: nav-item--disabled;
     cursor: not-allowed;
     color: ${theme.colors.n500};
   `;
@@ -144,7 +140,7 @@ const Aggregator = ({
   onClick,
   tracking,
   ...props
-}: AggregatorProps) => {
+}: AggregatorProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   const selectedChild = hasSelectedChild(children);
   const baseHandleClick = (event: MouseEvent | KeyboardEvent) => {

--- a/packages/circuit-ui/components/Sidebar/components/Backdrop/Backdrop.js
+++ b/packages/circuit-ui/components/Sidebar/components/Backdrop/Backdrop.js
@@ -18,7 +18,6 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 const baseStyles = ({ theme }) => css`
-  label: sidebar-backdrop;
   width: 100%;
   height: 100%;
   position: absolute;
@@ -36,7 +35,6 @@ const baseStyles = ({ theme }) => css`
 const visibleStyles = ({ visible }) =>
   visible &&
   css`
-    label: sidebar-backdrop--visible;
     visibility: visible;
     opacity: 0.56;
   `;

--- a/packages/circuit-ui/components/Sidebar/components/CloseButton/CloseButton.js
+++ b/packages/circuit-ui/components/Sidebar/components/CloseButton/CloseButton.js
@@ -20,7 +20,6 @@ import { css } from '@emotion/core';
 import BaseButton from '../../../CloseButton';
 
 const baseStyles = ({ theme }) => css`
-  label: sidebar-close-button;
   position: absolute;
   bottom: ${theme.spacings.mega};
   right: ${theme.spacings.mega};
@@ -36,7 +35,6 @@ const baseStyles = ({ theme }) => css`
 const visibleStyles = ({ visible }) =>
   visible &&
   css`
-    label: close-button--visible;
     visibility: visible;
     opacity: 1;
   `;

--- a/packages/circuit-ui/components/Sidebar/components/Footer/Footer.js
+++ b/packages/circuit-ui/components/Sidebar/components/Footer/Footer.js
@@ -18,7 +18,6 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 const baseStyles = ({ theme }) => css`
-  label: sidebar-footer;
   margin-top: auto;
   padding: ${theme.spacings.giga};
   background-color: ${theme.colors.n900};

--- a/packages/circuit-ui/components/Sidebar/components/Header/Header.js
+++ b/packages/circuit-ui/components/Sidebar/components/Header/Header.js
@@ -18,7 +18,6 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 const baseStyles = ({ theme }) => css`
-  label: sidebar-header;
   display: flex;
   align-self: flex-start;
   align-items: center;

--- a/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.js
+++ b/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.js
@@ -25,7 +25,6 @@ import NavLabel from '../NavLabel';
 import { getIcon } from './utils';
 
 const baseStyles = ({ theme }) => css`
-  label: nav-item;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -41,7 +40,6 @@ const baseStyles = ({ theme }) => css`
 const secondaryStyles = ({ theme, secondary }) =>
   secondary &&
   css`
-    label: nav-item--secondary;
     margin: 0px ${theme.spacings.giga};
     padding: ${theme.spacings.bit} 0px;
     transition: color ${theme.transitions.default},
@@ -52,7 +50,6 @@ const hoverStyles = ({ theme, selected, disabled }) =>
   !disabled &&
   !selected &&
   css`
-    label: nav-item--hover;
     &:hover {
       color: ${theme.colors.n100};
     }
@@ -61,7 +58,6 @@ const hoverStyles = ({ theme, selected, disabled }) =>
 const selectedStyles = ({ theme, selected }) =>
   selected &&
   css`
-    label: nav-item--active;
     font-weight: ${theme.fontWeight.bold};
     color: ${theme.colors.white};
   `;
@@ -69,7 +65,6 @@ const selectedStyles = ({ theme, selected }) =>
 const disabledStyles = ({ theme, disabled }) =>
   disabled &&
   css`
-    label: nav-item--disabled;
     cursor: not-allowed;
     color: ${theme.colors.n500};
   `;

--- a/packages/circuit-ui/components/Sidebar/components/NavLabel/NavLabel.js
+++ b/packages/circuit-ui/components/Sidebar/components/NavLabel/NavLabel.js
@@ -18,7 +18,6 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 const baseStyles = ({ theme }) => css`
-  label: nav-label;
   display: block;
   margin-left: ${theme.spacings.kilo};
 `;
@@ -26,7 +25,6 @@ const baseStyles = ({ theme }) => css`
 const secondaryStyles = ({ theme, secondary }) =>
   secondary &&
   css`
-    label: nav-label--secondary;
     margin-left: 0px;
     margin-top: -${theme.spacings.kilo};
     transition: margin-top ${theme.transitions.slow};
@@ -36,7 +34,6 @@ const secondaryVisibleStyles = ({ secondary, visible }) =>
   secondary &&
   visible &&
   css`
-    label: nav-label--secondary--visible;
     margin-top: 0px;
   `;
 

--- a/packages/circuit-ui/components/Sidebar/components/NavList/NavList.js
+++ b/packages/circuit-ui/components/Sidebar/components/NavList/NavList.js
@@ -19,7 +19,6 @@ import { css } from '@emotion/core';
 import { TrackingElement } from '@sumup/collector';
 
 const baseStyles = () => css`
-  label: nav-list;
   height: auto;
   justify-self: flex-start;
   overflow-y: auto;

--- a/packages/circuit-ui/components/Sidebar/components/Separator/Separator.js
+++ b/packages/circuit-ui/components/Sidebar/components/Separator/Separator.js
@@ -18,7 +18,6 @@ import { css } from '@emotion/core';
 import Hr from '../../../Hr';
 
 const hrStyles = (theme) => css`
-  label: sidebar-separator;
   border: 1px solid ${theme.colors.n700};
 `;
 

--- a/packages/circuit-ui/components/Sidebar/components/SubNavList/SubNavList.js
+++ b/packages/circuit-ui/components/Sidebar/components/SubNavList/SubNavList.js
@@ -25,7 +25,6 @@ const SUB_NAV_ITEM_HEIGHT = 32;
 
 /* eslint-disable max-len */
 const baseStyles = ({ theme }) => css`
-  label: sub-nav-list;
   margin: -${theme.spacings.byte} 0 ${theme.spacings.byte} ${theme.spacings.tera};
   list-style: none;
   height: 0;
@@ -39,7 +38,6 @@ const baseStyles = ({ theme }) => css`
 const visibleStyles = ({ theme, visible, children }) =>
   visible &&
   css`
-    label: sub-nav-list--visible;
     height: calc(${SUB_NAV_ITEM_HEIGHT}px * ${children.length});
     position: relative;
     opacity: 1;
@@ -52,7 +50,6 @@ const visibleStyles = ({ theme, visible, children }) =>
 const listStyles = ({ theme, children }) =>
   children &&
   css`
-    label: sub-nav-list__children;
     &::before {
       content: '';
       width: 2px;
@@ -67,7 +64,6 @@ const listStyles = ({ theme, children }) =>
 const selectedItemStyles = ({ theme, selectedChildIndex }) =>
   selectedChildIndex >= 0 &&
   css`
-    label: sub-nav-list--selected;
     &::after {
       content: '';
       width: 2px;

--- a/packages/circuit-ui/components/Spinner/Spinner.tsx
+++ b/packages/circuit-ui/components/Spinner/Spinner.tsx
@@ -33,7 +33,6 @@ export interface SpinnerProps extends Omit<HTMLProps<HTMLDivElement>, 'size'> {
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: spinner;
   display: block;
   border-radius: ${theme.borderRadius.circle};
   border: ${theme.borderWidth.mega} solid currentColor;
@@ -59,7 +58,6 @@ const sizeStyles = ({ theme, size = 'kilo' }: SpinnerProps & StyleProps) => {
   };
 
   return css({
-    label: `spinner-label--${size}`,
     ...sizeMap[size],
   });
 };

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -35,7 +35,6 @@ export interface SubHeadlineProps
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: sub-headline;
   text-transform: uppercase;
   font-weight: ${theme.fontWeight.bold};
   font-size: ${theme.typography.subHeadline.fontSize};
@@ -55,7 +54,6 @@ const noMarginStyles = ({ noMargin }: SubHeadlineProps) => {
     return null;
   }
   return css`
-    label: sub-heading--no-margin;
     margin-bottom: 0;
   `;
 };

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -83,7 +83,6 @@ type TableContainerElProps = Pick<
 >;
 
 const tableContainerBaseStyles = () => css`
-  label: table-container;
   position: relative;
 `;
 
@@ -106,7 +105,6 @@ const shadowStyles = ({
 }: TableContainerElProps & StyleProps) =>
   !noShadow &&
   css`
-    label: table-container--shadow;
     border: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
   `;
 
@@ -128,7 +126,6 @@ const containerStyles = ({
 }: ScrollContainerElElProps & StyleProps) =>
   rowHeaders &&
   css`
-    label: table-container;
     border-radius: ${theme.borderRadius.bit};
     ${theme.mq.untilMega} {
       height: unset;
@@ -155,7 +152,6 @@ const ScrollContainer = styled.div<ScrollContainerElElProps>`
 type TableElProps = Pick<TableProps, 'borderCollapsed' | 'rowHeaders'>;
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: table;
   background-color: ${theme.colors.white};
   border-collapse: separate;
   width: 100%;
@@ -164,7 +160,6 @@ const baseStyles = ({ theme }: StyleProps) => css`
 const responsiveStyles = ({ theme, rowHeaders }: TableElProps & StyleProps) =>
   rowHeaders &&
   css`
-    label: table--responsive;
     ${theme.mq.untilMega} {
       margin-left: -145px;
       width: calc(100% + 145px);

--- a/packages/circuit-ui/components/Table/components/TableCell/TableCell.ts
+++ b/packages/circuit-ui/components/Table/components/TableCell/TableCell.ts
@@ -42,7 +42,6 @@ const baseStyles = ({
   theme,
   align = 'left',
 }: TableCellProps & StyleProps) => css`
-  label: table-cell;
   background-color: ${theme.colors.white};
   border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
   padding: ${theme.spacings.giga};
@@ -59,7 +58,6 @@ const presentationStyles = ({
 }: TableCellProps & StyleProps) =>
   role === PRESENTATION &&
   css`
-    label: table-cell--presentation;
     display: none;
 
     ${header &&
@@ -84,14 +82,12 @@ const hoverStyles = ({
 }: TableCellProps & StyleProps) =>
   isHovered &&
   css`
-    label: table-cell--hover;
     background-color: ${theme.colors.n100};
   `;
 
 const condensedStyles = ({ condensed, theme }: TableCellProps & StyleProps) =>
   condensed &&
   css`
-    label: table-cell--condensed;
     padding: ${theme.spacings.kilo} ${theme.spacings.mega};
     ${typography('two')(theme)};
   `;
@@ -105,7 +101,6 @@ const condensedPresentationStyles = ({
   condensed &&
   role === PRESENTATION &&
   css`
-    label: table-cell-presentation--condensed;
     padding: ${theme.spacings.kilo} ${theme.spacings.mega};
     ${typography('two')(theme)};
 

--- a/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
@@ -85,7 +85,6 @@ const fixedStyles = ({
   scrollable &&
   top && // we need this check despite the TS types
   css`
-    label: table-head--fixed;
     transform: translateY(${top}px);
 
     ${theme.mq.untilMega} {

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -186,31 +186,43 @@ const TableHeader: FC<TableHeaderProps> = ({
   sortParams = { sortable: false },
   onClick,
   ...props
-}) => (
-  <StyledHeader
-    condensed={condensed}
-    align={align}
-    scope={scope}
-    fixed={fixed}
-    isHovered={isHovered}
-    sortable={sortParams.sortable}
-    isSorted={!!sortParams.isSorted}
-    aria-label={sortParams.sortLabel}
-    aria-sort={
-      sortParams.sortable ? sortParams.sortDirection || 'none' : undefined
-    }
-    onClick={onClick}
-    {...props}
-  >
-    {sortParams.sortable && (
-      <SortArrow
-        label={sortParams.sortLabel}
-        direction={sortParams.sortDirection}
-        onClick={onClick}
-      />
-    )}
-    {children}
-  </StyledHeader>
-);
+}) => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    sortParams.sortable &&
+    !sortParams.sortLabel
+  ) {
+    throw new Error(
+      'The Table component is missing a `sortLabel` prop. This is an accessibility requirement. Do not pass `sortable` to disable the row sorting functionality.',
+    );
+  }
+  return (
+    <StyledHeader
+      condensed={condensed}
+      align={align}
+      scope={scope}
+      fixed={fixed}
+      isHovered={isHovered}
+      sortable={sortParams.sortable}
+      isSorted={!!sortParams.isSorted}
+      aria-label={sortParams.sortLabel}
+      aria-sort={
+        sortParams.sortable ? sortParams.sortDirection || 'none' : undefined
+      }
+      onClick={onClick}
+      {...props}
+    >
+      {sortParams.sortable && (
+        <SortArrow
+          label={sortParams.sortLabel}
+          direction={sortParams.sortDirection}
+          onClick={onClick}
+        />
+      )}
+      {children}
+    </StyledHeader>
+  );
+};
 
 export default TableHeader;

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -63,7 +63,6 @@ type ThElProps = Omit<TableHeaderProps, 'sortParams'> & {
 };
 
 const baseStyles = ({ theme, align }: StyleProps & ThElProps) => css`
-  label: table-header;
   background-color: ${theme.colors.white};
   border-bottom: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
   padding: ${theme.spacings.giga};
@@ -75,14 +74,12 @@ const baseStyles = ({ theme, align }: StyleProps & ThElProps) => css`
 const hoveredStyles = ({ theme, isHovered }: StyleProps & ThElProps) =>
   isHovered &&
   css`
-    label: table-cell--hover;
     background-color: ${theme.colors.n100};
   `;
 
 const colStyles = ({ theme, scope }: StyleProps & ThElProps) =>
   scope === 'col' &&
   css`
-    label: table-header--col;
     ${typography('two')(theme)};
     color: ${theme.colors.n700};
     font-weight: ${theme.fontWeight.bold};
@@ -94,7 +91,6 @@ const colStyles = ({ theme, scope }: StyleProps & ThElProps) =>
 const fixedStyles = ({ theme, fixed }: StyleProps & ThElProps) =>
   fixed &&
   css`
-    label: table-header--fixed;
     ${theme.mq.untilMega} {
       left: 0;
       top: auto;
@@ -107,7 +103,6 @@ const fixedStyles = ({ theme, fixed }: StyleProps & ThElProps) =>
 const sortableStyles = ({ theme, sortable }: StyleProps & ThElProps) =>
   sortable &&
   css`
-    label: table-header--sortable;
     cursor: pointer;
     position: relative;
     user-select: none;
@@ -149,7 +144,6 @@ const sortableActiveStyles = ({ sortable, isSorted }: ThElProps) =>
 const condensedStyles = ({ condensed, theme }: StyleProps & ThElProps) =>
   condensed &&
   css`
-    label: table-header--condensed;
     ${typography('two')(theme)};
     vertical-align: middle;
     padding: ${theme.spacings.kilo} ${theme.spacings.mega};
@@ -163,7 +157,6 @@ const condensedColStyles = ({
   condensed &&
   scope === 'col' &&
   css`
-    label: table-header-condensed--col;
     padding: ${theme.spacings.byte} ${theme.spacings.mega};
   `;
 

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -194,7 +194,7 @@ const TableHeader: FC<TableHeaderProps> = ({
     !sortParams.sortLabel
   ) {
     throw new Error(
-      'The Table component is missing a `sortLabel` prop. This is an accessibility requirement. Do not pass `sortable` to disable the row sorting functionality.',
+      'The Table component is missing a `sortLabel` prop. This is an accessibility requirement. Omit the `sortable` prop if you intend to disable the row sorting functionality.',
     );
   }
   return (

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
@@ -27,7 +27,6 @@ type TableRowProps = {
 };
 
 const baseStyles = () => css`
-  label: table-row;
   vertical-align: middle;
 
   tbody & {
@@ -46,7 +45,6 @@ const baseStyles = () => css`
 const clickableStyles = ({ theme, onClick }: StyleProps & TableRowProps) =>
   onClick &&
   css`
-    label: table-row--clickable;
     cursor: pointer;
     position: relative;
 

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.js
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.js
@@ -21,7 +21,6 @@ import { css } from '@emotion/core';
 import { typography, focusVisible } from '../../../../styles/style-mixins';
 
 const defaultTabStyles = ({ theme }) => css`
-  label: tab;
   padding: ${theme.spacings.kilo} ${theme.spacings.tera};
   color: ${theme.colors.n700};
   text-decoration: none;
@@ -49,7 +48,6 @@ const defaultTabStyles = ({ theme }) => css`
 const selectedTabStyles = ({ theme, selected }) =>
   selected &&
   css`
-    label: tab--selected;
     position: relative;
     color: ${theme.colors.n900};
 

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.js
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.js
@@ -34,7 +34,6 @@ const Wrapper = styled.div(
 );
 
 const navigationBaseStyles = css`
-  label: tablist;
   display: flex;
   flex-wrap: nowrap;
 `;

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -85,7 +85,6 @@ type TagElProps = Omit<TagProps, 'prefix' | 'suffix' | 'removeButtonLabel'> & {
 };
 
 const tagBaseStyles = ({ theme }: StyleProps) => css`
-  label: tag;
   display: inline-flex;
   align-items: center;
   margin: 0;
@@ -104,14 +103,12 @@ const tagBaseStyles = ({ theme }: StyleProps) => css`
 const tagRemovableStyles = ({ theme, removable }: StyleProps & TagElProps) =>
   removable &&
   css`
-    label: tag--removable;
     padding-right: calc(${theme.spacings.bit} + ${theme.spacings.tera});
   `;
 
 const tagClickableStyles = ({ theme, onClick }: StyleProps & TagElProps) =>
   onClick &&
   css`
-    label: tag--clickable;
     cursor: pointer;
     outline: 0;
     text-align: left;
@@ -131,7 +128,6 @@ const tagClickableStyles = ({ theme, onClick }: StyleProps & TagElProps) =>
 const tagSelectedStyles = ({ theme, selected }: StyleProps & TagElProps) =>
   selected &&
   css`
-    label: tag--selected;
     background-color: ${theme.colors.p500};
     border-color: ${theme.colors.p700};
     color: ${theme.colors.white};
@@ -145,8 +141,6 @@ const tagSelectedClickableStyles = ({
   selected &&
   onClick &&
   css`
-    label: tag--selected--clickable;
-
     &:active {
       color: ${theme.colors.white};
     }
@@ -167,21 +161,18 @@ const TagElement = styled('div')<TagElProps>(
 );
 
 const prefixStyles = (theme: Theme) => css`
-  label: tag__prefix;
   flex-shrink: 0;
   margin-left: -${theme.spacings.bit};
   margin-right: ${theme.spacings.bit};
 `;
 
 const suffixStyles = (theme: Theme) => css`
-  label: tag__suffix;
   flex-shrink: 0;
   margin-left: ${theme.spacings.bit};
   margin-right: -${theme.spacings.bit};
 `;
 
 const closeButtonStyles = ({ theme }: StyleProps) => css`
-  label: tag__close-button;
   position: absolute;
   top: 50%;
   right: ${BORDER_WIDTH};
@@ -192,7 +183,6 @@ const closeButtonStyles = ({ theme }: StyleProps) => css`
 const RemoveButton = styled(CloseButton)<CloseButtonProps>(closeButtonStyles);
 
 const Container = styled.div`
-  label: tag__container;
   position: relative;
 `;
 

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -210,7 +210,7 @@ export const Tag = forwardRef(
       !removeButtonLabel
     ) {
       throw new Error(
-        'The Tag component is missing a `removeButtonLabel` prop. This is an accessibility requirement. Do not pass `onRemove` to disable the removing functionality.',
+        'The Tag component is missing a `removeButtonLabel` prop. This is an accessibility requirement. Omit the `onRemove` prop if you intend to disable the tag removing functionality.',
       );
     }
     const as = onClick ? 'button' : 'div';

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -203,6 +203,16 @@ export const Tag = forwardRef(
     }: TagProps,
     ref: BaseProps['ref'],
   ) => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      onRemove &&
+      !removeButtonLabel
+    ) {
+      throw new Error(
+        'The Tag component is missing a `removeButtonLabel` prop. This is an accessibility requirement. Do not pass `onRemove` to disable the removing functionality.',
+      );
+    }
     const as = onClick ? 'button' : 'div';
     const handleClick = useClickEvent(onClick, tracking, 'tag');
 

--- a/packages/circuit-ui/components/TextArea/TextArea.tsx
+++ b/packages/circuit-ui/components/TextArea/TextArea.tsx
@@ -22,7 +22,6 @@ import { InputProps } from '../Input/Input';
 export type TextAreaProps = InputProps;
 
 const textAreaStyles = css`
-  label: text-area;
   overflow: auto;
   resize: vertical;
 `;

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -110,25 +110,30 @@ export const Toggle = forwardRef(
     { label, explanation, noMargin, ...props }: ToggleProps,
     ref: ToggleProps['ref'],
   ) => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !label
+    ) {
+      throw new Error(
+        'The Toggle component is missing a `label` prop. This is an accessibility requirement.',
+      );
+    }
     const switchId = uniqueId('toggle-switch_');
     const labelId = uniqueId('toggle-label_');
     return (
       <ToggleWrapper noMargin={noMargin} disabled={props.disabled}>
         <Switch {...props} aria-labelledby={labelId} id={switchId} ref={ref} />
-        {(label || explanation) && (
-          <ToggleTextWrapper id={labelId} htmlFor={switchId}>
-            {label && (
-              <Body size="one" noMargin>
-                {label}
-              </Body>
-            )}
-            {explanation && (
-              <ToggleExplanation size="two" noMargin>
-                {explanation}
-              </ToggleExplanation>
-            )}
-          </ToggleTextWrapper>
-        )}
+        <ToggleTextWrapper id={labelId} htmlFor={switchId}>
+          <Body size="one" noMargin>
+            {label}
+          </Body>
+          {explanation && (
+            <ToggleExplanation size="two" noMargin>
+              {explanation}
+            </ToggleExplanation>
+          )}
+        </ToggleTextWrapper>
       </ToggleWrapper>
     );
   },

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -44,7 +44,6 @@ export interface ToggleProps extends SwitchProps {
 }
 
 const textWrapperStyles = ({ theme }: StyleProps) => css`
-  label: toggle__text-wrapper;
   display: block;
   margin-left: ${theme.spacings.kilo};
   cursor: pointer;
@@ -58,7 +57,6 @@ const textWrapperStyles = ({ theme }: StyleProps) => css`
 const ToggleTextWrapper = styled('label')<NoTheme>(textWrapperStyles);
 
 const explanationStyles = ({ theme }: StyleProps) => css`
-  label: toggle__explanation;
   color: ${theme.colors.n700};
 `;
 
@@ -67,7 +65,6 @@ const ToggleExplanation = styled(Body)<BodyProps>(explanationStyles);
 type WrapperElProps = Pick<ToggleProps, 'noMargin' | 'disabled'>;
 
 const toggleWrapperStyles = ({ theme }: StyleProps) => css`
-  label: toggle;
   display: flex;
   align-items: flex-start;
   margin-bottom: ${theme.spacings.mega};
@@ -81,7 +78,6 @@ const toggleWrapperStyles = ({ theme }: StyleProps) => css`
 const toggleWrapperDisabledStyles = ({ disabled }: WrapperElProps) =>
   disabled &&
   css`
-    label: toggle--disabled;
     ${disableVisually()};
   `;
 
@@ -96,7 +92,6 @@ const toggleWrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
     return null;
   }
   return css`
-    label: toggle--no-margin;
     margin-bottom: 0;
   `;
 };

--- a/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
+++ b/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
@@ -55,7 +55,6 @@ const knobShadow = (color: string) => `0 2px 0 0 ${color}`;
 type TrackElProps = Omit<SwitchProps, 'checkedLabel' | 'uncheckedLabel'>;
 
 const trackBaseStyles = ({ theme }: StyleProps) => css`
-  label: toggle__switch;
   margin: 0;
   padding: 0;
   border: 0;
@@ -75,7 +74,6 @@ const trackBaseStyles = ({ theme }: StyleProps) => css`
 const trackOnStyles = ({ theme, checked }: StyleProps & TrackElProps) =>
   checked &&
   css`
-    label: toggle__switch--checked;
     background-color: ${theme.colors.p500};
   `;
 
@@ -88,7 +86,6 @@ const SwitchTrack = styled('button')<TrackElProps>(
 type KnobElProps = Pick<SwitchProps, 'checked'>;
 
 const knobBaseStyles = ({ theme }: StyleProps) => css`
-  label: toggle__switch-knob;
   display: block;
   background-color: ${theme.colors.white};
   box-shadow: ${knobShadow(theme.colors.n500)};
@@ -104,7 +101,6 @@ const knobBaseStyles = ({ theme }: StyleProps) => css`
 const knobOnStyles = ({ theme, checked }: StyleProps & KnobElProps) =>
   checked &&
   css`
-    label: toggle__switch-knob--checked;
     box-shadow: ${knobShadow(theme.colors.p700)};
     transform: translate3d(
       calc(${TRACK_WIDTH} - ${KNOB_SIZE} - ${theme.spacings.bit}),
@@ -113,14 +109,10 @@ const knobOnStyles = ({ theme, checked }: StyleProps & KnobElProps) =>
     );
   `;
 
-const labelBaseStyles = () => css`
-  label: toggle__switch-label;
-`;
-
 const SwitchKnob = styled('span')<KnobElProps>(knobBaseStyles, knobOnStyles);
 
 // Important for accessibility
-const SwitchLabel = styled('span')(labelBaseStyles, hideVisually);
+const SwitchLabel = styled('span')(hideVisually);
 
 /**
  * A simple Switch component.

--- a/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
+++ b/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
@@ -122,13 +122,22 @@ export const Switch = forwardRef(
     {
       checked = false,
       onChange,
-      checkedLabel = 'on',
-      uncheckedLabel = 'off',
+      checkedLabel,
+      uncheckedLabel,
       tracking,
       ...props
     }: SwitchProps,
     ref: SwitchProps['ref'],
   ) => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      (!checkedLabel || !uncheckedLabel)
+    ) {
+      throw new Error(
+        'The Switch component is missing a `checkedLabel` and/or an `uncheckedLabel` prop. This is an accessibility requirement.',
+      );
+    }
     const handleChange = useClickEvent(onChange, tracking, 'toggle');
     return (
       <SwitchTrack

--- a/packages/circuit-ui/components/Tooltip/Tooltip.js
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.js
@@ -25,7 +25,6 @@ import {
 } from '../../util/shared-prop-types';
 
 const baseStyles = ({ theme }) => css`
-  label: tooltip;
   display: inline-block;
   width: auto;
   max-width: 280px;
@@ -116,7 +115,6 @@ const positionAndAlignStyles = ({
   position = 'right',
   align = 'center',
 }) => css`
-  label: ${`tooltip--${position}-${align}`};
   ${getAlignmentStyles({ theme, position, align })};
   ${getPositionStyles({ theme, position })};
 `;

--- a/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
+++ b/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
@@ -34,7 +34,6 @@ export interface ValidationHintProps extends HTMLProps<HTMLSpanElement> {
 }
 
 const baseStyles = ({ theme }: StyleProps) => css`
-  label: validation-hint;
   display: block;
   margin-top: ${theme.spacings.bit};
   color: ${theme.colors.n700};
@@ -44,14 +43,12 @@ const baseStyles = ({ theme }: StyleProps) => css`
 const validStyles = ({ theme, showValid }: StyleProps & ValidationHintProps) =>
   showValid &&
   css`
-    label: validation-hint--valid;
     color: ${theme.colors.success};
   `;
 
 const invalidStyles = ({ theme, invalid }: StyleProps & ValidationHintProps) =>
   invalid &&
   css`
-    label: validation-hint--invalid;
     color: ${theme.colors.danger};
   `;
 
@@ -65,7 +62,6 @@ const Wrapper = styled('span')<ValidationHintProps>(
 const iconStyles = (color: 'danger' | 'warning' | 'success') => (
   theme: Theme,
 ) => css`
-  label: ${`validation-hint__icon--${color}`};
   display: inline-block;
   width: ${theme.iconSizes.kilo};
   height: ${theme.iconSizes.kilo};


### PR DESCRIPTION
## Purpose

Circuit V3 will make all label props required in components where it is important for accessibility and used to be optional.

In TypeScript files, this is already enough to enforce accessibility good practices, but it would not be a guarantee in JavaScript.

Some components are enforcing this in JavaScript by checking if the label prop is truthy before rendering it:

_Before:_

```tsx
type ClosableProps = { onClose?: () => void; closeButtonLabel?: string }

const Closable: FC<ClosableProps> = ({ children, onClose, closeButtonLabel = "Close" }) => (
  <div>
    {children}
    {onClose && <CloseButton onClose={onClose} label={label} />}
  </div>
)
```

_After:_

```tsx
type ClosableProps =
  | { onClose?: () => void; closeButtonLabel: string }
  | { onClose?: never; closeButtonLabel?: never };

const Closable: FC<ClosableProps> = ({ children, onClose, closeButtonLabel }) => (
  <div>
    {children}
    {onClose && closeButtonLabel && <CloseButton onClose={onClose} label={label} />}
  </div>
)
```

However, this pattern has a major drawback: if a label is not passed by mistake, the component would not work as expected but the developer would not know about it.

## Approach and changes

An alternative solution is to throw a runtime error in development if the required label prop is missing. This approach doesn't break the build or the tests, but still ensures that labels are passed as expected.

- Throw an error in development for all components that require one or multiple label props
- Remove all legacy Emotion `label` rules from the `css` strings (unnecessary since #983)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~[ ] Unit and integration tests~
* ~[ ] Meets minimum browser support~
* [x] Meets accessibility requirements ❤️ 
