### PR TITLE
Explicitly set arg type for `as` prop

### DIFF
--- a/packages/circuit-ui/components/Anchor/Anchor.stories.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.stories.tsx
@@ -25,6 +25,7 @@ export default {
   argTypes: {
     href: { control: 'text' },
     children: { control: 'text' },
+    as: { control: 'text' },
   },
 };
 

--- a/packages/circuit-ui/components/Body/Body.stories.tsx
+++ b/packages/circuit-ui/components/Body/Body.stories.tsx
@@ -27,6 +27,9 @@ export default {
   parameters: {
     docs: { page: docs },
   },
+  argTypes: {
+    as: { control: 'text' },
+  },
 };
 
 export const Base = (args: BodyProps) => (


### PR DESCRIPTION
Fixes #1229.

## Purpose

The `as` prop can be an HTML element or a React component. Storybook infers this as an object arg type.

## Approach and changes

- Explicitly set the arg type for the `as` prop as a string

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
