### PR TITLE
Add badge to secondary nav items

### DIFF
--- a/.changeset/perfect-seas-rule.md
+++ b/.changeset/perfect-seas-rule.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added the option to display a badge next to a secondary navigation link.

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
@@ -51,6 +51,7 @@ export const baseArgs = {
       href: '/shop',
       onClick: action('Shop'),
       isActive: true,
+      badge: true,
       secondaryGroups: [
         {
           secondaryLinks: [
@@ -58,6 +59,7 @@ export const baseArgs = {
               label: 'Shirts',
               href: '/shop/shirts',
               onClick: action('Shop → Shirts'),
+              badge: { label: 'New' },
             },
             {
               label: 'Pants',
@@ -94,7 +96,6 @@ export const baseArgs = {
       label: 'Orders',
       href: '/orders',
       onClick: action('Orders'),
-      badge: { label: 'new' },
     },
     {
       icon: Heart,

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
@@ -67,7 +67,7 @@ describe('PrimaryLink', () => {
     it('should render with badge styles', () => {
       const wrapper = renderPrimaryLink(create, {
         ...baseProps,
-        badge: { label: 'Badge' },
+        badge: true,
       });
       expect(wrapper).toMatchSnapshot();
     });

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -23,12 +23,10 @@ import styled, { StyleProps } from '../../../../styles/styled';
 import {
   focusVisible,
   disableVisually,
-  hideVisually,
   cx,
 } from '../../../../styles/style-mixins';
 import { useClickEvent } from '../../../../hooks/useClickEvent';
 import { ClickEvent } from '../../../../types/events';
-import { uniqueId } from '../../../../util/id';
 import { useComponents } from '../../../ComponentsContext';
 import Body from '../../../Body';
 import { Skeleton } from '../../../Skeleton';
@@ -196,11 +194,8 @@ export function PrimaryLink({
     'primary-link',
   );
 
-  const badgeId = badge && uniqueId();
   const suffix = Suffix && <Suffix css={suffixStyles} role="presentation" />;
   const isExternalLink = isExternal || props.target === '_blank';
-
-  const hasBadge = Boolean(badge);
 
   return (
     <Anchor
@@ -212,24 +207,18 @@ export function PrimaryLink({
       // @ts-expect-error The type for the `as` prop is missing in Emotion's prop types.
       as={props.href ? Link : 'button'}
     >
-      <Skeleton css={cx(iconStyles, hasBadge && iconWithBadgeStyles)}>
+      <Skeleton css={cx(iconStyles, badge && iconWithBadgeStyles)}>
         <Icon role="presentation" size="large" />
       </Skeleton>
       <Skeleton>
         <Label
           variant={isActive || isOpen ? 'highlight' : undefined}
-          aria-describedby={badgeId}
           as="span"
           noMargin
         >
           {label}
         </Label>
       </Skeleton>
-      {badge && (
-        <div id={badgeId} css={hideVisually}>
-          {badge.label}
-        </div>
-      )}
       {/* TODO: Make this accessible to screen readers */}
       {isExternalLink && (
         <ArrowRight

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/__snapshots__/PrimaryLink.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/__snapshots__/PrimaryLink.spec.tsx.snap
@@ -165,7 +165,7 @@ exports[`PrimaryLink styles should render with active styles 1`] = `
 `;
 
 exports[`PrimaryLink styles should render with badge styles 1`] = `
-.circuit-4 {
+.circuit-3 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
@@ -189,39 +189,39 @@ exports[`PrimaryLink styles should render with badge styles 1`] = `
   transition: color 120ms ease-in-out,background-color 120ms ease-in-out;
 }
 
-.circuit-4:focus {
+.circuit-3:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-4:focus::-moz-focus-inner {
+.circuit-3:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-4:focus:not(:focus-visible) {
+.circuit-3:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-4:hover {
+.circuit-3:hover {
   background-color: #F5F5F5;
 }
 
-.circuit-4:active {
+.circuit-3:active {
   background-color: #E6E6E6;
 }
 
-.circuit-4:disabled {
+.circuit-3:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (max-width:959px) {
-  .circuit-4 {
+  .circuit-3 {
     margin-bottom: 1px;
   }
 
-  .circuit-4::after {
+  .circuit-3::after {
     content: '';
     display: block;
     position: absolute;
@@ -236,7 +236,7 @@ exports[`PrimaryLink styles should render with badge styles 1`] = `
 }
 
 @media (min-width:960px) {
-  .circuit-4 {
+  .circuit-3 {
     padding: 12px;
     margin-bottom: 12px;
   }
@@ -296,21 +296,8 @@ exports[`PrimaryLink styles should render with badge styles 1`] = `
   border-radius: 100%;
 }
 
-.circuit-3 {
-  border: 0;
-  -webkit-clip: rect(0 0 0 0);
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
 <a
-  class="circuit-4"
+  class="circuit-3"
   href="/url"
 >
   <span
@@ -338,18 +325,11 @@ exports[`PrimaryLink styles should render with badge styles 1`] = `
     class="circuit-2"
   >
     <span
-      aria-describedby="1"
       class="circuit-1"
     >
       Label
     </span>
   </span>
-  <div
-    class="circuit-3"
-    id="1"
-  >
-    Badge
-  </div>
 </a>
 `;
 

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.spec.tsx
@@ -46,6 +46,7 @@ describe('SecondaryLinks', () => {
             label: 'Pants',
             href: '/shop/pants',
             onClick: jest.fn(),
+            badge: { label: 'New' },
           },
           {
             label: 'Socks',

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -25,6 +25,7 @@ import { useClickEvent } from '../../../../hooks/useClickEvent';
 import { useFocusList, FocusProps } from '../../../../hooks/useFocusList';
 import SubHeadline from '../../../SubHeadline';
 import Body from '../../../Body';
+import Badge from '../../../Badge';
 import { useComponents } from '../../../ComponentsContext';
 import { SecondaryGroupProps, SecondaryLinkProps } from '../../types';
 import { Skeleton } from '../../../Skeleton';
@@ -46,10 +47,15 @@ const listStyles = css`
   list-style: none;
 `;
 
+const badgeStyles = (theme: Theme) => css`
+  margin-left: ${theme.spacings.byte};
+`;
+
 function SecondaryLink({
   label,
   onClick,
   tracking,
+  badge,
   ...props
 }: SecondaryLinkProps) {
   const { Link } = useComponents();
@@ -78,6 +84,11 @@ function SecondaryLink({
             {label}
           </Body>
         </Skeleton>
+        {badge && (
+          <Badge variant="promo" as="span" css={badgeStyles}>
+            {badge.label}
+          </Badge>
+        )}
       </SecondaryAnchor>
     </li>
   );

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SecondaryLinks styles should render with default styles 1`] = `
-.circuit-19 {
+.circuit-20 {
   list-style: none;
 }
 
-.circuit-9 {
+.circuit-10 {
   list-style: none;
 }
 
@@ -82,7 +82,25 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   margin-bottom: 0;
 }
 
-.circuit-8 {
+.circuit-5 {
+  border-radius: 999999px;
+  color: #FFF;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  -webkit-letter-spacing: 0.25px;
+  -moz-letter-spacing: 0.25px;
+  -ms-letter-spacing: 0.25px;
+  letter-spacing: 0.25px;
+  background-color: #CA58FF;
+  color: #FFF;
+  margin-left: 8px;
+}
+
+.circuit-9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -109,40 +127,40 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   hyphens: auto;
 }
 
-.circuit-8:hover {
+.circuit-9:hover {
   background-color: #F0F6FF;
 }
 
-.circuit-8:active {
+.circuit-9:active {
   background-color: #E6E6E6;
 }
 
-.circuit-8:focus {
+.circuit-9:focus {
   outline: 0;
   box-shadow: inset 0 0 0 4px #AFD0FE;
 }
 
-.circuit-8:focus::-moz-focus-inner {
+.circuit-9:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-8:focus:not(:focus-visible) {
+.circuit-9:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-8:disabled {
+.circuit-9:disabled {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
 @media (min-width:960px) {
-  .circuit-8 {
+  .circuit-9 {
     padding: 12px 20px;
   }
 }
 
-.circuit-6 {
+.circuit-7 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -151,13 +169,13 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   font-weight: 700;
 }
 
-.circuit-11 {
+.circuit-12 {
   display: inline-block;
   line-height: 1;
   margin: 32px 16px 8px;
 }
 
-.circuit-10 {
+.circuit-11 {
   text-transform: uppercase;
   font-weight: 700;
   font-size: 14px;
@@ -168,12 +186,12 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
 }
 
 <ul
-  class="circuit-19"
+  class="circuit-20"
   role="list"
 >
   <li>
     <ul
-      class="circuit-9"
+      class="circuit-10"
       role="list"
     >
       <li>
@@ -208,12 +226,17 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
               Pants
             </p>
           </span>
+          <span
+            class="circuit-5"
+          >
+            New
+          </span>
         </a>
       </li>
       <li>
         <a
           aria-current="page"
-          class="circuit-8"
+          class="circuit-9"
           data-focus-list="1"
           href="/shop/socks"
         >
@@ -221,7 +244,7 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
             class="circuit-1"
           >
             <strong
-              class="circuit-6"
+              class="circuit-7"
             >
               Socks
             </strong>
@@ -232,16 +255,16 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   </li>
   <li>
     <span
-      class="circuit-11"
+      class="circuit-12"
     >
       <h3
-        class="circuit-10"
+        class="circuit-11"
       >
         For Kids
       </h3>
     </span>
     <ul
-      class="circuit-9"
+      class="circuit-10"
       role="list"
     >
       <li>

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -42,9 +42,7 @@ export interface PrimaryLinkProps extends HTMLProps<HTMLAnchorElement> {
   /**
    * TODO: Add description
    */
-  badge?: {
-    label: string;
-  };
+  badge?: boolean;
   /**
    * Additional data that is dispatched with the tracking event.
    */
@@ -87,4 +85,10 @@ export interface SecondaryLinkProps {
    * Additional data that is dispatched with the tracking event.
    */
   tracking?: TrackingProps;
+  /**
+   * TODO: Add description
+   */
+  badge?: {
+    label: string;
+  };
 }


### PR DESCRIPTION
## Purpose

The new side navigation groups more navigation items together, so it’s not clear which secondary navigation item is new when the primary navigation item has a badge.

We should add a badge to the secondary navigation item as well. If any of the secondary navigation items have a badge, show the badge on the primary nav item (same logic as the active state).

## Approach and changes

- Add the option to display a badge next to a secondary navigation link

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
