### PR TITLE
Hide deprecation warnings on prod and test environments

### DIFF
--- a/.changeset/yellow-ads-judge.md
+++ b/.changeset/yellow-ads-judge.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Hid deprecation warnings on prod and test environments.

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -100,17 +100,19 @@ const variantStyles = ({ theme, variant }: BodyProps & StyleProps) => {
 };
 
 const marginStyles = ({ noMargin }: BodyProps & StyleProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test' &&
-    !noMargin
-  ) {
-    deprecate(
-      'Body',
-      'The default outer spacing in the Body component is deprecated.',
-      'Use the `noMargin` prop to silence this warning.',
-      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
-    );
+  if (!noMargin) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      deprecate(
+        'Body',
+        'The default outer spacing in the Body component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      );
+    }
+
     return null;
   }
 

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -100,7 +100,11 @@ const variantStyles = ({ theme, variant }: BodyProps & StyleProps) => {
 };
 
 const marginStyles = ({ noMargin }: BodyProps & StyleProps) => {
-  if (!noMargin) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !noMargin
+  ) {
     deprecate(
       'Body',
       'The default outer spacing in the Body component is deprecated.',

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -134,17 +134,18 @@ const wrapperBaseStyles = ({ theme }: StyleProps) => css`
 `;
 
 const wrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test' &&
-    !noMargin
-  ) {
-    deprecate(
-      'Checkbox',
-      'The default outer spacing in the Checkbox component is deprecated.',
-      'Use the `noMargin` prop to silence this warning.',
-      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
-    );
+  if (!noMargin) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      deprecate(
+        'Checkbox',
+        'The default outer spacing in the Checkbox component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      );
+    }
 
     return null;
   }

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -134,7 +134,11 @@ const wrapperBaseStyles = ({ theme }: StyleProps) => css`
 `;
 
 const wrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
-  if (!noMargin) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !noMargin
+  ) {
     deprecate(
       'Checkbox',
       'The default outer spacing in the Checkbox component is deprecated.',

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -56,17 +56,19 @@ const sizeStyles = ({ theme, size = 'one' }: StyleProps & HeadlineProps) => {
   `;
 };
 const noMarginStyles = ({ noMargin }: HeadlineProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test' &&
-    !noMargin
-  ) {
-    deprecate(
-      'Headline',
-      'The default outer spacing in the Headline component is deprecated.',
-      'Use the `noMargin` prop to silence this warning.',
-      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
-    );
+  if (!noMargin) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      deprecate(
+        'Headline',
+        'The default outer spacing in the Headline component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      );
+    }
+
     return null;
   }
 

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -56,7 +56,11 @@ const sizeStyles = ({ theme, size = 'one' }: StyleProps & HeadlineProps) => {
   `;
 };
 const noMarginStyles = ({ noMargin }: HeadlineProps) => {
-  if (!noMargin) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !noMargin
+  ) {
     deprecate(
       'Headline',
       'The default outer spacing in the Headline component is deprecated.',

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
@@ -36,17 +36,19 @@ export interface InlineMessageProps {
 }
 
 const marginStyles = ({ noMargin }: InlineMessageProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test' &&
-    !noMargin
-  ) {
-    deprecate(
-      'InlineMessage',
-      'The default outer spacing in the InlineMessage component is deprecated.',
-      'Use the `noMargin` prop to silence this warning.',
-      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
-    );
+  if (!noMargin) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      deprecate(
+        'InlineMessage',
+        'The default outer spacing in the InlineMessage component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      );
+    }
+
     return null;
   }
 

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
@@ -36,7 +36,11 @@ export interface InlineMessageProps {
 }
 
 const marginStyles = ({ noMargin }: InlineMessageProps) => {
-  if (!noMargin) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !noMargin
+  ) {
     deprecate(
       'InlineMessage',
       'The default outer spacing in the InlineMessage component is deprecated.',

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -120,7 +120,11 @@ const labelNoMarginStyles = ({
   theme,
   noMargin,
 }: StyleProps & LabelElProps) => {
-  if (!noMargin) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !noMargin
+  ) {
     deprecate(
       'Input',
       'The default outer spacing in the Input component is deprecated.',

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -120,17 +120,18 @@ const labelNoMarginStyles = ({
   theme,
   noMargin,
 }: StyleProps & LabelElProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test' &&
-    !noMargin
-  ) {
-    deprecate(
-      'Input',
-      'The default outer spacing in the Input component is deprecated.',
-      'Use the `noMargin` prop to silence this warning.',
-      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
-    );
+  if (!noMargin) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      deprecate(
+        'Input',
+        'The default outer spacing in the Input component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      );
+    }
 
     return css`
       margin-bottom: ${theme.spacings.mega};

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -82,17 +82,19 @@ const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
 };
 
 const marginStyles = ({ noMargin }: ListProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test' &&
-    !noMargin
-  ) {
-    deprecate(
-      'List',
-      'The default outer spacing in the List component is deprecated.',
-      'Use the `noMargin` prop to silence this warning.',
-      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
-    );
+  if (!noMargin) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      deprecate(
+        'List',
+        'The default outer spacing in the List component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      );
+    }
+
     return null;
   }
   return css`

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -82,7 +82,11 @@ const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
 };
 
 const marginStyles = ({ noMargin }: ListProps) => {
-  if (!noMargin) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !noMargin
+  ) {
     deprecate(
       'List',
       'The default outer spacing in the List component is deprecated.',

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -139,7 +139,11 @@ const SelectContainer = styled('div')<ContainerElProps>(
 type LabelElProps = Pick<SelectProps, 'noMargin' | 'inline'>;
 
 const labelMarginStyles = ({ theme, noMargin }: StyleProps & LabelElProps) => {
-  if (!noMargin) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !noMargin
+  ) {
     deprecate(
       'Select',
       'The default outer spacing in the Select component is deprecated.',

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -139,17 +139,19 @@ const SelectContainer = styled('div')<ContainerElProps>(
 type LabelElProps = Pick<SelectProps, 'noMargin' | 'inline'>;
 
 const labelMarginStyles = ({ theme, noMargin }: StyleProps & LabelElProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test' &&
-    !noMargin
-  ) {
-    deprecate(
-      'Select',
-      'The default outer spacing in the Select component is deprecated.',
-      'Use the `noMargin` prop to silence this warning.',
-      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
-    );
+  if (!noMargin) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      deprecate(
+        'Select',
+        'The default outer spacing in the Select component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      );
+    }
+
     return css`
       margin-bottom: ${theme.spacings.mega};
     `;

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -121,17 +121,19 @@ const disabledStyles = ({ disabled }: LabelElProps) =>
   disabled && css(disableVisually());
 
 const noMarginStyles = ({ noMargin }: LabelElProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test' &&
-    !noMargin
-  ) {
-    deprecate(
-      'Selector',
-      'The default outer spacing in the Selector component is deprecated.',
-      'Use the `noMargin` prop to silence this warning.',
-      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
-    );
+  if (!noMargin) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      deprecate(
+        'Selector',
+        'The default outer spacing in the Selector component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      );
+    }
+
     return null;
   }
   return css`

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -121,7 +121,11 @@ const disabledStyles = ({ disabled }: LabelElProps) =>
   disabled && css(disableVisually());
 
 const noMarginStyles = ({ noMargin }: LabelElProps) => {
-  if (!noMargin) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !noMargin
+  ) {
     deprecate(
       'Selector',
       'The default outer spacing in the Selector component is deprecated.',

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -43,17 +43,19 @@ const baseStyles = ({ theme }: StyleProps) => css`
 `;
 
 const noMarginStyles = ({ noMargin }: SubHeadlineProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test' &&
-    !noMargin
-  ) {
-    deprecate(
-      'SubHeadline',
-      'The default outer spacing in the SubHeadline component is deprecated.',
-      'Use the `noMargin` prop to silence this warning.',
-      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
-    );
+  if (!noMargin) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      deprecate(
+        'SubHeadline',
+        'The default outer spacing in the SubHeadline component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      );
+    }
+
     return null;
   }
   return css`

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -43,7 +43,11 @@ const baseStyles = ({ theme }: StyleProps) => css`
 `;
 
 const noMarginStyles = ({ noMargin }: SubHeadlineProps) => {
-  if (!noMargin) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !noMargin
+  ) {
     deprecate(
       'SubHeadline',
       'The default outer spacing in the SubHeadline component is deprecated.',

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -82,7 +82,11 @@ const toggleWrapperDisabledStyles = ({ disabled }: WrapperElProps) =>
   `;
 
 const toggleWrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
-  if (!noMargin) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !noMargin
+  ) {
     deprecate(
       'Toggle',
       'The default outer spacing in the Toggle component is deprecated.',

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -82,17 +82,19 @@ const toggleWrapperDisabledStyles = ({ disabled }: WrapperElProps) =>
   `;
 
 const toggleWrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    process.env.NODE_ENV !== 'test' &&
-    !noMargin
-  ) {
-    deprecate(
-      'Toggle',
-      'The default outer spacing in the Toggle component is deprecated.',
-      'Use the `noMargin` prop to silence this warning.',
-      'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
-    );
+  if (!noMargin) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      deprecate(
+        'Toggle',
+        'The default outer spacing in the Toggle component is deprecated.',
+        'Use the `noMargin` prop to silence this warning.',
+        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      );
+    }
+
     return null;
   }
   return css`


### PR DESCRIPTION
## Purpose

As title suggests.

## Approach and changes

Add a check for `process.env` before printing the warnings. This affected every `noMargin` deprecation warning.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
