### PR TITLE
Don't require label for hidden Input

### DIFF
--- a/.changeset/beige-dots-speak.md
+++ b/.changeset/beige-dots-speak.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed the requirement for a label for hidden Inputs.

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -318,6 +318,7 @@ export const Input = forwardRef(
       process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
+      props.type !== 'hidden' &&
       !label
     ) {
       throw new Error(


### PR DESCRIPTION
## Purpose

Inputs with `type="hidden"` are invisible to users, no matter what input device they use. Thus, they don't require labels.

## Approach and changes

- Don't throw error when a label is missing on a hidden input

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
