### PR TITLE
Add an escape hatch for a11y errors

### DIFF
--- a/.changeset/green-moons-clean.md
+++ b/.changeset/green-moons-clean.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added an escape hatch to silence accessibility errors in development when the `UNSAFE_DISABLE_ACCESSIBILITY_ERRORS` environment variable is set to `true`.

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+const webpack = require('webpack');
+
 module.exports = {
   stories: [
     '../packages/**/*.stories.@(js|ts|tsx|mdx)',
@@ -20,12 +22,12 @@ module.exports = {
   features: {
     postcss: false,
   },
-  webpackFinal: transpileModules,
-  managerWebpack: transpileModules,
+  webpackFinal: createWebpackConfig,
+  managerWebpack: createWebpackConfig,
 };
 
-// Transpile all node_modules under the @sumup/* namespace.
-function transpileModules(config) {
+function createWebpackConfig(config) {
+  // Transpile all node_modules under the @sumup/* namespace.
   config.module.rules = config.module.rules.map((rule) => {
     // Modify all rules that apply to story files.
     if (
@@ -40,5 +42,14 @@ function transpileModules(config) {
     }
     return rule;
   });
+  // Expose environment variables to Storybook
+  config.plugins = [
+    ...config.plugins,
+    new webpack.DefinePlugin({
+      'process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS': JSON.stringify(
+        process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS,
+      ),
+    }),
+  ];
   return config;
 }

--- a/packages/circuit-ui/components/Hamburger/Hamburger.stories.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.stories.tsx
@@ -31,6 +31,6 @@ export const Base = (args: HamburgerProps) => {
 };
 
 Base.args = {
-  activeLabel: 'Close menu',
+  // activeLabel: 'Close menu',
   inactiveLabel: 'Open menu',
 };

--- a/packages/circuit-ui/components/Hamburger/Hamburger.stories.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.stories.tsx
@@ -31,6 +31,6 @@ export const Base = (args: HamburgerProps) => {
 };
 
 Base.args = {
-  // activeLabel: 'Close menu',
+  activeLabel: 'Close menu',
   inactiveLabel: 'Open menu',
 };

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -166,6 +166,7 @@ export const Hamburger = ({
   ...props
 }: HamburgerProps): JSX.Element => {
   if (
+    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     (!activeLabel || !inactiveLabel)

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -57,6 +57,7 @@ export const IconButton = forwardRef(
     const child = Children.only(children);
     const icon = cloneElement(child, { role: 'presentation' });
     if (
+      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -279,6 +279,7 @@ export const ImageInput = ({
   ...props
 }: ImageInputProps): JSX.Element => {
   if (
+    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     (!label || !clearButtonLabel || !loadingLabel)

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -310,6 +310,7 @@ export const Input = forwardRef(
     ref: InputProps['ref'],
   ): ReturnType => {
     if (
+      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/LoadingButton/LoadingButton.tsx
+++ b/packages/circuit-ui/components/LoadingButton/LoadingButton.tsx
@@ -90,6 +90,7 @@ export const LoadingButton: FC<LoadingButtonProps> = ({
   ...props
 }) => {
   if (
+    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     !loadingLabel

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -153,6 +153,7 @@ export const Modal: ModalComponent<ModalProps> = ({
   ...props
 }) => {
   if (
+    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     !preventClose &&

--- a/packages/circuit-ui/components/ModalContext/ModalContext.tsx
+++ b/packages/circuit-ui/components/ModalContext/ModalContext.tsx
@@ -36,6 +36,7 @@ if (typeof window !== 'undefined') {
   if (appElement) {
     ReactModal.setAppElement(appElement);
   } else if (
+    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'
   ) {

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -103,6 +103,7 @@ export const Pagination = ({
   ...props
 }: PaginationProps): ReactNode => {
   if (
+    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     (!label || !previousLabel || !nextLabel)

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -232,6 +232,7 @@ export function ProgressBar({
   ...props
 }: ProgressBarProps): JSX.Element {
   if (
+    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     !label

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -105,6 +105,7 @@ export const RadioButtonGroup = forwardRef(
     ref: RadioButtonGroupProps['ref'],
   ) => {
     if (
+      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -58,6 +58,7 @@ export const SearchInput = forwardRef(
     ref: SearchInputProps['ref'],
   ) => {
     if (
+      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       onClear &&

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -322,6 +322,7 @@ export const Select = forwardRef(
     ref?: SelectProps['ref'],
   ): ReturnType => {
     if (
+      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -141,6 +141,7 @@ export const SelectorGroup = forwardRef(
     ref: SelectorGroupProps['ref'],
   ) => {
     if (
+      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
@@ -142,6 +142,7 @@ const Aggregator = ({
   ...props
 }: AggregatorProps): JSX.Element => {
   if (
+    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     !label

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -188,6 +188,7 @@ const TableHeader: FC<TableHeaderProps> = ({
   ...props
 }) => {
   if (
+    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     sortParams.sortable &&

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -204,6 +204,7 @@ export const Tag = forwardRef(
     ref: BaseProps['ref'],
   ) => {
     if (
+      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       onRemove &&

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -111,6 +111,7 @@ export const Toggle = forwardRef(
     ref: ToggleProps['ref'],
   ) => {
     if (
+      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
+++ b/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
@@ -130,6 +130,7 @@ export const Switch = forwardRef(
     ref: SwitchProps['ref'],
   ) => {
     if (
+      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       (!checkedLabel || !uncheckedLabel)


### PR DESCRIPTION
## Purpose

#1080 introduced a mechanism that throws at missing accessible labels across all components.

However, this would require large-scale change in some applications, so we're also providing an escape hatch to allow developers to work on their applications while labels are still not provided, for example while they're being written and localized.

The errors will not be thrown if the `UNSAFE_DISABLE_ACCESSIBILITY_ERRORS` environment variable is set to `true`.

Note that depending on the application, this environment variable will need to be exposed differently.

In a Next.js application, it can be added in the `next.config.js`:

```js
module.exports = {
  // ...
  env: {
    // ...
    UNSAFE_DISABLE_ACCESSIBILITY_ERRORS: process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS,
  },
};
```

In other applications, the Webpack config can be extended with the [Webpack DefinePlugin](https://webpack.js.org/plugins/define-plugin/):

_(note: this is the approach this PR is taking for the Circuit UI Storybook)_

```js
const webpack = require('webpack');
module.exports = {
  plugins = [
    new webpack.DefinePlugin({
      'process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS': JSON.stringify(
        process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS,
      ),
    }),
  ];
};
```

Then, the variable can be set in the console to bypass accessibility errors in development:

```sh
UNSAFE_DISABLE_ACCESSIBILITY_ERRORS=true yarn dev
```

## Approach and changes

- add a check for the `UNSAFE_DISABLE_ACCESSIBILITY_ERRORS` environment variable before throwing when labels are missing in development
- extend Storybook Webpack plugin to accept the environment variable from the console (for local testing mostly, but this escape hatch should obviously not be used in Circuit)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~[ ] Unit and integration tests~
* ~[ ] Meets minimum browser support~
* ~[ ] Meets accessibility requirements~
