### PR TITLE
Add missing flags to icons manifest

### DIFF
--- a/.changeset/poor-monkeys-buy.md
+++ b/.changeset/poor-monkeys-buy.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': patch
+---
+
+Added missing flag icons to the manifest (AR, AU, CA, CO, HR, PE, RO, and SL) .

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -291,7 +291,17 @@
       "size": "24"
     },
     {
+      "name": "flag_ar",
+      "category": "Country flag",
+      "size": "16"
+    },
+    {
       "name": "flag_at",
+      "category": "Country flag",
+      "size": "16"
+    },
+    {
+      "name": "flag_au",
       "category": "Country flag",
       "size": "16"
     },
@@ -311,12 +321,22 @@
       "size": "16"
     },
     {
+      "name": "flag_ca",
+      "category": "Country flag",
+      "size": "16"
+    },
+    {
       "name": "flag_ch",
       "category": "Country flag",
       "size": "16"
     },
     {
       "name": "flag_cl",
+      "category": "Country flag",
+      "size": "16"
+    },
+    {
+      "name": "flag_co",
       "category": "Country flag",
       "size": "16"
     },
@@ -371,6 +391,11 @@
       "size": "16"
     },
     {
+      "name": "flag_hr",
+      "category": "Country flag",
+      "size": "16"
+    },
+    {
       "name": "flag_hu",
       "category": "Country flag",
       "size": "16"
@@ -416,12 +441,22 @@
       "size": "16"
     },
     {
+      "name": "flag_pe",
+      "category": "Country flag",
+      "size": "16"
+    },
+    {
       "name": "flag_pl",
       "category": "Country flag",
       "size": "16"
     },
     {
       "name": "flag_pt",
+      "category": "Country flag",
+      "size": "16"
+    },
+    {
+      "name": "flag_ro",
       "category": "Country flag",
       "size": "16"
     },
@@ -437,6 +472,11 @@
     },
     {
       "name": "flag_sk",
+      "category": "Country flag",
+      "size": "16"
+    },
+    {
+      "name": "flag_sl",
       "category": "Country flag",
       "size": "16"
     },


### PR DESCRIPTION
## Purpose

All icons that are in the file system should be reflected in the manifest. Otherwise, they don't show up in the docs and aren't exported as React components.

## Approach and changes

- Add missing flags to icons manifest: AR, AU, CA, CO, HR, PE, RO, and SL

_Before_

![Screenshot 2021-11-04 at 11 31 28](https://user-images.githubusercontent.com/11017722/140298833-13dc0ae3-529b-4907-b5e0-2db8ff4398f5.png)

_After_

![Screenshot 2021-11-04 at 11 32 10](https://user-images.githubusercontent.com/11017722/140298899-317259f1-06e7-4ab6-ae7d-eaa310df6334.png)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
