### PR TITLE
Pass a label to the ImageInput's presentational AddButton to prevent it from throwing

### DIFF
--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -426,7 +426,7 @@ export const ImageInput = ({
             variant="primary"
             aria-hidden="true"
             tabIndex={-1}
-            label=""
+            label={label} // We need to pass a label here to prevent IconButton from throwing
             disabled={isLoading}
           >
             <Plus />

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -426,7 +426,7 @@ export const ImageInput = ({
             variant="primary"
             aria-hidden="true"
             tabIndex={-1}
-            label={label} // We need to pass a label here to prevent IconButton from throwing
+            label="-" // We need to pass a label here to prevent IconButton from throwing
             disabled={isLoading}
           >
             <Plus />

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -891,7 +891,7 @@ exports[`ImageInput styles should render with default styles 1`] = `
       aria-hidden="true"
       class="circuit-5"
       tabindex="-1"
-      title=""
+      title="-"
       type="button"
     >
       <svg
@@ -911,7 +911,9 @@ exports[`ImageInput styles should render with default styles 1`] = `
       </svg>
       <span
         class="circuit-4"
-      />
+      >
+        -
+      </span>
     </button>
     <span
       class="circuit-7"
@@ -1232,7 +1234,7 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
       aria-hidden="true"
       class="circuit-5"
       tabindex="-1"
-      title=""
+      title="-"
       type="button"
     >
       <svg
@@ -1252,7 +1254,9 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
       </svg>
       <span
         class="circuit-4"
-      />
+      >
+        -
+      </span>
     </button>
     <span
       class="circuit-7"


### PR DESCRIPTION
## Purpose

This is a side-effect of #1080. The `ImageInput` has a presentational `IconButton` that still needs to receive a label to prevent it from throwing.

## Approach and changes

- Solution in this PR: pass the `label` to the `ImageInput`'s presentational `AddButton`
  - This doesn't have any effect, the icon is completely hidden from screen readers
  - The downside of this approach is that TypeScript is not enough to catch this issue, since `""` is a valid value for the `IconButton`'s `label` prop, but it will still throw
  - This can also cause confusion if others have a presentational IconButton (but this is very much an edge case)
- An alternative solution: throw if label is undefined, not if it is falsy
  - We could technically still have `label=""`, both in valid use cases (like the ImageInput) and invalid ones (did not provide a label)
  - This would align the throwing behavior with TypeScript

I tend to favor the second approach but I'd like to hear your thoughts @connor-baer 🙂 

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
