### PR TITLE
Add useCollapsible hook

### DIFF
--- a/.changeset/beige-ads-shave.md
+++ b/.changeset/beige-ads-shave.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a `useCollapsible` hook to build accessible and smoothly animated collapsible sections.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -13,20 +13,14 @@
  * limitations under the License.
  */
 
-import {
-  forwardRef,
-  HTMLProps,
-  ReactNode,
-  MouseEvent,
-  KeyboardEvent,
-  Ref,
-} from 'react';
+import { forwardRef, HTMLProps, ReactNode, Ref } from 'react';
 import { css } from '@emotion/core';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 import { Theme } from '@sumup/design-tokens';
 
 import { focusVisible } from '../../styles/style-mixins';
 import { ReturnType } from '../../types/return-type';
+import { ClickEvent } from '../../types/events';
 import { Body, BodyProps } from '../Body/Body';
 import { useComponents } from '../ComponentsContext';
 import { useClickEvent } from '../../hooks/useClickEvent';
@@ -36,7 +30,7 @@ export interface BaseProps extends BodyProps {
   /**
    * Function that's called when the button is clicked.
    */
-  onClick?: (event: MouseEvent | KeyboardEvent) => void;
+  onClick?: (event: ClickEvent) => void;
   /**
    * Additional data that is dispatched with the tracking event.
    */

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -13,16 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  forwardRef,
-  Ref,
-  HTMLProps,
-  ReactNode,
-  FC,
-  SVGProps,
-  MouseEvent,
-  KeyboardEvent,
-} from 'react';
+import { forwardRef, Ref, HTMLProps, ReactNode, FC, SVGProps } from 'react';
 import { css } from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 import { Theme } from '@sumup/design-tokens';
@@ -35,6 +26,7 @@ import {
   focusVisible,
 } from '../../styles/style-mixins';
 import { ReturnType } from '../../types/return-type';
+import { ClickEvent } from '../../types/events';
 import { useComponents } from '../ComponentsContext';
 import { useClickEvent } from '../../hooks/useClickEvent';
 
@@ -72,7 +64,7 @@ export interface BaseProps {
   /**
    * Function that's called when the button is clicked.
    */
-  'onClick'?: (event: MouseEvent | KeyboardEvent) => void;
+  'onClick'?: (event: ClickEvent) => void;
   /**
    * Additional data that is dispatched with the tracking event.
    */

--- a/packages/circuit-ui/components/Card/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Card/components/Header/Header.tsx
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
-import { FC, ReactNode, MouseEvent, KeyboardEvent } from 'react';
+import { FC, ReactNode } from 'react';
 import { css } from '@emotion/core';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 
+import { ClickEvent } from '../../../../types/events';
 import styled, { StyleProps } from '../../../../styles/styled';
 import {
   CloseButton,
@@ -29,7 +30,7 @@ type CloseProps =
        * Callback for the close button. If not specified, the button won't
        * be shown.
        */
-      onClose?: (event: MouseEvent | KeyboardEvent) => void;
+      onClose?: (event: ClickEvent) => void;
       /**
        * Text label for the close button for screen readers.
        * Important for accessibility.

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -20,20 +20,19 @@ import {
   ChangeEvent,
   ClipboardEvent,
   DragEvent,
-  MouseEvent,
-  KeyboardEvent,
   Fragment,
 } from 'react';
 import { css } from '@emotion/core';
 import { Bin, Plus } from '@sumup/icons';
 
+import { ClickEvent } from '../../types/events';
+import styled, { StyleProps } from '../../styles/styled';
+import { uniqueId } from '../../util/id';
+import { focusOutline, hideVisually } from '../../styles/style-mixins';
 import Label from '../Label';
 import IconButton from '../IconButton';
 import Spinner from '../Spinner';
 import ValidationHint from '../ValidationHint';
-import styled, { StyleProps } from '../../styles/styled';
-import { uniqueId } from '../../util/id';
-import { focusOutline, hideVisually } from '../../styles/style-mixins';
 
 export interface ImageInputProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'onChange'> {
@@ -53,7 +52,7 @@ export interface ImageInputProps
   /**
    * A callback function to call when the input is cleared.
    */
-  onClear: (event: MouseEvent | KeyboardEvent) => void | Promise<void>;
+  onClear: (event: ClickEvent) => void | Promise<void>;
   /**
    * An accessible label for the "clear" icon button.
    */
@@ -319,7 +318,7 @@ export const ImageInput = ({
     }
   };
 
-  const handleClear = (event: MouseEvent | KeyboardEvent) => {
+  const handleClear = (event: ClickEvent) => {
     Promise.resolve(onClear(event))
       .then(() => {
         clearInputElement();

--- a/packages/circuit-ui/components/ModalContext/types.ts
+++ b/packages/circuit-ui/components/ModalContext/types.ts
@@ -13,11 +13,12 @@
  * limitations under the License.
  */
 
-import { MouseEvent, KeyboardEvent } from 'react';
 import { Props as ReactModalProps } from 'react-modal';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 
-type OnClose = (event?: MouseEvent | KeyboardEvent) => void;
+import { ClickEvent } from '../../types/events';
+
+type OnClose = (event?: ClickEvent) => void;
 
 export interface BaseModalProps
   extends Omit<

--- a/packages/circuit-ui/components/Notification/Notification.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { FC, SVGProps, ReactNode, MouseEvent, KeyboardEvent } from 'react';
+import { FC, SVGProps, ReactNode } from 'react';
 import { css } from '@emotion/core';
 import {
   CircleCheckmarkFilled,
@@ -22,8 +22,9 @@ import {
 } from '@sumup/icons';
 import { Theme } from '@sumup/design-tokens';
 
+import { ClickEvent } from '../../types/events';
 import styled, { NoTheme, StyleProps } from '../../styles/styled';
-import { CloseButton, CloseButtonProps } from '../CloseButton/CloseButton';
+import CloseButton, { CloseButtonProps } from '../CloseButton';
 
 type Variant = 'success' | 'error' | 'warning';
 
@@ -31,7 +32,7 @@ export interface NotificationProps {
   variant: Variant;
   children: ReactNode;
   icon?: FC<SVGProps<SVGSVGElement>>;
-  onClose?: (event: MouseEvent | KeyboardEvent) => void;
+  onClose?: (event: ClickEvent) => void;
   closeLabel?: string;
 }
 

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -17,9 +17,9 @@
 
 import { Bin, CirclePlus, Zap } from '@sumup/icons';
 import { Placement } from '@popperjs/core';
-import { KeyboardEvent, MouseEvent } from 'react';
 
 import { act, axe, RenderFn, render, userEvent } from '../../util/test-utils';
+import { ClickEvent } from '../../types/events';
 
 import {
   PopoverItem,
@@ -66,7 +66,7 @@ describe('PopoverItem', () => {
       const props = {
         ...baseProps,
         href: 'https://sumup.com',
-        onClick: jest.fn((event: KeyboardEvent | MouseEvent) => {
+        onClick: jest.fn((event: ClickEvent) => {
           event.preventDefault();
         }),
         icon: Zap,

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -19,8 +19,6 @@ import {
   FC,
   Fragment,
   HTMLProps,
-  KeyboardEvent,
-  MouseEvent,
   Ref,
   SVGProps,
   useEffect,
@@ -35,15 +33,16 @@ import { usePopper } from 'react-popper';
 import { Placement, State, Modifier } from '@popperjs/core';
 import { useTheme } from 'emotion-theming';
 
+import { ClickEvent } from '../../types/events';
 import styled, { StyleProps } from '../../styles/styled';
 import { listItem, shadow, typography } from '../../styles/style-mixins';
-import { useComponents } from '../ComponentsContext';
-import { useClickEvent } from '../../hooks/useClickEvent';
 import { uniqueId } from '../../util/id';
+import { useClickEvent } from '../../hooks/useClickEvent';
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import { useFocusList } from '../../hooks/useFocusList';
 import { isArrowDown, isArrowUp } from '../../util/key-codes';
+import { useComponents } from '../ComponentsContext';
 import Portal from '../Portal';
 import Hr from '../Hr';
 import { useStackContext } from '../StackContext';
@@ -56,7 +55,7 @@ export interface BaseProps {
   /**
    * Function that's called when the item is clicked.
    */
-  onClick?: (event: MouseEvent | KeyboardEvent) => void;
+  onClick?: (event: ClickEvent) => void;
   /**
    * Display an icon in addition to the label.
    */
@@ -253,7 +252,7 @@ export interface PopoverProps {
    * The element that toggles the Popover when clicked.
    */
   component: (props: {
-    'onClick': (event: MouseEvent | KeyboardEvent) => void;
+    'onClick': (event: ClickEvent) => void;
     'onKeyDown': (event: KeyboardEvent) => void;
     'id': string;
     'aria-haspopup': boolean;
@@ -363,7 +362,7 @@ export const Popover = ({
 
   const focusProps = useFocusList();
 
-  const handleTriggerClick = (event: MouseEvent | KeyboardEvent) => {
+  const handleTriggerClick = (event: ClickEvent) => {
     // This prevents the event from bubbling which would trigger the
     // useClickOutside above and would prevent the popover from closing.
     event.stopPropagation();

--- a/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
@@ -16,24 +16,17 @@
 // TODO: Improve types
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 
-import {
-  useState,
-  useEffect,
-  FC,
-  SVGProps,
-  MouseEvent,
-  ReactNode,
-  KeyboardEvent,
-} from 'react';
+import { useState, useEffect, FC, SVGProps, ReactNode } from 'react';
 import { css } from '@emotion/core';
 import { TrackingElement } from '@sumup/collector';
 import { isEmpty } from 'lodash/fp';
 
+import { ClickEvent } from '../../../../types/events';
 import styled, { StyleProps } from '../../../../styles/styled';
+import { useClickEvent } from '../../../../hooks/useClickEvent';
 import SubNavList from '../SubNavList';
 import BaseNavLabel from '../NavLabel';
 import { hasSelectedChild, getIcon } from '../NavItem/utils';
-import { useClickEvent } from '../../../../hooks/useClickEvent';
 
 export interface AggregatorProps {
   /**
@@ -59,7 +52,7 @@ export interface AggregatorProps {
   /**
    * The onClick method to handle the click event on the NavAggregator
    */
-  onClick?: (event: MouseEvent | KeyboardEvent) => void;
+  onClick?: (event: ClickEvent) => void;
   /**
    * Additional data that is dispatched with click tracking event.
    */
@@ -153,7 +146,7 @@ const Aggregator = ({
   }
   const [isOpen, setIsOpen] = useState(false);
   const selectedChild = hasSelectedChild(children);
-  const baseHandleClick = (event: MouseEvent | KeyboardEvent) => {
+  const baseHandleClick = (event: ClickEvent) => {
     if (onClick) {
       onClick(event);
     }

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { HTMLProps, FC, MouseEventHandler } from 'react';
+import { HTMLProps, FC } from 'react';
 import { css } from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 
@@ -21,6 +21,7 @@ import { focusOutline, typography } from '../../../../styles/style-mixins';
 import SortArrow from '../SortArrow';
 import styled, { StyleProps } from '../../../../styles/styled';
 import { SortParams } from '../../types';
+import { ClickEvent } from '../../../../types/events';
 
 export interface TableHeaderProps
   extends Omit<HTMLProps<HTMLTableHeaderCellElement>, 'onClick'> {
@@ -47,7 +48,9 @@ export interface TableHeaderProps
   /**
    * Props related to table sorting. Defaults to not sortable.
    */
-  onClick?: MouseEventHandler<HTMLTableHeaderCellElement | HTMLButtonElement>;
+  onClick?: (
+    event: ClickEvent<HTMLTableHeaderCellElement | HTMLButtonElement>,
+  ) => void;
   /**
    * Props related to table sorting. Defaults to not sortable.
    */

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
@@ -13,17 +13,16 @@
  * limitations under the License.
  */
 
-import { FC, MouseEvent, KeyboardEvent } from 'react';
+import { FC } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 
 import { focusOutline } from '../../../../styles/style-mixins';
 import { StyleProps } from '../../../../styles/styled';
+import { ClickEvent } from '../../../../types/events';
 
 type TableRowProps = {
-  onClick?: (
-    event: MouseEvent<HTMLTableRowElement> | KeyboardEvent<HTMLTableRowElement>,
-  ) => void;
+  onClick?: (event: ClickEvent<HTMLTableRowElement>) => void;
 };
 
 const baseStyles = () => css`

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -13,23 +13,16 @@
  * limitations under the License.
  */
 
-import {
-  HTMLProps,
-  Ref,
-  FC,
-  SVGProps,
-  MouseEvent,
-  KeyboardEvent,
-  forwardRef,
-} from 'react';
+import { HTMLProps, Ref, FC, SVGProps, forwardRef } from 'react';
 import { css } from '@emotion/core';
 import { Dispatch as TrackingProps } from '@sumup/collector';
 import { Theme } from '@sumup/design-tokens';
 
+import { ClickEvent } from '../../types/events';
 import styled, { StyleProps } from '../../styles/styled';
 import { typography, focusVisible } from '../../styles/style-mixins';
 import { useClickEvent } from '../../hooks/useClickEvent';
-import { CloseButton, CloseButtonProps } from '../CloseButton/CloseButton';
+import CloseButton, { CloseButtonProps } from '../CloseButton';
 
 type BaseProps = {
   /**
@@ -47,7 +40,7 @@ type BaseProps = {
   /**
    * Function that's called when the button is clicked.
    */
-  onClick?: (event: MouseEvent | KeyboardEvent) => void;
+  onClick?: (event: ClickEvent) => void;
   /**
    * Additional data that is dispatched with the tracking event.
    */
@@ -64,7 +57,7 @@ type RemoveProps =
        * Renders a close button inside the tag and calls the provided function
        * when the button is clicked.
        */
-      onRemove: (event: MouseEvent | KeyboardEvent) => void;
+      onRemove: (event: ClickEvent) => void;
       /**
        * Text label for the remove icon for screen readers.
        * Important for accessibility.

--- a/packages/circuit-ui/hooks/useAnimation/index.ts
+++ b/packages/circuit-ui/hooks/useAnimation/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { useAnimation } from './useAnimation';

--- a/packages/circuit-ui/hooks/useAnimation/useAnimation.spec.ts
+++ b/packages/circuit-ui/hooks/useAnimation/useAnimation.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook, actHook } from '../../util/test-utils';
+
+import { useAnimation } from './useAnimation';
+
+describe('useAnimation', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  it('should return the animation state and a callback', () => {
+    const { result } = renderHook(() => useAnimation());
+    const [isAnimating, animateFn] = result.current;
+
+    expect(isAnimating).toBeFalsy();
+    expect(typeof animateFn).toBe('function');
+  });
+
+  it('should run the animation when the callback is called', () => {
+    const animation = {
+      duration: 500,
+      onStart: jest.fn(),
+      onEnd: jest.fn(),
+    };
+    const { result } = renderHook(() => useAnimation());
+    const [, animateFn] = result.current;
+
+    actHook(() => {
+      animateFn(animation);
+    });
+
+    expect(result.current[0]).toBeTruthy();
+
+    actHook(() => {
+      jest.advanceTimersByTime(animation.duration);
+    });
+
+    expect(result.current[0]).toBeFalsy();
+  });
+
+  it('should call onStart at the start of the animation', () => {
+    const animation = {
+      duration: 500,
+      onStart: jest.fn(),
+      onEnd: jest.fn(),
+    };
+    const { result } = renderHook(() => useAnimation());
+    const [, animateFn] = result.current;
+
+    actHook(() => {
+      animateFn(animation);
+    });
+
+    expect(animation.onStart).toHaveBeenCalledTimes(1);
+
+    actHook(() => {
+      jest.advanceTimersByTime(animation.duration);
+    });
+
+    expect(animation.onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onEnd at the end of the animation', () => {
+    const animation = {
+      duration: 500,
+      onStart: jest.fn(),
+      onEnd: jest.fn(),
+    };
+    const { result } = renderHook(() => useAnimation());
+    const [, animateFn] = result.current;
+
+    actHook(() => {
+      animateFn(animation);
+    });
+
+    expect(animation.onEnd).not.toHaveBeenCalled();
+
+    actHook(() => {
+      jest.advanceTimersByTime(animation.duration);
+    });
+
+    expect(animation.onEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/circuit-ui/hooks/useAnimation/useAnimation.ts
+++ b/packages/circuit-ui/hooks/useAnimation/useAnimation.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef, useState, useEffect } from 'react';
+
+type Animation = {
+  duration: number;
+  onStart: () => void;
+  onEnd: () => void;
+};
+
+type Timeout = ReturnType<typeof setTimeout>;
+
+/**
+ * Helper to animate between complex states. It calls callback functions
+ * at the start and end of the animation duration.
+ */
+export function useAnimation(): [boolean, (animation: Animation) => void] {
+  const timerId = useRef<Timeout | null>(null);
+  const [animation, setAnimation] = useState<Animation | null>(null);
+
+  useEffect(() => {
+    if (!animation) {
+      return undefined;
+    }
+
+    if (timerId.current) {
+      clearTimeout(timerId.current);
+    }
+
+    if (animation.onStart) {
+      animation.onStart();
+    }
+
+    timerId.current = setTimeout(() => {
+      if (animation.onEnd) {
+        animation.onEnd();
+      }
+      setAnimation(null);
+    }, animation.duration);
+
+    return () => {
+      if (timerId.current) {
+        clearTimeout(timerId.current);
+        timerId.current = null;
+      }
+    };
+  }, [animation]);
+
+  const isAnimating = Boolean(animation);
+
+  return [isAnimating, setAnimation];
+}

--- a/packages/circuit-ui/hooks/useClickOutside/useClickOutside.docs.mdx
+++ b/packages/circuit-ui/hooks/useClickOutside/useClickOutside.docs.mdx
@@ -9,7 +9,7 @@ Calls a function when clicking outside an element.
 <Story id="hooks-useclickoutside--example" />
 
 ```ts
-useClickOutside(
+function useClickOutside(
   ref: RefObject<HTMLElement>,
   callback: (event: KeyboardEvent) => void,
   active = true,

--- a/packages/circuit-ui/hooks/useCollapsible/index.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { useCollapsible } from './useCollapsible';

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.docs.mdx
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.docs.mdx
@@ -25,4 +25,4 @@ function useCollapsible({
 
 Collapsible sections are a common interaction pattern on the web. They let users toggle the visibility of content by clicking that content's label.
 
-This hook provides the basic building blocks to build such a component. It returns [prop getters](https://kentcdodds.com/blog/how-to-give-rendering-control-to-users-with-prop-getters) for the content and content label which ensures an accessible and smooth user experience. Refer to [Inclusive Components](https://inclusive-components.design/collapsible-sections/) by _Heydon Pickering_ for detailed instructions on how to build a collapsible section component.
+This hook provides the basic building blocks to build such a component. It returns [prop getters](https://kentcdodds.com/blog/how-to-give-rendering-control-to-users-with-prop-getters) for the content and content label which ensures an accessible and smooth user experience. Refer to [Inclusive Components](https://inclusive-components.design/collapsible-sections/) by Heydon Pickering for detailed instructions on how to build a collapsible section component.

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.docs.mdx
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.docs.mdx
@@ -1,0 +1,28 @@
+import { Status, Story } from '../../../../.storybook/components';
+
+# useCollapsible()
+
+<Status.Stable />
+
+A hook to build accessible and smoothly animated [collapsible sections](https://inclusive-components.design/collapsible-sections/).
+
+<Story id="hooks-usecollapsible--example" />
+
+```ts
+function useCollapsible({
+  initialOpen?: boolean;
+  duration?: number;
+  id?: string;
+}): {
+  isOpen: boolean;
+  toggleOpen: () => void;
+  getButtonProps: (props?: { onClick?: (event: MouseEvent | KeyboardEvent) => void; }) => ButtonProps;
+  getContentProps: (props?: { style?: Record<string, string>; }) => ContentProps;
+};
+```
+
+## Usage
+
+Collapsible sections are a common interaction pattern on the web. They let users toggle the visibility of content by clicking that content's label.
+
+This hook provides the basic building blocks to build such a component. It returns [prop getters](https://kentcdodds.com/blog/how-to-give-rendering-control-to-users-with-prop-getters) for the content and content label which ensures an accessible and smooth user experience. Refer to [Inclusive Components](https://inclusive-components.design/collapsible-sections/) by _Heydon Pickering_ for detailed instructions on how to build a collapsible section component.

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.spec.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MouseEvent } from 'react';
+
+import { renderHook, actHook } from '../../util/test-utils';
+
+import { useCollapsible, getHeight } from './useCollapsible';
+
+describe('useCollapsible', () => {
+  it('should return the open state and a toggle callback', () => {
+    const { result } = renderHook(() => useCollapsible());
+    const { isOpen, toggleOpen } = result.current;
+
+    expect(isOpen).toBeFalsy();
+    expect(typeof toggleOpen).toBe('function');
+  });
+
+  it('should accept an initial state', () => {
+    const initialOpen = true;
+    const { result } = renderHook(() => useCollapsible({ initialOpen }));
+    const { isOpen } = result.current;
+
+    expect(isOpen).toBeTruthy();
+  });
+
+  it('should accept a custom id', () => {
+    const id = 'foo';
+    const { result } = renderHook(() => useCollapsible({ id }));
+    const { getButtonProps, getContentProps } = result.current;
+
+    const buttonProps = getButtonProps();
+    const contentProps = getContentProps();
+
+    expect(buttonProps['aria-controls']).toBe(id);
+    expect(contentProps.id).toBe(id);
+  });
+
+  it('should call a custom onClick prop on the button element', () => {
+    const customProps = { onClick: jest.fn() };
+    const event = ({ fizz: 'buzz' } as unknown) as MouseEvent;
+    const { result } = renderHook(() => useCollapsible());
+    const { getButtonProps } = result.current;
+
+    const actual = getButtonProps(customProps);
+
+    actHook(() => {
+      actual.onClick(event);
+    });
+
+    expect(customProps.onClick).toHaveBeenCalledTimes(1);
+    expect(customProps.onClick).toHaveBeenCalledWith(event);
+  });
+
+  it('should add custom styles to the content element', () => {
+    const customProps = { style: { color: 'red' } };
+    const { result } = renderHook(() => useCollapsible());
+    const { getContentProps } = result.current;
+
+    const actual = getContentProps(customProps);
+    const expected = expect.objectContaining({
+      style: expect.objectContaining({ color: 'red' }),
+    });
+
+    expect(actual).toEqual(expected);
+  });
+
+  describe('when closed', () => {
+    const initialOpen = false;
+
+    it('should return a getter for the button props', () => {
+      const { result } = renderHook(() => useCollapsible({ initialOpen }));
+      const { getButtonProps } = result.current;
+
+      const actual = getButtonProps();
+      const expected = expect.objectContaining({
+        'onClick': expect.any(Function),
+        'tabIndex': 0,
+        'aria-controls': expect.any(String),
+        'aria-expanded': 'false',
+      });
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return a getter for the content props', () => {
+      const { result } = renderHook(() => useCollapsible({ initialOpen }));
+      const { getContentProps } = result.current;
+
+      const actual = getContentProps();
+      const expected = expect.objectContaining({
+        'ref': { current: null },
+        'id': expect.any(String),
+        'style': {
+          overflow: 'hidden',
+          willChange: 'height',
+          opacity: 0,
+          height: 0,
+          transition: 'all 300ms ease-in-out',
+          visibility: 'hidden',
+        },
+        'aria-hidden': 'true',
+      });
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('when open', () => {
+    const initialOpen = true;
+
+    it('should return a getter for the button props', () => {
+      const { result } = renderHook(() => useCollapsible({ initialOpen }));
+      const { getButtonProps } = result.current;
+
+      const actual = getButtonProps();
+      const expected = expect.objectContaining({
+        'onClick': expect.any(Function),
+        'tabIndex': 0,
+        'aria-controls': expect.any(String),
+        'aria-expanded': 'true',
+      });
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('should return a getter for the content props', () => {
+      const { result } = renderHook(() => useCollapsible({ initialOpen }));
+      const { getContentProps } = result.current;
+
+      const actual = getContentProps();
+      const expected = expect.objectContaining({
+        'ref': { current: null },
+        'id': expect.any(String),
+        'style': {
+          overflow: 'hidden',
+          willChange: 'height',
+          opacity: 1,
+          height: 'auto',
+          transition: 'all 300ms ease-in-out',
+          visibility: 'visible',
+        },
+        'aria-hidden': null,
+      });
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('toggling', () => {
+    it('should toggle the open state when the button is clicked', () => {
+      const event = ({ fizz: 'buzz' } as unknown) as MouseEvent;
+      const { result } = renderHook(() => useCollapsible());
+      const { getButtonProps } = result.current;
+
+      expect(result.current.isOpen).toBeFalsy();
+
+      actHook(() => {
+        getButtonProps().onClick(event);
+      });
+
+      expect(result.current.isOpen).toBeTruthy();
+    });
+
+    it('should toggle the open state when the callback is called', () => {
+      const { result } = renderHook(() => useCollapsible());
+
+      expect(result.current.isOpen).toBeFalsy();
+
+      actHook(() => {
+        result.current.toggleOpen();
+      });
+
+      expect(result.current.isOpen).toBeTruthy();
+    });
+  });
+
+  describe('getHeight', () => {
+    it('should return "auto" when the element is falsy', () => {
+      const element = null;
+      const actual = getHeight(element);
+      const expected = 'auto';
+      expect(actual).toBe(expected);
+    });
+
+    it('should return "auto" when the current element is falsy', () => {
+      const element = { current: null };
+      const actual = getHeight(element);
+      const expected = 'auto';
+      expect(actual).toBe(expected);
+    });
+
+    it('should return the scroll height in pixels for the element', () => {
+      const element = { scrollHeight: 20 } as HTMLElement;
+      const ref = { current: element };
+      const actual = getHeight(ref);
+      const expected = '20px';
+      expect(actual).toBe(expected);
+    });
+  });
+});

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.stories.tsx
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.stories.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Body from '../../components/Body';
+import Button from '../../components/Button';
+import { spacing } from '../../styles/style-mixins';
+
+import { CollapsibleOptions, useCollapsible } from './useCollapsible';
+import docs from './useCollapsible.docs.mdx';
+
+export default {
+  title: 'Hooks/useCollapsible',
+  parameters: {
+    docs: { page: docs },
+  },
+};
+
+export const Example = (args: CollapsibleOptions) => {
+  const { isOpen, getButtonProps, getContentProps } = useCollapsible(args);
+
+  return (
+    <section>
+      <Button {...getButtonProps()}>
+        {isOpen ? 'Close section' : 'Open section'}
+      </Button>
+      <Body {...getContentProps()} css={spacing({ top: 'kilo' })} noMargin>
+        {
+          'Lorem ipsum dolor amet swag pickled humblebrag retro farm-to-table, shoreditch typewriter deep v single-origin coffee green juice coloring book venmo chambray. Marfa authentic blue bottle mixtape tofu adaptogen. IPhone chia blog palo santo mlkshk tattooed jean shorts yr locavore ennui scenester. Wolf tousled pok pok sartorial scenester man bun salvia quinoa raclette sriracha roof party pour-over venmo hammock. Four dollar toast typewriter 3 wolf moon letterpress disrupt pabst. Neutra irony tousled iPhone banh mi wayfarers hoodie waistcoat.'
+        }
+      </Body>
+    </section>
+  );
+};
+
+Example.args = {
+  initialOpen: false,
+  duration: 300,
+};

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  useState,
+  useRef,
+  useCallback,
+  RefObject,
+  KeyboardEvent,
+  MouseEvent,
+} from 'react';
+
+import { uniqueId } from '../../util/id';
+import { useAnimation } from '../useAnimation';
+
+const DEFAULT_HEIGHT = 'auto';
+
+export type CollapsibleOptions = {
+  initialOpen?: boolean;
+  duration?: number;
+  id?: string;
+};
+
+type ButtonProps = {
+  'onClick': (event: MouseEvent | KeyboardEvent) => void;
+  'tabIndex': number;
+  'aria-controls': string;
+  'aria-expanded': 'true' | 'false';
+};
+
+type ContentProps<T> = {
+  'ref': RefObject<T>;
+  'id': string;
+  'style': {
+    overflow: 'hidden';
+    willChange: 'height';
+    opacity: 1 | 0;
+    height: string | 0;
+  };
+  'aria-hidden': null | 'true';
+};
+
+type Collapsible<T> = {
+  isOpen: boolean;
+  toggleOpen: () => void;
+  getButtonProps: (props?: {
+    onClick?: (event: MouseEvent | KeyboardEvent) => void;
+  }) => ButtonProps;
+  getContentProps: (props?: {
+    style?: Record<string, string>;
+  }) => ContentProps<T>;
+};
+
+/**
+ * A hook to build accessible and smoothly animated collapsible sections.
+ * Based on https://inclusive-components.design/collapsible-sections/
+ */
+export function useCollapsible<T extends HTMLElement = HTMLElement>({
+  initialOpen = false,
+  duration = 300,
+  id,
+}: CollapsibleOptions = {}): Collapsible<T> {
+  const detailElement = useRef<T>(null);
+  const [isOpen, setOpen] = useState(initialOpen);
+  const [height, setHeight] = useState(getHeight(detailElement));
+  const [, setAnimating] = useAnimation();
+
+  const detailId = id || uniqueId('collapsible_');
+
+  const toggleOpen = useCallback(() => {
+    setAnimating({
+      duration,
+      onStart: () => {
+        setHeight(getHeight(detailElement));
+        if (!isOpen) {
+          setOpen(true);
+        }
+      },
+      onEnd: () => {
+        if (isOpen) {
+          setOpen(false);
+        }
+        setHeight(DEFAULT_HEIGHT);
+      },
+    });
+  }, [isOpen, detailElement, setAnimating, duration]);
+
+  return {
+    isOpen,
+    toggleOpen,
+    getButtonProps: (props = {}) => ({
+      'onClick': (event: MouseEvent | KeyboardEvent) => {
+        if (props.onClick) {
+          props.onClick(event);
+        }
+        toggleOpen();
+      },
+      'tabIndex': 0,
+      'aria-controls': detailId,
+      'aria-expanded': isOpen ? 'true' : 'false',
+    }),
+    getContentProps: (props = {}) => ({
+      'ref': detailElement,
+      'id': detailId,
+      'style': {
+        overflow: 'hidden',
+        willChange: 'height',
+        opacity: isOpen ? 1 : 0,
+        height: isOpen ? height : 0,
+        visibility: isOpen ? 'visible' : 'hidden',
+        transition: `all ${duration}ms ease-in-out`,
+        ...props.style,
+      },
+      'aria-hidden': isOpen ? null : 'true',
+    }),
+  };
+}
+
+export function getHeight(element: RefObject<HTMLElement>): string {
+  if (!element || !element.current) {
+    return DEFAULT_HEIGHT;
+  }
+  return `${element.current.scrollHeight}px`;
+}

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
@@ -72,18 +72,16 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
   duration = 300,
   id,
 }: CollapsibleOptions = {}): Collapsible<T> {
-  const detailElement = useRef<T>(null);
+  const contentId = id || uniqueId('collapsible_');
+  const contentElement = useRef<T>(null);
   const [isOpen, setOpen] = useState(initialOpen);
-  const [height, setHeight] = useState(getHeight(detailElement));
+  const [height, setHeight] = useState(getHeight(contentElement));
   const [, setAnimating] = useAnimation();
-
-  const detailId = id || uniqueId('collapsible_');
-
   const toggleOpen = useCallback(() => {
     setAnimating({
       duration,
       onStart: () => {
-        setHeight(getHeight(detailElement));
+        setHeight(getHeight(contentElement));
         if (!isOpen) {
           setOpen(true);
         }
@@ -95,7 +93,7 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
         setHeight(DEFAULT_HEIGHT);
       },
     });
-  }, [isOpen, detailElement, setAnimating, duration]);
+  }, [isOpen, setAnimating, duration]);
 
   return {
     isOpen,
@@ -108,12 +106,12 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
         toggleOpen();
       },
       'tabIndex': 0,
-      'aria-controls': detailId,
+      'aria-controls': contentId,
       'aria-expanded': isOpen ? 'true' : 'false',
     }),
     getContentProps: (props = {}) => ({
-      'ref': detailElement,
-      'id': detailId,
+      'ref': contentElement,
+      'id': contentId,
       'style': {
         overflow: 'hidden',
         willChange: 'height',

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
@@ -13,15 +13,9 @@
  * limitations under the License.
  */
 
-import {
-  useState,
-  useRef,
-  useCallback,
-  RefObject,
-  KeyboardEvent,
-  MouseEvent,
-} from 'react';
+import { useState, useRef, useCallback, RefObject } from 'react';
 
+import { ClickEvent } from '../../types/events';
 import { uniqueId } from '../../util/id';
 import { useAnimation } from '../useAnimation';
 
@@ -34,7 +28,7 @@ export type CollapsibleOptions = {
 };
 
 type ButtonProps = {
-  'onClick': (event: MouseEvent | KeyboardEvent) => void;
+  'onClick': (event: ClickEvent) => void;
   'tabIndex': number;
   'aria-controls': string;
   'aria-expanded': 'true' | 'false';
@@ -56,7 +50,7 @@ type Collapsible<T> = {
   isOpen: boolean;
   toggleOpen: () => void;
   getButtonProps: (props?: {
-    onClick?: (event: MouseEvent | KeyboardEvent) => void;
+    onClick?: (event: ClickEvent) => void;
   }) => ButtonProps;
   getContentProps: (props?: {
     style?: Record<string, string>;
@@ -99,7 +93,7 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
     isOpen,
     toggleOpen,
     getButtonProps: (props = {}) => ({
-      'onClick': (event: MouseEvent | KeyboardEvent) => {
+      'onClick': (event: ClickEvent) => {
         if (props.onClick) {
           props.onClick(event);
         }

--- a/packages/circuit-ui/hooks/useEscapeKey/useEscapeKey.docs.mdx
+++ b/packages/circuit-ui/hooks/useEscapeKey/useEscapeKey.docs.mdx
@@ -9,7 +9,7 @@ Calls a function when the escape key is pressed.
 <Story id="hooks-useescapekey--example" />
 
 ```ts
-useEscapeKey(
+function useEscapeKey(
   callback: (event: KeyboardEvent) => void,
   active = true,
 ): void;

--- a/packages/circuit-ui/hooks/useFocusList/useFocusList.docs.mdx
+++ b/packages/circuit-ui/hooks/useFocusList/useFocusList.docs.mdx
@@ -9,7 +9,7 @@ Enables keyboard navigation for a list of focusable elements.
 <Story id="hooks-usefocuslist--example" />
 
 ```ts
-useFocusList(): {
+function useFocusList(): {
   'data-focus-list': string;
   'onKeyDown': (event: KeyboardEvent) => void;
 };

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -173,3 +173,4 @@ export { uniqueId } from './util/id';
 export { useClickOutside } from './hooks/useClickOutside';
 export { useEscapeKey } from './hooks/useEscapeKey';
 export { useFocusList } from './hooks/useFocusList';
+export { useCollapsible } from './hooks/useCollapsible';

--- a/packages/circuit-ui/types/events.ts
+++ b/packages/circuit-ui/types/events.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+export type ClickEvent<T = Element> =
+  | React.MouseEvent<T>
+  | React.KeyboardEvent<T>;


### PR DESCRIPTION
## Purpose

Collapsible sections are a common interaction pattern on the web. There are a large number of implementations across SumUp's applications — many of them inaccessible and jarringly animated. 

We need a similar expandable section for the new side navigation on mobile. I figured that by abstracting the logic away in a hook, it could be used to improve the existing use cases. 

## Approach and changes

- Add a `useCollapsible` hook to build accessible and smoothly animated collapsible sections

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
