### PR TITLE
Remove optional chaining from NotificationModal

### DIFF
--- a/.changeset/wicked-snails-explode.md
+++ b/.changeset/wicked-snails-explode.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed optional chaining from the NotificationModal for compatibility with Node 12.

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
@@ -179,8 +179,13 @@ export const NotificationModal: ModalComponent<NotificationModalProps> = ({
 
         function wrapOnClick(onClick?: ButtonProps['onClick']) {
           return (event: ClickEvent) => {
-            handleClose?.(event);
-            onClick?.(event);
+            // FIXME switch to an optional call when apps are on Node 14
+            if (handleClose) {
+              handleClose(event);
+            }
+            if (onClick) {
+              onClick(event);
+            }
           };
         }
 
@@ -206,11 +211,11 @@ export const NotificationModal: ModalComponent<NotificationModalProps> = ({
             {actions && (
               <ButtonGroup
                 actions={{
-                  primary: actions?.primary && {
+                  primary: {
                     ...actions.primary,
                     onClick: wrapOnClick(actions.primary.onClick),
                   },
-                  secondary: actions?.secondary && {
+                  secondary: actions.secondary && {
                     ...actions.secondary,
                     onClick: wrapOnClick(actions.secondary.onClick),
                   },


### PR DESCRIPTION
## Purpose

We used optional chaining and optional calls in the NotificationModal, but these ES features are not supported before Node 14 and they're causing issues in some build processes (e.g. Storybook on Node 12).

## Approach and changes

Replace the optional calls by if statements and remove the unnecessary optional chaining.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
