### PR TITLE
Stabilize the context value of the ModalProvider

### DIFF
--- a/packages/circuit-ui/components/ModalContext/ModalContext.spec.tsx
+++ b/packages/circuit-ui/components/ModalContext/ModalContext.spec.tsx
@@ -74,7 +74,7 @@ describe('ModalContext', () => {
         return (
           <>
             <button onClick={() => setModal(modal)}>Open modal</button>
-            <button onClick={() => removeModal(modal.id)}>Close modal</button>
+            <button onClick={() => removeModal(modal)}>Close modal</button>
           </>
         );
       };

--- a/packages/circuit-ui/components/ModalContext/createUseModal.spec.tsx
+++ b/packages/circuit-ui/components/ModalContext/createUseModal.spec.tsx
@@ -59,10 +59,14 @@ describe('createUseModal', () => {
     const { result } = renderHook(() => useModal(), { wrapper });
 
     actHook(() => {
+      result.current.setModal({});
+    });
+
+    actHook(() => {
       result.current.removeModal();
     });
 
-    const expected = expect.any(String);
+    const expected = expect.any(Object);
     expect(removeModal).toHaveBeenCalledWith(expected);
   });
 });

--- a/packages/circuit-ui/components/ModalContext/createUseModal.ts
+++ b/packages/circuit-ui/components/ModalContext/createUseModal.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { useContext, useMemo, useCallback } from 'react';
+import { useContext, useMemo, useCallback, useRef } from 'react';
 
 import { uniqueId } from '../../util/id';
 
@@ -28,17 +28,22 @@ export function createUseModal<T extends BaseModalProps>(
     removeModal: () => void;
   } => {
     const id = useMemo(uniqueId, []);
+    const modalRef = useRef<Omit<T, 'isOpen'> | null>(null);
     const context = useContext(ModalContext);
 
     const setModal = useCallback(
       (props: Omit<T, 'isOpen'>): void => {
+        modalRef.current = props;
         context.setModal({ ...props, id, component });
       },
       [context, id],
     );
 
     const removeModal = useCallback((): void => {
-      context.removeModal(id);
+      if (modalRef.current) {
+        context.removeModal({ ...modalRef.current, id, component });
+        modalRef.current = null;
+      }
     }, [context, id]);
 
     return { setModal, removeModal };


### PR DESCRIPTION
## Purpose

This prevents infinite render loops where calling `setModal` would update the modal state which in turn would change the modal context and thus rerender the component that originally called `setState`, starting the loop anew. 

This also removes the temporary fix from #1070.

## Approach and changes

- Store the modal locally in the `useModal` hook so the `removeModal` hook doesn't need to depend on the `modals` state. 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
