### PR TITLE
Add codemod for LoadingButton → Button

### DIFF
--- a/.changeset/cuddly-seals-wait.md
+++ b/.changeset/cuddly-seals-wait.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Added a codemod for the LoadingButton → Button migration (🤖 _component-names-v4-1_).

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/component-names-v4-1.input.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/component-names-v4-1.input.js
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+import { LoadingButton } from '@sumup/circuit-ui';
+
+const BaseLoadingButton = () => <LoadingButton />;
+
+const LoadingButtonStyle = styled(LoadingButton)`
+  color: red;
+`;

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/component-names-v4-1.output.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/component-names-v4-1.output.js
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+import { Button } from '@sumup/circuit-ui';
+
+const BaseLoadingButton = () => <Button />;
+
+const LoadingButtonStyle = styled(Button)`
+  color: red;
+`;

--- a/packages/circuit-ui/cli/migrate/__tests__/migrate.spec.js
+++ b/packages/circuit-ui/cli/migrate/__tests__/migrate.spec.js
@@ -57,6 +57,9 @@ defineTest('label-prop-names');
 // v4
 defineTest('icons-v2');
 
+// v4.1
+defineTest('component-names-v4-1');
+
 function defineTest(transformName, testFilePrefix, testOptions = {}) {
   const dirName = __dirname;
   const fixtureDir = path.join(dirName, '..', '__testfixtures__');

--- a/packages/circuit-ui/cli/migrate/component-names-v4-1.ts
+++ b/packages/circuit-ui/cli/migrate/component-names-v4-1.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform } from 'jscodeshift';
+
+import { findImportsByPath } from './utils';
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const oldComponentName = 'LoadingButton';
+  const newComponentName = 'Button';
+
+  const imports = findImportsByPath(j, root, '@sumup/circuit-ui');
+
+  const componentImport = imports.find((i) => i.name === oldComponentName);
+
+  if (!componentImport) {
+    return;
+  }
+
+  root
+    .find(j.Identifier)
+    .filter((nodePath) => nodePath.node.name === oldComponentName)
+    .replaceWith(j.identifier(newComponentName));
+
+  return root.toSource();
+};
+
+export default transform;


### PR DESCRIPTION
Relates to #1167.

## Purpose

Although this isn't a breaking change (yet), we should make the migration as easy as possible for developers.

## Approach and changes

- Add a codemod to rename LoadingButton to Button. Their APIs are identical.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
