### PR TITLE
Type the grid components to prevent wrong type inference

### DIFF
--- a/.changeset/itchy-ducks-smell.md
+++ b/.changeset/itchy-ducks-smell.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Typed the grid components to prevent wrong type inference.

--- a/packages/circuit-ui/components/Col/Col.stories.js
+++ b/packages/circuit-ui/components/Col/Col.stories.js
@@ -18,7 +18,7 @@ import { css } from '@emotion/react';
 
 import docs from '../Grid/Grid.docs.mdx';
 
-import Col from './Col';
+import Col from '.';
 
 const colControl = {
   control: {

--- a/packages/circuit-ui/components/Col/index.ts
+++ b/packages/circuit-ui/components/Col/index.ts
@@ -13,6 +13,17 @@
  * limitations under the License.
  */
 
-import Grid from './Grid';
+import { FC } from 'react';
+import { Theme } from '@sumup/design-tokens';
 
-export default Grid;
+import Col from './Col';
+
+type ColBreakpoint = 'default' | keyof Theme['breakpoints'];
+
+type ObjectColSizing = {
+  [k in ColBreakpoint]?: number;
+};
+
+type ColSizing = ObjectColSizing | number | string;
+
+export default Col as FC<{ skip?: ColSizing; span?: ColSizing }>;

--- a/packages/circuit-ui/components/Grid/Grid.stories.js
+++ b/packages/circuit-ui/components/Grid/Grid.stories.js
@@ -18,8 +18,9 @@ import styled from '@emotion/styled';
 import Col from '../Col';
 import Row from '../Row';
 
-import Grid from './Grid';
 import docs from './Grid.docs.mdx';
+
+import Grid from '.';
 
 export default {
   title: 'Layout/Grid/Grid',

--- a/packages/circuit-ui/components/Grid/index.ts
+++ b/packages/circuit-ui/components/Grid/index.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
-import Row from './Row';
+import { FC } from 'react';
 
-export default Row;
+import Grid from './Grid';
+
+export default Grid as FC;

--- a/packages/circuit-ui/components/Row/Row.stories.js
+++ b/packages/circuit-ui/components/Row/Row.stories.js
@@ -18,7 +18,7 @@ import styled from '@emotion/styled';
 import docs from '../Grid/Grid.docs.mdx';
 import Col from '../Col';
 
-import Row from './Row';
+import Row from '.';
 
 export default {
   title: 'Layout/Grid/Row',

--- a/packages/circuit-ui/components/Row/index.ts
+++ b/packages/circuit-ui/components/Row/index.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
-import Col from './Col';
+import { FC } from 'react';
 
-export default Col;
+import Row from './Row';
+
+export default Row as FC;


### PR DESCRIPTION
## Purpose

The JS grid components were inferred to not accept any props, which was causing issues in our TS applications.

## Approach and changes

Add typings for the components in their `index.ts` files, to avoid having to migrate them to TS (they should be replaced eventually, see #535). Props to @connor-baer for the idea 💡 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
