### PR TITLE
Fix the  TopNavigation's ProfileWrapper padding when no userId is provided

### DIFF
--- a/.changeset/pink-rocks-dream.md
+++ b/.changeset/pink-rocks-dream.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the `TopNavigation`'s `ProfileWrapper` padding when no `userId` is provided.

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -38,10 +38,12 @@ const AvatarPlaceholder = () => (
   </svg>
 );
 
+type ProfileWrapperProps = { isActive?: boolean; hasUserId: boolean };
+
 const profileWrapperStyles = ({
   theme,
   hasUserId,
-}: StyleProps & { hasUserId?: boolean }) => css`
+}: StyleProps & ProfileWrapperProps) => css`
   padding: ${theme.spacings.kilo};
   border-left: ${theme.borderWidth.kilo} solid ${theme.colors.n200};
 
@@ -51,8 +53,6 @@ const profileWrapperStyles = ({
       : `${theme.spacings.kilo} ${theme.spacings.mega}`};
   }
 `;
-
-type ProfileWrapperProps = { isActive?: boolean; hasUserId: boolean };
 
 const ProfileWrapper = styled.button<ProfileWrapperProps>(
   navigationItem,

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -45,12 +45,11 @@ const profileWrapperStyles = ({
   padding: ${theme.spacings.kilo};
   border-left: ${theme.borderWidth.kilo} solid ${theme.colors.n200};
 
-  ${hasUserId &&
-  css`
-    ${theme.mq.mega} {
-      padding: ${theme.spacings.bit} ${theme.spacings.mega};
-    }
-  `}
+  ${theme.mq.mega} {
+    padding: ${hasUserId
+      ? `${theme.spacings.bit} ${theme.spacings.mega}`
+      : `${theme.spacings.kilo} ${theme.spacings.mega}`};
+  }
 `;
 
 type ProfileWrapperProps = { isActive?: boolean; hasUserId: boolean };

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -38,16 +38,27 @@ const AvatarPlaceholder = () => (
   </svg>
 );
 
-const profileWrapperStyles = ({ theme }: StyleProps) => css`
+const profileWrapperStyles = ({
+  theme,
+  hasUserId,
+}: StyleProps & { hasUserId?: boolean }) => css`
   padding: ${theme.spacings.kilo};
   border-left: ${theme.borderWidth.kilo} solid ${theme.colors.n200};
 
-  ${theme.mq.mega} {
-    padding: ${theme.spacings.bit} ${theme.spacings.mega};
-  }
+  ${hasUserId &&
+  css`
+    ${theme.mq.mega} {
+      padding: ${theme.spacings.bit} ${theme.spacings.mega};
+    }
+  `}
 `;
 
-const ProfileWrapper = styled.button(navigationItem, profileWrapperStyles);
+type ProfileWrapperProps = { isActive?: boolean; hasUserId: boolean };
+
+const ProfileWrapper = styled.button<ProfileWrapperProps>(
+  navigationItem,
+  profileWrapperStyles,
+);
 
 const userAvatarStyles = ({ theme }: StyleProps) => css`
   width: ${theme.iconSizes.mega};
@@ -141,6 +152,7 @@ function Profile({
       aria-label={profileLabel}
       title={profileLabel}
       isActive={isOpen || profileIsActive}
+      hasUserId={!!userId}
     >
       {userAvatar ? (
         <UserAvatar {...userAvatar} variant="identity" />

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
@@ -53,6 +53,12 @@ exports[`ProfileMenu styles should render with a profile picture 1`] = `
   box-shadow: none;
 }
 
+@media (min-width:768px) {
+  .circuit-5 {
+    padding: 12px 16px;
+  }
+}
+
 .circuit-0 {
   display: block;
   width: 96px;
@@ -245,6 +251,12 @@ exports[`ProfileMenu styles should render without a profile picture 1`] = `
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+}
+
+@media (min-width:768px) {
+  .circuit-4 {
+    padding: 12px 16px;
+  }
 }
 
 @media (max-width:767px) {

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
@@ -53,12 +53,6 @@ exports[`ProfileMenu styles should render with a profile picture 1`] = `
   box-shadow: none;
 }
 
-@media (min-width:768px) {
-  .circuit-5 {
-    padding: 4px 16px;
-  }
-}
-
 .circuit-0 {
   display: block;
   width: 96px;
@@ -251,12 +245,6 @@ exports[`ProfileMenu styles should render without a profile picture 1`] = `
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-}
-
-@media (min-width:768px) {
-  .circuit-4 {
-    padding: 4px 16px;
-  }
 }
 
 @media (max-width:767px) {


### PR DESCRIPTION
## Purpose

When the optional `userId` prop is not provided, on desktop, the `ProfileWrapper`'s padding is too small to cover the height of the TopNavigation.

<img width="968" alt="Screenshot 2021-08-13 at 15 11 04" src="https://user-images.githubusercontent.com/35560568/129361980-c02d1b4a-5811-471d-b03c-d4e4c2803dba.png">

## Approach and changes

Pass a `hasUserId` prop to the `ProfileWrapper` and ensure that the right padding is set.

<img width="968" alt="Screenshot 2021-08-13 at 15 09 03" src="https://user-images.githubusercontent.com/35560568/129362637-cd5bf25f-b3f8-4413-a2c5-5e0d96832a65.png">

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
