### PR TITLE
Close the Popover also when a PopoverItem doesn't have an onClick

### DIFF
--- a/.changeset/early-zebras-hammer.md
+++ b/.changeset/early-zebras-hammer.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the click handler to close the Popover when a PopoverItem doesn't have an onClick.

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -390,8 +390,8 @@ export const Popover = ({
   ) => {
     if (onClick) {
       onClick(event);
-      onToggle(false);
     }
+    onToggle(false);
   };
 
   return (


### PR DESCRIPTION
Follow-up to #1124 

## Purpose

The behavior introduced in #1124 didn't work when a PopoverItem didn't have an `onClick` (when it was only a link with an `href`, for example).

## Approach and changes

Fixed it.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests 👉 I decided not to add a new test to cover this, I think the specs from #1124 are enough. Let me know if you disagree
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
