### PR TITLE
Add border-radius changes to v3 migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -421,10 +421,19 @@ Here's an overview of how the component heights have changed:
 
 We recommend verifying these changes visually at the end of the migration.
 
-In addition to its increased height, the `Button`'s default size was renamed from `mega` to `giga` to align it with the new size values (see the table above). (_🤖 \_button-default-size_)
+In addition to its increased height, the `Button`'s default size was renamed from `mega` to `giga` to align it with the new size values (see the table above). (🤖 _button-default-size_)
 
 ### Other changes
 
+- The design tokens **borderRadius** scale was changed. (🤖 _theme-border-radius_)
+  | value | v2 name | v3 name |
+  | --- | --- | --- |
+  | 1px | `kilo` | - (remove the radius or hardcode) |
+  | 4px | `mega` | `bit` |
+  | 6px | `giga` | - (migrate to `byte`) |
+  | 8px | `tera` | `byte` |
+  | 12px | `peta` | `kilo` |
+  | 16px | - | `mega` (new value) |
 - The **NotificationBanner** component has been renamed to **NotificationCard**. (🤖 _component-names-v3_)
 - Label prop names across components were harmonized to follow the _<description>Label_ pattern. (🤖 _label-prop-names_)
   - **CardHeader**: `labelCloseButton` 👉 `closeButtonLabel`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -428,12 +428,12 @@ In addition to its increased height, the `Button`'s default size was renamed fro
 - The design tokens **borderRadius** scale was changed. (🤖 _theme-border-radius_)
   | value | v2 name | v3 name |
   | --- | --- | --- |
-  | 1px | `kilo` | - (remove the radius or hardcode) |
+  | 1px | `kilo` | — (remove the radius or hardcode) |
   | 4px | `mega` | `bit` |
-  | 6px | `giga` | - (migrate to `byte`) |
+  | 6px | `giga` | — (migrate to `byte`) |
   | 8px | `tera` | `byte` |
   | 12px | `peta` | `kilo` |
-  | 16px | - | `mega` (new value) |
+  | 16px | — | `mega` (new value) |
 - The **NotificationBanner** component has been renamed to **NotificationCard**. (🤖 _component-names-v3_)
 - Label prop names across components were harmonized to follow the _<description>Label_ pattern. (🤖 _label-prop-names_)
   - **CardHeader**: `labelCloseButton` 👉 `closeButtonLabel`


### PR DESCRIPTION
## Purpose

We were missing information about the border-radius scale changes in the migration guide for v3 (implementation PR: #980)

## Approach and changes

Add an entry to the migration guide with the changes and a reference to the codemod:

<img width="927" alt="Screenshot 2021-11-09 at 11 08 09" src="https://user-images.githubusercontent.com/35560568/140904695-20c1e793-ee56-4a77-9871-1f55c73bed14.png">

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~

