### PR TITLE
Track events without onClick handler

### DIFF
--- a/.changeset/mighty-dragons-march.md
+++ b/.changeset/mighty-dragons-march.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Fixed the `useClickEvent` hook to track events even if no custom `onClick` handler is defined.

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -171,7 +171,7 @@ const Label = styled(Body)(labelStyles);
 export function PrimaryLink({
   icon: Icon,
   label,
-  onClick = () => {}, // Can't be undefined in order to trigger useClickEvent
+  onClick,
   isActive,
   isOpen,
   isExternal,

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -58,7 +58,7 @@ const labelStyles = (theme: Theme) => css`
 
 function SecondaryLink({
   label,
-  onClick = () => {}, // Can't be undefined in order to trigger useClickEvent
+  onClick,
   tracking,
   badge,
   ...props

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -86,7 +86,7 @@ export interface UtilityLinkProps
 function UtilityLink({
   icon: Icon,
   label,
-  onClick = () => {}, // Can't be undefined in order to trigger useClickEvent
+  onClick,
   tracking,
   ...props
 }: UtilityLinkProps) {

--- a/packages/circuit-ui/hooks/useClickEvent/useClickEvent.spec.ts
+++ b/packages/circuit-ui/hooks/useClickEvent/useClickEvent.spec.ts
@@ -104,7 +104,7 @@ describe('useClickEvent', () => {
       // useClickTrigger
       Collector.useClickTrigger = jest.fn(() => dispatch);
 
-      const onClick = jest.fn();
+      const onClick = undefined;
       const { result } = renderHook(() =>
         useClickEvent(onClick, tracking, defaultComponentName),
       );

--- a/packages/circuit-ui/hooks/useClickEvent/useClickEvent.ts
+++ b/packages/circuit-ui/hooks/useClickEvent/useClickEvent.ts
@@ -24,13 +24,12 @@ export function useClickEvent<Event>(
   const { label, component = defaultComponentName, customParameters } =
     tracking || {};
 
-  /**
-   * FIXME tracking should also work if onClick is falsy, e.g. if it's a link. This will be a breaking change.
-   */
-  return onClick && label
+  return label
     ? (event: Event): void => {
         dispatch({ label, component, customParameters });
-        onClick(event);
+        if (onClick) {
+          onClick(event);
+        }
       }
     : onClick;
 }


### PR DESCRIPTION
## Purpose

Links without a custom `onClick` aren't tracked by the `useClickEvent` hook.

## Approach and changes

- Fixed the `useClickEvent` hook to track events even if no custom `onClick` handler is defined.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
