### PR TITLE
Close the Popover when an item is clicked

### DIFF
--- a/.changeset/eight-papayas-complain.md
+++ b/.changeset/eight-papayas-complain.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Changed the Popover behavior to close when one of the items is clicked.

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -212,6 +212,18 @@ describe('Popover', () => {
       expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
     });
 
+    it('should close the popover when clicking a popover item', () => {
+      const { getAllByRole } = renderPopover(baseProps);
+
+      const popoverItems = getAllByRole('menuitem');
+
+      act(() => {
+        userEvent.click(popoverItems[0]);
+      });
+
+      expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
+    });
+
     it('should move focus to the first popover item after opening', () => {
       const { getAllByRole, rerender } = renderPopover({
         ...baseProps,

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -384,6 +384,16 @@ export const Popover = ({
     }
   };
 
+  const handlePopoverItemClick = (
+    event: ClickEvent,
+    onClick: BaseProps['onClick'],
+  ) => {
+    if (onClick) {
+      onClick(event);
+      onToggle(false);
+    }
+  };
+
   return (
     <Fragment>
       <TriggerElement ref={triggerEl}>
@@ -419,7 +429,14 @@ export const Popover = ({
               isDivider(action) ? (
                 <Hr css={dividerStyles} key={index} />
               ) : (
-                <PopoverItem key={index} {...action} {...focusProps} />
+                <PopoverItem
+                  key={index}
+                  {...action}
+                  {...focusProps}
+                  onClick={(event) =>
+                    handlePopoverItemClick(event, action.onClick)
+                  }
+                />
               ),
             )}
           </PopoverMenu>


### PR DESCRIPTION
## Purpose

As the title suggests. It seems that this should be the expected behavior of a Popover from a usability perspective.

## Approach and changes

Call `onToggle(false)` along with `onClick` when clocking a popover item.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
