### PR TITLE
Improve tracking of stateful components

### DIFF
--- a/.changeset/calm-items-repair.md
+++ b/.changeset/calm-items-repair.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added tracking support to the ProfileMenu.

--- a/.changeset/cold-oranges-suffer.md
+++ b/.changeset/cold-oranges-suffer.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Changed the Modal's tracking event to include the `open`/`close` data in the tracking label.

--- a/.changeset/curvy-clocks-serve.md
+++ b/.changeset/curvy-clocks-serve.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Renamed and grouped the TopNavigation props that are forwarded to the ProfileMenu.

--- a/.changeset/plenty-hotels-applaud.md
+++ b/.changeset/plenty-hotels-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Marked the `label` property of the `tracking` prop as required. This matches the existing behaviour where click events are only tracked if the `label` property is provided.

--- a/.changeset/small-seahorses-remember.md
+++ b/.changeset/small-seahorses-remember.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added tracking support to the Popover.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -21,7 +21,6 @@ import {
   Ref,
 } from 'react';
 import { css } from '@emotion/react';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 import { Theme } from '@sumup/design-tokens';
 
 import { focusVisible } from '../../styles/style-mixins';
@@ -30,7 +29,7 @@ import { ClickEvent } from '../../types/events';
 import { AsPropType } from '../../types/prop-types';
 import { Body, BodyProps } from '../Body/Body';
 import { useComponents } from '../ComponentsContext';
-import { useClickEvent } from '../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 
 export interface BaseProps extends BodyProps {
   children: ReactNode;

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -25,7 +25,6 @@ import {
 import { css } from '@emotion/react';
 import isPropValid from '@emotion/is-prop-valid';
 import { Theme } from '@sumup/design-tokens';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import styled, { StyleProps } from '../../styles/styled';
 import {
@@ -37,7 +36,7 @@ import { ReturnType } from '../../types/return-type';
 import { ClickEvent } from '../../types/events';
 import { AsPropType } from '../../types/prop-types';
 import { useComponents } from '../ComponentsContext';
-import { useClickEvent } from '../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 
 export interface BaseProps {
   'children': ReactNode;

--- a/packages/circuit-ui/components/Card/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Card/components/Header/Header.tsx
@@ -15,7 +15,6 @@
 
 import { FC, ReactNode } from 'react';
 import { css } from '@emotion/react';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import { ClickEvent } from '../../../../types/events';
 import styled, { StyleProps } from '../../../../styles/styled';
@@ -23,6 +22,7 @@ import {
   CloseButton,
   CloseButtonProps,
 } from '../../../CloseButton/CloseButton';
+import { TrackingProps } from '../../../../hooks/useClickEvent';
 
 type CloseProps =
   | {
@@ -89,7 +89,7 @@ export const CardHeader: FC<CardHeaderProps> = ({
   onClose,
   children,
   closeButtonLabel,
-  tracking = {},
+  tracking,
   ...props
 }) => (
   <CardHeaderContainer {...props}>
@@ -98,7 +98,9 @@ export const CardHeader: FC<CardHeaderProps> = ({
       <CardHeaderCloseButton
         onClick={onClose}
         label={closeButtonLabel}
-        tracking={{ component: 'close-button', ...tracking }}
+        tracking={
+          tracking ? { component: 'close-button', ...tracking } : undefined
+        }
       />
     )}
   </CardHeaderContainer>

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -16,7 +16,6 @@
 import { InputHTMLAttributes, Ref, forwardRef } from 'react';
 import { css } from '@emotion/react';
 import { Checkmark } from '@sumup/icons';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import styled, { StyleProps } from '../../styles/styled';
 import {
@@ -25,7 +24,7 @@ import {
   focusOutline,
 } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
-import { useClickEvent } from '../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import { deprecate } from '../../util/logger';
 import Tooltip from '../Tooltip';
 

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -14,9 +14,9 @@
  */
 
 import { css } from '@emotion/react';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import styled, { StyleProps } from '../../styles/styled';
+import { TrackingProps } from '../../hooks/useClickEvent';
 import { IconButton, IconButtonProps } from '../IconButton/IconButton';
 import { Skeleton } from '../Skeleton';
 
@@ -164,7 +164,7 @@ export const Hamburger = ({
   activeLabel,
   inactiveLabel,
   size = 'giga',
-  tracking = {},
+  tracking,
   ...props
 }: HamburgerProps): JSX.Element => {
   if (
@@ -183,7 +183,7 @@ export const Hamburger = ({
       {...props}
       size={size}
       label={isActive ? activeLabel : inactiveLabel}
-      tracking={{ component: 'hamburger', ...tracking }}
+      tracking={tracking ? { component: 'hamburger', ...tracking } : undefined}
       type="button"
     >
       <Box size={size}>

--- a/packages/circuit-ui/components/ModalContext/ModalContext.tsx
+++ b/packages/circuit-ui/components/ModalContext/ModalContext.tsx
@@ -93,8 +93,12 @@ export function ModalProvider<TProps extends BaseModalProps>({
 
   const setModal = useCallback(
     (modal: ModalState<TProps>) => {
-      if (modal.tracking) {
-        sendEvent({ component: 'modal-open', ...modal.tracking });
+      if (modal.tracking && modal.tracking.label) {
+        sendEvent({
+          component: 'modal',
+          ...modal.tracking,
+          label: `${modal.tracking.label}|open`,
+        });
       }
       dispatch({ type: 'push', item: modal });
     },
@@ -103,8 +107,12 @@ export function ModalProvider<TProps extends BaseModalProps>({
 
   const removeModal = useCallback(
     (modal: ModalState<TProps>) => {
-      if (modal.tracking) {
-        sendEvent({ component: 'modal-close', ...modal.tracking });
+      if (modal.tracking && modal.tracking.label) {
+        sendEvent({
+          component: 'modal',
+          ...modal.tracking,
+          label: `${modal.tracking.label}|close`,
+        });
       }
       if (modal.onClose) {
         modal.onClose();

--- a/packages/circuit-ui/components/ModalContext/types.ts
+++ b/packages/circuit-ui/components/ModalContext/types.ts
@@ -14,9 +14,9 @@
  */
 
 import { Props as ReactModalProps } from 'react-modal';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import { ClickEvent } from '../../types/events';
+import { TrackingProps } from '../../hooks/useClickEvent';
 
 type OnClose = (event?: ClickEvent) => void;
 

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -29,7 +29,6 @@ import {
 } from 'react';
 import useLatest from 'use-latest';
 import usePrevious from 'use-previous';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 import { usePopper } from 'react-popper';
 import { Placement, State, Modifier } from '@popperjs/core';
 import isPropValid from '@emotion/is-prop-valid';
@@ -40,7 +39,7 @@ import { AsPropType } from '../../types/prop-types';
 import styled, { StyleProps } from '../../styles/styled';
 import { listItem, shadow, typography } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
-import { useClickEvent } from '../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 import { useClickOutside } from '../../hooks/useClickOutside';
 import { useFocusList } from '../../hooks/useFocusList';

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -33,6 +33,7 @@ import { usePopper } from 'react-popper';
 import { Placement, State, Modifier } from '@popperjs/core';
 import isPropValid from '@emotion/is-prop-valid';
 import { IconProps } from '@sumup/icons';
+import { useClickTrigger } from '@sumup/collector';
 
 import { ClickEvent } from '../../types/events';
 import { AsPropType } from '../../types/prop-types';
@@ -48,6 +49,7 @@ import { useComponents } from '../ComponentsContext';
 import Portal from '../Portal';
 import Hr from '../Hr';
 import { useStackContext } from '../StackContext';
+import { isFunction } from '../../util/type-check';
 
 export interface BaseProps {
   /**
@@ -211,6 +213,8 @@ function isDivider(action: Action): action is Divider {
   return 'type' in action && action.type === 'divider';
 }
 
+type OnToggle = (open: boolean | ((prevOpen: boolean) => boolean)) => void;
+
 export interface PopoverProps {
   /**
    * Determines whether the Popover is open or closed.
@@ -219,7 +223,7 @@ export interface PopoverProps {
   /**
    * Function that is called when toggles the Popover.
    */
-  onToggle: (open: boolean | ((prevOpen: boolean) => boolean)) => void;
+  onToggle: OnToggle;
   /**
    * An array of PopoverItem or Divider.
    */
@@ -249,6 +253,10 @@ export interface PopoverProps {
     'aria-controls': string;
     'aria-expanded': boolean;
   }) => JSX.Element;
+  /**
+   * Additional data that is dispatched with the tracking event.
+   */
+  tracking?: TrackingProps;
 }
 
 type TriggerKey = 'ArrowUp' | 'ArrowDown';
@@ -261,6 +269,7 @@ export const Popover = ({
   fallbackPlacements = ['top', 'right', 'left'],
   component: Component,
   modifiers = [],
+  tracking,
   ...props
 }: PopoverProps): JSX.Element | null => {
   const theme = useTheme();
@@ -270,6 +279,24 @@ export const Popover = ({
   const menuEl = useRef<HTMLDivElement>(null);
   const triggerId = useMemo(() => uniqueId('trigger_'), []);
   const menuId = useMemo(() => uniqueId('popover_'), []);
+
+  const sendEvent = useClickTrigger();
+
+  const handleToggle: OnToggle = (state) => {
+    onToggle((prev) => {
+      const next = isFunction(state) ? state(prev) : state;
+
+      if (tracking && tracking.label) {
+        sendEvent({
+          component: 'popover',
+          ...tracking,
+          label: `${tracking.label}|${next ? 'open' : 'close'}`,
+        });
+      }
+
+      return next;
+    });
+  };
 
   // Popper custom modifier to apply bottom sheet for mobile.
   // The window.matchMedia() is a useful API for this, it allows you to change the styles based on a condition.
@@ -328,8 +355,8 @@ export const Popover = ({
   // re-attached on every render.
   const popperRef = useLatest(popperElement);
 
-  useEscapeKey(() => onToggle(false), isOpen);
-  useClickOutside(popperRef, () => onToggle(false), isOpen);
+  useEscapeKey(() => handleToggle(false), isOpen);
+  useClickOutside(popperRef, () => handleToggle(false), isOpen);
 
   const prevOpen = usePrevious(isOpen);
 
@@ -365,17 +392,17 @@ export const Popover = ({
     // This prevents the event from bubbling which would trigger the
     // useClickOutside above and would prevent the popover from closing.
     event.stopPropagation();
-    onToggle((prev) => !prev);
+    handleToggle((prev) => !prev);
   };
 
   const handleTriggerKeyDown = (event: KeyboardEvent) => {
     if (isArrowDown(event)) {
       triggerKey.current = 'ArrowDown';
-      onToggle(true);
+      handleToggle(true);
     }
     if (isArrowUp(event)) {
       triggerKey.current = 'ArrowUp';
-      onToggle((prev) => !prev);
+      handleToggle((prev) => !prev);
     }
   };
 
@@ -386,7 +413,7 @@ export const Popover = ({
     if (onClick) {
       onClick(event);
     }
-    onToggle(false);
+    handleToggle(false);
   };
 
   return (

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -21,7 +21,6 @@ import {
   ReactNode,
 } from 'react';
 import { css } from '@emotion/react';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import styled, { StyleProps } from '../../styles/styled';
 import {
@@ -30,7 +29,7 @@ import {
   focusOutline,
 } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
-import { useClickEvent } from '../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 
 export interface RadioButtonProps
   extends InputHTMLAttributes<HTMLInputElement> {

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -17,7 +17,6 @@ import { FC, ReactNode, Ref, SelectHTMLAttributes, forwardRef } from 'react';
 import { css } from '@emotion/react';
 import { ChevronDown, ChevronUp } from '@sumup/icons';
 import { Theme } from '@sumup/design-tokens';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import { uniqueId } from '../../util/id';
 import styled, { StyleProps } from '../../styles/styled';
@@ -27,7 +26,7 @@ import {
   inputOutline,
 } from '../../styles/style-mixins';
 import { ReturnType } from '../../types/return-type';
-import { useClickEvent } from '../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import Label from '../Label';
 import ValidationHint from '../ValidationHint';
 import { deprecate } from '../../util/logger';

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -15,7 +15,6 @@
 
 import { Fragment, Ref, InputHTMLAttributes, forwardRef } from 'react';
 import { css } from '@emotion/react';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import styled, { StyleProps } from '../../styles/styled';
 import {
@@ -24,7 +23,7 @@ import {
   focusOutline,
 } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
-import { useClickEvent } from '../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import { deprecate } from '../../util/logger';
 
 export type SelectorSize = 'kilo' | 'mega' | 'flexible';

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -14,9 +14,9 @@
  */
 
 import { FC, MouseEvent, KeyboardEvent, AnchorHTMLAttributes } from 'react';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 import { IconProps } from '@sumup/icons';
 
+import { TrackingProps } from '../../hooks/useClickEvent';
 import { BadgeProps } from '../Badge';
 
 export interface PrimaryLinkProps

--- a/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
@@ -23,7 +23,7 @@ import { isEmpty } from 'lodash/fp';
 
 import { ClickEvent } from '../../../../types/events';
 import styled, { StyleProps } from '../../../../styles/styled';
-import { useClickEvent } from '../../../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../../../hooks/useClickEvent';
 import { Child, hasSelectedChild, getIcon } from '../../SidebarService';
 import { SubNavList } from '../SubNavList';
 import { NavLabel } from '../NavLabel';
@@ -40,15 +40,15 @@ export interface AggregatorProps {
   /**
    * The icon to be shown when the NavAggregator is not selected
    */
-  defaultIcon: ReactElement;
+  defaultIcon?: ReactElement;
   /**
    * The icon to be shown when the NavAggregator is selected
    */
-  selectedIcon: ReactElement;
+  selectedIcon?: ReactElement;
   /**
    * Disables the Aggregator and all children
    */
-  disabled: boolean;
+  disabled?: boolean;
   /**
    * The onClick method to handle the click event on the NavAggregator
    */
@@ -56,16 +56,10 @@ export interface AggregatorProps {
   /**
    * Additional data that is dispatched with click tracking event.
    */
-  tracking?: {
-    label?: string;
-    component?: string;
-    customParameters?: {
-      [key: string]: unknown;
-    };
-  };
+  tracking?: TrackingProps;
 }
 
-type Disabled = { disabled: boolean };
+type Disabled = { disabled?: boolean };
 type Selected = { selected: boolean };
 
 const baseStyles = ({ theme }: StyleProps) => css`

--- a/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.tsx
@@ -16,10 +16,9 @@
 import { ReactElement } from 'react';
 import { css } from '@emotion/react';
 import isPropValid from '@emotion/is-prop-valid';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import styled, { StyleProps } from '../../../../styles/styled';
-import { useClickEvent } from '../../../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../../../hooks/useClickEvent';
 import { ClickEvent } from '../../../../types/events';
 import { AsPropType } from '../../../../types/prop-types';
 import { useComponents } from '../../../ComponentsContext';

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -22,13 +22,12 @@ import {
   ButtonHTMLAttributes,
 } from 'react';
 import { css } from '@emotion/react';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 import { Theme } from '@sumup/design-tokens';
 
 import { ClickEvent } from '../../types/events';
 import styled, { StyleProps } from '../../styles/styled';
 import { typography, focusVisible } from '../../styles/style-mixins';
-import { useClickEvent } from '../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import CloseButton, { CloseButtonProps } from '../CloseButton';
 
 type BaseProps = {
@@ -244,10 +243,9 @@ export const Tag = forwardRef(
             data-testid="tag-close"
             size="kilo"
             onClick={onRemove}
-            tracking={{
-              component: 'tag-remove',
-              ...tracking,
-            }}
+            tracking={
+              tracking ? { component: 'tag-remove', ...tracking } : undefined
+            }
           />
         )}
       </Container>

--- a/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
+++ b/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
@@ -15,11 +15,10 @@
 
 import { ButtonHTMLAttributes, Ref, forwardRef } from 'react';
 import { css } from '@emotion/react';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 
 import styled, { StyleProps } from '../../../../styles/styled';
 import { focusVisible, hideVisually } from '../../../../styles/style-mixins';
-import { useClickEvent } from '../../../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../../../hooks/useClickEvent';
 
 export interface SwitchProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.spec.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.spec.tsx
@@ -38,25 +38,29 @@ describe('TopNavigation', () => {
       activeLabel: 'Close menu',
       inactiveLabel: 'Open menu',
     },
-    userName: 'Jane Doe',
-    userId: 'ID: AC3YULT8',
-    profileLabel: 'Open profile menu',
-    profileActions: [
-      {
-        onClick: jest.fn(),
-        children: 'View profile',
-      },
-      {
-        onClick: jest.fn(),
-        children: 'Settings',
-      },
-      { type: 'divider' },
-      {
-        onClick: jest.fn(),
-        children: 'Logout',
-        destructive: true,
-      },
-    ] as PopoverProps['actions'],
+    user: {
+      name: 'Jane Doe',
+      id: 'ID: AC3YULT8',
+    },
+    profileMenu: {
+      label: 'Open profile menu',
+      actions: [
+        {
+          onClick: jest.fn(),
+          children: 'View profile',
+        },
+        {
+          onClick: jest.fn(),
+          children: 'Settings',
+        },
+        { type: 'divider' },
+        {
+          onClick: jest.fn(),
+          children: 'Logout',
+          destructive: true,
+        },
+      ] as PopoverProps['actions'],
+    },
     links: [
       {
         icon: Shop,

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
@@ -46,25 +46,29 @@ const baseArgs = {
       <SumUpLogo />
     </a>
   ),
-  userName: 'Jane Doe',
-  userId: 'ID: AC3YULT8',
-  profileLabel: 'Open profile menu',
-  profileActions: [
-    {
-      onClick: action('View profile'),
-      children: 'View profile',
-    },
-    {
-      onClick: action('Settings'),
-      children: 'Settings',
-    },
-    { type: 'divider' },
-    {
-      onClick: action('Logout'),
-      children: 'Logout',
-      destructive: true,
-    },
-  ],
+  user: {
+    name: 'Jane Doe',
+    id: 'ID: AC3YULT8',
+  },
+  profileMenu: {
+    label: 'Open profile menu',
+    actions: [
+      {
+        onClick: action('View profile'),
+        children: 'View profile',
+      },
+      {
+        onClick: action('Settings'),
+        children: 'Settings',
+      },
+      { type: 'divider' },
+      {
+        onClick: action('Logout'),
+        children: 'Logout',
+        destructive: true,
+      },
+    ],
+  },
   links: [
     {
       icon: Shop,

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
@@ -26,6 +26,7 @@ import { SkeletonContainer } from '../Skeleton';
 import { ProfileMenu, ProfileMenuProps } from './components/ProfileMenu';
 import { UtilityLinks, UtilityLinksProps } from './components/UtilityLinks';
 import { TRACKING_ELEMENTS } from './constants';
+import { UserProps } from './types';
 
 const CONTENT_HEIGHT = '56px';
 export const TOP_NAVIGATION_HEIGHT =
@@ -93,23 +94,18 @@ const wrapperStyles = css`
   height: 100%;
 `;
 
-export interface TopNavigationProps
-  extends ProfileMenuProps,
-    Partial<UtilityLinksProps> {
+export interface TopNavigationProps extends Partial<UtilityLinksProps> {
   logo: ReactNode;
   hamburger?: HamburgerProps;
+  user: UserProps;
+  profileMenu: Omit<ProfileMenuProps, 'user'>;
   isLoading?: boolean;
 }
 
 export function TopNavigation({
   logo,
-  userAvatar,
-  userName,
-  userId,
-  profileLabel,
-  profileActions,
-  profileIsActive,
-  profileTrackingLabel,
+  user,
+  profileMenu,
   links,
   hamburger,
   isLoading,
@@ -128,15 +124,7 @@ export function TopNavigation({
         </div>
         <SkeletonContainer css={wrapperStyles} isLoading={Boolean(isLoading)}>
           {links && <UtilityLinks links={links} />}
-          <ProfileMenu
-            userAvatar={userAvatar}
-            userName={userName}
-            userId={userId}
-            profileLabel={profileLabel}
-            profileActions={profileActions}
-            profileIsActive={profileIsActive}
-            profileTrackingLabel={profileTrackingLabel}
-          />
+          <ProfileMenu {...profileMenu} user={user} />
         </SkeletonContainer>
       </Header>
     </TrackingElement>

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.spec.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.spec.tsx
@@ -20,9 +20,9 @@ import { ProfileMenu } from './ProfileMenu';
 
 describe('ProfileMenu', () => {
   const baseProps = {
-    userName: 'Jane Doe',
-    profileLabel: 'Open profile menu',
-    profileActions: [
+    user: { name: 'Jane Doe' },
+    label: 'Open profile menu',
+    actions: [
       {
         onClick: jest.fn(),
         children: 'View profile',
@@ -45,7 +45,7 @@ describe('ProfileMenu', () => {
       const { container } = render(
         <ProfileMenu
           {...baseProps}
-          userAvatar={{ src: 'profile.png', alt: '' }}
+          user={{ ...baseProps.user, avatar: { src: 'profile.png', alt: '' } }}
         />,
       );
 

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -26,6 +26,7 @@ import Popover, { PopoverProps } from '../../../Popover';
 import { Skeleton } from '../../../Skeleton';
 import { TRACKING_ELEMENTS } from '../../constants';
 import { UserProps } from '../../types';
+import { TrackingProps } from '../../../../hooks/useClickEvent';
 
 const profileWrapperStyles = ({ theme }: StyleProps) => css`
   height: 100%;
@@ -150,6 +151,10 @@ export interface ProfileMenuProps extends ProfileProps {
    * a profile action.
    */
   trackingLabel?: string;
+  /**
+   * Additional data that is dispatched with the tracking event.
+   */
+  tracking?: TrackingProps;
 }
 
 export function ProfileMenu({
@@ -158,6 +163,7 @@ export function ProfileMenu({
   actions,
   isActive,
   trackingLabel,
+  tracking,
 }: ProfileMenuProps): JSX.Element {
   const [isOpen, setOpen] = useState(false);
   const offsetModifier = { name: 'offset', options: { offset: [-16, 8] } };
@@ -182,6 +188,9 @@ export function ProfileMenu({
         actions={actions}
         placement="bottom-end"
         modifiers={[offsetModifier]}
+        tracking={
+          tracking ? { ...tracking, component: 'profile_menu' } : undefined
+        }
       />
     </TrackingElement>
   );

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -20,11 +20,12 @@ import { TrackingElement } from '@sumup/collector';
 
 import styled, { NoTheme, StyleProps } from '../../../../styles/styled';
 import { hideVisually, navigationItem } from '../../../../styles/style-mixins';
-import Avatar, { AvatarProps } from '../../../Avatar';
+import Avatar from '../../../Avatar';
 import Body from '../../../Body';
 import Popover, { PopoverProps } from '../../../Popover';
 import { Skeleton } from '../../../Skeleton';
 import { TRACKING_ELEMENTS } from '../../constants';
+import { UserProps } from '../../types';
 
 const profileWrapperStyles = ({ theme }: StyleProps) => css`
   height: 100%;
@@ -88,19 +89,11 @@ interface ProfileProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * A description of the button which opens the profile menu.
    */
-  profileLabel: string;
+  label: string;
   /**
-   * A user's profile photo.
+   * The user's profile.
    */
-  userAvatar?: AvatarProps;
-  /**
-   * A user's name. Strings longer than 20 characters are truncated.
-   */
-  userName: string;
-  /**
-   * An optional user id such as the SumUp merchant code.
-   */
-  userId?: string;
+  user: UserProps;
   /**
    * Whether the associated popover is open.
    */
@@ -108,29 +101,21 @@ interface ProfileProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * Whether the profile page is the currently active page.
    */
-  profileIsActive?: boolean;
+  isActive?: boolean;
 }
 
-function Profile({
-  userAvatar,
-  userName,
-  userId,
-  profileLabel,
-  profileIsActive,
-  isOpen,
-  ...props
-}: ProfileProps) {
+function Profile({ user, label, isActive, isOpen, ...props }: ProfileProps) {
   return (
     <ProfileWrapper
       {...props}
       type="button"
-      aria-label={profileLabel}
-      title={profileLabel}
-      isActive={isOpen || profileIsActive}
+      aria-label={label}
+      title={label}
+      isActive={isOpen || isActive}
     >
       <Skeleton circle>
-        {userAvatar ? (
-          <UserAvatar {...userAvatar} variant="identity" />
+        {user.avatar ? (
+          <UserAvatar {...user.avatar} variant="identity" />
         ) : (
           <ProfileIcon role="presentation" />
         )}
@@ -138,13 +123,13 @@ function Profile({
       <UserDetails>
         <Skeleton css={truncateStyles}>
           <Body size="two" variant="highlight" noMargin>
-            {userName}
+            {user.name}
           </Body>
         </Skeleton>
-        {userId && (
+        {user.id && (
           <Skeleton css={truncateStyles}>
             <Body size="two" noMargin>
-              {userId}
+              {user.id}
             </Body>
           </Skeleton>
         )}
@@ -159,22 +144,20 @@ export interface ProfileMenuProps extends ProfileProps {
    * A collection of actions to be rendered in the profile menu.
    * Same API as the Popover actions.
    */
-  profileActions: PopoverProps['actions'];
+  actions: PopoverProps['actions'];
   /**
    * An optional label that is added to the element tree when clicking
    * a profile action.
    */
-  profileTrackingLabel?: string;
+  trackingLabel?: string;
 }
 
 export function ProfileMenu({
-  userAvatar,
-  userName,
-  userId,
-  profileLabel,
-  profileActions,
-  profileIsActive,
-  profileTrackingLabel,
+  user,
+  label,
+  actions,
+  isActive,
+  trackingLabel,
 }: ProfileMenuProps): JSX.Element {
   const [isOpen, setOpen] = useState(false);
   const offsetModifier = { name: 'offset', options: { offset: [-16, 8] } };
@@ -182,7 +165,7 @@ export function ProfileMenu({
   return (
     <TrackingElement
       name={TRACKING_ELEMENTS.PROFILE_SECTION}
-      label={profileTrackingLabel}
+      label={trackingLabel}
     >
       <Popover
         isOpen={isOpen}
@@ -191,14 +174,12 @@ export function ProfileMenu({
           <Profile
             {...popoverProps}
             isOpen={isOpen}
-            profileLabel={profileLabel}
-            userAvatar={userAvatar}
-            userName={userName}
-            userId={userId}
-            profileIsActive={profileIsActive}
+            label={label}
+            user={user}
+            isActive={isActive}
           />
         )}
-        actions={profileActions}
+        actions={actions}
         placement="bottom-end"
         modifiers={[offsetModifier]}
       />

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -16,13 +16,12 @@
 import { MouseEvent, KeyboardEvent, FC, AnchorHTMLAttributes } from 'react';
 import { css } from '@emotion/react';
 import { Theme } from '@sumup/design-tokens';
-import { Dispatch as TrackingProps } from '@sumup/collector';
 import { IconProps } from '@sumup/icons';
 
 import styled, { NoTheme, StyleProps } from '../../../../styles/styled';
 import { hideVisually, navigationItem } from '../../../../styles/style-mixins';
 import { AsPropType } from '../../../../types/prop-types';
-import { useClickEvent } from '../../../../hooks/useClickEvent';
+import { useClickEvent, TrackingProps } from '../../../../hooks/useClickEvent';
 import Body from '../../../Body';
 import { useComponents } from '../../../ComponentsContext';
 import { Skeleton } from '../../../Skeleton';

--- a/packages/circuit-ui/components/TopNavigation/types.ts
+++ b/packages/circuit-ui/components/TopNavigation/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AvatarProps } from '../Avatar';
+
+export type UserProps = {
+  /**
+   * A unique user id such as the SumUp merchant code.
+   */
+  id?: string;
+  /**
+   * A user's name. Can be the first or last name or a combination of both.
+   */
+  name: string;
+  /**
+   * A user's profile photo.
+   */
+  avatar?: AvatarProps;
+};

--- a/packages/circuit-ui/hooks/useClickEvent/index.ts
+++ b/packages/circuit-ui/hooks/useClickEvent/index.ts
@@ -14,3 +14,5 @@
  */
 
 export { useClickEvent } from './useClickEvent';
+
+export type { TrackingProps } from './useClickEvent';

--- a/packages/circuit-ui/hooks/useClickEvent/useClickEvent.ts
+++ b/packages/circuit-ui/hooks/useClickEvent/useClickEvent.ts
@@ -15,9 +15,13 @@
 
 import { useClickTrigger, Dispatch } from '@sumup/collector';
 
+import { Require } from '../../types/util';
+
+export type TrackingProps = Require<Dispatch, 'label'>;
+
 export function useClickEvent<Event>(
   onClick?: (event: Event) => void,
-  tracking?: Dispatch,
+  tracking?: TrackingProps,
   defaultComponentName?: string,
 ): ((event: Event) => void) | undefined {
   const dispatch = useClickTrigger();


### PR DESCRIPTION
Addresses [WE-714](https://sumupteam.atlassian.net/browse/WE-714).

## Purpose

Until now, we haven't had a consistent way to track stateful components, specifically events related to a state transition. This PR introduces the convention to append a state enum to the tracking label, separated by a pipe (`|`).

## Approach and changes

- Add tracking support to the Popover and ProfileMenu components
- Adapt the Modal tracking to the new convention
- Mark the tracking `label` as required in TypeScript
- Rename and group the ProfileMenu props to make them less verbose

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
