### PR TITLE
Fix a wobble in the SideNavigation

### DIFF
--- a/.changeset/healthy-geese-type.md
+++ b/.changeset/healthy-geese-type.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed a small wobble in the SideNavigation in Safari on some external displays.

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -79,6 +79,7 @@ const primaryWrapperStyles = ({ theme }: StyleProps) => css`
   background-color: ${theme.colors.bodyBg};
   padding-top: ${theme.spacings.kilo};
   overflow-y: auto;
+  overflow-x: hidden;
   box-shadow: 1px 0 ${theme.colors.n300};
   transition: width ${theme.transitions.default},
     box-shadow ${theme.transitions.default};

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
@@ -42,6 +42,7 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   background-color: #FFF;
   padding-top: 12px;
   overflow-y: auto;
+  overflow-x: hidden;
   box-shadow: 1px 0 #CCC;
   -webkit-transition: width 120ms ease-in-out,box-shadow 120ms ease-in-out;
   transition: width 120ms ease-in-out,box-shadow 120ms ease-in-out;
@@ -477,6 +478,7 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
   background-color: #FFF;
   padding-top: 12px;
   overflow-y: auto;
+  overflow-x: hidden;
   box-shadow: 1px 0 #CCC;
   -webkit-transition: width 120ms ease-in-out,box-shadow 120ms ease-in-out;
   transition: width 120ms ease-in-out,box-shadow 120ms ease-in-out;


### PR DESCRIPTION
## Purpose

In Safari on some external displays, the SideNavigation would wobble on hover:

https://user-images.githubusercontent.com/11017722/136971378-f7859ac8-3b13-4a66-8806-e1dcb2475045.mov

## Approach and changes

- Add `overflow-x: hidden` to the nav which fixes the wobble in some (but not all) cases

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
