### PR TITLE
Fixes to the navigation components

### DIFF
--- a/.changeset/bright-emus-impress.md
+++ b/.changeset/bright-emus-impress.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Changed the styles returned by the `useCollapsible` hook to only hide vertical overflow, fixing a compatibility issue with the form components.

--- a/.changeset/cool-ladybugs-teach.md
+++ b/.changeset/cool-ladybugs-teach.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed a number of issues in the navigation components, including adding a min-width when the secondary nav is hidden, closing the mobile navigation modal when a link is clicked, and exporting additional navigation types.

--- a/.changeset/five-peaches-perform.md
+++ b/.changeset/five-peaches-perform.md
@@ -1,5 +1,5 @@
 ---
-'@sumup/circuit-ui': minor
+'@sumup/circuit-ui': patch
 ---
 
 Prevented interactions with content behind the Popover overlay.

--- a/.changeset/five-peaches-perform.md
+++ b/.changeset/five-peaches-perform.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Prevented interactions with content behind the Popover overlay.

--- a/.changeset/pink-rocks-dream.md
+++ b/.changeset/pink-rocks-dream.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the `TopNavigation`'s profile menu alignment when no `userId` is provided.

--- a/.changeset/strong-cooks-repair.md
+++ b/.changeset/strong-cooks-repair.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': minor
+---
+
+Exported the `IconProps` interface publicly.

--- a/packages/circuit-ui/components/Notification/Notification.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.tsx
@@ -13,12 +13,13 @@
  * limitations under the License.
  */
 
-import { FC, SVGProps, ReactNode } from 'react';
+import { FC, ReactNode } from 'react';
 import { css } from '@emotion/core';
 import {
   CircleCheckmarkFilled,
   CircleCrossFilled,
   CircleWarningFilled,
+  IconProps,
 } from '@sumup/icons';
 import { Theme } from '@sumup/design-tokens';
 
@@ -31,7 +32,7 @@ type Variant = 'success' | 'error' | 'warning';
 export interface NotificationProps {
   variant: Variant;
   children: ReactNode;
-  icon?: FC<SVGProps<SVGSVGElement>>;
+  icon?: FC<IconProps>;
   onClose?: (event: ClickEvent) => void;
   closeLabel?: string;
 }

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -188,7 +188,6 @@ const overlayStyles = ({ theme }: StyleProps) => css`
     left: 0;
     right: 0;
     background-color: ${theme.colors.overlay};
-    pointer-events: none;
     visibility: hidden;
     opacity: 0;
     transition: opacity ${theme.transitions.default},

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -115,16 +115,13 @@ export const PopoverItem = ({
   tracking,
   ...props
 }: PopoverItemProps): JSX.Element => {
-  const components = useComponents();
-
-  // Need to typecast here because the styled component types restrict the
-  // `as` prop to a string. It's safe to ignore that constraint here.
-  const Link = (components.Link as unknown) as string;
+  const { Link } = useComponents();
 
   const handleClick = useClickEvent(onClick, tracking, 'popover-item');
 
   return (
     <PopoverItemWrapper
+      // @ts-expect-error The type for the `as` prop is missing in Emotion's prop types.
       as={props.href ? Link : 'button'}
       onClick={handleClick}
       role="menuitem"

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -33,6 +33,7 @@ import { Dispatch as TrackingProps } from '@sumup/collector';
 import { usePopper } from 'react-popper';
 import { Placement, State, Modifier } from '@popperjs/core';
 import { useTheme } from 'emotion-theming';
+import isPropValid from '@emotion/is-prop-valid';
 
 import { ClickEvent } from '../../types/events';
 import styled, { StyleProps } from '../../styles/styled';
@@ -99,11 +100,9 @@ const itemWrapperStyles = () => css`
   width: 100%;
 `;
 
-const PopoverItemWrapper = styled('button')<PopoverItemWrapperProps>(
-  listItem,
-  itemWrapperStyles,
-  typography('one'),
-);
+const PopoverItemWrapper = styled('button', {
+  shouldForwardProp: isPropValid,
+})<PopoverItemWrapperProps>(listItem, itemWrapperStyles, typography('one'));
 
 const iconStyles = (theme: Theme) => css`
   margin-right: ${theme.spacings.byte};

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -20,7 +20,6 @@ import {
   Fragment,
   HTMLProps,
   Ref,
-  SVGProps,
   useEffect,
   useMemo,
   useRef,
@@ -34,6 +33,7 @@ import { usePopper } from 'react-popper';
 import { Placement, State, Modifier } from '@popperjs/core';
 import { useTheme } from 'emotion-theming';
 import isPropValid from '@emotion/is-prop-valid';
+import { IconProps } from '@sumup/icons';
 
 import { ClickEvent } from '../../types/events';
 import styled, { StyleProps } from '../../styles/styled';
@@ -61,7 +61,7 @@ export interface BaseProps {
   /**
    * Display an icon in addition to the label.
    */
-  icon?: FC<SVGProps<SVGSVGElement>>;
+  icon?: FC<IconProps>;
   /**
    * Destructive variant, changes the color of label and icon from blue to red to signal to the user that the action
    * is irreversible or otherwise dangerous. Interactive states are the same for destructive variant.
@@ -130,7 +130,7 @@ export const PopoverItem = ({
       role="menuitem"
       {...props}
     >
-      {Icon && <Icon css={iconStyles} />}
+      {Icon && <Icon css={iconStyles} size="large" />}
       {children}
     </PopoverItemWrapper>
   );

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -324,10 +324,14 @@ export const Popover = ({
   // Note: the usePopper hook intentionally takes the DOM node, not refs, in order to be able to update when the nodes change.
   // A callback ref is used here to permit this behaviour, and useState is an appropriate way to implement this.
   const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
-  const { styles, attributes } = usePopper(triggerEl.current, popperElement, {
-    placement,
-    modifiers: [mobilePosition, flip, ...modifiers],
-  });
+  const { styles, attributes, update } = usePopper(
+    triggerEl.current,
+    popperElement,
+    {
+      placement,
+      modifiers: [mobilePosition, flip, ...modifiers],
+    },
+  );
 
   // This is a performance optimization to prevent event listeners from being
   // re-attached on every render.
@@ -339,6 +343,11 @@ export const Popover = ({
   const prevOpen = usePrevious(isOpen);
 
   useEffect(() => {
+    if (update) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      update();
+    }
+
     // Focus the first or last element after opening
     if (!prevOpen && isOpen) {
       const element = (triggerKey.current && triggerKey.current === 'ArrowUp'
@@ -357,7 +366,7 @@ export const Popover = ({
     }
 
     triggerKey.current = null;
-  }, [isOpen, prevOpen]);
+  }, [isOpen, prevOpen, update]);
 
   const focusProps = useFocusList();
 

--- a/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
+++ b/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
@@ -71,7 +71,6 @@ exports[`Popover styles should render popover on auto 1`] = `
     left: 0;
     right: 0;
     background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
     visibility: hidden;
     opacity: 0;
     -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
@@ -341,7 +340,6 @@ exports[`Popover styles should render popover on bottom 1`] = `
     left: 0;
     right: 0;
     background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
     visibility: hidden;
     opacity: 0;
     -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
@@ -611,7 +609,6 @@ exports[`Popover styles should render popover on left 1`] = `
     left: 0;
     right: 0;
     background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
     visibility: hidden;
     opacity: 0;
     -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
@@ -881,7 +878,6 @@ exports[`Popover styles should render popover on right 1`] = `
     left: 0;
     right: 0;
     background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
     visibility: hidden;
     opacity: 0;
     -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
@@ -1151,7 +1147,6 @@ exports[`Popover styles should render popover on top 1`] = `
     left: 0;
     right: 0;
     background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
     visibility: hidden;
     opacity: 0;
     -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
@@ -1486,7 +1481,6 @@ exports[`Popover styles should render with closed styles 1`] = `
     left: 0;
     right: 0;
     background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
     visibility: hidden;
     opacity: 0;
     -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
@@ -1675,7 +1669,6 @@ exports[`Popover styles should render with default styles 1`] = `
     left: 0;
     right: 0;
     background-color: rgba(0,0,0,0.4);
-    pointer-events: none;
     visibility: hidden;
     opacity: 0;
     -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
@@ -32,7 +32,6 @@ export default {
   excludeStories: /.*Args$/,
 };
 
-/* eslint-disable react/display-name */
 export const baseArgs = {
   isOpen: true,
   closeButtonLabel: 'Close navigation',
@@ -40,13 +39,13 @@ export const baseArgs = {
   secondaryNavigationLabel: 'Secondary',
   primaryLinks: [
     {
-      icon: (props) => <House {...props} size="large" />,
+      icon: House,
       label: 'Home',
       href: '/',
       onClick: action('Home'),
     },
     {
-      icon: (props) => <ShoppingBag {...props} size="large" />,
+      icon: ShoppingBag,
       label: 'Shop',
       href: '/shop',
       onClick: action('Shop'),
@@ -90,20 +89,20 @@ export const baseArgs = {
       ],
     },
     {
-      icon: (props) => <Package {...props} size="large" />,
+      icon: Package,
       label: 'Orders',
       href: '/orders',
       onClick: action('Orders'),
-      badge: { label: 'new ' },
+      badge: { label: 'new' },
     },
     {
-      icon: (props) => <Heart {...props} size="large" />,
+      icon: Heart,
       label: 'Wishlist',
       href: '/wishlist',
       onClick: action('Wishlist'),
     },
     {
-      icon: (props) => <LiveChat {...props} size="large" />,
+      icon: LiveChat,
       label: 'Support',
       href: 'https://support.example.com',
       onClick: action('Support'),

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.spec.tsx
@@ -65,8 +65,15 @@ describe('DesktopNavigation', () => {
 
   describe('styles', () => {
     it('should render with secondary links', () => {
-      const wrapper = renderDesktopNavigation(create, defaultProps);
-      expect(wrapper).toMatchSnapshot();
+      const { container, getAllByRole } = renderDesktopNavigation(
+        render,
+        defaultProps,
+      );
+
+      const lists = getAllByRole('list');
+
+      expect(lists).toHaveLength(3);
+      expect(container).toMatchSnapshot();
     });
 
     it('should render without secondary links', () => {
@@ -78,11 +85,19 @@ describe('DesktopNavigation', () => {
             label: 'Home',
             href: '/',
             onClick: jest.fn(),
+            secondaryGroups: [],
           },
         ],
       };
-      const wrapper = renderDesktopNavigation(create, props);
-      expect(wrapper).toMatchSnapshot();
+      const { container, getAllByRole } = renderDesktopNavigation(
+        render,
+        props,
+      );
+
+      const lists = getAllByRole('list');
+
+      expect(lists).toHaveLength(1);
+      expect(container).toMatchSnapshot();
     });
   });
 

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -49,6 +49,10 @@ const wrapperStyles = ({ theme }: StyleProps) => css`
   ${theme.mq.untilGiga} {
     display: none;
   }
+  ${theme.mq.giga} {
+    min-width: ${PRIMARY_NAVIGATION_WIDTH};
+    flex-shrink: 0;
+  }
 `;
 
 const Wrapper = styled.div(wrapperStyles);

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -135,7 +135,7 @@ export function DesktopNavigation({
           ))}
         </ul>
       </PrimaryNavigationWrapper>
-      {secondaryGroups && (
+      {secondaryGroups && secondaryGroups.length > 0 && (
         <SecondaryNavigationWrapper
           {...props}
           aria-label={secondaryNavigationLabel}

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
@@ -7,6 +7,15 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   }
 }
 
+@media (min-width:960px) {
+  .circuit-14 {
+    min-width: 48px;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+  }
+}
+
 .circuit-4 {
   position: fixed;
   z-index: 800;
@@ -394,6 +403,15 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
 @media (max-width:959px) {
   .circuit-5 {
     display: none;
+  }
+}
+
+@media (min-width:960px) {
+  .circuit-5 {
+    min-width: 48px;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
   }
 }
 

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
@@ -292,110 +292,112 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   margin-bottom: 0;
 }
 
-<div
-  class="circuit-14"
->
-  <nav
-    aria-label="Primary"
-    class="circuit-4"
+<div>
+  <div
+    class="circuit-14"
   >
-    <ul
-      class="circuit-3"
-      role="list"
+    <nav
+      aria-label="Primary"
+      class="circuit-4"
     >
-      <li>
-        <a
-          aria-current="page"
-          class="circuit-2"
-          data-focus-list="1"
-          href="/shop"
-        >
-          <div
-            class="circuit-0"
+      <ul
+        class="circuit-3"
+        role="list"
+      >
+        <li>
+          <a
+            aria-current="page"
+            class="circuit-2"
+            data-focus-list="1"
+            href="/shop"
           >
-            <svg
-              fill="none"
-              height="24"
-              role="presentation"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="circuit-0"
             >
-              <path
-                d="M4.5 7h15m-15 0L3.119 19.893A1 1 0 004.113 21h15.774a1 1 0 00.994-1.107L19.5 7m-15 0l3.201-3.659A1 1 0 018.454 3h7.092a1 1 0 01.753.341L19.5 7"
-                stroke="currentColor"
-                stroke-width="2"
-              />
-              <path
-                d="M16 11a4 4 0 01-8 0"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-width="2"
-              />
-            </svg>
-          </div>
-          <span
-            class="circuit-1"
+              <svg
+                fill="none"
+                height="24"
+                role="presentation"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M4.5 7h15m-15 0L3.119 19.893A1 1 0 004.113 21h15.774a1 1 0 00.994-1.107L19.5 7m-15 0l3.201-3.659A1 1 0 018.454 3h7.092a1 1 0 01.753.341L19.5 7"
+                  stroke="currentColor"
+                  stroke-width="2"
+                />
+                <path
+                  d="M16 11a4 4 0 01-8 0"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </div>
+            <span
+              class="circuit-1"
+            >
+              Shop
+            </span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+    <nav
+      aria-label="Secondary"
+      class="circuit-13"
+    >
+      <h2
+        class="circuit-5"
+      >
+        Shop
+      </h2>
+      <ul
+        class="circuit-12"
+        role="list"
+      >
+        <li>
+          <h3
+            class="circuit-6"
           >
-            Shop
-          </span>
-        </a>
-      </li>
-    </ul>
-  </nav>
-  <nav
-    aria-label="Secondary"
-    class="circuit-13"
-  >
-    <h2
-      class="circuit-5"
-    >
-      Shop
-    </h2>
-    <ul
-      class="circuit-12"
-      role="list"
-    >
-      <li>
-        <h3
-          class="circuit-6"
-        >
-          For Kids
-        </h3>
-        <ul
-          class="circuit-11"
-          role="list"
-        >
-          <li>
-            <a
-              class="circuit-8"
-              data-focus-list="2"
-              href="/shop/toys"
-            >
-              <p
-                class="circuit-7"
+            For Kids
+          </h3>
+          <ul
+            class="circuit-11"
+            role="list"
+          >
+            <li>
+              <a
+                class="circuit-8"
+                data-focus-list="2"
+                href="/shop/toys"
               >
-                Toys
-              </p>
-            </a>
-          </li>
-          <li>
-            <a
-              class="circuit-8"
-              data-focus-list="2"
-              href="/shop/books"
-            >
-              <p
-                class="circuit-7"
+                <p
+                  class="circuit-7"
+                >
+                  Toys
+                </p>
+              </a>
+            </li>
+            <li>
+              <a
+                class="circuit-8"
+                data-focus-list="2"
+                href="/shop/books"
               >
-                Books
-              </p>
-            </a>
-          </li>
-        </ul>
-      </li>
-    </ul>
-  </nav>
+                <p
+                  class="circuit-7"
+                >
+                  Books
+                </p>
+              </a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+  </div>
 </div>
 `;
 
@@ -569,50 +571,52 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
   }
 }
 
-<div
-  class="circuit-5"
->
-  <nav
-    aria-label="Primary"
-    class="circuit-4"
+<div>
+  <div
+    class="circuit-5"
   >
-    <ul
-      class="circuit-3"
-      role="list"
+    <nav
+      aria-label="Primary"
+      class="circuit-4"
     >
-      <li>
-        <a
-          class="circuit-2"
-          data-focus-list="3"
-          href="/"
-        >
-          <div
-            class="circuit-0"
+      <ul
+        class="circuit-3"
+        role="list"
+      >
+        <li>
+          <a
+            class="circuit-2"
+            data-focus-list="3"
+            href="/"
           >
-            <svg
-              fill="none"
-              height="24"
-              role="presentation"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="circuit-0"
             >
-              <path
-                clip-rule="evenodd"
-                d="M12 4.271l8 5.714v8.765c0 .69-.56 1.25-1.25 1.25H13v-6h-2v6H5.25C4.56 20 4 19.44 4 18.75V9.985l8-5.714zm-6 6.744V18h3v-6h6v6h3v-6.985l-6-4.286-6 4.286z"
-                fill="currentColor"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </div>
-          <span
-            class="circuit-1"
-          >
-            Home
-          </span>
-        </a>
-      </li>
-    </ul>
-  </nav>
+              <svg
+                fill="none"
+                height="24"
+                role="presentation"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  clip-rule="evenodd"
+                  d="M12 4.271l8 5.714v8.765c0 .69-.56 1.25-1.25 1.25H13v-6h-2v6H5.25C4.56 20 4 19.44 4 18.75V9.985l8-5.714zm-6 6.744V18h3v-6h6v6h3v-6.985l-6-4.286-6 4.286z"
+                  fill="currentColor"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </div>
+            <span
+              class="circuit-1"
+            >
+              Home
+            </span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
 </div>
 `;

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.spec.tsx
@@ -95,6 +95,7 @@ describe('MobileNavigation', () => {
             label: 'Home',
             href: '/',
             onClick: jest.fn(),
+            secondaryGroups: [],
           },
         ],
       };

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
@@ -34,6 +34,7 @@ import { PrimaryLinkProps } from '../../types';
 import { PrimaryLink } from '../PrimaryLink';
 import { SecondaryLinks } from '../SecondaryLinks';
 import { Require } from '../../../../types/util';
+import { ClickEvent } from '../../../../types/events';
 
 const TRANSITION_DURATION = 120;
 const HEADER_HEIGHT = 56;
@@ -51,6 +52,18 @@ export interface MobileNavigationProps extends BaseModalProps {
    * TODO: Add description
    */
   primaryNavigationLabel: string;
+}
+
+function combineClickHandlers(
+  ...fns: (undefined | ((event: ClickEvent) => void))[]
+) {
+  return (event: ClickEvent) => {
+    fns.forEach((fn) => {
+      if (fn) {
+        fn(event);
+      }
+    });
+  };
 }
 
 type ChevronProps = { isOpen: boolean };
@@ -83,13 +96,26 @@ const groupStyles = (theme: Theme) => css`
 function Group({
   secondaryGroups,
   href,
+  onClose,
   ...props
-}: Require<PrimaryLinkProps, 'secondaryGroups'>): JSX.Element {
+}: Require<PrimaryLinkProps, 'secondaryGroups'> & {
+  onClose: BaseModalProps['onClose'];
+}): JSX.Element {
   const {
     isOpen,
     getButtonProps,
     getContentProps,
   } = useCollapsible<HTMLUListElement>();
+
+  const mappedSecondaryGroups = secondaryGroups.map(
+    ({ secondaryLinks, ...group }) => ({
+      ...group,
+      secondaryLinks: secondaryLinks.map(({ onClick, ...link }) => ({
+        ...link,
+        onClick: combineClickHandlers(onClick, onClose),
+      })),
+    }),
+  );
 
   return (
     <Fragment>
@@ -102,7 +128,7 @@ function Group({
       <SecondaryLinks
         {...getContentProps()}
         css={groupStyles}
-        secondaryGroups={secondaryGroups}
+        secondaryGroups={mappedSecondaryGroups}
       />
     </Fragment>
   );
@@ -254,19 +280,26 @@ export const MobileNavigation: ModalComponent<MobileNavigationProps> = ({
 
                 <nav aria-label={primaryNavigationLabel}>
                   <ul css={listStyles}>
-                    {primaryLinks.map(({ secondaryGroups, ...link }) => (
-                      <li key={link.label}>
-                        {secondaryGroups ? (
-                          <Group
-                            {...link}
-                            secondaryGroups={secondaryGroups}
-                            {...focusProps}
-                          />
-                        ) : (
-                          <PrimaryLink {...link} {...focusProps} />
-                        )}
-                      </li>
-                    ))}
+                    {primaryLinks.map(
+                      ({ secondaryGroups, onClick, ...link }) => (
+                        <li key={link.label}>
+                          {secondaryGroups ? (
+                            <Group
+                              {...link}
+                              secondaryGroups={secondaryGroups}
+                              onClose={onClose}
+                              {...focusProps}
+                            />
+                          ) : (
+                            <PrimaryLink
+                              {...link}
+                              {...focusProps}
+                              onClick={combineClickHandlers(onClick, onClose)}
+                            />
+                          )}
+                        </li>
+                      ),
+                    )}
                   </ul>
                 </nav>
               </Content>

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
@@ -283,7 +283,7 @@ export const MobileNavigation: ModalComponent<MobileNavigationProps> = ({
                     {primaryLinks.map(
                       ({ secondaryGroups, onClick, ...link }) => (
                         <li key={link.label}>
-                          {secondaryGroups ? (
+                          {secondaryGroups && secondaryGroups.length > 0 ? (
                             <Group
                               {...link}
                               secondaryGroups={secondaryGroups}

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/__snapshots__/MobileNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/__snapshots__/MobileNavigation.spec.tsx.snap
@@ -517,7 +517,7 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
                   class="circuit-13"
                   id="collapsible_2"
                   role="list"
-                  style="overflow: hidden; will-change: height; opacity: 0; height: 0px; visibility: hidden; transition: all 200ms ease-in-out;"
+                  style="overflow-y: hidden; will-change: height; opacity: 0; height: 0px; visibility: hidden; transition: all 200ms ease-in-out;"
                 >
                   <li>
                     <h3

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -219,7 +219,7 @@ export function PrimaryLink({
       as={props.href ? Link : 'button'}
     >
       <IconContainer hasBadge={Boolean(badge)}>
-        <Icon role="presentation" />
+        <Icon role="presentation" size="large" />
       </IconContainer>
       <Label
         variant={isActive || isOpen ? 'highlight' : undefined}

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -25,6 +25,7 @@ import { useClickEvent } from '../../../../hooks/useClickEvent';
 import { useFocusList, FocusProps } from '../../../../hooks/useFocusList';
 import SubHeadline from '../../../SubHeadline';
 import Body from '../../../Body';
+import { useComponents } from '../../../ComponentsContext';
 import { SecondaryGroupProps, SecondaryLinkProps } from '../../types';
 
 const anchorStyles = ({ theme }: StyleProps) => css`
@@ -50,6 +51,8 @@ function SecondaryLink({
   tracking,
   ...props
 }: SecondaryLinkProps) {
+  const { Link } = useComponents();
+
   const handleClick = useClickEvent<MouseEvent | KeyboardEvent>(
     onClick,
     tracking,
@@ -62,6 +65,8 @@ function SecondaryLink({
         {...props}
         onClick={handleClick}
         aria-current={props.isActive ? 'page' : undefined}
+        // @ts-expect-error The type for the `as` prop is missing in Emotion's prop types.
+        as={props.href ? Link : 'button'}
       >
         <Body
           size="one"

--- a/packages/circuit-ui/components/SideNavigation/index.ts
+++ b/packages/circuit-ui/components/SideNavigation/index.ts
@@ -16,3 +16,9 @@
 export { SideNavigation } from './SideNavigation';
 
 export type { SideNavigationProps } from './SideNavigation';
+
+export type {
+  PrimaryLinkProps,
+  SecondaryGroupProps,
+  SecondaryLinkProps,
+} from './types';

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -13,15 +13,16 @@
  * limitations under the License.
  */
 
-import { HTMLProps, FC, SVGProps, MouseEvent, KeyboardEvent } from 'react';
+import { HTMLProps, FC, MouseEvent, KeyboardEvent } from 'react';
 import { Dispatch as TrackingProps } from '@sumup/collector';
+import { IconProps } from '@sumup/icons';
 
 export interface PrimaryLinkProps extends HTMLProps<HTMLAnchorElement> {
   /**
    * Display an icon in addition to the text to help to identify the link.
    * On narrow viewports, only the icon is displayed.
    */
-  icon: FC<SVGProps<SVGSVGElement>>;
+  icon: FC<IconProps>;
   /**
    * Short label to describe the target of the link.
    */

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
@@ -66,8 +66,7 @@ const baseArgs = {
   ],
   links: [
     {
-      // eslint-disable-next-line react/display-name
-      icon: (props) => <ShoppingCart {...props} size="large" />,
+      icon: ShoppingCart,
       label: 'Shop',
       href: '/shop',
       onClick: action('Shop'),

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
@@ -83,7 +83,7 @@ const Logo = styled.div(logoStyles);
 
 const Wrapper = styled.div`
   display: flex;
-  align-items: center;
+  align-items: stretch;
 `;
 
 export interface TopNavigationProps

--- a/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
@@ -542,15 +542,21 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
           <svg
             class="circuit-6"
             fill="none"
-            height="16"
+            height="24"
             role="presentation"
-            viewBox="0 0 16 16"
-            width="16"
+            viewBox="0 0 24 24"
+            width="24"
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
               clip-rule="evenodd"
-              d="M0 1a1 1 0 011-1H3.72l.229.684L4.387 2h10.209c.929 0 1.533.978 1.117 1.809l-1.542 3.085A2 2 0 0112.382 8H5.618l-1 2H13a1 1 0 110 2H3.808a1.5 1.5 0 01-1.34-2.17L3.92 6.922 2.718 3.316 2.279 2H1a1 1 0 01-1-1zm5.72 5h6.662l1-2H5.054l.667 2zM2 14.5a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zM12.5 13a1.5 1.5 0 100 3 1.5 1.5 0 000-3z"
+              d="M5.46 3.719A1 1 0 004.5 3H3a1 1 0 100 2h.751l3.29 11.219a1 1 0 00.959.718h9a1 1 0 100-2H8.749L5.459 3.72zM9.25 18a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm6.5 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+            <path
+              clip-rule="evenodd"
+              d="M20.811 5.415A1 1 0 0020 5H6a1 1 0 000 2h12.613l-1.334 4H7v2h11a1 1 0 00.949-.684l2-6a1 1 0 00-.138-.9z"
               fill="currentColor"
               fill-rule="evenodd"
             />

--- a/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
@@ -34,10 +34,10 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
 }
 
 .circuit-3 {
@@ -230,6 +230,17 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
   height: 100%;
 }
 
+.circuit-9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .circuit-8 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -344,6 +355,7 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
   cursor: pointer;
   -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
   transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+  height: 100%;
   padding: 12px;
   border-left: 1px solid #E6E6E6;
 }
@@ -533,7 +545,7 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
       class="circuit-5"
     >
       <div
-        class="circuit-5"
+        class="circuit-9"
       >
         <a
           class="circuit-8"

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -39,6 +39,7 @@ const AvatarPlaceholder = () => (
 );
 
 const profileWrapperStyles = ({ theme }: StyleProps) => css`
+  height: 100%;
   padding: ${theme.spacings.kilo};
   border-left: ${theme.borderWidth.kilo} solid ${theme.colors.n200};
 

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
@@ -22,6 +22,7 @@ exports[`ProfileMenu styles should render with a profile picture 1`] = `
   cursor: pointer;
   -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
   transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+  height: 100%;
   padding: 12px;
   border-left: 1px solid #E6E6E6;
 }
@@ -222,6 +223,7 @@ exports[`ProfileMenu styles should render without a profile picture 1`] = `
   cursor: pointer;
   -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
   transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+  height: 100%;
   padding: 12px;
   border-left: 1px solid #E6E6E6;
 }

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -23,6 +23,7 @@ import styled, { StyleProps } from '../../../../styles/styled';
 import { hideVisually, navigationItem } from '../../../../styles/style-mixins';
 import { useClickEvent } from '../../../../hooks/useClickEvent';
 import Body from '../../../Body';
+import { useComponents } from '../../../ComponentsContext';
 
 const anchorStyles = ({ theme }: StyleProps) => css`
   text-decoration: none;
@@ -89,10 +90,17 @@ function UtilityLink({
   tracking,
   ...props
 }: UtilityLinkProps) {
+  const { Link } = useComponents();
+
   const handleClick = useClickEvent(onClick, tracking, 'utility-link');
 
   return (
-    <UtilityAnchor {...props} onClick={handleClick}>
+    <UtilityAnchor
+      {...props}
+      onClick={handleClick}
+      // @ts-expect-error The type for the `as` prop is missing in Emotion's prop types.
+      as={props.href ? Link : 'button'}
+    >
       <Icon css={iconStyles} role="presentation" size="large" />
       <UtilityLabel variant={props.isActive ? 'highlight' : undefined} noMargin>
         {label}

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
-import { MouseEvent, KeyboardEvent, FC, SVGProps, HTMLProps } from 'react';
+import { MouseEvent, KeyboardEvent, FC, HTMLProps } from 'react';
 import { css } from '@emotion/core';
 import { Theme } from '@sumup/design-tokens';
 import { Dispatch as TrackingProps } from '@sumup/collector';
+import { IconProps } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../../../styles/styled';
 import { hideVisually, navigationItem } from '../../../../styles/style-mixins';
@@ -58,7 +59,7 @@ export interface UtilityLinkProps extends HTMLProps<HTMLAnchorElement> {
    * Display an icon in addition to the text to help to identify the link.
    * On narrow viewports, only the icon is displayed.
    */
-  icon: FC<SVGProps<SVGSVGElement>>;
+  icon: FC<IconProps>;
   /**
    * Short label to describe the target of the link.
    */
@@ -92,7 +93,7 @@ function UtilityLink({
 
   return (
     <UtilityAnchor {...props} onClick={handleClick}>
-      <Icon css={iconStyles} role="presentation" />
+      <Icon css={iconStyles} role="presentation" size="large" />
       <UtilityLabel variant={props.isActive ? 'highlight' : undefined} noMargin>
         {label}
       </UtilityLabel>

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.spec.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.spec.ts
@@ -103,7 +103,7 @@ describe('useCollapsible', () => {
         'ref': { current: null },
         'id': expect.any(String),
         'style': {
-          overflow: 'hidden',
+          overflowY: 'hidden',
           willChange: 'height',
           opacity: 0,
           height: 0,
@@ -143,7 +143,7 @@ describe('useCollapsible', () => {
         'ref': { current: null },
         'id': expect.any(String),
         'style': {
-          overflow: 'hidden',
+          overflowY: 'hidden',
           willChange: 'height',
           opacity: 1,
           height: 'auto',

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
@@ -37,7 +37,7 @@ type ContentProps<T> = {
   'ref': RefObject<T>;
   'id': string;
   'style': {
-    overflow: 'hidden';
+    overflowY: 'hidden';
     willChange: 'height';
     opacity: 1 | 0;
     height: string | 0;
@@ -106,7 +106,7 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
       'ref': contentElement,
       'id': contentId,
       'style': {
-        overflow: 'hidden',
+        overflowY: 'hidden',
         willChange: 'height',
         opacity: isOpen ? 1 : 0,
         height: isOpen ? height : 0,

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -103,7 +103,12 @@ export type { PaginationProps } from './components/Pagination';
 export { TopNavigation } from './components/TopNavigation';
 export type { TopNavigationProps } from './components/TopNavigation';
 export { SideNavigation } from './components/SideNavigation';
-export type { SideNavigationProps } from './components/SideNavigation';
+export type {
+  SideNavigationProps,
+  PrimaryLinkProps,
+  SecondaryGroupProps,
+  SecondaryLinkProps,
+} from './components/SideNavigation';
 export { Tabs, TabList, TabPanel, Tab } from './components/Tabs';
 export { default as Sidebar } from './components/Sidebar';
 export {

--- a/packages/icons/scripts/web.ts
+++ b/packages/icons/scripts/web.ts
@@ -108,7 +108,10 @@ function buildDeclarationFile(components: Component[]): string {
   return dedent`
     import { FC, SVGProps } from 'react';
 
-    interface IconProps extends React.SVGProps<SVGSVGElement> {
+    export interface IconProps extends React.SVGProps<SVGSVGElement> {
+      /**
+       * Choose between the small (16px) or large (24px) size. Default \`small\`.
+       */
       size?: 'small' | 'large';
     }
 


### PR DESCRIPTION
Fixes #1112.

## Purpose

While integrating the new navigation components into an application, we've discovered a number of bugs.

## Approach and changes

- Filter non-HTML attributes in Popover
- Update the Popover position on open
- Prevent interactions with elements behind Popover overlay
- Export navigation types
- Fix the navigation's min-width when the secondary nav is hidden
- Close the mobile navigation modal when a link is clicked
- Only hide _vertical_ overflow in `useCollapsible`

## Definition of done

* [ ] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
