### PR TITLE
Fix nav tracking by passing a defaut noop as onClick

### DIFF
--- a/.changeset/purple-berries-deliver.md
+++ b/.changeset/purple-berries-deliver.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the nav tracking by passing a defaut noop as onClick. This will be fixed in collector in the next major.

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -176,7 +176,7 @@ const Label = styled(Body)(labelStyles);
 export function PrimaryLink({
   icon: Icon,
   label,
-  onClick = () => {}, // Can't de undefined in order to trigger useClickEvent
+  onClick = () => {}, // Can't be undefined in order to trigger useClickEvent
   isActive,
   isOpen,
   isExternal,

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -176,7 +176,7 @@ const Label = styled(Body)(labelStyles);
 export function PrimaryLink({
   icon: Icon,
   label,
-  onClick,
+  onClick = () => {}, // Can't de undefined in order to trigger useClickEvent
   isActive,
   isOpen,
   isExternal,

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -55,7 +55,7 @@ const badgeStyles = (theme: Theme) => css`
 
 function SecondaryLink({
   label,
-  onClick,
+  onClick = () => {}, // Can't de undefined in order to trigger useClickEvent
   tracking,
   badge,
   ...props

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -55,7 +55,7 @@ const badgeStyles = (theme: Theme) => css`
 
 function SecondaryLink({
   label,
-  onClick = () => {}, // Can't de undefined in order to trigger useClickEvent
+  onClick = () => {}, // Can't be undefined in order to trigger useClickEvent
   tracking,
   badge,
   ...props

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -87,7 +87,7 @@ export interface UtilityLinkProps extends HTMLProps<HTMLAnchorElement> {
 function UtilityLink({
   icon: Icon,
   label,
-  onClick = () => {}, // Can't de undefined in order to trigger useClickEvent
+  onClick = () => {}, // Can't be undefined in order to trigger useClickEvent
   tracking,
   ...props
 }: UtilityLinkProps) {

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -87,7 +87,7 @@ export interface UtilityLinkProps extends HTMLProps<HTMLAnchorElement> {
 function UtilityLink({
   icon: Icon,
   label,
-  onClick,
+  onClick = () => {}, // Can't de undefined in order to trigger useClickEvent
   tracking,
   ...props
 }: UtilityLinkProps) {

--- a/packages/circuit-ui/hooks/useClickEvent/useClickEvent.ts
+++ b/packages/circuit-ui/hooks/useClickEvent/useClickEvent.ts
@@ -25,7 +25,7 @@ export function useClickEvent<Event>(
     tracking || {};
 
   /**
-   * FIXME tracking should also work if onClick is falsy, e.g. if it's a link. This is a breaking change
+   * FIXME tracking should also work if onClick is falsy, e.g. if it's a link. This will be a breaking change.
    */
   return onClick && label
     ? (event: Event): void => {

--- a/packages/circuit-ui/hooks/useClickEvent/useClickEvent.ts
+++ b/packages/circuit-ui/hooks/useClickEvent/useClickEvent.ts
@@ -24,6 +24,9 @@ export function useClickEvent<Event>(
   const { label, component = defaultComponentName, customParameters } =
     tracking || {};
 
+  /**
+   * FIXME tracking should also work if onClick is falsy, e.g. if it's a link. This is a breaking change
+   */
   return onClick && label
     ? (event: Event): void => {
         dispatch({ label, component, customParameters });


### PR DESCRIPTION
## Purpose

The nav tracking doesn't work as expected because the `useClickEvent` doesn't send a tracking event if `onClick` is falsy. Most of the nav items being anchors, they don't have `onClick`s and the events are not firing.

## Approach and changes

Make all navigation element `onClick`s default to a noop function in order to trigger an event even if no `onClick` is passed.

This will be addressed in the `useClickEvent` hook but will be a breaking change as it is likely to heavily influence data.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~[ ] Unit and integration tests~
* ~[ ] Meets minimum browser support~
* ~[ ] Meets accessibility requirements~
