### PR TITLE
Fix useMedia for Safari <14

### DIFF
--- a/.changeset/long-teachers-pay.md
+++ b/.changeset/long-teachers-pay.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the useMedia hook (used in the navigation components) for Safari <14.

--- a/packages/circuit-ui/hooks/useMedia/useMedia.ts
+++ b/packages/circuit-ui/hooks/useMedia/useMedia.ts
@@ -34,10 +34,14 @@ export function useMedia(query: string, initialState = false): boolean {
       setMatch(mqList.matches);
     };
 
-    mqList.addEventListener('change', onChange);
+    /**
+     * We are using the deprecated addListener here because Safari <14 doesn't
+     * support addEventListener for MediaQueryLists.
+     */
+    mqList.addListener(onChange);
 
     return () => {
-      mqList.removeEventListener('change', onChange);
+      mqList.removeListener(onChange);
     };
   }, [query]);
 


### PR DESCRIPTION
## Purpose

The `useMedia` hook is using `mqList.addEventListener()`, which is unsupported in Safari <14.

Thanks @hris27 for reporting!

## Approach and changes

Switch to the deprecated `mqList.addListener` (same approach as [`react-use`](https://github.com/streamich/react-use/blob/master/src/useMedia.ts))

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
