### PR TITLE
Add skeleton loading state to navigation components

### DIFF
--- a/.changeset/grumpy-elephants-look.md
+++ b/.changeset/grumpy-elephants-look.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a skeleton loading UI to the TopNavigation and SideNavigation components.

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
@@ -33,6 +33,7 @@ export default {
 };
 
 export const baseArgs = {
+  isLoading: false,
   isOpen: true,
   closeButtonLabel: 'Close navigation',
   primaryNavigationLabel: 'Primary',

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
@@ -35,6 +35,7 @@ export interface SideNavigationProps
 }
 
 export function SideNavigation({
+  isLoading,
   isOpen,
   onClose,
   primaryLinks,
@@ -89,6 +90,7 @@ export function SideNavigation({
 
   return (
     <DesktopNavigation
+      isLoading={isLoading}
       primaryLinks={primaryLinks}
       primaryNavigationLabel={primaryNavigationLabel}
       secondaryNavigationLabel={secondaryNavigationLabel}

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.spec.tsx
@@ -16,7 +16,7 @@
 /* eslint-disable react/display-name */
 import { House, ShoppingBag } from '@sumup/icons';
 
-import { create, render, axe, RenderFn } from '../../../../util/test-utils';
+import { render, axe, RenderFn } from '../../../../util/test-utils';
 
 import { DesktopNavigation, DesktopNavigationProps } from './DesktopNavigation';
 

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -24,11 +24,16 @@ import { shadow, hideScrollbar } from '../../../../styles/style-mixins';
 import { useFocusList } from '../../../../hooks/useFocusList';
 import { TOP_NAVIGATION_HEIGHT } from '../../../TopNavigation/TopNavigation';
 import Headline from '../../../Headline';
+import { Skeleton, SkeletonContainer } from '../../../Skeleton';
 import { PrimaryLinkProps } from '../../types';
 import { SecondaryLinks } from '../SecondaryLinks';
 import { PrimaryLink } from '../PrimaryLink';
 
 export interface DesktopNavigationProps {
+  /**
+   * TODO: Add description
+   */
+  isLoading?: boolean;
   /**
    * TODO: Add description
    */
@@ -55,7 +60,7 @@ const wrapperStyles = ({ theme }: StyleProps) => css`
   }
 `;
 
-const Wrapper = styled.div(wrapperStyles);
+const Wrapper = styled(SkeletonContainer)(wrapperStyles);
 
 const primaryWrapperStyles = ({ theme }: StyleProps) => css`
   position: fixed;
@@ -106,10 +111,11 @@ const listStyles = css`
 `;
 
 const headlineStyles = (theme: Theme) => css`
-  padding: ${theme.spacings.giga} ${theme.spacings.mega} ${theme.spacings.kilo};
+  margin: ${theme.spacings.giga} ${theme.spacings.mega} ${theme.spacings.kilo};
 `;
 
 export function DesktopNavigation({
+  isLoading,
   primaryLinks,
   primaryNavigationLabel,
   secondaryNavigationLabel,
@@ -125,7 +131,7 @@ export function DesktopNavigation({
     activePrimaryLink && activePrimaryLink.secondaryGroups;
 
   return (
-    <Wrapper>
+    <Wrapper isLoading={Boolean(isLoading)}>
       <PrimaryNavigationWrapper {...props} aria-label={primaryNavigationLabel}>
         <ul role="list" css={listStyles}>
           {primaryLinks.map((link) => (
@@ -140,9 +146,11 @@ export function DesktopNavigation({
           {...props}
           aria-label={secondaryNavigationLabel}
         >
-          <Headline as="h2" size="four" css={headlineStyles} noMargin>
-            {activePrimaryLink && activePrimaryLink.label}
-          </Headline>
+          <Skeleton css={headlineStyles}>
+            <Headline as="h2" size="four" noMargin>
+              {activePrimaryLink && activePrimaryLink.label}
+            </Headline>
+          </Skeleton>
           <SecondaryLinks secondaryGroups={secondaryGroups} />
         </SecondaryNavigationWrapper>
       )}

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
@@ -1,14 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DesktopNavigation styles should render with secondary links 1`] = `
+.circuit-19[aria-busy='true'] {
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 @media (max-width:959px) {
-  .circuit-14 {
+  .circuit-19 {
     display: none;
   }
 }
 
 @media (min-width:960px) {
-  .circuit-14 {
+  .circuit-19 {
     min-width: 48px;
     -webkit-flex-shrink: 0;
     -ms-flex-negative: 0;
@@ -16,7 +24,7 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   }
 }
 
-.circuit-4 {
+.circuit-5 {
   position: fixed;
   z-index: 800;
   top: 49px;
@@ -44,21 +52,21 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   scrollbar-width: none;
 }
 
-.circuit-4:hover,
-.circuit-4:focus-within {
+.circuit-5:hover,
+.circuit-5:focus-within {
   box-shadow: 0 3px 8px 0 rgba(0,0,0,0.2);
   width: 220px;
 }
 
-.circuit-4::-webkit-scrollbar {
+.circuit-5::-webkit-scrollbar {
   display: none;
 }
 
-.circuit-3 {
+.circuit-4 {
   list-style: none;
 }
 
-.circuit-2 {
+.circuit-3 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -83,39 +91,39 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   color: #3063E9;
 }
 
-.circuit-2:focus {
+.circuit-3:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-2:focus::-moz-focus-inner {
+.circuit-3:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-2:focus:not(:focus-visible) {
+.circuit-3:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-2:hover {
+.circuit-3:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-2:active {
+.circuit-3:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:disabled {
+.circuit-3:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (max-width:959px) {
-  .circuit-2 {
+  .circuit-3 {
     margin-bottom: 1px;
   }
 
-  .circuit-2::after {
+  .circuit-3::after {
     content: '';
     display: block;
     position: absolute;
@@ -130,17 +138,19 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
 }
 
 @media (min-width:960px) {
-  .circuit-2 {
+  .circuit-3 {
     padding: 12px;
     margin-bottom: 12px;
   }
 }
 
-.circuit-2:hover {
+.circuit-3:hover {
   background-color: #F0F6FF;
 }
 
 .circuit-0 {
+  display: inline-block;
+  line-height: 1;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -148,6 +158,11 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   width: 24px;
   height: 24px;
   margin-right: 12px;
+}
+
+.circuit-2 {
+  display: inline-block;
+  line-height: 1;
 }
 
 .circuit-1 {
@@ -176,7 +191,7 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   }
 }
 
-.circuit-13 {
+.circuit-18 {
   position: -webkit-sticky;
   position: sticky;
   top: 49px;
@@ -195,21 +210,32 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   border-right: 1px solid #E6E6E6;
 }
 
-.circuit-5 {
+.circuit-7 {
+  display: inline-block;
+  line-height: 1;
+  margin: 24px 16px 12px;
+}
+
+.circuit-6 {
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
   font-size: 18px;
   line-height: 24px;
   margin-bottom: 0;
-  padding: 24px 16px 12px;
 }
 
-.circuit-12 {
+.circuit-17 {
   list-style: none;
 }
 
-.circuit-6 {
+.circuit-9 {
+  display: inline-block;
+  line-height: 1;
+  margin: 32px 16px 8px;
+}
+
+.circuit-8 {
   text-transform: uppercase;
   font-weight: 700;
   font-size: 14px;
@@ -217,14 +243,13 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   margin-bottom: 12px;
   color: #000;
   margin-bottom: 0;
-  padding: 32px 16px 8px;
 }
 
-.circuit-11 {
+.circuit-16 {
   list-style: none;
 }
 
-.circuit-8 {
+.circuit-12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -251,40 +276,40 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   hyphens: auto;
 }
 
-.circuit-8:hover {
+.circuit-12:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-8:active {
+.circuit-12:active {
   background-color: #E6E6E6;
 }
 
-.circuit-8:focus {
+.circuit-12:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-8:focus::-moz-focus-inner {
+.circuit-12:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-8:focus:not(:focus-visible) {
+.circuit-12:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-8:disabled {
+.circuit-12:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (min-width:960px) {
-  .circuit-8 {
+  .circuit-12 {
     padding: 12px 20px;
   }
 }
 
-.circuit-7 {
+.circuit-10 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -294,24 +319,25 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
 
 <div>
   <div
-    class="circuit-14"
+    aria-busy="false"
+    class="circuit-19"
   >
     <nav
       aria-label="Primary"
-      class="circuit-4"
+      class="circuit-5"
     >
       <ul
-        class="circuit-3"
+        class="circuit-4"
         role="list"
       >
         <li>
           <a
             aria-current="page"
-            class="circuit-2"
+            class="circuit-3"
             data-focus-list="1"
             href="/shop"
           >
-            <div
+            <span
               class="circuit-0"
             >
               <svg
@@ -334,11 +360,15 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
                   stroke-width="2"
                 />
               </svg>
-            </div>
+            </span>
             <span
-              class="circuit-1"
+              class="circuit-2"
             >
-              Shop
+              <span
+                class="circuit-1"
+              >
+                Shop
+              </span>
             </span>
           </a>
         </li>
@@ -346,51 +376,67 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
     </nav>
     <nav
       aria-label="Secondary"
-      class="circuit-13"
+      class="circuit-18"
     >
-      <h2
-        class="circuit-5"
+      <span
+        class="circuit-7"
       >
-        Shop
-      </h2>
+        <h2
+          class="circuit-6"
+        >
+          Shop
+        </h2>
+      </span>
       <ul
-        class="circuit-12"
+        class="circuit-17"
         role="list"
       >
         <li>
-          <h3
-            class="circuit-6"
+          <span
+            class="circuit-9"
           >
-            For Kids
-          </h3>
+            <h3
+              class="circuit-8"
+            >
+              For Kids
+            </h3>
+          </span>
           <ul
-            class="circuit-11"
+            class="circuit-16"
             role="list"
           >
             <li>
               <a
-                class="circuit-8"
+                class="circuit-12"
                 data-focus-list="2"
                 href="/shop/toys"
               >
-                <p
-                  class="circuit-7"
+                <span
+                  class="circuit-2"
                 >
-                  Toys
-                </p>
+                  <p
+                    class="circuit-10"
+                  >
+                    Toys
+                  </p>
+                </span>
               </a>
             </li>
             <li>
               <a
-                class="circuit-8"
+                class="circuit-12"
                 data-focus-list="2"
                 href="/shop/books"
               >
-                <p
-                  class="circuit-7"
+                <span
+                  class="circuit-2"
                 >
-                  Books
-                </p>
+                  <p
+                    class="circuit-10"
+                  >
+                    Books
+                  </p>
+                </span>
               </a>
             </li>
           </ul>
@@ -402,14 +448,22 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
 `;
 
 exports[`DesktopNavigation styles should render without secondary links 1`] = `
+.circuit-6[aria-busy='true'] {
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 @media (max-width:959px) {
-  .circuit-5 {
+  .circuit-6 {
     display: none;
   }
 }
 
 @media (min-width:960px) {
-  .circuit-5 {
+  .circuit-6 {
     min-width: 48px;
     -webkit-flex-shrink: 0;
     -ms-flex-negative: 0;
@@ -417,7 +471,7 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
   }
 }
 
-.circuit-4 {
+.circuit-5 {
   position: fixed;
   z-index: 800;
   top: 49px;
@@ -445,21 +499,23 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
   scrollbar-width: none;
 }
 
-.circuit-4:hover,
-.circuit-4:focus-within {
+.circuit-5:hover,
+.circuit-5:focus-within {
   box-shadow: 0 3px 8px 0 rgba(0,0,0,0.2);
   width: 220px;
 }
 
-.circuit-4::-webkit-scrollbar {
+.circuit-5::-webkit-scrollbar {
   display: none;
 }
 
-.circuit-3 {
+.circuit-4 {
   list-style: none;
 }
 
 .circuit-0 {
+  display: inline-block;
+  line-height: 1;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -470,6 +526,11 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
 }
 
 .circuit-2 {
+  display: inline-block;
+  line-height: 1;
+}
+
+.circuit-3 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -493,39 +554,39 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
   transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
 }
 
-.circuit-2:focus {
+.circuit-3:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-2:focus::-moz-focus-inner {
+.circuit-3:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-2:focus:not(:focus-visible) {
+.circuit-3:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-2:hover {
+.circuit-3:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-2:active {
+.circuit-3:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:disabled {
+.circuit-3:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (max-width:959px) {
-  .circuit-2 {
+  .circuit-3 {
     margin-bottom: 1px;
   }
 
-  .circuit-2::after {
+  .circuit-3::after {
     content: '';
     display: block;
     position: absolute;
@@ -540,7 +601,7 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
 }
 
 @media (min-width:960px) {
-  .circuit-2 {
+  .circuit-3 {
     padding: 12px;
     margin-bottom: 12px;
   }
@@ -573,23 +634,24 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
 
 <div>
   <div
-    class="circuit-5"
+    aria-busy="false"
+    class="circuit-6"
   >
     <nav
       aria-label="Primary"
-      class="circuit-4"
+      class="circuit-5"
     >
       <ul
-        class="circuit-3"
+        class="circuit-4"
         role="list"
       >
         <li>
           <a
-            class="circuit-2"
+            class="circuit-3"
             data-focus-list="3"
             href="/"
           >
-            <div
+            <span
               class="circuit-0"
             >
               <svg
@@ -607,11 +669,15 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
                   fill-rule="evenodd"
                 />
               </svg>
-            </div>
+            </span>
             <span
-              class="circuit-1"
+              class="circuit-2"
             >
-              Home
+              <span
+                class="circuit-1"
+              >
+                Home
+              </span>
             </span>
           </a>
         </li>

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/__snapshots__/MobileNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/__snapshots__/MobileNavigation.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MobileNavigation styles should render with secondary links 1`] = `
-.circuit-16 {
+.circuit-20 {
   position: fixed;
   top: 0;
   right: 0;
@@ -21,7 +21,7 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
   overflow: hidden;
 }
 
-.circuit-16::after {
+.circuit-20::after {
   content: '';
   display: block;
   position: fixed;
@@ -32,14 +32,14 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
   background: linear-gradient( rgba(255,255,255,0), rgba(255,255,255,0.66), rgba(255,255,255,1) );
 }
 
-.circuit-17 {
+.circuit-21 {
   opacity: 1 !important;
   -webkit-transform: translateY(0) !important;
   -ms-transform: translateY(0) !important;
   transform: translateY(0) !important;
 }
 
-.circuit-18 {
+.circuit-22 {
   position: fixed;
   top: 0;
   left: 0;
@@ -52,11 +52,11 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
   z-index: 1000;
 }
 
-.circuit-19 {
+.circuit-23 {
   opacity: 1;
 }
 
-.circuit-15 {
+.circuit-19 {
   height: 100%;
   max-width: 480px;
   overflow-y: auto;
@@ -159,8 +159,621 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
   width: 1px;
 }
 
-.circuit-14 {
+.circuit-18 {
   list-style: none;
+}
+
+.circuit-7 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+  background: none;
+  border: none;
+  outline: none;
+  text-align: left;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #000;
+  padding: 24px;
+  -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+  color: #3063E9;
+}
+
+.circuit-7:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 4px #AFD0FE;
+}
+
+.circuit-7:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-7:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-7:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-7:active {
+  background-color: #E6E6E6;
+}
+
+.circuit-7:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+@media (max-width:959px) {
+  .circuit-7 {
+    margin-bottom: 1px;
+  }
+
+  .circuit-7::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 100%;
+    right: 24px;
+    left: 24px;
+    width: calc(100% - 2 * 24px);
+    border-bottom: 1px solid #E6E6E6;
+    -webkit-transition: width 120ms ease-in-out,right 120ms ease-in-out,left 120ms ease-in-out;
+    transition: width 120ms ease-in-out,right 120ms ease-in-out,left 120ms ease-in-out;
+  }
+}
+
+@media (min-width:960px) {
+  .circuit-7 {
+    padding: 12px;
+    margin-bottom: 12px;
+  }
+}
+
+.circuit-7:hover {
+  background-color: #F0F6FF;
+}
+
+.circuit-3 {
+  display: inline-block;
+  line-height: 1;
+  position: relative;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  margin-right: 12px;
+}
+
+.circuit-5 {
+  display: inline-block;
+  line-height: 1;
+}
+
+.circuit-4 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+  font-weight: 700;
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+@media (max-width:959px) {
+  .circuit-4 {
+    font-size: 24px;
+    line-height: 28px;
+  }
+}
+
+@media (min-width:960px) {
+  .circuit-4 {
+    max-width: 160px;
+  }
+}
+
+.circuit-6 {
+  -webkit-transform: rotate(0deg);
+  -ms-transform: rotate(0deg);
+  transform: rotate(0deg);
+  -webkit-transition: -webkit-transform 120ms ease-in-out;
+  -webkit-transition: transform 120ms ease-in-out;
+  transition: transform 120ms ease-in-out;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  margin-left: auto;
+  -webkit-transition: -webkit-transform 120ms ease-in-out;
+  -webkit-transition: transform 120ms ease-in-out;
+  transition: transform 120ms ease-in-out;
+}
+
+.circuit-17 {
+  list-style: none;
+  border-bottom: 1px solid #E6E6E6;
+  margin-bottom: -1px;
+}
+
+.circuit-17 > *:last-child {
+  padding-bottom: 24px;
+}
+
+.circuit-9 {
+  display: inline-block;
+  line-height: 1;
+  margin: 32px 16px 8px;
+}
+
+.circuit-8 {
+  text-transform: uppercase;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 12px;
+  color: #000;
+  margin-bottom: 0;
+}
+
+.circuit-16 {
+  list-style: none;
+}
+
+.circuit-12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: none;
+  outline: none;
+  color: #1A1A1A;
+  background-color: #FFF;
+  text-align: left;
+  cursor: pointer;
+  -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  padding: 16px 24px;
+  word-break: break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
+}
+
+.circuit-12:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-12:active {
+  background-color: #E6E6E6;
+}
+
+.circuit-12:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 4px #AFD0FE;
+}
+
+.circuit-12:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-12:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-12:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+@media (min-width:960px) {
+  .circuit-12 {
+    padding: 12px 20px;
+  }
+}
+
+.circuit-10 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+<body
+  class="ReactModal__Body--open"
+>
+  <div
+    data-react-modal-body-trap=""
+    style="position: absolute; opacity: 0;"
+    tabindex="0"
+  />
+  <div />
+  <div
+    data-react-modal-body-trap=""
+    style="position: absolute; opacity: 0;"
+    tabindex="0"
+  />
+  <div
+    class="ReactModalPortal"
+  >
+    <div
+      class="circuit-22 circuit-23"
+    >
+      <div
+        aria-modal="true"
+        class="circuit-20 circuit-21"
+        role="dialog"
+        tabindex="-1"
+      >
+        <div
+          class="circuit-19"
+        >
+          <div
+            class="circuit-2"
+          >
+            <button
+              class="circuit-1"
+              title="Close navigation modal"
+              type="button"
+            >
+              <svg
+                fill="none"
+                height="16"
+                role="presentation"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 3l10 10m0-10L3 13"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-width="2"
+                />
+              </svg>
+              <span
+                class="circuit-0"
+              >
+                Close navigation modal
+              </span>
+            </button>
+          </div>
+          <nav
+            aria-label="Primary"
+          >
+            <ul
+              class="circuit-18"
+            >
+              <li>
+                <button
+                  aria-controls="collapsible_2"
+                  aria-current="page"
+                  aria-expanded="false"
+                  class="circuit-7"
+                  data-focus-list="1"
+                >
+                  <span
+                    class="circuit-3"
+                  >
+                    <svg
+                      fill="none"
+                      height="24"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M4.5 7h15m-15 0L3.119 19.893A1 1 0 004.113 21h15.774a1 1 0 00.994-1.107L19.5 7m-15 0l3.201-3.659A1 1 0 018.454 3h7.092a1 1 0 01.753.341L19.5 7"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M16 11a4 4 0 01-8 0"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    class="circuit-5"
+                  >
+                    <span
+                      class="circuit-4"
+                    >
+                      Shop
+                    </span>
+                  </span>
+                  <svg
+                    class="circuit-6"
+                    fill="none"
+                    height="16"
+                    role="presentation"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M4 6l4 4 4-4"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                    />
+                  </svg>
+                </button>
+                <ul
+                  aria-hidden="true"
+                  class="circuit-17"
+                  id="collapsible_2"
+                  role="list"
+                  style="overflow-y: hidden; will-change: height; opacity: 0; height: 0px; visibility: hidden; transition: all 200ms ease-in-out;"
+                >
+                  <li>
+                    <span
+                      class="circuit-9"
+                    >
+                      <h3
+                        class="circuit-8"
+                      >
+                        For Kids
+                      </h3>
+                    </span>
+                    <ul
+                      class="circuit-16"
+                      role="list"
+                    >
+                      <li>
+                        <a
+                          class="circuit-12"
+                          data-focus-list="3"
+                          href="/shop/toys"
+                        >
+                          <span
+                            class="circuit-5"
+                          >
+                            <p
+                              class="circuit-10"
+                            >
+                              Toys
+                            </p>
+                          </span>
+                        </a>
+                      </li>
+                      <li>
+                        <a
+                          class="circuit-12"
+                          data-focus-list="3"
+                          href="/shop/books"
+                        >
+                          <span
+                            class="circuit-5"
+                          >
+                            <p
+                              class="circuit-10"
+                            >
+                              Books
+                            </p>
+                          </span>
+                        </a>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`MobileNavigation styles should render without secondary links 1`] = `
+.circuit-9 {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  opacity: 0;
+  -webkit-transform: translateY(-25%);
+  -ms-transform: translateY(-25%);
+  transform: translateY(-25%);
+  -webkit-transition: opacity 120ms ease-in-out, -webkit-transform 120ms ease-in-out;
+  -webkit-transition: opacity 120ms ease-in-out, transform 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out, transform 120ms ease-in-out;
+  outline: none;
+  background-color: #FFF;
+  overflow: hidden;
+}
+
+.circuit-9::after {
+  content: '';
+  display: block;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 16px;
+  background: linear-gradient( rgba(255,255,255,0), rgba(255,255,255,0.66), rgba(255,255,255,1) );
+}
+
+.circuit-10 {
+  opacity: 1 !important;
+  -webkit-transform: translateY(0) !important;
+  -ms-transform: translateY(0) !important;
+  transform: translateY(0) !important;
+}
+
+.circuit-11 {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  opacity: 0;
+  -webkit-transition: opacity 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out;
+  background: rgba(0,0,0,0.4);
+  z-index: 1000;
+}
+
+.circuit-12 {
+  opacity: 1;
+}
+
+.circuit-8 {
+  height: 100%;
+  max-width: 480px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 0 auto;
+  padding-top: 56px;
+  padding-bottom: calc(env(safe-area-inset-bottom) + 32px);
+}
+
+.circuit-2 {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  z-index: 1;
+  padding: 4px;
+  background: linear-gradient( to bottom,rgba(255,255,255,1),rgba(255,255,255,1) 60%,rgba(255,255,255,0) );
+}
+
+.circuit-1 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  padding: calc(16px - 1px);
+  border-color: transparent !important;
+  background-color: transparent;
+}
+
+.circuit-1:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-1:disabled,
+.circuit-1[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-1:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-1:active,
+.circuit-1[aria-expanded='true'],
+.circuit-1[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-0 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  list-style: none;
+}
+
+.circuit-3 {
+  display: inline-block;
+  line-height: 1;
+  position: relative;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  margin-right: 12px;
+}
+
+.circuit-5 {
+  display: inline-block;
+  line-height: 1;
 }
 
 .circuit-6 {
@@ -185,7 +798,6 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
   padding: 24px;
   -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
   transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
-  color: #3063E9;
 }
 
 .circuit-6:focus {
@@ -241,583 +853,6 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
   }
 }
 
-.circuit-6:hover {
-  background-color: #F0F6FF;
-}
-
-.circuit-3 {
-  position: relative;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  margin-right: 12px;
-}
-
-.circuit-4 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 0;
-  font-weight: 700;
-  max-width: 100%;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-
-@media (max-width:959px) {
-  .circuit-4 {
-    font-size: 24px;
-    line-height: 28px;
-  }
-}
-
-@media (min-width:960px) {
-  .circuit-4 {
-    max-width: 160px;
-  }
-}
-
-.circuit-5 {
-  -webkit-transform: rotate(0deg);
-  -ms-transform: rotate(0deg);
-  transform: rotate(0deg);
-  -webkit-transition: -webkit-transform 120ms ease-in-out;
-  -webkit-transition: transform 120ms ease-in-out;
-  transition: transform 120ms ease-in-out;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  width: 16px;
-  height: 16px;
-  margin-left: auto;
-  -webkit-transition: -webkit-transform 120ms ease-in-out;
-  -webkit-transition: transform 120ms ease-in-out;
-  transition: transform 120ms ease-in-out;
-}
-
-.circuit-13 {
-  list-style: none;
-  border-bottom: 1px solid #E6E6E6;
-  margin-bottom: -1px;
-}
-
-.circuit-13 > *:last-child {
-  padding-bottom: 24px;
-}
-
-.circuit-7 {
-  text-transform: uppercase;
-  font-weight: 700;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 12px;
-  color: #000;
-  margin-bottom: 0;
-  padding: 32px 16px 8px;
-}
-
-.circuit-12 {
-  list-style: none;
-}
-
-.circuit-9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: none;
-  outline: none;
-  color: #1A1A1A;
-  background-color: #FFF;
-  text-align: left;
-  cursor: pointer;
-  -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  padding: 16px 24px;
-  word-break: break-word;
-  -webkit-hyphens: auto;
-  -moz-hyphens: auto;
-  -ms-hyphens: auto;
-  hyphens: auto;
-}
-
-.circuit-9:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-9:active {
-  background-color: #E6E6E6;
-}
-
-.circuit-9:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 4px #AFD0FE;
-}
-
-.circuit-9:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-9:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-9:disabled {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-@media (min-width:960px) {
-  .circuit-9 {
-    padding: 12px 20px;
-  }
-}
-
-.circuit-8 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 0;
-}
-
-<body
-  class="ReactModal__Body--open"
->
-  <div
-    data-react-modal-body-trap=""
-    style="position: absolute; opacity: 0;"
-    tabindex="0"
-  />
-  <div />
-  <div
-    data-react-modal-body-trap=""
-    style="position: absolute; opacity: 0;"
-    tabindex="0"
-  />
-  <div
-    class="ReactModalPortal"
-  >
-    <div
-      class="circuit-18 circuit-19"
-    >
-      <div
-        aria-modal="true"
-        class="circuit-16 circuit-17"
-        role="dialog"
-        tabindex="-1"
-      >
-        <div
-          class="circuit-15"
-        >
-          <div
-            class="circuit-2"
-          >
-            <button
-              class="circuit-1"
-              title="Close navigation modal"
-              type="button"
-            >
-              <svg
-                fill="none"
-                height="16"
-                role="presentation"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 3l10 10m0-10L3 13"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-width="2"
-                />
-              </svg>
-              <span
-                class="circuit-0"
-              >
-                Close navigation modal
-              </span>
-            </button>
-          </div>
-          <nav
-            aria-label="Primary"
-          >
-            <ul
-              class="circuit-14"
-            >
-              <li>
-                <button
-                  aria-controls="collapsible_2"
-                  aria-current="page"
-                  aria-expanded="false"
-                  class="circuit-6"
-                  data-focus-list="1"
-                >
-                  <div
-                    class="circuit-3"
-                  >
-                    <svg
-                      fill="none"
-                      height="24"
-                      role="presentation"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M4.5 7h15m-15 0L3.119 19.893A1 1 0 004.113 21h15.774a1 1 0 00.994-1.107L19.5 7m-15 0l3.201-3.659A1 1 0 018.454 3h7.092a1 1 0 01.753.341L19.5 7"
-                        stroke="currentColor"
-                        stroke-width="2"
-                      />
-                      <path
-                        d="M16 11a4 4 0 01-8 0"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </div>
-                  <span
-                    class="circuit-4"
-                  >
-                    Shop
-                  </span>
-                  <svg
-                    class="circuit-5"
-                    fill="none"
-                    height="16"
-                    role="presentation"
-                    viewBox="0 0 16 16"
-                    width="16"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M4 6l4 4 4-4"
-                      stroke="currentColor"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                    />
-                  </svg>
-                </button>
-                <ul
-                  aria-hidden="true"
-                  class="circuit-13"
-                  id="collapsible_2"
-                  role="list"
-                  style="overflow-y: hidden; will-change: height; opacity: 0; height: 0px; visibility: hidden; transition: all 200ms ease-in-out;"
-                >
-                  <li>
-                    <h3
-                      class="circuit-7"
-                    >
-                      For Kids
-                    </h3>
-                    <ul
-                      class="circuit-12"
-                      role="list"
-                    >
-                      <li>
-                        <a
-                          class="circuit-9"
-                          data-focus-list="3"
-                          href="/shop/toys"
-                        >
-                          <p
-                            class="circuit-8"
-                          >
-                            Toys
-                          </p>
-                        </a>
-                      </li>
-                      <li>
-                        <a
-                          class="circuit-9"
-                          data-focus-list="3"
-                          href="/shop/books"
-                        >
-                          <p
-                            class="circuit-8"
-                          >
-                            Books
-                          </p>
-                        </a>
-                      </li>
-                    </ul>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </nav>
-        </div>
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`MobileNavigation styles should render without secondary links 1`] = `
-.circuit-8 {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  opacity: 0;
-  -webkit-transform: translateY(-25%);
-  -ms-transform: translateY(-25%);
-  transform: translateY(-25%);
-  -webkit-transition: opacity 120ms ease-in-out, -webkit-transform 120ms ease-in-out;
-  -webkit-transition: opacity 120ms ease-in-out, transform 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out, transform 120ms ease-in-out;
-  outline: none;
-  background-color: #FFF;
-  overflow: hidden;
-}
-
-.circuit-8::after {
-  content: '';
-  display: block;
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  height: 16px;
-  background: linear-gradient( rgba(255,255,255,0), rgba(255,255,255,0.66), rgba(255,255,255,1) );
-}
-
-.circuit-9 {
-  opacity: 1 !important;
-  -webkit-transform: translateY(0) !important;
-  -ms-transform: translateY(0) !important;
-  transform: translateY(0) !important;
-}
-
-.circuit-10 {
-  position: fixed;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  opacity: 0;
-  -webkit-transition: opacity 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out;
-  background: rgba(0,0,0,0.4);
-  z-index: 1000;
-}
-
-.circuit-11 {
-  opacity: 1;
-}
-
-.circuit-7 {
-  height: 100%;
-  max-width: 480px;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  margin: 0 auto;
-  padding-top: 56px;
-  padding-bottom: calc(env(safe-area-inset-bottom) + 32px);
-}
-
-.circuit-2 {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
-  z-index: 1;
-  padding: 4px;
-  background: linear-gradient( to bottom,rgba(255,255,255,1),rgba(255,255,255,1) 60%,rgba(255,255,255,0) );
-}
-
-.circuit-1 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #FFF;
-  border-color: #999;
-  color: #000;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  padding: calc(16px - 1px);
-  border-color: transparent !important;
-  background-color: transparent;
-}
-
-.circuit-1:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-1:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-1:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-1:disabled,
-.circuit-1[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-1:hover {
-  background-color: #F5F5F5;
-  border-color: #666;
-}
-
-.circuit-1:active,
-.circuit-1[aria-expanded='true'],
-.circuit-1[aria-pressed='true'] {
-  background-color: #E6E6E6;
-  border-color: #333;
-}
-
-.circuit-0 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-6 {
-  list-style: none;
-}
-
-.circuit-3 {
-  position: relative;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  margin-right: 12px;
-}
-
-.circuit-5 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 100%;
-  background: none;
-  border: none;
-  outline: none;
-  text-align: left;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #000;
-  padding: 24px;
-  -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
-}
-
-.circuit-5:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 4px #AFD0FE;
-}
-
-.circuit-5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-5:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-5:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-5:active {
-  background-color: #E6E6E6;
-}
-
-.circuit-5:disabled {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-@media (max-width:959px) {
-  .circuit-5 {
-    margin-bottom: 1px;
-  }
-
-  .circuit-5::after {
-    content: '';
-    display: block;
-    position: absolute;
-    top: 100%;
-    right: 24px;
-    left: 24px;
-    width: calc(100% - 2 * 24px);
-    border-bottom: 1px solid #E6E6E6;
-    -webkit-transition: width 120ms ease-in-out,right 120ms ease-in-out,left 120ms ease-in-out;
-    transition: width 120ms ease-in-out,right 120ms ease-in-out,left 120ms ease-in-out;
-  }
-}
-
-@media (min-width:960px) {
-  .circuit-5 {
-    padding: 12px;
-    margin-bottom: 12px;
-  }
-}
-
 .circuit-4 {
   font-weight: 400;
   margin-bottom: 16px;
@@ -864,16 +899,16 @@ exports[`MobileNavigation styles should render without secondary links 1`] = `
     class="ReactModalPortal"
   >
     <div
-      class="circuit-10 circuit-11"
+      class="circuit-11 circuit-12"
     >
       <div
         aria-modal="true"
-        class="circuit-8 circuit-9"
+        class="circuit-9 circuit-10"
         role="dialog"
         tabindex="-1"
       >
         <div
-          class="circuit-7"
+          class="circuit-8"
         >
           <div
             class="circuit-2"
@@ -909,15 +944,15 @@ exports[`MobileNavigation styles should render without secondary links 1`] = `
             aria-label="Primary"
           >
             <ul
-              class="circuit-6"
+              class="circuit-7"
             >
               <li>
                 <a
-                  class="circuit-5"
+                  class="circuit-6"
                   data-focus-list="4"
                   href="/"
                 >
-                  <div
+                  <span
                     class="circuit-3"
                   >
                     <svg
@@ -935,11 +970,15 @@ exports[`MobileNavigation styles should render without secondary links 1`] = `
                         fill-rule="evenodd"
                       />
                     </svg>
-                  </div>
+                  </span>
                   <span
-                    class="circuit-4"
+                    class="circuit-5"
                   >
-                    Home
+                    <span
+                      class="circuit-4"
+                    >
+                      Home
+                    </span>
                   </span>
                 </a>
               </li>

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -27,11 +27,12 @@ import {
   cx,
 } from '../../../../styles/style-mixins';
 import { useClickEvent } from '../../../../hooks/useClickEvent';
-import { useComponents } from '../../../ComponentsContext';
-import Body from '../../../Body';
-import { PrimaryLinkProps as PrimaryLinkType } from '../../types';
 import { ClickEvent } from '../../../../types/events';
 import { uniqueId } from '../../../../util/id';
+import { useComponents } from '../../../ComponentsContext';
+import Body from '../../../Body';
+import { Skeleton } from '../../../Skeleton';
+import { PrimaryLinkProps as PrimaryLinkType } from '../../types';
 
 export interface PrimaryLinkProps extends PrimaryLinkType {
   isOpen?: boolean;
@@ -122,7 +123,7 @@ const Anchor = styled('a', {
   anchorOpenStyles,
 );
 
-const iconContainerStyles = ({ theme }: StyleProps) => css`
+const iconStyles = (theme: Theme) => css`
   position: relative;
   flex-shrink: 0;
   width: ${theme.iconSizes.mega};
@@ -130,28 +131,19 @@ const iconContainerStyles = ({ theme }: StyleProps) => css`
   margin-right: ${theme.spacings.kilo};
 `;
 
-const iconContainerWithBadgeStyles = ({
-  theme,
-  hasBadge,
-}: StyleProps & { hasBadge: boolean }) =>
-  hasBadge &&
-  css`
-    &::before {
-      display: block;
-      content: '';
-      position: absolute;
-      top: -8px;
-      right: -8px;
-      width: 10px;
-      height: 10px;
-      background-color: ${theme.colors.v500};
-      border-radius: ${theme.borderRadius.circle};
-    }
-  `;
-
-const IconContainer = styled('div', {
-  shouldForwardProp: (prop) => isPropValid(prop),
-})<{ hasBadge: boolean }>(iconContainerStyles, iconContainerWithBadgeStyles);
+const iconWithBadgeStyles = (theme: Theme) => css`
+  &::before {
+    display: block;
+    content: '';
+    position: absolute;
+    top: -8px;
+    right: -8px;
+    width: 10px;
+    height: 10px;
+    background-color: ${theme.colors.v500};
+    border-radius: ${theme.borderRadius.circle};
+  }
+`;
 
 const suffixStyles = (theme: Theme) => css`
   flex-shrink: 0;
@@ -208,6 +200,8 @@ export function PrimaryLink({
   const suffix = Suffix && <Suffix css={suffixStyles} role="presentation" />;
   const isExternalLink = isExternal || props.target === '_blank';
 
+  const hasBadge = Boolean(badge);
+
   return (
     <Anchor
       {...props}
@@ -218,17 +212,19 @@ export function PrimaryLink({
       // @ts-expect-error The type for the `as` prop is missing in Emotion's prop types.
       as={props.href ? Link : 'button'}
     >
-      <IconContainer hasBadge={Boolean(badge)}>
+      <Skeleton css={cx(iconStyles, hasBadge && iconWithBadgeStyles)}>
         <Icon role="presentation" size="large" />
-      </IconContainer>
-      <Label
-        variant={isActive || isOpen ? 'highlight' : undefined}
-        aria-describedby={badgeId}
-        as="span"
-        noMargin
-      >
-        {label}
-      </Label>
+      </Skeleton>
+      <Skeleton>
+        <Label
+          variant={isActive || isOpen ? 'highlight' : undefined}
+          aria-describedby={badgeId}
+          as="span"
+          noMargin
+        >
+          {label}
+        </Label>
+      </Skeleton>
       {badge && (
         <div id={badgeId} css={hideVisually}>
           {badge.label}

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/__snapshots__/PrimaryLink.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/__snapshots__/PrimaryLink.spec.tsx.snap
@@ -2,6 +2,8 @@
 
 exports[`PrimaryLink styles should render with active styles 1`] = `
 .circuit-0 {
+  display: inline-block;
+  line-height: 1;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -12,6 +14,11 @@ exports[`PrimaryLink styles should render with active styles 1`] = `
 }
 
 .circuit-2 {
+  display: inline-block;
+  line-height: 1;
+}
+
+.circuit-3 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -36,39 +43,39 @@ exports[`PrimaryLink styles should render with active styles 1`] = `
   color: #3063E9;
 }
 
-.circuit-2:focus {
+.circuit-3:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-2:focus::-moz-focus-inner {
+.circuit-3:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-2:focus:not(:focus-visible) {
+.circuit-3:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-2:hover {
+.circuit-3:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-2:active {
+.circuit-3:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:disabled {
+.circuit-3:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (max-width:959px) {
-  .circuit-2 {
+  .circuit-3 {
     margin-bottom: 1px;
   }
 
-  .circuit-2::after {
+  .circuit-3::after {
     content: '';
     display: block;
     position: absolute;
@@ -83,13 +90,13 @@ exports[`PrimaryLink styles should render with active styles 1`] = `
 }
 
 @media (min-width:960px) {
-  .circuit-2 {
+  .circuit-3 {
     padding: 12px;
     margin-bottom: 12px;
   }
 }
 
-.circuit-2:hover {
+.circuit-3:hover {
   background-color: #F0F6FF;
 }
 
@@ -121,10 +128,10 @@ exports[`PrimaryLink styles should render with active styles 1`] = `
 
 <a
   aria-current="page"
-  class="circuit-2"
+  class="circuit-3"
   href="/url"
 >
-  <div
+  <span
     class="circuit-0"
   >
     <svg
@@ -144,16 +151,209 @@ exports[`PrimaryLink styles should render with active styles 1`] = `
         stroke-width="2"
       />
     </svg>
-  </div>
+  </span>
   <span
-    class="circuit-1"
+    class="circuit-2"
   >
-    Label
+    <span
+      class="circuit-1"
+    >
+      Label
+    </span>
   </span>
 </a>
 `;
 
 exports[`PrimaryLink styles should render with badge styles 1`] = `
+.circuit-4 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+  background: none;
+  border: none;
+  outline: none;
+  text-align: left;
+  cursor: pointer;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #000;
+  padding: 24px;
+  -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-4:active {
+  background-color: #E6E6E6;
+}
+
+.circuit-4:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+@media (max-width:959px) {
+  .circuit-4 {
+    margin-bottom: 1px;
+  }
+
+  .circuit-4::after {
+    content: '';
+    display: block;
+    position: absolute;
+    top: 100%;
+    right: 24px;
+    left: 24px;
+    width: calc(100% - 2 * 24px);
+    border-bottom: 1px solid #E6E6E6;
+    -webkit-transition: width 120ms ease-in-out,right 120ms ease-in-out,left 120ms ease-in-out;
+    transition: width 120ms ease-in-out,right 120ms ease-in-out,left 120ms ease-in-out;
+  }
+}
+
+@media (min-width:960px) {
+  .circuit-4 {
+    padding: 12px;
+    margin-bottom: 12px;
+  }
+}
+
+.circuit-2 {
+  display: inline-block;
+  line-height: 1;
+}
+
+.circuit-1 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+@media (max-width:959px) {
+  .circuit-1 {
+    font-size: 24px;
+    line-height: 28px;
+  }
+}
+
+@media (min-width:960px) {
+  .circuit-1 {
+    max-width: 160px;
+  }
+}
+
+.circuit-0 {
+  display: inline-block;
+  line-height: 1;
+  position: relative;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  margin-right: 12px;
+}
+
+.circuit-0::before {
+  display: block;
+  content: '';
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  width: 10px;
+  height: 10px;
+  background-color: #CA58FF;
+  border-radius: 100%;
+}
+
+.circuit-3 {
+  border: 0;
+  -webkit-clip: rect(0 0 0 0);
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+<a
+  class="circuit-4"
+  href="/url"
+>
+  <span
+    class="circuit-0"
+  >
+    <svg
+      fill="none"
+      height="16"
+      role="presentation"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clip-rule="evenodd"
+        d="M9.316 5.2V2.8c0-.994-.819-1.8-1.829-1.8L5.048 6.4V13h6.877a1.214 1.214 0 001.22-1.02l.841-5.4a1.187 1.187 0 00-.285-.968 1.228 1.228 0 00-.934-.412h-3.45zM5.048 13H3.22A1.21 1.21 0 012 11.8V7.6c0-.663.546-1.2 1.22-1.2h1.828V13z"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+      />
+    </svg>
+  </span>
+  <span
+    class="circuit-2"
+  >
+    <span
+      aria-describedby="1"
+      class="circuit-1"
+    >
+      Label
+    </span>
+  </span>
+  <div
+    class="circuit-3"
+    id="1"
+  >
+    Badge
+  </div>
+</a>
+`;
+
+exports[`PrimaryLink styles should render with default styles 1`] = `
 .circuit-3 {
   position: relative;
   display: -webkit-box;
@@ -231,6 +431,23 @@ exports[`PrimaryLink styles should render with badge styles 1`] = `
   }
 }
 
+.circuit-0 {
+  display: inline-block;
+  line-height: 1;
+  position: relative;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  margin-right: 12px;
+}
+
+.circuit-2 {
+  display: inline-block;
+  line-height: 1;
+}
+
 .circuit-1 {
   font-weight: 400;
   margin-bottom: 16px;
@@ -254,48 +471,13 @@ exports[`PrimaryLink styles should render with badge styles 1`] = `
   .circuit-1 {
     max-width: 160px;
   }
-}
-
-.circuit-0 {
-  position: relative;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  margin-right: 12px;
-}
-
-.circuit-0::before {
-  display: block;
-  content: '';
-  position: absolute;
-  top: -8px;
-  right: -8px;
-  width: 10px;
-  height: 10px;
-  background-color: #CA58FF;
-  border-radius: 100%;
-}
-
-.circuit-2 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
 }
 
 <a
   class="circuit-3"
   href="/url"
 >
-  <div
+  <span
     class="circuit-0"
   >
     <svg
@@ -315,170 +497,23 @@ exports[`PrimaryLink styles should render with badge styles 1`] = `
         stroke-width="2"
       />
     </svg>
-  </div>
-  <span
-    aria-describedby="1"
-    class="circuit-1"
-  >
-    Label
   </span>
-  <div
-    class="circuit-2"
-    id="1"
-  >
-    Badge
-  </div>
-</a>
-`;
-
-exports[`PrimaryLink styles should render with default styles 1`] = `
-.circuit-2 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 100%;
-  background: none;
-  border: none;
-  outline: none;
-  text-align: left;
-  cursor: pointer;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  color: #000;
-  padding: 24px;
-  -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
-}
-
-.circuit-2:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 4px #AFD0FE;
-}
-
-.circuit-2:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-2:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-2:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-2:active {
-  background-color: #E6E6E6;
-}
-
-.circuit-2:disabled {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-@media (max-width:959px) {
-  .circuit-2 {
-    margin-bottom: 1px;
-  }
-
-  .circuit-2::after {
-    content: '';
-    display: block;
-    position: absolute;
-    top: 100%;
-    right: 24px;
-    left: 24px;
-    width: calc(100% - 2 * 24px);
-    border-bottom: 1px solid #E6E6E6;
-    -webkit-transition: width 120ms ease-in-out,right 120ms ease-in-out,left 120ms ease-in-out;
-    transition: width 120ms ease-in-out,right 120ms ease-in-out,left 120ms ease-in-out;
-  }
-}
-
-@media (min-width:960px) {
-  .circuit-2 {
-    padding: 12px;
-    margin-bottom: 12px;
-  }
-}
-
-.circuit-0 {
-  position: relative;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  margin-right: 12px;
-}
-
-.circuit-1 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 0;
-  max-width: 100%;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
-
-@media (max-width:959px) {
-  .circuit-1 {
-    font-size: 24px;
-    line-height: 28px;
-  }
-}
-
-@media (min-width:960px) {
-  .circuit-1 {
-    max-width: 160px;
-  }
-}
-
-<a
-  class="circuit-2"
-  href="/url"
->
-  <div
-    class="circuit-0"
-  >
-    <svg
-      fill="none"
-      height="16"
-      role="presentation"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        clip-rule="evenodd"
-        d="M9.316 5.2V2.8c0-.994-.819-1.8-1.829-1.8L5.048 6.4V13h6.877a1.214 1.214 0 001.22-1.02l.841-5.4a1.187 1.187 0 00-.285-.968 1.228 1.228 0 00-.934-.412h-3.45zM5.048 13H3.22A1.21 1.21 0 012 11.8V7.6c0-.663.546-1.2 1.22-1.2h1.828V13z"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-      />
-    </svg>
-  </div>
   <span
-    class="circuit-1"
+    class="circuit-2"
   >
-    Label
+    <span
+      class="circuit-1"
+    >
+      Label
+    </span>
   </span>
 </a>
 `;
 
 exports[`PrimaryLink styles should render with open styles 1`] = `
 .circuit-0 {
+  display: inline-block;
+  line-height: 1;
   position: relative;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
@@ -486,6 +521,11 @@ exports[`PrimaryLink styles should render with open styles 1`] = `
   width: 24px;
   height: 24px;
   margin-right: 12px;
+}
+
+.circuit-2 {
+  display: inline-block;
+  line-height: 1;
 }
 
 .circuit-1 {
@@ -514,7 +554,7 @@ exports[`PrimaryLink styles should render with open styles 1`] = `
   }
 }
 
-.circuit-2 {
+.circuit-3 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -538,39 +578,39 @@ exports[`PrimaryLink styles should render with open styles 1`] = `
   transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
 }
 
-.circuit-2:focus {
+.circuit-3:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-2:focus::-moz-focus-inner {
+.circuit-3:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-2:focus:not(:focus-visible) {
+.circuit-3:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-2:hover {
+.circuit-3:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-2:active {
+.circuit-3:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:disabled {
+.circuit-3:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (max-width:959px) {
-  .circuit-2 {
+  .circuit-3 {
     margin-bottom: 1px;
   }
 
-  .circuit-2::after {
+  .circuit-3::after {
     content: '';
     display: block;
     position: absolute;
@@ -585,14 +625,14 @@ exports[`PrimaryLink styles should render with open styles 1`] = `
 }
 
 @media (min-width:960px) {
-  .circuit-2 {
+  .circuit-3 {
     padding: 12px;
     margin-bottom: 12px;
   }
 }
 
 @media (max-width:959px) {
-  .circuit-2::after {
+  .circuit-3::after {
     right: 0;
     left: 0;
     width: 100%;
@@ -600,10 +640,10 @@ exports[`PrimaryLink styles should render with open styles 1`] = `
 }
 
 <a
-  class="circuit-2"
+  class="circuit-3"
   href="/url"
 >
-  <div
+  <span
     class="circuit-0"
   >
     <svg
@@ -623,11 +663,15 @@ exports[`PrimaryLink styles should render with open styles 1`] = `
         stroke-width="2"
       />
     </svg>
-  </div>
+  </span>
   <span
-    class="circuit-1"
+    class="circuit-2"
   >
-    Label
+    <span
+      class="circuit-1"
+    >
+      Label
+    </span>
   </span>
 </a>
 `;

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -27,6 +27,7 @@ import SubHeadline from '../../../SubHeadline';
 import Body from '../../../Body';
 import { useComponents } from '../../../ComponentsContext';
 import { SecondaryGroupProps, SecondaryLinkProps } from '../../types';
+import { Skeleton } from '../../../Skeleton';
 
 const anchorStyles = ({ theme }: StyleProps) => css`
   text-decoration: none;
@@ -68,20 +69,22 @@ function SecondaryLink({
         // @ts-expect-error The type for the `as` prop is missing in Emotion's prop types.
         as={props.href ? Link : 'button'}
       >
-        <Body
-          size="one"
-          variant={props.isActive ? 'highlight' : undefined}
-          noMargin
-        >
-          {label}
-        </Body>
+        <Skeleton>
+          <Body
+            size="one"
+            variant={props.isActive ? 'highlight' : undefined}
+            noMargin
+          >
+            {label}
+          </Body>
+        </Skeleton>
       </SecondaryAnchor>
     </li>
   );
 }
 
 const subHeadlineStyles = (theme: Theme) => css`
-  padding: ${theme.spacings.tera} ${theme.spacings.mega} ${theme.spacings.byte};
+  margin: ${theme.spacings.tera} ${theme.spacings.mega} ${theme.spacings.byte};
 `;
 
 function SecondaryGroup({
@@ -92,9 +95,11 @@ function SecondaryGroup({
   return (
     <li>
       {label && (
-        <SubHeadline as="h3" css={subHeadlineStyles} noMargin>
-          {label}
-        </SubHeadline>
+        <Skeleton css={subHeadlineStyles}>
+          <SubHeadline as="h3" noMargin>
+            {label}
+          </SubHeadline>
+        </Skeleton>
       )}
       <ul role="list" css={listStyles}>
         {secondaryLinks.map((link) => (

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SecondaryLinks styles should render with default styles 1`] = `
-.circuit-13 {
+.circuit-19 {
   list-style: none;
 }
 
-.circuit-6 {
+.circuit-9 {
   list-style: none;
 }
 
-.circuit-1 {
+.circuit-2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -36,37 +36,42 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   hyphens: auto;
 }
 
-.circuit-1:hover {
+.circuit-2:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-1:active {
+.circuit-2:active {
   background-color: #E6E6E6;
 }
 
-.circuit-1:focus {
+.circuit-2:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-1:focus::-moz-focus-inner {
+.circuit-2:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-1:focus:not(:focus-visible) {
+.circuit-2:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-1:disabled {
+.circuit-2:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (min-width:960px) {
-  .circuit-1 {
+  .circuit-2 {
     padding: 12px 20px;
   }
+}
+
+.circuit-1 {
+  display: inline-block;
+  line-height: 1;
 }
 
 .circuit-0 {
@@ -77,7 +82,7 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   margin-bottom: 0;
 }
 
-.circuit-5 {
+.circuit-8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -104,40 +109,40 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   hyphens: auto;
 }
 
-.circuit-5:hover {
+.circuit-8:hover {
   background-color: #F0F6FF;
 }
 
-.circuit-5:active {
+.circuit-8:active {
   background-color: #E6E6E6;
 }
 
-.circuit-5:focus {
+.circuit-8:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-5:focus::-moz-focus-inner {
+.circuit-8:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-5:focus:not(:focus-visible) {
+.circuit-8:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-5:disabled {
+.circuit-8:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (min-width:960px) {
-  .circuit-5 {
+  .circuit-8 {
     padding: 12px 20px;
   }
 }
 
-.circuit-4 {
+.circuit-6 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -146,7 +151,13 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   font-weight: 700;
 }
 
-.circuit-7 {
+.circuit-11 {
+  display: inline-block;
+  line-height: 1;
+  margin: 32px 16px 8px;
+}
+
+.circuit-10 {
   text-transform: uppercase;
   font-weight: 700;
   font-size: 14px;
@@ -154,94 +165,117 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   margin-bottom: 12px;
   color: #000;
   margin-bottom: 0;
-  padding: 32px 16px 8px;
 }
 
 <ul
-  class="circuit-13"
+  class="circuit-19"
   role="list"
 >
   <li>
     <ul
-      class="circuit-6"
+      class="circuit-9"
       role="list"
     >
       <li>
         <a
-          class="circuit-1"
+          class="circuit-2"
           data-focus-list="1"
           href="/shop/shirts"
         >
-          <p
-            class="circuit-0"
+          <span
+            class="circuit-1"
           >
-            Shirts
-          </p>
+            <p
+              class="circuit-0"
+            >
+              Shirts
+            </p>
+          </span>
         </a>
       </li>
       <li>
         <a
-          class="circuit-1"
+          class="circuit-2"
           data-focus-list="1"
           href="/shop/pants"
         >
-          <p
-            class="circuit-0"
+          <span
+            class="circuit-1"
           >
-            Pants
-          </p>
+            <p
+              class="circuit-0"
+            >
+              Pants
+            </p>
+          </span>
         </a>
       </li>
       <li>
         <a
           aria-current="page"
-          class="circuit-5"
+          class="circuit-8"
           data-focus-list="1"
           href="/shop/socks"
         >
-          <strong
-            class="circuit-4"
+          <span
+            class="circuit-1"
           >
-            Socks
-          </strong>
+            <strong
+              class="circuit-6"
+            >
+              Socks
+            </strong>
+          </span>
         </a>
       </li>
     </ul>
   </li>
   <li>
-    <h3
-      class="circuit-7"
+    <span
+      class="circuit-11"
     >
-      For Kids
-    </h3>
+      <h3
+        class="circuit-10"
+      >
+        For Kids
+      </h3>
+    </span>
     <ul
-      class="circuit-6"
+      class="circuit-9"
       role="list"
     >
       <li>
         <a
-          class="circuit-1"
+          class="circuit-2"
           data-focus-list="1"
           href="/shop/toys"
         >
-          <p
-            class="circuit-0"
+          <span
+            class="circuit-1"
           >
-            Toys
-          </p>
+            <p
+              class="circuit-0"
+            >
+              Toys
+            </p>
+          </span>
         </a>
       </li>
       <li>
         <a
-          class="circuit-1"
+          class="circuit-2"
           data-focus-list="1"
           href="/shop/books"
         >
-          <p
-            class="circuit-0"
+          <span
+            class="circuit-1"
           >
-            Books
-          </p>
+            <p
+              class="circuit-0"
+            >
+              Books
+            </p>
+          </span>
         </a>
       </li>
     </ul>

--- a/packages/circuit-ui/components/Skeleton/Skeleton.spec.tsx
+++ b/packages/circuit-ui/components/Skeleton/Skeleton.spec.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, SumUp Ltd.
+ * Copyright 2021, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -43,6 +43,11 @@ describe('Skeleton', () => {
   describe('styles', () => {
     it('should render with loading styles', () => {
       const wrapper = renderSkeleton(create, baseProps);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render with circular styles', () => {
+      const wrapper = renderSkeleton(create, { ...baseProps, circle: true });
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/packages/circuit-ui/components/Skeleton/Skeleton.spec.tsx
+++ b/packages/circuit-ui/components/Skeleton/Skeleton.spec.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRef } from 'react';
+
+import { create, render, axe, RenderFn } from '../../util/test-utils';
+
+import {
+  Skeleton,
+  SkeletonProps,
+  SkeletonContainer,
+  SkeletonContainerProps,
+} from './Skeleton';
+
+describe('Skeleton', () => {
+  function renderSkeleton<T>(
+    renderFn: RenderFn<T>,
+    { isLoading, children, ...props }: SkeletonProps & SkeletonContainerProps,
+  ) {
+    return renderFn(
+      <SkeletonContainer isLoading={isLoading}>
+        <Skeleton {...props}>
+          <p>{children}</p>
+        </Skeleton>
+      </SkeletonContainer>,
+    );
+  }
+
+  const baseProps = { isLoading: true, children: 'content' };
+
+  describe('styles', () => {
+    it('should render with loading styles', () => {
+      const wrapper = renderSkeleton(create, baseProps);
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+
+  describe('business logic', () => {
+    it('should hide the content while loading', () => {
+      const { getByText } = renderSkeleton(render, baseProps);
+      expect(getByText('content')).not.toBeVisible();
+    });
+
+    it('should show the content when loaded', () => {
+      const { getByText } = renderSkeleton(render, {
+        ...baseProps,
+        isLoading: false,
+      });
+      expect(getByText('content')).toBeVisible();
+    });
+
+    it('should accept a working ref for the SkeletonContainer', () => {
+      const ref = createRef<HTMLDivElement>();
+      const { container } = render(
+        <SkeletonContainer ref={ref} {...baseProps} />,
+      );
+      const element = container.querySelector('div');
+      expect(ref.current).toBe(element);
+    });
+
+    it('should accept a working ref for the Skeleton', () => {
+      const ref = createRef<HTMLSpanElement>();
+      const { container } = render(<Skeleton ref={ref} {...baseProps} />);
+      const element = container.querySelector('span');
+      expect(ref.current).toBe(element);
+    });
+  });
+
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const { container } = renderSkeleton(render, baseProps);
+      const actual = await axe(container);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/circuit-ui/components/Skeleton/Skeleton.tsx
+++ b/packages/circuit-ui/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext, ReactNode, forwardRef, Ref } from 'react';
+import { css, keyframes } from '@emotion/core';
+import isPropValid from '@emotion/is-prop-valid';
+
+import styled, { StyleProps } from '../../styles/styled';
+
+const SkeletonContext = createContext(false);
+
+export interface SkeletonContainerProps {
+  /**
+   * The SkeletonContainer should wrap the entire section that's loading.
+   */
+  children: ReactNode;
+  /**
+   * Whether the section content is loading.
+   */
+  isLoading: boolean;
+  /**
+   * A reference to the HTML DOM element.
+   */
+  ref?: Ref<HTMLDivElement>;
+}
+
+const containerStyles = css`
+  &[aria-busy='true'] {
+    pointer-events: none;
+    user-select: none;
+  }
+`;
+
+const Container = styled('div', {
+  // `inert` is a new HTML attribute to prevent user input events in an area.
+  // This is a progressive enhancement since few browsers support it yet.
+  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert
+  shouldForwardProp: (prop) => isPropValid(prop) || prop === 'inert',
+})<{ inert: boolean }>(containerStyles);
+
+/**
+ * The SkeletonContainer wraps a section that's loading. It disables user
+ * interactions within and signals to screen readers that content is being
+ * loaded.
+ */
+export const SkeletonContainer = forwardRef(
+  (
+    { children, isLoading, ...props }: SkeletonContainerProps,
+    ref: SkeletonContainerProps['ref'],
+  ) => (
+    <SkeletonContext.Provider value={isLoading}>
+      <Container {...props} ref={ref} aria-busy={isLoading} inert={isLoading}>
+        {children}
+      </Container>
+    </SkeletonContext.Provider>
+  ),
+);
+
+SkeletonContainer.displayName = 'SkeletonContainer';
+
+export interface SkeletonProps {
+  /**
+   * The content that should be replaced by a skeleton element when it being
+   * loaded.
+   */
+  children: ReactNode;
+  /**
+   * Whether the skeleton should be circular instead of rectangular.
+   * Default: `false`.
+   */
+  circle?: boolean;
+  /**
+   * A reference to the HTML DOM element.
+   */
+  ref?: Ref<HTMLSpanElement>;
+}
+
+const PULSE_WIDTH = '8rem';
+
+const pulse = keyframes`
+  0% {
+    background-position: -${PULSE_WIDTH} 0;
+  }
+  50% {
+    background-position: calc(${PULSE_WIDTH} + 100%) 0;
+  }
+  100% {
+    background-position: calc(${PULSE_WIDTH} + 100%) 0;
+  }
+`;
+
+const baseStyles = css`
+  display: inline-block;
+  line-height: 1;
+`;
+
+const placeholderStyles = ({
+  theme,
+  circle,
+}: StyleProps & SkeletonProps) => css`
+  border-radius: ${circle
+    ? theme.borderRadius.circle
+    : theme.borderRadius.byte};
+  background-color: ${theme.colors.n200};
+  background-image: linear-gradient(
+    90deg,
+    ${theme.colors.n200},
+    ${theme.colors.n100},
+    ${theme.colors.n200}
+  );
+  background-size: ${PULSE_WIDTH} 100%;
+  background-repeat: no-repeat;
+  animation: ${pulse} 3s ease-in-out infinite;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+
+  > * {
+    visibility: hidden !important;
+  }
+`;
+
+const Placeholder = styled.span(baseStyles, placeholderStyles);
+const Content = styled.span(baseStyles);
+
+/**
+ * A placeholder for asynchronously loaded content with a subtle loading
+ * animation. Only works when wrapped in a SkeletonContainer.
+ */
+export const Skeleton = forwardRef(
+  ({ children, ...props }: SkeletonProps, ref: SkeletonProps['ref']) => {
+    const isLoading = useContext(SkeletonContext);
+
+    if (isLoading) {
+      return (
+        <Placeholder {...props} ref={ref}>
+          {children}
+        </Placeholder>
+      );
+    }
+
+    return (
+      <Content {...props} ref={ref}>
+        {children}
+      </Content>
+    );
+  },
+);
+
+Skeleton.displayName = 'Skeleton';

--- a/packages/circuit-ui/components/Skeleton/Skeleton.tsx
+++ b/packages/circuit-ui/components/Skeleton/Skeleton.tsx
@@ -52,8 +52,7 @@ const Container = styled('div', {
 
 /**
  * The SkeletonContainer wraps a section that's loading. It disables user
- * interactions within and signals to screen readers that content is being
- * loaded.
+ * interactions and signals to screen readers that content is being loaded.
  */
 export const SkeletonContainer = forwardRef(
   (

--- a/packages/circuit-ui/components/Skeleton/__snapshots__/Skeleton.spec.tsx.snap
+++ b/packages/circuit-ui/components/Skeleton/__snapshots__/Skeleton.spec.tsx.snap
@@ -1,5 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Skeleton styles should render with circular styles 1`] = `
+@keyframes animation-0 {
+  0% {
+    background-position: -8rem 0;
+  }
+
+  50% {
+    background-position: calc(8rem + 100%) 0;
+  }
+
+  100% {
+    background-position: calc(8rem + 100%) 0;
+  }
+}
+
+@keyframes animation-0 {
+  0% {
+    background-position: -8rem 0;
+  }
+
+  50% {
+    background-position: calc(8rem + 100%) 0;
+  }
+
+  100% {
+    background-position: calc(8rem + 100%) 0;
+  }
+}
+
+.circuit-1[aria-busy='true'] {
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.circuit-0 {
+  display: inline-block;
+  line-height: 1;
+  border-radius: 100%;
+  background-color: #E6E6E6;
+  background-image: linear-gradient( 90deg,#E6E6E6,#F5F5F5,#E6E6E6 );
+  background-size: 8rem 100%;
+  background-repeat: no-repeat;
+  -webkit-animation: animation-0 3s ease-in-out infinite;
+  animation: animation-0 3s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .circuit-0 {
+    -webkit-animation: none;
+    animation: none;
+  }
+}
+
+.circuit-0 > * {
+  visibility: hidden !important;
+}
+
+<div
+  aria-busy="true"
+  class="circuit-1"
+>
+  <span
+    class="circuit-0"
+  >
+    <p>
+      content
+    </p>
+  </span>
+</div>
+`;
+
 exports[`Skeleton styles should render with loading styles 1`] = `
 @keyframes animation-0 {
   0% {

--- a/packages/circuit-ui/components/Skeleton/__snapshots__/Skeleton.spec.tsx.snap
+++ b/packages/circuit-ui/components/Skeleton/__snapshots__/Skeleton.spec.tsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Skeleton styles should render with loading styles 1`] = `
+@keyframes animation-0 {
+  0% {
+    background-position: -8rem 0;
+  }
+
+  50% {
+    background-position: calc(8rem + 100%) 0;
+  }
+
+  100% {
+    background-position: calc(8rem + 100%) 0;
+  }
+}
+
+.circuit-1[aria-busy='true'] {
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.circuit-0 {
+  display: inline-block;
+  line-height: 1;
+  border-radius: 8px;
+  background-color: #E6E6E6;
+  background-image: linear-gradient( 90deg,#E6E6E6,#F5F5F5,#E6E6E6 );
+  background-size: 8rem 100%;
+  background-repeat: no-repeat;
+  -webkit-animation: animation-0 3s ease-in-out infinite;
+  animation: animation-0 3s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion:reduce) {
+  .circuit-0 {
+    -webkit-animation: none;
+    animation: none;
+  }
+}
+
+.circuit-0 > * {
+  visibility: hidden !important;
+}
+
+<div
+  aria-busy="true"
+  class="circuit-1"
+>
+  <span
+    class="circuit-0"
+  >
+    <p>
+      content
+    </p>
+  </span>
+</div>
+`;

--- a/packages/circuit-ui/components/Skeleton/index.ts
+++ b/packages/circuit-ui/components/Skeleton/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { Skeleton, SkeletonContainer } from './Skeleton';
+
+export type { SkeletonProps, SkeletonContainerProps } from './Skeleton';

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
@@ -35,6 +35,7 @@ export default {
 };
 
 const baseArgs = {
+  isLoading: false,
   logo: (
     <a
       href="https://sumup.com"

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
@@ -20,6 +20,7 @@ import { Theme } from '@sumup/design-tokens';
 import styled, { StyleProps } from '../../styles/styled';
 import { focusVisible } from '../../styles/style-mixins';
 import Hamburger, { HamburgerProps } from '../Hamburger';
+import { SkeletonContainer } from '../Skeleton';
 
 import { ProfileMenu, ProfileMenuProps } from './components/ProfileMenu';
 import { UtilityLinks, UtilityLinksProps } from './components/UtilityLinks';
@@ -81,7 +82,7 @@ const logoStyles = ({ theme }: StyleProps) => css`
 
 const Logo = styled.div(logoStyles);
 
-const Wrapper = styled.div`
+const wrapperStyles = css`
   display: flex;
   align-items: stretch;
 `;
@@ -91,6 +92,7 @@ export interface TopNavigationProps
     Partial<UtilityLinksProps> {
   logo: ReactNode;
   hamburger?: HamburgerProps;
+  isLoading?: boolean;
 }
 
 export function TopNavigation({
@@ -103,15 +105,16 @@ export function TopNavigation({
   profileIsActive,
   links,
   hamburger,
+  isLoading,
   ...props
 }: TopNavigationProps): JSX.Element {
   return (
     <Header role="banner" {...props}>
-      <Wrapper>
+      <div css={wrapperStyles}>
         {hamburger && <Hamburger {...hamburger} css={hamburgerStyles} />}
         <Logo>{logo}</Logo>
-      </Wrapper>
-      <Wrapper>
+      </div>
+      <SkeletonContainer css={wrapperStyles} isLoading={Boolean(isLoading)}>
         {links && <UtilityLinks links={links} />}
         <ProfileMenu
           userAvatar={userAvatar}
@@ -121,7 +124,7 @@ export function TopNavigation({
           profileActions={profileActions}
           profileIsActive={profileIsActive}
         />
-      </Wrapper>
+      </SkeletonContainer>
     </Header>
   );
 }

--- a/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TopNavigation styles should match the snapshot 1`] = `
-.circuit-17 {
+.circuit-21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -21,7 +21,7 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
 }
 
 @media (min-width:480px) {
-  .circuit-17 {
+  .circuit-21 {
     position: -webkit-sticky;
     position: sticky;
     top: 0;
@@ -230,7 +230,26 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
   height: 100%;
 }
 
-.circuit-9 {
+.circuit-20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.circuit-20[aria-busy='true'] {
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.circuit-10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -241,7 +260,7 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
   align-items: center;
 }
 
-.circuit-8 {
+.circuit-9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -264,40 +283,42 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
   border-left: 1px solid #E6E6E6;
 }
 
-.circuit-8:hover {
+.circuit-9:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-8:active {
+.circuit-9:active {
   background-color: #E6E6E6;
 }
 
-.circuit-8:focus {
+.circuit-9:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-8:focus::-moz-focus-inner {
+.circuit-9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-8:focus:not(:focus-visible) {
+.circuit-9:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-8:disabled {
+.circuit-9:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (min-width:480px) {
-  .circuit-8 {
+  .circuit-9 {
     padding: 12px 16px;
   }
 }
 
 .circuit-6 {
+  display: inline-block;
+  line-height: 1;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -309,6 +330,11 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
   .circuit-6 {
     margin-right: 8px;
   }
+}
+
+.circuit-8 {
+  display: inline-block;
+  line-height: 1;
 }
 
 .circuit-7 {
@@ -334,11 +360,11 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
   }
 }
 
-.circuit-15 {
+.circuit-19 {
   display: inline-block;
 }
 
-.circuit-14 {
+.circuit-18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -360,41 +386,41 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
   border-left: 1px solid #E6E6E6;
 }
 
-.circuit-14:hover {
+.circuit-18:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-14:active {
+.circuit-18:active {
   background-color: #E6E6E6;
 }
 
-.circuit-14:focus {
+.circuit-18:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-14:focus::-moz-focus-inner {
+.circuit-18:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-14:focus:not(:focus-visible) {
+.circuit-18:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-14:disabled {
+.circuit-18:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (min-width:768px) {
-  .circuit-14 {
+  .circuit-18 {
     padding: 4px 16px;
   }
 }
 
 @media (max-width:767px) {
-  .circuit-12 {
+  .circuit-16 {
     border: 0;
     -webkit-clip: rect(0 0 0 0);
     clip: rect(0 0 0 0);
@@ -409,53 +435,51 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
 }
 
 @media (min-width:768px) {
-  .circuit-12 {
+  .circuit-16 {
     margin: 0 12px;
     max-width: 20ch;
-    text-overflow: ellipsis;
   }
 }
 
-.circuit-10 {
+.circuit-13 {
+  display: inline-block;
+  line-height: 1;
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.circuit-12 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
   margin-bottom: 0;
   font-weight: 700;
-  display: block;
-  max-width: 132px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
-.circuit-11 {
+.circuit-14 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
   margin-bottom: 0;
-  display: block;
-  max-width: 132px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
-.circuit-13 {
+.circuit-17 {
   display: none;
 }
 
 @media (min-width:768px) {
-  .circuit-13 {
+  .circuit-17 {
     display: block;
     -webkit-transition: -webkit-transform 120ms ease-in-out;
     -webkit-transition: transform 120ms ease-in-out;
     transition: transform 120ms ease-in-out;
   }
 
-  button[aria-expanded='true'] .circuit-13 {
+  button[aria-expanded='true'] .circuit-17 {
     -webkit-transform: rotate(180deg);
     -ms-transform: rotate(180deg);
     transform: rotate(180deg);
@@ -464,7 +488,7 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
 
 <div>
   <header
-    class="circuit-17"
+    class="circuit-21"
     role="banner"
   >
     <div
@@ -542,85 +566,105 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
       </div>
     </div>
     <div
-      class="circuit-5"
+      aria-busy="false"
+      class="circuit-20"
     >
       <div
-        class="circuit-9"
+        class="circuit-10"
       >
         <a
-          class="circuit-8"
+          class="circuit-9"
           href="/shop"
         >
-          <svg
+          <span
             class="circuit-6"
-            fill="none"
-            height="24"
-            role="presentation"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
           >
-            <path
-              clip-rule="evenodd"
-              d="M5.46 3.719A1 1 0 004.5 3H3a1 1 0 100 2h.751l3.29 11.219a1 1 0 00.959.718h9a1 1 0 100-2H8.749L5.459 3.72zM9.25 18a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm6.5 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5z"
-              fill="currentColor"
-              fill-rule="evenodd"
-            />
-            <path
-              clip-rule="evenodd"
-              d="M20.811 5.415A1 1 0 0020 5H6a1 1 0 000 2h12.613l-1.334 4H7v2h11a1 1 0 00.949-.684l2-6a1 1 0 00-.138-.9z"
-              fill="currentColor"
-              fill-rule="evenodd"
-            />
-          </svg>
-          <p
-            class="circuit-7"
+            <svg
+              fill="none"
+              height="24"
+              role="presentation"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M5.46 3.719A1 1 0 004.5 3H3a1 1 0 100 2h.751l3.29 11.219a1 1 0 00.959.718h9a1 1 0 100-2H8.749L5.459 3.72zM9.25 18a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5zm6.5 0a1.25 1.25 0 110 2.5 1.25 1.25 0 010-2.5z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+              <path
+                clip-rule="evenodd"
+                d="M20.811 5.415A1 1 0 0020 5H6a1 1 0 000 2h12.613l-1.334 4H7v2h11a1 1 0 00.949-.684l2-6a1 1 0 00-.138-.9z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+          </span>
+          <span
+            class="circuit-8"
           >
-            Shop
-          </p>
+            <p
+              class="circuit-7"
+            >
+              Shop
+            </p>
+          </span>
         </a>
       </div>
       <div
-        class="circuit-15"
+        class="circuit-19"
       >
         <button
           aria-controls="popover_2"
           aria-expanded="false"
           aria-haspopup="true"
           aria-label="Open profile menu"
-          class="circuit-14"
+          class="circuit-18"
           id="trigger_1"
           title="Open profile menu"
           type="button"
         >
-          <svg
-            fill="none"
-            height="24"
-            role="presentation"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
+          <span
+            class="circuit-8"
           >
-            <path
-              d="M22.981 21.22A11.074 11.074 0 0012.001 12a11.074 11.074 0 00-10.982 9.22A1.576 1.576 0 002.6 23h18.8a1.577 1.577 0 001.581-1.78zm-10.98-1.72a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm4.5-14a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z"
-              fill="currentColor"
-            />
-          </svg>
+            <svg
+              fill="none"
+              height="24"
+              role="presentation"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M22.981 21.22A11.074 11.074 0 0012.001 12a11.074 11.074 0 00-10.982 9.22A1.576 1.576 0 002.6 23h18.8a1.577 1.577 0 001.581-1.78zm-10.98-1.72a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm4.5-14a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
           <div
-            class="circuit-12"
+            class="circuit-16"
           >
-            <strong
-              class="circuit-10"
+            <span
+              class="circuit-13"
             >
-              Jane Doe
-            </strong>
-            <p
-              class="circuit-11"
+              <strong
+                class="circuit-12"
+              >
+                Jane Doe
+              </strong>
+            </span>
+            <span
+              class="circuit-13"
             >
-              ID: AC3YULT8
-            </p>
+              <p
+                class="circuit-14"
+              >
+                ID: AC3YULT8
+              </p>
+            </span>
           </div>
           <svg
-            class="circuit-13"
+            class="circuit-17"
             fill="none"
             height="16"
             viewBox="0 0 16 16"

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -22,6 +22,7 @@ import { hideVisually, navigationItem } from '../../../../styles/style-mixins';
 import Avatar, { AvatarProps } from '../../../Avatar';
 import Body from '../../../Body';
 import Popover, { PopoverProps } from '../../../Popover';
+import { Skeleton } from '../../../Skeleton';
 
 const AvatarPlaceholder = () => (
   <svg
@@ -70,7 +71,6 @@ const userDetailsStyles = ({ theme }: StyleProps) => css`
   ${theme.mq.mega} {
     margin: 0 ${theme.spacings.kilo};
     max-width: 20ch;
-    text-overflow: ellipsis;
   }
 `;
 
@@ -78,7 +78,6 @@ const UserDetails = styled.div(userDetailsStyles);
 
 const truncateStyles = css`
   display: block;
-  max-width: 132px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -143,18 +142,26 @@ function Profile({
       title={profileLabel}
       isActive={isOpen || profileIsActive}
     >
-      {userAvatar ? (
-        <UserAvatar {...userAvatar} variant="identity" />
-      ) : (
-        <AvatarPlaceholder />
-      )}
+      <Skeleton circle>
+        {userAvatar ? (
+          <UserAvatar {...userAvatar} variant="identity" />
+        ) : (
+          <AvatarPlaceholder />
+        )}
+      </Skeleton>
       <UserDetails>
-        <Body size="two" css={truncateStyles} variant="highlight" noMargin>
-          {userName}
-        </Body>
-        <Body size="two" css={truncateStyles} noMargin>
-          {userId}
-        </Body>
+        <Skeleton css={truncateStyles}>
+          <Body size="two" variant="highlight" noMargin>
+            {userName}
+          </Body>
+        </Skeleton>
+        {userId && (
+          <Skeleton css={truncateStyles}>
+            <Body size="two" noMargin>
+              {userId}
+            </Body>
+          </Skeleton>
+        )}
       </UserDetails>
       <Chevron />
     </ProfileWrapper>

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
@@ -1,6 +1,207 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProfileMenu styles should render with a profile picture 1`] = `
+.circuit-7 {
+  display: inline-block;
+}
+
+.circuit-6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border: none;
+  outline: none;
+  color: #1A1A1A;
+  background-color: #FFF;
+  text-align: left;
+  cursor: pointer;
+  -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
+  height: 100%;
+  padding: 12px;
+  border-left: 1px solid #E6E6E6;
+}
+
+.circuit-6:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-6:active {
+  background-color: #E6E6E6;
+}
+
+.circuit-6:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-6:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+@media (min-width:768px) {
+  .circuit-6 {
+    padding: 4px 16px;
+  }
+}
+
+.circuit-1 {
+  display: inline-block;
+  line-height: 1;
+}
+
+.circuit-0 {
+  display: block;
+  width: 96px;
+  height: 96px;
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.1);
+  background-color: #CCC;
+  border-radius: 100%;
+  object-fit: cover;
+  object-position: center;
+  width: 24px;
+  height: 24px;
+}
+
+@media (min-width:768px) {
+  .circuit-0 {
+    width: 32px;
+    height: 32px;
+  }
+}
+
+@media (max-width:767px) {
+  .circuit-4 {
+    border: 0;
+    -webkit-clip: rect(0 0 0 0);
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+}
+
+@media (min-width:768px) {
+  .circuit-4 {
+    margin: 0 12px;
+    max-width: 20ch;
+  }
+}
+
+.circuit-3 {
+  display: inline-block;
+  line-height: 1;
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.circuit-2 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 14px;
+  line-height: 20px;
+  margin-bottom: 0;
+  font-weight: 700;
+}
+
+.circuit-5 {
+  display: none;
+}
+
+@media (min-width:768px) {
+  .circuit-5 {
+    display: block;
+    -webkit-transition: -webkit-transform 120ms ease-in-out;
+    -webkit-transition: transform 120ms ease-in-out;
+    transition: transform 120ms ease-in-out;
+  }
+
+  button[aria-expanded='true'] .circuit-5 {
+    -webkit-transform: rotate(180deg);
+    -ms-transform: rotate(180deg);
+    transform: rotate(180deg);
+  }
+}
+
+<div>
+  <div
+    class="circuit-7"
+  >
+    <button
+      aria-controls="popover_2"
+      aria-expanded="false"
+      aria-haspopup="true"
+      aria-label="Open profile menu"
+      class="circuit-6"
+      id="trigger_1"
+      title="Open profile menu"
+      type="button"
+    >
+      <span
+        class="circuit-1"
+      >
+        <img
+          alt=""
+          class="circuit-0"
+          src="profile.png"
+        />
+      </span>
+      <div
+        class="circuit-4"
+      >
+        <span
+          class="circuit-3"
+        >
+          <strong
+            class="circuit-2"
+          >
+            Jane Doe
+          </strong>
+        </span>
+      </div>
+      <svg
+        class="circuit-5"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M4 6l4 4 4-4"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`ProfileMenu styles should render without a profile picture 1`] = `
 .circuit-6 {
   display: inline-block;
 }
@@ -61,23 +262,8 @@ exports[`ProfileMenu styles should render with a profile picture 1`] = `
 }
 
 .circuit-0 {
-  display: block;
-  width: 96px;
-  height: 96px;
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.1);
-  background-color: #CCC;
-  border-radius: 100%;
-  object-fit: cover;
-  object-position: center;
-  width: 24px;
-  height: 24px;
-}
-
-@media (min-width:768px) {
-  .circuit-0 {
-    width: 32px;
-    height: 32px;
-  }
+  display: inline-block;
+  line-height: 1;
 }
 
 @media (max-width:767px) {
@@ -99,8 +285,16 @@ exports[`ProfileMenu styles should render with a profile picture 1`] = `
   .circuit-3 {
     margin: 0 12px;
     max-width: 20ch;
-    text-overflow: ellipsis;
   }
+}
+
+.circuit-2 {
+  display: inline-block;
+  line-height: 1;
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .circuit-1 {
@@ -110,24 +304,6 @@ exports[`ProfileMenu styles should render with a profile picture 1`] = `
   line-height: 20px;
   margin-bottom: 0;
   font-weight: 700;
-  display: block;
-  max-width: 132px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.circuit-2 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 0;
-  display: block;
-  max-width: 132px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 .circuit-4 {
@@ -154,222 +330,46 @@ exports[`ProfileMenu styles should render with a profile picture 1`] = `
     class="circuit-6"
   >
     <button
-      aria-controls="popover_2"
-      aria-expanded="false"
-      aria-haspopup="true"
-      aria-label="Open profile menu"
-      class="circuit-5"
-      id="trigger_1"
-      title="Open profile menu"
-      type="button"
-    >
-      <img
-        alt=""
-        class="circuit-0"
-        src="profile.png"
-      />
-      <div
-        class="circuit-3"
-      >
-        <strong
-          class="circuit-1"
-        >
-          Jane Doe
-        </strong>
-        <p
-          class="circuit-2"
-        />
-      </div>
-      <svg
-        class="circuit-4"
-        fill="none"
-        height="16"
-        viewBox="0 0 16 16"
-        width="16"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M4 6l4 4 4-4"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-        />
-      </svg>
-    </button>
-  </div>
-</div>
-`;
-
-exports[`ProfileMenu styles should render without a profile picture 1`] = `
-.circuit-5 {
-  display: inline-block;
-}
-
-.circuit-4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  border: none;
-  outline: none;
-  color: #1A1A1A;
-  background-color: #FFF;
-  text-align: left;
-  cursor: pointer;
-  -webkit-transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
-  height: 100%;
-  padding: 12px;
-  border-left: 1px solid #E6E6E6;
-}
-
-.circuit-4:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-4:active {
-  background-color: #E6E6E6;
-}
-
-.circuit-4:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 4px #AFD0FE;
-}
-
-.circuit-4:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-4:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-4:disabled {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-@media (min-width:768px) {
-  .circuit-4 {
-    padding: 4px 16px;
-  }
-}
-
-@media (max-width:767px) {
-  .circuit-2 {
-    border: 0;
-    -webkit-clip: rect(0 0 0 0);
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
-}
-
-@media (min-width:768px) {
-  .circuit-2 {
-    margin: 0 12px;
-    max-width: 20ch;
-    text-overflow: ellipsis;
-  }
-}
-
-.circuit-0 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 0;
-  font-weight: 700;
-  display: block;
-  max-width: 132px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.circuit-1 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 14px;
-  line-height: 20px;
-  margin-bottom: 0;
-  display: block;
-  max-width: 132px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.circuit-3 {
-  display: none;
-}
-
-@media (min-width:768px) {
-  .circuit-3 {
-    display: block;
-    -webkit-transition: -webkit-transform 120ms ease-in-out;
-    -webkit-transition: transform 120ms ease-in-out;
-    transition: transform 120ms ease-in-out;
-  }
-
-  button[aria-expanded='true'] .circuit-3 {
-    -webkit-transform: rotate(180deg);
-    -ms-transform: rotate(180deg);
-    transform: rotate(180deg);
-  }
-}
-
-<div>
-  <div
-    class="circuit-5"
-  >
-    <button
       aria-controls="popover_7"
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Open profile menu"
-      class="circuit-4"
+      class="circuit-5"
       id="trigger_6"
       title="Open profile menu"
       type="button"
     >
-      <svg
-        fill="none"
-        height="24"
-        role="presentation"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
+      <span
+        class="circuit-0"
       >
-        <path
-          d="M22.981 21.22A11.074 11.074 0 0012.001 12a11.074 11.074 0 00-10.982 9.22A1.576 1.576 0 002.6 23h18.8a1.577 1.577 0 001.581-1.78zm-10.98-1.72a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm4.5-14a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z"
-          fill="currentColor"
-        />
-      </svg>
-      <div
-        class="circuit-2"
-      >
-        <strong
-          class="circuit-0"
+        <svg
+          fill="none"
+          height="24"
+          role="presentation"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          Jane Doe
-        </strong>
-        <p
-          class="circuit-1"
-        />
+          <path
+            d="M22.981 21.22A11.074 11.074 0 0012.001 12a11.074 11.074 0 00-10.982 9.22A1.576 1.576 0 002.6 23h18.8a1.577 1.577 0 001.581-1.78zm-10.98-1.72a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm4.5-14a4.5 4.5 0 11-9 0 4.5 4.5 0 019 0z"
+            fill="currentColor"
+          />
+        </svg>
+      </span>
+      <div
+        class="circuit-3"
+      >
+        <span
+          class="circuit-2"
+        >
+          <strong
+            class="circuit-1"
+          >
+            Jane Doe
+          </strong>
+        </span>
       </div>
       <svg
-        class="circuit-3"
+        class="circuit-4"
         fill="none"
         height="16"
         viewBox="0 0 16 16"

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -24,6 +24,7 @@ import { hideVisually, navigationItem } from '../../../../styles/style-mixins';
 import { useClickEvent } from '../../../../hooks/useClickEvent';
 import Body from '../../../Body';
 import { useComponents } from '../../../ComponentsContext';
+import { Skeleton } from '../../../Skeleton';
 
 const anchorStyles = ({ theme }: StyleProps) => css`
   text-decoration: none;
@@ -101,10 +102,17 @@ function UtilityLink({
       // @ts-expect-error The type for the `as` prop is missing in Emotion's prop types.
       as={props.href ? Link : 'button'}
     >
-      <Icon css={iconStyles} role="presentation" size="large" />
-      <UtilityLabel variant={props.isActive ? 'highlight' : undefined} noMargin>
-        {label}
-      </UtilityLabel>
+      <Skeleton css={iconStyles}>
+        <Icon role="presentation" size="large" />
+      </Skeleton>
+      <Skeleton>
+        <UtilityLabel
+          variant={props.isActive ? 'highlight' : undefined}
+          noMargin
+        >
+          {label}
+        </UtilityLabel>
+      </Skeleton>
     </UtilityAnchor>
   );
 }

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/__snapshots__/UtilityLinks.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/__snapshots__/UtilityLinks.spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UtilityLinks styles should match the snapshot 1`] = `
-.circuit-3 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -12,7 +12,7 @@ exports[`UtilityLinks styles should match the snapshot 1`] = `
   align-items: center;
 }
 
-.circuit-2 {
+.circuit-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -35,40 +35,42 @@ exports[`UtilityLinks styles should match the snapshot 1`] = `
   border-left: 1px solid #E6E6E6;
 }
 
-.circuit-2:hover {
+.circuit-3:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-2:active {
+.circuit-3:active {
   background-color: #E6E6E6;
 }
 
-.circuit-2:focus {
+.circuit-3:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-2:focus::-moz-focus-inner {
+.circuit-3:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-2:focus:not(:focus-visible) {
+.circuit-3:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-2:disabled {
+.circuit-3:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (min-width:480px) {
-  .circuit-2 {
+  .circuit-3 {
     padding: 12px 16px;
   }
 }
 
 .circuit-0 {
+  display: inline-block;
+  line-height: 1;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -80,6 +82,11 @@ exports[`UtilityLinks styles should match the snapshot 1`] = `
   .circuit-0 {
     margin-right: 8px;
   }
+}
+
+.circuit-2 {
+  display: inline-block;
+  line-height: 1;
 }
 
 .circuit-1 {
@@ -107,73 +114,80 @@ exports[`UtilityLinks styles should match the snapshot 1`] = `
 
 <div>
   <div
-    class="circuit-3"
+    class="circuit-4"
   >
     <a
-      class="circuit-2"
+      class="circuit-3"
       href="/more"
     >
-      <svg
+      <span
         class="circuit-0"
-        fill="none"
-        height="24"
-        role="presentation"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
       >
-        <path
-          d="M12 21a9 9 0 100-18 9 9 0 000 18z"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-        />
-        <circle
-          cx="12"
-          cy="11.5"
-          r=".5"
-          stroke="currentColor"
-          stroke-miterlimit="16"
-        />
-        <circle
-          r="1"
-          stroke="currentColor"
-          stroke-miterlimit="16"
-          transform="matrix(-1 0 0 1 12 12)"
-        />
-        <circle
-          cx="16"
-          cy="11.5"
-          r=".5"
-          stroke="currentColor"
-          stroke-miterlimit="16"
-        />
-        <circle
-          r="1"
-          stroke="currentColor"
-          stroke-miterlimit="16"
-          transform="matrix(-1 0 0 1 16 12)"
-        />
-        <circle
-          cx="8"
-          cy="11.5"
-          r=".5"
-          stroke="currentColor"
-          stroke-miterlimit="16"
-        />
-        <circle
-          r="1"
-          stroke="currentColor"
-          stroke-miterlimit="16"
-          transform="matrix(-1 0 0 1 8 12)"
-        />
-      </svg>
-      <p
-        class="circuit-1"
+        <svg
+          fill="none"
+          height="24"
+          role="presentation"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 21a9 9 0 100-18 9 9 0 000 18z"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <circle
+            cx="12"
+            cy="11.5"
+            r=".5"
+            stroke="currentColor"
+            stroke-miterlimit="16"
+          />
+          <circle
+            r="1"
+            stroke="currentColor"
+            stroke-miterlimit="16"
+            transform="matrix(-1 0 0 1 12 12)"
+          />
+          <circle
+            cx="16"
+            cy="11.5"
+            r=".5"
+            stroke="currentColor"
+            stroke-miterlimit="16"
+          />
+          <circle
+            r="1"
+            stroke="currentColor"
+            stroke-miterlimit="16"
+            transform="matrix(-1 0 0 1 16 12)"
+          />
+          <circle
+            cx="8"
+            cy="11.5"
+            r=".5"
+            stroke="currentColor"
+            stroke-miterlimit="16"
+          />
+          <circle
+            r="1"
+            stroke="currentColor"
+            stroke-miterlimit="16"
+            transform="matrix(-1 0 0 1 8 12)"
+          />
+        </svg>
+      </span>
+      <span
+        class="circuit-2"
       >
-        More
-      </p>
+        <p
+          class="circuit-1"
+        >
+          More
+        </p>
+      </span>
     </a>
   </div>
 </div>


### PR DESCRIPTION
## Purpose

In SumUp's dashboard app, the navigation links are asynchronously loaded. The navigation components are part of the app shell which wraps the entire navigation. To avoid a layout shift, we have to render the navigation components before or alongside the main content. In other words, we can't render the main content until the navigation data has loaded. Unless...

A [**skeleton screen**](https://www.lukew.com/ff/entry.asp?1797https://www.lukew.com/ff/entry.asp?1797) is a method of displaying the outline (skeleton) of the content to come, typically using gray boxes and lines instead of a progress bar while content is loading. This creates the sense that things are happening immediately as information is incrementally displayed on the screen. 

Using this technique, we can parallelize the loading of the navigation data and main content. This improves both the actual and perceived performance of the page.

![The top and side navigation show a skeleton UI while loading](https://user-images.githubusercontent.com/11017722/129486681-9b36a870-5f74-43d1-bd0f-f62b2f230ed8.png)

## Approach and changes

Added the SkeletonContainer and Skeleton components: 

- The SkeletonContainer wraps a component whose data is loading. It disables user interactions and signals to screen readers that content is being loaded.
- The Skeleton component is a placeholder for the loading content with a subtle animation. It only works when wrapped in a SkeletonContainer.

There are two ways to implement skeleton screens: (1) replace the entire component with a separate one while loading or (2) replace the individual content nodes while loading. Approach 1 seems to be favored by most third-party libraries I could find. I chose the second one because it has several advantages: 

- The content structure and layout styles aren't duplicated which makes maintenance easier.
- The skeleton elements always take up exactly the same amount of space as the content they're replacing. This prevents layout shifts once the actual data has loaded which would make for [very bad UX](https://timkadlec.com/remembers/2020-11-02-skeleton-screens/).
- The TypeScript types aren't dependent on whether the data is loading. Any props that are required should be replaced by dummy data while loading. This ensures realistic-looking skeleton screens and also avoids layout shifts.


I have not publicly exported the skeleton components yet since I want to get feedback from the design team first and want to refine the API with the engineering team.

---

Added a skeleton UI to the TopNavigation and SideNavigation components when their data is loading.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
