### PR TITLE
Import IconProps from @sumup/icons

### DIFF
--- a/.changeset/nine-items-reply.md
+++ b/.changeset/nine-items-reply.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the import of IconProps. This could have caused TypeScript build failures.

--- a/.changeset/nine-items-reply.md
+++ b/.changeset/nine-items-reply.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Fixed the import of IconProps. This could have caused TypeScript build failures.
+Fixed the import of `IconProps` in the `IconButton` component. This was causing TypeScript build failures.

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -16,11 +16,11 @@
 import { Children, cloneElement, ReactElement, forwardRef, Ref } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
 import { Theme } from '@sumup/design-tokens';
+import { IconProps } from '@sumup/icons';
 
 import { hideVisually } from '../../styles/style-mixins';
 import styled from '../../styles/styled';
 import { Button, ButtonProps } from '../Button/Button';
-import { IconProps } from '../../../icons/dist';
 
 export interface IconButtonProps extends Omit<ButtonProps, 'icon' | 'stretch'> {
   /**


### PR DESCRIPTION
## Purpose

Import IconProps from `@sumup/icons` instead of the `dist` folder directly. While this wasn't an issue locally, it broke TS builds in some applications (where `skipLibCheck` wasn't disabled).

## Approach and changes

☝️ 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
