### PR TITLE
Fix useCollapsible not closing immediately

### DIFF
--- a/.changeset/proud-apples-attack.md
+++ b/.changeset/proud-apples-attack.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Exposed the `isAnimating` state from the useCollapsible hook.

--- a/.changeset/warm-meals-invite.md
+++ b/.changeset/warm-meals-invite.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed a bug in the `useCollapsible` hook to start the closing animation immediately.

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.spec.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.spec.ts
@@ -15,7 +15,7 @@
 
 import { MouseEvent } from 'react';
 
-import { renderHook, actHook } from '../../util/test-utils';
+import { renderHook, actHook, waitFor } from '../../util/test-utils';
 
 import { useCollapsible, getHeight } from './useCollapsible';
 
@@ -158,7 +158,7 @@ describe('useCollapsible', () => {
   });
 
   describe('toggling', () => {
-    it('should toggle the open state when the button is clicked', () => {
+    it('should toggle the open state when the button is clicked', async () => {
       const event = ({ fizz: 'buzz' } as unknown) as MouseEvent;
       const { result } = renderHook(() => useCollapsible());
       const { getButtonProps } = result.current;
@@ -169,10 +169,12 @@ describe('useCollapsible', () => {
         getButtonProps().onClick(event);
       });
 
-      expect(result.current.isOpen).toBeTruthy();
+      await waitFor(() => {
+        expect(result.current.isOpen).toBeTruthy();
+      });
     });
 
-    it('should toggle the open state when the callback is called', () => {
+    it('should toggle the open state when the callback is called', async () => {
       const { result } = renderHook(() => useCollapsible());
 
       expect(result.current.isOpen).toBeFalsy();
@@ -181,7 +183,9 @@ describe('useCollapsible', () => {
         result.current.toggleOpen();
       });
 
-      expect(result.current.isOpen).toBeTruthy();
+      await waitFor(() => {
+        expect(result.current.isOpen).toBeTruthy();
+      });
     });
   });
 

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
@@ -76,18 +76,18 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
       duration,
       onStart: () => {
         setHeight(getHeight(contentElement));
-        if (!isOpen) {
-          setOpen(true);
-        }
+        // The timeout forces the state update into the next animation frame.
+        // This ensures that the browsers renders the new height
+        // before the state is toggled.
+        setTimeout(() => {
+          setOpen((prev) => !prev);
+        });
       },
       onEnd: () => {
-        if (isOpen) {
-          setOpen(false);
-        }
         setHeight(DEFAULT_HEIGHT);
       },
     });
-  }, [isOpen, setAnimating, duration]);
+  }, [setAnimating, duration]);
 
   return {
     isOpen,

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
@@ -48,6 +48,7 @@ type ContentProps<T> = {
 type Collapsible<T> = {
   isOpen: boolean;
   toggleOpen: () => void;
+  isAnimating: boolean;
   getButtonProps: (props?: {
     onClick?: (event: ClickEvent) => void;
   }) => ButtonProps;
@@ -69,7 +70,7 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
   const contentElement = useRef<T>(null);
   const [isOpen, setOpen] = useState(initialOpen);
   const [height, setHeight] = useState(getHeight(contentElement));
-  const [, setAnimating] = useAnimation();
+  const [isAnimating, setAnimating] = useAnimation();
 
   const toggleOpen = useCallback(() => {
     setAnimating({
@@ -91,6 +92,7 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
   return {
     isOpen,
     toggleOpen,
+    isAnimating,
     getButtonProps: (props = {}) => ({
       'onClick': (event: ClickEvent) => {
         if (props.onClick) {

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
@@ -76,10 +76,9 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
       duration,
       onStart: () => {
         setHeight(getHeight(contentElement));
-        // The timeout forces the state update into the next animation frame.
-        // This ensures that the browsers renders the new height
-        // before the state is toggled.
-        setTimeout(() => {
+        // Delaying the state update until the next animation frame ensures that
+        // the browsers renders the new height before the animation starts.
+        window.requestAnimationFrame(() => {
           setOpen((prev) => !prev);
         });
       },


### PR DESCRIPTION
## Purpose

Reported by @vascofg:

> There seems to be a bug in the [useCollapsible](https://circuit.sumup.com/?path=/story/hooks-usecollapsible--example) hooks. When the component is already opened, the animation only starts after the specified duration has elapsed.

## Approach and changes

- Toggle the open state at the start of the animation
- Return the `isAnimating` state from the hook

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
