### PR TITLE
Add new components for large typography

### DIFF
--- a/.changeset/breezy-mirrors-glow.md
+++ b/.changeset/breezy-mirrors-glow.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Introduced the `Title` and `BodyLarge` components for rendering copy with large typography, for example on landing pages.

--- a/.changeset/hip-pigs-grin.md
+++ b/.changeset/hip-pigs-grin.md
@@ -1,0 +1,5 @@
+---
+'@sumup/design-tokens': minor
+---
+
+Added new `typography.title` and `typography.bodyLarge` values to the theme.

--- a/.changeset/late-shirts-marry.md
+++ b/.changeset/late-shirts-marry.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Adapted the tracking of the `Headline` component for better readability.

--- a/.storybook/components/Link.js
+++ b/.storybook/components/Link.js
@@ -11,8 +11,8 @@ const Link = ({ children, href, ...props }) => {
   const storyName = decodeURIComponent(href);
 
   if (isStoryName(storyName)) {
-    const [group, component, name = 'page'] = splitStoryName(storyName);
-    const kind = `${group}|${component}`;
+    const [group, component, name = 'base'] = splitStoryName(storyName);
+    const kind = `${group}/${component}`;
     return (
       <LinkTo {...props} kind={kind} story={name}>
         {children}

--- a/.storybook/components/Preview.js
+++ b/.storybook/components/Preview.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Canvas } from '@storybook/addon-docs/blocks';
+import { Canvas } from '@storybook/addon-docs';
 import { ThemeProvider } from '@emotion/react';
 import { light } from '@sumup/design-tokens';
 

--- a/.storybook/components/Story.js
+++ b/.storybook/components/Story.js
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Story as StorybookStory } from '@storybook/addon-docs/blocks';
+import { Story as StorybookStory } from '@storybook/addon-docs';
 
 import Preview from './Preview';
 

--- a/.storybook/components/index.js
+++ b/.storybook/components/index.js
@@ -16,7 +16,7 @@
 import {
   ArgsTable as Props,
   PRIMARY_STORY,
-} from '@storybook/addon-docs/blocks';
+} from '@storybook/addon-docs';
 
 Props.defaultProps = { ...Props.defaultProps, story: PRIMARY_STORY };
 
@@ -27,7 +27,7 @@ export {
   IconGallery,
   IconItem,
   Typeset,
-} from '@storybook/addon-docs/blocks';
+} from '@storybook/addon-docs';
 
 export { default as Status } from './Statuses';
 export { default as Preview } from './Preview';

--- a/.storybook/util/story-helpers.js
+++ b/.storybook/util/story-helpers.js
@@ -1,4 +1,4 @@
-import { some, startsWith, get } from 'lodash/fp';
+import { get } from 'lodash/fp';
 
 function getPosition(item, order = []) {
   const array = Array.isArray(order) ? order : Object.keys(order);
@@ -53,5 +53,5 @@ export function splitStoryName(storyName) {
 const LINK_PREFIXES = ['/', 'http', 'mailto', '#', 'tel'];
 
 export function isStoryName(name) {
-  return !some((prefix) => startsWith(prefix, name), LINK_PREFIXES);
+  return !LINK_PREFIXES.some((prefix) => name.startsWith(prefix));
 }

--- a/.storybook/util/theme.js
+++ b/.storybook/util/theme.js
@@ -36,11 +36,11 @@ const withThemeProvider = (Component, baseProps = {}) => (props = {}) => (
 const TEXT_SIZE = 'one';
 
 const headlineStyles = (theme) => css`
-  margin-bottom: ${theme.spacings.mega};
+  margin-bottom: ${theme.spacings.giga};
 
   *:not(h1):not(h2):not(h3) + & {
     margin-top: ${theme.spacings.peta};
-    margin-bottom: ${theme.spacings.mega};
+    margin-bottom: ${theme.spacings.giga};
   }
 `;
 
@@ -53,43 +53,62 @@ export const components = {
     as: 'h1',
     size: 'one',
     css: headlineStyles,
+    noMargin: true,
   }),
   h2: withThemeProvider(Headline, {
     as: 'h2',
     size: 'two',
     css: headlineStyles,
+    noMargin: true,
   }),
   h3: withThemeProvider(Headline, {
     as: 'h3',
     size: 'three',
     css: headlineStyles,
+    noMargin: true,
   }),
   h4: withThemeProvider(Headline, {
     as: 'h4',
     size: 'four',
     css: spacing({ top: 'giga' }),
+    noMargin: true,
   }),
   h5: withThemeProvider(SubHeadline, {
     as: 'h5',
     css: spacing({ top: 'giga' }),
+    noMargin: true,
   }),
   p: withThemeProvider(Body, {
     as: 'p',
     size: TEXT_SIZE,
-    css: spacing({ bottom: 'kilo' }),
+    css: spacing({ bottom: 'giga' }),
+    noMargin: true,
   }),
-  li: withThemeProvider(Body, { as: 'li', size: TEXT_SIZE }),
+  li: withThemeProvider(Body, {
+    as: 'li',
+    size: TEXT_SIZE,
+    noMargin: true,
+  }),
   strong: withThemeProvider(Body, {
     as: 'strong',
     size: TEXT_SIZE,
     variant: 'highlight',
+    noMargin: true,
   }),
   em: withThemeProvider(Body, {
     as: 'em',
     size: TEXT_SIZE,
     css: italicStyles,
+    noMargin: true,
   }),
-  ul: withThemeProvider(List),
-  ol: withThemeProvider(List, { variant: 'ordered' }),
+  ul: withThemeProvider(List, {
+    css: spacing({ bottom: 'giga' }),
+    noMargin: true,
+  }),
+  ol: withThemeProvider(List, {
+    variant: 'ordered',
+    css: spacing({ bottom: 'giga' }),
+    noMargin: true,
+  }),
   a: withThemeProvider(Link, { size: TEXT_SIZE }),
 };

--- a/packages/circuit-ui/components/Body/Body.docs.mdx
+++ b/packages/circuit-ui/components/Body/Body.docs.mdx
@@ -4,23 +4,30 @@ import { Status, Props, Story } from '../../../../.storybook/components';
 
 <Status.Stable />
 
-Body is used to present the core textual content for our users. They are contained within headlines and subheadlines
-and have five different variants `highlight`, `quote`, `success`, `error` and `subtle` to tailor it according to the content we are
-presenting.
+The Body component is used to present content to our users.
 
 <Story id="typography-body--base" />
 <Props />
 
 ## Usage guidelines
 
-- **Do** use the `one` size as the default for body text
-- **Do** use spacing to better organize textual information, such as different paragraphs
-- **Do** use different variants of the body component
+- **Do** use the [Headline](Typography/Headline) and [SubHeadline](Typography/SubHeadline) components as well as semantic HTML elements to split the content into sections.
+- **Do** use spacing to better format textual information, such as spacing between different paragraphs. The [`spacing()`](Features/Style-Mixins/spacing) style mixin is recommended.
+- **Do** use different variants of the BodyLarge component instead of styling it manually.
+- **Do** use the `as` prop to render the desired HTML element. The BodyLarge renders a `<p>` by default, except with the `highlight` or `quote` variants (see below).
+
+## Component variations
 
 ### Sizes
+
+The Body component comes in two sizes. Use the default `one` size in most cases. Consider using the [BodyLarge component](Typography/BodyLarge) for large typography in specific cases.
 
 <Story id="typography-body--sizes" />
 
 ### Variants
+
+The Body component accepts five different variants—`highlight`, `quote`, `success`, `error` and `subtle`—to tailor it according to the content we are presenting.
+
+The `highlight` variant will render a `<strong>` element by default, while the `quote` variant will render a `blockquote`.
 
 <Story id="typography-body--variants" />

--- a/packages/circuit-ui/components/Body/Body.spec.tsx
+++ b/packages/circuit-ui/components/Body/Body.spec.tsx
@@ -26,24 +26,49 @@ describe('Body', () => {
     expect(actual).toMatchSnapshot();
   });
 
-  const elements = ['p', 'article', 'div'];
-  it.each(elements)('should render as %s element', (as) => {
-    const { container } = render(
-      <Body as={as}>{`${as.toUpperCase()} text`}</Body>,
-    );
-    const actual = container.querySelector(as);
-    expect(actual).toBeVisible();
+  const sizes: BodyProps['size'][] = ['one', 'two'];
+  it.each(sizes)('should render with size "%s"', (size) => {
+    const actual = create(<Body size={size}>{size} Body</Body>);
+    expect(actual).toMatchSnapshot();
   });
 
-  const sizes: BodyProps['size'][] = ['one', 'two'];
-  it.each(sizes)('should render with size %s', (size) => {
-    const actual = create(<Body size={size}>{`${size as string} text`}</Body>);
+  const variants = [
+    'highlight',
+    'quote',
+    'success',
+    'error',
+    'subtle',
+  ] as BodyProps['variant'][];
+  it.each(variants)('should render as a "%s" variant', (variant) => {
+    const actual = create(<Body variant={variant}>{variant} Body</Body>);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with no margin styles when passed the noMargin prop', () => {
-    const actual = create(<Body noMargin />);
+    const actual = create(<Body noMargin>noMargin Body</Body>);
     expect(actual).toMatchSnapshot();
+  });
+
+  /**
+   * Logic tests.
+   */
+  const elements = ['p', 'article', 'div'] as const;
+  it.each(elements)('should render as a "%s" element', (as) => {
+    const { container } = render(<Body as={as}>{as} Body</Body>);
+    const actual = container.querySelector(as);
+    expect(actual).toBeVisible();
+  });
+
+  it('should render the "highlight" variant as a "strong" element', () => {
+    const { container } = render(<Body variant="highlight">Highlight</Body>);
+    const actual = container.querySelector('strong');
+    expect(actual).toBeVisible();
+  });
+
+  it('should render the "quote" variant as a "blockquote" element', () => {
+    const { container } = render(<Body variant="quote">Quote</Body>);
+    const actual = container.querySelector('blockquote');
+    expect(actual).toBeVisible();
   });
 
   /**

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -53,16 +53,10 @@ const baseStyles = ({ theme }: StyleProps) => css`
   margin-bottom: ${theme.spacings.mega};
 `;
 
-const sizeStyles = ({ theme, size = 'one' }: BodyProps & StyleProps) => {
-  if (!size) {
-    return null;
-  }
-
-  return css`
-    font-size: ${theme.typography.body[size].fontSize};
-    line-height: ${theme.typography.body[size].lineHeight};
-  `;
-};
+const sizeStyles = ({ theme, size = 'one' }: BodyProps & StyleProps) => css`
+  font-size: ${theme.typography.body[size].fontSize};
+  line-height: ${theme.typography.body[size].lineHeight};
+`;
 
 const variantStyles = ({ theme, variant }: BodyProps & StyleProps) => {
   switch (variant) {

--- a/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
+++ b/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
@@ -1,5 +1,92 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Body should render as a "error" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  color: #D23F47;
+}
+
+<p
+  class="circuit-0"
+>
+  error
+   Body
+</p>
+`;
+
+exports[`Body should render as a "highlight" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 700;
+}
+
+<strong
+  class="circuit-0"
+>
+  highlight
+   Body
+</strong>
+`;
+
+exports[`Body should render as a "quote" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  font-style: italic;
+  padding-left: 12px;
+  border-left: 2px solid #3063E9;
+}
+
+<blockquote
+  class="circuit-0"
+>
+  quote
+   Body
+</blockquote>
+`;
+
+exports[`Body should render as a "subtle" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  color: #666;
+}
+
+<p
+  class="circuit-0"
+>
+  subtle
+   Body
+</p>
+`;
+
+exports[`Body should render as a "success" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  color: #138849;
+}
+
+<p
+  class="circuit-0"
+>
+  success
+   Body
+</p>
+`;
+
 exports[`Body should render with default styles 1`] = `
 .circuit-0 {
   font-weight: 400;
@@ -26,10 +113,12 @@ exports[`Body should render with no margin styles when passed the noMargin prop 
 
 <p
   class="circuit-0"
-/>
+>
+  noMargin Body
+</p>
 `;
 
-exports[`Body should render with size one 1`] = `
+exports[`Body should render with size "one" 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
@@ -40,11 +129,12 @@ exports[`Body should render with size one 1`] = `
 <p
   class="circuit-0"
 >
-  one text
+  one
+   Body
 </p>
 `;
 
-exports[`Body should render with size two 1`] = `
+exports[`Body should render with size "two" 1`] = `
 .circuit-0 {
   font-weight: 400;
   margin-bottom: 16px;
@@ -55,6 +145,7 @@ exports[`Body should render with size two 1`] = `
 <p
   class="circuit-0"
 >
-  two text
+  two
+   Body
 </p>
 `;

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.docs.mdx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.docs.mdx
@@ -1,0 +1,27 @@
+import { Status, Props, Story } from '../../../../.storybook/components';
+
+# BodyLarge
+
+<Status.Stable />
+
+The BodyLarge component is used to render content with large typography. Typically, large typography is intended for landing pages. In most cases, the [Body](Typography/Body) should be used instead.
+
+<Story id="typography-bodylarge--base" />
+<Props />
+
+## Usage guidelines
+
+- **Do** use the [Title](Typography/Title), [Headline](Typography/Headline), and [SubHeadline](Typography/SubHeadline) components as well as semantic HTML elements to split the content into sections.
+- **Do** use spacing to better format textual information, such as spacing between different paragraphs. The [`spacing()`](Features/Style-Mixins/spacing) style mixin is recommended.
+- **Do** use different variants of the BodyLarge component instead of styling it manually.
+- **Do** use the `as` prop to render the desired HTML element. The BodyLarge renders a `<p>` by default, except with the `highlight` or `quote` variants (see below).
+
+## Component variations
+
+### Variants
+
+The BodyLarge accepts five different variants—`highlight`, `quote`, `success`, `error` and `subtle`—to tailor it according to the content we are presenting.
+
+The `highlight` variant will render a `<strong>` element by default, while the `quote` variant will render a `blockquote`.
+
+<Story id="typography-bodylarge--variants" />

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.spec.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.spec.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { create, renderToHtml, axe, render } from '../../util/test-utils';
+
+import { BodyLarge, BodyLargeProps } from './BodyLarge';
+
+describe('BodyLarge', () => {
+  /**
+   * Style tests.
+   */
+  it('should render with default styles', () => {
+    const actual = create(<BodyLarge>BodyLarge</BodyLarge>);
+    expect(actual).toMatchSnapshot();
+  });
+
+  const variants = [
+    'highlight',
+    'quote',
+    'success',
+    'error',
+    'subtle',
+  ] as BodyLargeProps['variant'][];
+  it.each(variants)('should render as a "%s" variant', (variant) => {
+    const actual = create(
+      <BodyLarge variant={variant}>{variant} BodyLarge</BodyLarge>,
+    );
+    expect(actual).toMatchSnapshot();
+  });
+
+  /**
+   * Logic tests.
+   */
+  const elements = ['p', 'article', 'div'] as const;
+  it.each(elements)('should render as a "%s" element', (as) => {
+    const { container } = render(<BodyLarge as={as}>{as} BodyLarge</BodyLarge>);
+    const actual = container.querySelector(as);
+    expect(actual).toBeVisible();
+  });
+
+  it('should render the "highlight" variant as a "strong" element', () => {
+    const { container } = render(
+      <BodyLarge variant="highlight">Highlight</BodyLarge>,
+    );
+    const actual = container.querySelector('strong');
+    expect(actual).toBeVisible();
+  });
+
+  it('should render the "quote" variant as a "blockquote" element', () => {
+    const { container } = render(<BodyLarge variant="quote">Quote</BodyLarge>);
+    const actual = container.querySelector('blockquote');
+    expect(actual).toBeVisible();
+  });
+
+  /**
+   * Accessibility tests.
+   */
+  it('should meet accessibility guidelines', async () => {
+    const wrapper = renderToHtml(<BodyLarge>BodyLarge</BodyLarge>);
+    const actual = await axe(wrapper);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.stories.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.stories.tsx
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import docs from './BodyLarge.docs.mdx';
+import { BodyLargeProps } from './BodyLarge';
+
+import BodyLarge from '.';
+
+const content =
+  'An electronic circuit is composed of individual electronic components, such as resistors, transistors, capacitors, inductors and diodes, connected by conductive wires or traces through which electric current can flow.';
+
+export default {
+  title: 'Typography/BodyLarge',
+  component: BodyLarge,
+  parameters: {
+    docs: { page: docs },
+  },
+  argTypes: {
+    as: { control: 'text' },
+  },
+};
+
+export const Base = (args: BodyLargeProps) => (
+  <BodyLarge {...args}>{content}</BodyLarge>
+);
+
+const variants = ['highlight', 'quote', 'success', 'error', 'subtle'] as const;
+
+export const Variants = (args: BodyLargeProps) =>
+  variants.map((variant) => (
+    <BodyLarge key={variant} {...args} variant={variant}>
+      This is a {variant} BodyLarge
+    </BodyLarge>
+  ));

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.tsx
@@ -80,7 +80,7 @@ const variantStyles = ({ theme, variant }: BodyLargeProps & StyleProps) => {
 };
 
 const StyledBodyLarge = styled('p', {
-  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
+  shouldForwardProp: (prop) => isPropValid(prop),
 })<BodyLargeProps>(baseStyles, variantStyles);
 
 function getHTMLElement(variant?: Variant): AsPropType {

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.tsx
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { forwardRef, HTMLAttributes, Ref } from 'react';
+import { css } from '@emotion/react';
+import isPropValid from '@emotion/is-prop-valid';
+
+import styled, { StyleProps } from '../../styles/styled';
+import { AsPropType } from '../../types/prop-types';
+
+type Variant = 'highlight' | 'quote' | 'success' | 'error' | 'subtle';
+
+export interface BodyLargeProps extends HTMLAttributes<HTMLParagraphElement> {
+  /**
+   * Choose from style variants.
+   */
+  variant?: Variant;
+  /**
+   * Render the text using any HTML element.
+   */
+  as?: AsPropType;
+  /**
+   * The ref to the HTML DOM element.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ref?: Ref<any>;
+}
+
+const baseStyles = ({ theme }: StyleProps) => css`
+  font-weight: ${theme.fontWeight.regular};
+  font-size: ${theme.typography.bodyLarge.fontSize};
+  line-height: ${theme.typography.bodyLarge.lineHeight};
+`;
+
+const variantStyles = ({ theme, variant }: BodyLargeProps & StyleProps) => {
+  switch (variant) {
+    default: {
+      return null;
+    }
+    case 'highlight': {
+      return css`
+        font-weight: ${theme.fontWeight.bold};
+      `;
+    }
+    case 'quote': {
+      return css`
+        font-style: italic;
+        padding-left: ${theme.spacings.kilo};
+        border-left: ${theme.borderWidth.mega} solid ${theme.colors.p500};
+      `;
+    }
+    case 'success': {
+      return css`
+        color: ${theme.colors.success};
+      `;
+    }
+    case 'error': {
+      return css`
+        color: ${theme.colors.danger};
+      `;
+    }
+    case 'subtle': {
+      return css`
+        color: ${theme.colors.n700};
+      `;
+    }
+  }
+};
+
+const StyledBodyLarge = styled('p', {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
+})<BodyLargeProps>(baseStyles, variantStyles);
+
+function getHTMLElement(variant?: Variant): AsPropType {
+  if (variant === 'highlight') {
+    return 'strong';
+  }
+  if (variant === 'quote') {
+    return 'blockquote';
+  }
+  return 'p';
+}
+
+/**
+ * The BodyLarge component is used to present the core textual content
+ * to our users.
+ */
+export const BodyLarge = forwardRef(
+  (props: BodyLargeProps, ref?: BodyLargeProps['ref']) => {
+    const as = props.as || getHTMLElement(props.variant);
+    return <StyledBodyLarge {...props} ref={ref} as={as} />;
+  },
+);
+
+BodyLarge.displayName = 'BodyLarge';

--- a/packages/circuit-ui/components/BodyLarge/__snapshots__/BodyLarge.spec.tsx.snap
+++ b/packages/circuit-ui/components/BodyLarge/__snapshots__/BodyLarge.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`BodyLarge should render as a "error" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
   font-size: 20px;
-  line-height: 20px;
+  line-height: 28px;
   color: #D23F47;
 }
 
@@ -20,7 +20,7 @@ exports[`BodyLarge should render as a "highlight" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
   font-size: 20px;
-  line-height: 20px;
+  line-height: 28px;
   font-weight: 700;
 }
 
@@ -36,7 +36,7 @@ exports[`BodyLarge should render as a "quote" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
   font-size: 20px;
-  line-height: 20px;
+  line-height: 28px;
   font-style: italic;
   padding-left: 12px;
   border-left: 2px solid #3063E9;
@@ -54,7 +54,7 @@ exports[`BodyLarge should render as a "subtle" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
   font-size: 20px;
-  line-height: 20px;
+  line-height: 28px;
   color: #666;
 }
 
@@ -70,7 +70,7 @@ exports[`BodyLarge should render as a "success" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
   font-size: 20px;
-  line-height: 20px;
+  line-height: 28px;
   color: #138849;
 }
 
@@ -86,7 +86,7 @@ exports[`BodyLarge should render with default styles 1`] = `
 .circuit-0 {
   font-weight: 400;
   font-size: 20px;
-  line-height: 20px;
+  line-height: 28px;
 }
 
 <p

--- a/packages/circuit-ui/components/BodyLarge/__snapshots__/BodyLarge.spec.tsx.snap
+++ b/packages/circuit-ui/components/BodyLarge/__snapshots__/BodyLarge.spec.tsx.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BodyLarge should render as a "error" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 20px;
+  color: #D23F47;
+}
+
+<p
+  class="circuit-0"
+>
+  error
+   BodyLarge
+</p>
+`;
+
+exports[`BodyLarge should render as a "highlight" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 20px;
+  font-weight: 700;
+}
+
+<strong
+  class="circuit-0"
+>
+  highlight
+   BodyLarge
+</strong>
+`;
+
+exports[`BodyLarge should render as a "quote" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 20px;
+  font-style: italic;
+  padding-left: 12px;
+  border-left: 2px solid #3063E9;
+}
+
+<blockquote
+  class="circuit-0"
+>
+  quote
+   BodyLarge
+</blockquote>
+`;
+
+exports[`BodyLarge should render as a "subtle" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 20px;
+  color: #666;
+}
+
+<p
+  class="circuit-0"
+>
+  subtle
+   BodyLarge
+</p>
+`;
+
+exports[`BodyLarge should render as a "success" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 20px;
+  color: #138849;
+}
+
+<p
+  class="circuit-0"
+>
+  success
+   BodyLarge
+</p>
+`;
+
+exports[`BodyLarge should render with default styles 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 20px;
+}
+
+<p
+  class="circuit-0"
+>
+  BodyLarge
+</p>
+`;

--- a/packages/circuit-ui/components/BodyLarge/index.ts
+++ b/packages/circuit-ui/components/BodyLarge/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BodyLarge } from './BodyLarge';
+
+export type { BodyLargeProps } from './BodyLarge';
+
+export default BodyLarge;

--- a/packages/circuit-ui/components/Headline/Headline.docs.mdx
+++ b/packages/circuit-ui/components/Headline/Headline.docs.mdx
@@ -9,12 +9,7 @@ Headlines are used for titling major sections of the interface. They help better
 <Story id="typography-headline--base" />
 <Props />
 
-## Usage guidelines
-
-- **Do** position the heading above the content
-- **Do** use the `four` size for titling cards and `three` for pages
-
-## Content guidelines
+## Accessibility
 
 Nest headings by their rank (or level). The most important heading has rank 1 (`h1`), the least important heading rank 6 (`h6`). Headings with an equal or higher rank start a new section, headings with a lower rank start new subsections that are part of the higher-ranked section.
 
@@ -25,5 +20,9 @@ Skipping heading ranks can be confusing and should be avoided where possible: En
 ## Component variations
 
 ### Sizes
+
+The Headline component comes in four sizes.
+
+Use the `four` size for card headers and `three` for page titles in web applications. For specific use cases such as landing pages, consider using the [Title](Typography/Title) component.
 
 <Story id="typography-headline--sizes" />

--- a/packages/circuit-ui/components/Headline/Headline.spec.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.spec.tsx
@@ -21,7 +21,7 @@ describe('Headline', () => {
   /**
    * Style tests.
    */
-  const elements = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+  const elements = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
   it.each(elements)('should render as %s element', (element) => {
     const headline = create(
       <Headline as={element}>{`${element} headline`}</Headline>,
@@ -38,7 +38,11 @@ describe('Headline', () => {
   });
 
   it('should render with no margin styles when passed the noMargin prop', () => {
-    const actual = create(<Headline noMargin />);
+    const actual = create(
+      <Headline as="h2" noMargin>
+        Headline
+      </Headline>,
+    );
     expect(actual).toMatchSnapshot();
   });
 

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -32,7 +32,7 @@ export interface HeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
    */
   noMargin?: boolean;
   /**
-   * The HTML heading element to render. Defaults to `h2`.
+   * The HTML heading element to render.
    * Headings should be nested sequentially without skipping any levels.
    * Learn more at https://www.w3.org/WAI/tutorials/page-structure/headings/.
    */

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -46,16 +46,11 @@ const baseStyles = ({ theme }: StyleProps) => css`
   letter-spacing: -0.03em;
 `;
 
-const sizeStyles = ({ theme, size = 'one' }: StyleProps & HeadlineProps) => {
-  if (!size) {
-    return null;
-  }
+const sizeStyles = ({ theme, size = 'one' }: StyleProps & HeadlineProps) => css`
+  font-size: ${theme.typography.headline[size].fontSize};
+  line-height: ${theme.typography.headline[size].lineHeight};
+`;
 
-  return css`
-    font-size: ${theme.typography.headline[size].fontSize};
-    line-height: ${theme.typography.headline[size].lineHeight};
-  `;
-};
 const noMarginStyles = ({ noMargin }: HeadlineProps) => {
   if (!noMargin) {
     if (

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -24,7 +24,7 @@ type Size = 'one' | 'two' | 'three' | 'four';
 
 export interface HeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
   /**
-   * A Circuit UI headline size. Default `one`.
+   * A Circuit UI headline size. Defaults to `one`.
    */
   size?: Size;
   /**
@@ -32,9 +32,9 @@ export interface HeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
    */
   noMargin?: boolean;
   /**
-   * The HTML heading element to render. Headings should be nested sequentially
-   * without skipping any levels. Learn more at
-   * https://www.w3.org/WAI/tutorials/page-structure/headings/.
+   * The HTML heading element to render. Defaults to `h2`.
+   * Headings should be nested sequentially without skipping any levels.
+   * Learn more at https://www.w3.org/WAI/tutorials/page-structure/headings/.
    */
   as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
@@ -79,7 +79,7 @@ const noMarginStyles = ({ noMargin }: HeadlineProps) => {
 };
 
 /**
- * A flexible headline component capable of rendering using any HTML headline tag.
+ * A flexible headline component capable of rendering any HTML heading element.
  */
 export const Headline: FC<HeadlineProps> = styled('h2', {
   shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -43,6 +43,7 @@ const baseStyles = ({ theme }: StyleProps) => css`
   font-weight: ${theme.fontWeight.bold};
   margin-bottom: ${theme.spacings.giga};
   color: ${theme.colors.black};
+  letter-spacing: -0.03em;
 `;
 
 const sizeStyles = ({ theme, size = 'one' }: StyleProps & HeadlineProps) => {

--- a/packages/circuit-ui/components/Headline/__snapshots__/Headline.spec.tsx.snap
+++ b/packages/circuit-ui/components/Headline/__snapshots__/Headline.spec.tsx.snap
@@ -108,7 +108,9 @@ exports[`Headline should render with no margin styles when passed the noMargin p
 
 <h2
   class="circuit-0"
-/>
+>
+  Headline
+</h2>
 `;
 
 exports[`Headline should render with size four 1`] = `

--- a/packages/circuit-ui/components/Headline/__snapshots__/Headline.spec.tsx.snap
+++ b/packages/circuit-ui/components/Headline/__snapshots__/Headline.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`Headline should render as h1 element 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
 }
@@ -21,6 +22,7 @@ exports[`Headline should render as h2 element 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
 }
@@ -37,6 +39,7 @@ exports[`Headline should render as h3 element 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
 }
@@ -53,6 +56,7 @@ exports[`Headline should render as h4 element 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
 }
@@ -69,6 +73,7 @@ exports[`Headline should render as h5 element 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
 }
@@ -85,6 +90,7 @@ exports[`Headline should render as h6 element 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
 }
@@ -101,6 +107,7 @@ exports[`Headline should render with no margin styles when passed the noMargin p
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
   margin-bottom: 0;
@@ -118,6 +125,7 @@ exports[`Headline should render with size four 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
 }
@@ -134,6 +142,7 @@ exports[`Headline should render with size one 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
 }
@@ -150,6 +159,7 @@ exports[`Headline should render with size three 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 20px;
   line-height: 24px;
 }
@@ -166,6 +176,7 @@ exports[`Headline should render with size two 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 24px;
   line-height: 28px;
 }

--- a/packages/circuit-ui/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
@@ -54,6 +54,7 @@ exports[`NotificationBanner styles should render a promotional banner 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
   margin-bottom: 0;
@@ -318,6 +319,7 @@ exports[`NotificationBanner styles should render with default styles 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
   margin-bottom: 0;

--- a/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
@@ -46,6 +46,7 @@ exports[`NotificationFullscreen styles should render with default styles 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 24px;
   line-height: 28px;
   margin-top: 24px;
@@ -466,6 +467,7 @@ exports[`NotificationFullscreen styles should render with default styles with h1
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 24px;
   line-height: 28px;
   margin-top: 24px;

--- a/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
@@ -204,6 +204,7 @@ exports[`NotificationModal styles should render with default styles 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 20px;
   line-height: 24px;
   margin-bottom: 0;

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
@@ -211,6 +211,7 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   font-weight: 700;
   margin-bottom: 24px;
   color: #000;
+  letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
   margin-bottom: 0;

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -68,5 +68,5 @@ const noMarginStyles = ({ noMargin }: SubHeadlineProps) => {
  * element, except h1.
  */
 export const SubHeadline: FC<SubHeadlineProps> = styled('h3', {
-  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
+  shouldForwardProp: (prop) => isPropValid(prop),
 })<SubHeadlineProps>(baseStyles, noMarginStyles);

--- a/packages/circuit-ui/components/Title/Title.docs.mdx
+++ b/packages/circuit-ui/components/Title/Title.docs.mdx
@@ -4,17 +4,12 @@ import { Status, Props, Story } from '../../../../.storybook/components';
 
 <Status.Stable />
 
-The Title component is used to render headings with very large typography. Typically, large typography is intended for landing pages. In most cases, a [Headline](Typography/Headline) should be used instead.
+The Title component is used to render headings with large typography. Typically, large typography is intended for landing pages. In most cases, the [Headline](Typography/Headline) should be used instead.
 
 <Story id="typography-title--base" />
 <Props />
 
-## Usage guidelines
-
-- **Do** use the [Headline](Typography/Headline) component for headings in most cases.
-- **Do** nest headings sequentially according to the Content guidelines below.
-
-## Content guidelines
+## Accessibility
 
 Nest headings by their rank (or level). The most important heading has rank 1 (`h1`), the least important heading rank 6 (`h6`). Headings with an equal or higher rank start a new section, headings with a lower rank start new subsections that are part of the higher-ranked section.
 
@@ -25,5 +20,7 @@ Skipping heading ranks can be confusing and should be avoided where possible: En
 ## Component variations
 
 ### Sizes
+
+The Title component comes in four sizes. In most cases, use the [Headline component](Typography/Headline) component instead to render headings.
 
 <Story id="typography-title--sizes" />

--- a/packages/circuit-ui/components/Title/Title.docs.mdx
+++ b/packages/circuit-ui/components/Title/Title.docs.mdx
@@ -1,0 +1,29 @@
+import { Status, Props, Story } from '../../../../.storybook/components';
+
+# Title
+
+<Status.Stable />
+
+Titles are used for titling major sections of the interface. They help better organize the information for our users providing useful labels for each possible section.
+
+<Story id="typography-Title--base" />
+<Props />
+
+## Usage guidelines
+
+- **Do** position the heading above the content
+- **Do** use the `four` size for titling cards and `three` for pages
+
+## Content guidelines
+
+Nest headings by their rank (or level). The most important heading has rank 1 (`h1`), the least important heading rank 6 (`h6`). Headings with an equal or higher rank start a new section, headings with a lower rank start new subsections that are part of the higher-ranked section.
+
+Skipping heading ranks can be confusing and should be avoided where possible: Ensure that an `h2` is not followed directly by an `h4`, for example. It is ok to skip ranks when closing subsections, for instance, an `h2` beginning a new section can follow an `h4` as it closes the previous section.
+
+[Learn more about a proper page structure](https://www.w3.org/WAI/tutorials/page-structure/headings/).
+
+## Component variations
+
+### Sizes
+
+<Story id="typography-Title--sizes" />

--- a/packages/circuit-ui/components/Title/Title.docs.mdx
+++ b/packages/circuit-ui/components/Title/Title.docs.mdx
@@ -4,15 +4,15 @@ import { Status, Props, Story } from '../../../../.storybook/components';
 
 <Status.Stable />
 
-Titles are used for titling major sections of the interface. They help better organize the information for our users providing useful labels for each possible section.
+The Title component is used to render headings with very large typography. Typically, large typography is intended for landing pages. In most cases, a [Headline](Typography/Headline) should be used instead.
 
-<Story id="typography-Title--base" />
+<Story id="typography-title--base" />
 <Props />
 
 ## Usage guidelines
 
-- **Do** position the heading above the content
-- **Do** use the `four` size for titling cards and `three` for pages
+- **Do** use the [Headline](Typography/Headline) component for headings in most cases.
+- **Do** nest headings sequentially according to the Content guidelines below.
 
 ## Content guidelines
 
@@ -26,4 +26,4 @@ Skipping heading ranks can be confusing and should be avoided where possible: En
 
 ### Sizes
 
-<Story id="typography-Title--sizes" />
+<Story id="typography-title--sizes" />

--- a/packages/circuit-ui/components/Title/Title.spec.tsx
+++ b/packages/circuit-ui/components/Title/Title.spec.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { create, renderToHtml, axe } from '../../util/test-utils';
+
+import { Title } from './Title';
+
+describe('Title', () => {
+  /**
+   * Style tests.
+   */
+  const elements = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
+  it.each(elements)('should render as %s element', (element) => {
+    const title = create(<Title as={element}>{`${element} Title`}</Title>);
+    expect(title).toMatchSnapshot();
+  });
+
+  const sizes = ['one', 'two', 'three', 'four'] as const;
+  it.each(sizes)('should render with size %s', (size) => {
+    const title = create(
+      <Title as="h2" {...{ size }}>{`${size} Title`}</Title>,
+    );
+    expect(title).toMatchSnapshot();
+  });
+
+  it('should render with no margin styles when passed the noMargin prop', () => {
+    const actual = create(<Title as="h1" noMargin />);
+    expect(actual).toMatchSnapshot();
+  });
+
+  /**
+   * Accessibility tests.
+   */
+  it('should meet accessibility guidelines', async () => {
+    const wrapper = renderToHtml(<Title as="h2">Title</Title>);
+    const actual = await axe(wrapper);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/packages/circuit-ui/components/Title/Title.spec.tsx
+++ b/packages/circuit-ui/components/Title/Title.spec.tsx
@@ -35,11 +35,6 @@ describe('Title', () => {
     expect(title).toMatchSnapshot();
   });
 
-  it('should render with no margin styles when passed the noMargin prop', () => {
-    const actual = create(<Title as="h1" noMargin />);
-    expect(actual).toMatchSnapshot();
-  });
-
   /**
    * Accessibility tests.
    */

--- a/packages/circuit-ui/components/Title/Title.stories.tsx
+++ b/packages/circuit-ui/components/Title/Title.stories.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Title, TitleProps } from './Title';
+import docs from './Title.docs.mdx';
+
+export default {
+  title: 'Typography/Title',
+  component: Title,
+  parameters: {
+    docs: { page: docs },
+  },
+};
+
+export const Base = (args: TitleProps) => (
+  <Title {...args} noMargin>
+    This is a Title
+  </Title>
+);
+
+const sizes = ['one', 'two', 'three', 'four'] as const;
+
+export const Sizes = (args: TitleProps) =>
+  sizes.map((s) => (
+    <Title key={s} {...args} size={s} noMargin>
+      This is a Title {s}
+    </Title>
+  ));

--- a/packages/circuit-ui/components/Title/Title.stories.tsx
+++ b/packages/circuit-ui/components/Title/Title.stories.tsx
@@ -25,16 +25,14 @@ export default {
 };
 
 export const Base = (args: TitleProps) => (
-  <Title {...args} noMargin>
-    This is a Title
-  </Title>
+  <Title {...args}>This is a Title</Title>
 );
 
 const sizes = ['one', 'two', 'three', 'four'] as const;
 
 export const Sizes = (args: TitleProps) =>
   sizes.map((s) => (
-    <Title key={s} {...args} size={s} noMargin>
+    <Title key={s} {...args} size={s}>
       This is a Title {s}
     </Title>
   ));

--- a/packages/circuit-ui/components/Title/Title.tsx
+++ b/packages/circuit-ui/components/Title/Title.tsx
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FC, HTMLAttributes } from 'react';
+import { css } from '@emotion/react';
+import isPropValid from '@emotion/is-prop-valid';
+
+import styled, { StyleProps } from '../../styles/styled';
+
+type Size = 'one' | 'two' | 'three' | 'four';
+
+export interface TitleProps extends HTMLAttributes<HTMLHeadingElement> {
+  /**
+   * A Circuit UI title size. Defaults to `one`.
+   */
+  size?: Size;
+  /**
+   * The HTML heading element to render. Defaults to `h2`.
+   * Headings should be nested sequentially without skipping any levels.
+   * Learn more at https://www.w3.org/WAI/tutorials/page-structure/headings/.
+   */
+  as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+const baseStyles = ({ theme }: StyleProps) => css`
+  font-weight: ${theme.fontWeight.bold};
+  color: ${theme.colors.black};
+  letter-spacing: -0.03em;
+`;
+
+const sizeStyles = ({ theme, size = 'one' }: StyleProps & TitleProps) => {
+  if (!size) {
+    return null;
+  }
+
+  return css`
+    font-size: ${theme.typography.title[size].fontSize};
+    line-height: ${theme.typography.title[size].lineHeight};
+  `;
+};
+
+/**
+ * A flexible title component capable of rendering any HTML heading element.
+ */
+export const Title: FC<TitleProps> = styled('h2', {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
+})<TitleProps>(baseStyles, sizeStyles);

--- a/packages/circuit-ui/components/Title/Title.tsx
+++ b/packages/circuit-ui/components/Title/Title.tsx
@@ -27,7 +27,7 @@ export interface TitleProps extends HTMLAttributes<HTMLHeadingElement> {
    */
   size?: Size;
   /**
-   * The HTML heading element to render. Defaults to `h2`.
+   * The HTML heading element to render.
    * Headings should be nested sequentially without skipping any levels.
    * Learn more at https://www.w3.org/WAI/tutorials/page-structure/headings/.
    */

--- a/packages/circuit-ui/components/Title/__snapshots__/Title.spec.tsx.snap
+++ b/packages/circuit-ui/components/Title/__snapshots__/Title.spec.tsx.snap
@@ -1,0 +1,161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Title should render as h1 element 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  color: #000;
+  letter-spacing: -0.03em;
+  font-size: 120px;
+  line-height: 120px;
+}
+
+<h1
+  class="circuit-0"
+>
+  h1 Title
+</h1>
+`;
+
+exports[`Title should render as h2 element 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  color: #000;
+  letter-spacing: -0.03em;
+  font-size: 120px;
+  line-height: 120px;
+}
+
+<h2
+  class="circuit-0"
+>
+  h2 Title
+</h2>
+`;
+
+exports[`Title should render as h3 element 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  color: #000;
+  letter-spacing: -0.03em;
+  font-size: 120px;
+  line-height: 120px;
+}
+
+<h3
+  class="circuit-0"
+>
+  h3 Title
+</h3>
+`;
+
+exports[`Title should render as h4 element 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  color: #000;
+  letter-spacing: -0.03em;
+  font-size: 120px;
+  line-height: 120px;
+}
+
+<h4
+  class="circuit-0"
+>
+  h4 Title
+</h4>
+`;
+
+exports[`Title should render as h5 element 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  color: #000;
+  letter-spacing: -0.03em;
+  font-size: 120px;
+  line-height: 120px;
+}
+
+<h5
+  class="circuit-0"
+>
+  h5 Title
+</h5>
+`;
+
+exports[`Title should render as h6 element 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  color: #000;
+  letter-spacing: -0.03em;
+  font-size: 120px;
+  line-height: 120px;
+}
+
+<h6
+  class="circuit-0"
+>
+  h6 Title
+</h6>
+`;
+
+exports[`Title should render with size four 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  color: #000;
+  letter-spacing: -0.03em;
+  font-size: 56px;
+  line-height: 56px;
+}
+
+<h2
+  class="circuit-0"
+>
+  four Title
+</h2>
+`;
+
+exports[`Title should render with size one 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  color: #000;
+  letter-spacing: -0.03em;
+  font-size: 120px;
+  line-height: 120px;
+}
+
+<h2
+  class="circuit-0"
+>
+  one Title
+</h2>
+`;
+
+exports[`Title should render with size three 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  color: #000;
+  letter-spacing: -0.03em;
+  font-size: 64px;
+  line-height: 64px;
+}
+
+<h2
+  class="circuit-0"
+>
+  three Title
+</h2>
+`;
+
+exports[`Title should render with size two 1`] = `
+.circuit-0 {
+  font-weight: 700;
+  color: #000;
+  letter-spacing: -0.03em;
+  font-size: 96px;
+  line-height: 96px;
+}
+
+<h2
+  class="circuit-0"
+>
+  two Title
+</h2>
+`;

--- a/packages/circuit-ui/components/Title/index.ts
+++ b/packages/circuit-ui/components/Title/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Title } from './Title';
+
+export type { TitleProps } from './Title';
+
+export default Title;

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -18,10 +18,14 @@ import * as sharedPropTypes from './util/shared-prop-types';
 // Typography
 export { default as Headline } from './components/Headline';
 export type { HeadlineProps } from './components/Headline';
+export { default as Title } from './components/Title';
+export type { TitleProps } from './components/Title';
 export { default as SubHeadline } from './components/SubHeadline';
 export type { SubHeadlineProps } from './components/SubHeadline';
 export { default as Body } from './components/Body';
 export type { BodyProps } from './components/Body';
+export { default as BodyLarge } from './components/BodyLarge';
+export type { BodyLargeProps } from './components/BodyLarge';
 export { default as Anchor } from './components/Anchor';
 export type { AnchorProps } from './components/Anchor';
 export { default as List } from './components/List';

--- a/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
@@ -189,7 +189,7 @@ Object {
     },
     "bodyLarge": Object {
       "fontSize": "20px",
-      "lineHeight": "20px",
+      "lineHeight": "28px",
     },
     "headline": Object {
       "four": Object {

--- a/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
@@ -187,6 +187,10 @@ Object {
         "lineHeight": "20px",
       },
     },
+    "bodyLarge": Object {
+      "fontSize": "20px",
+      "lineHeight": "20px",
+    },
     "headline": Object {
       "four": Object {
         "fontSize": "18px",
@@ -208,6 +212,24 @@ Object {
     "subHeadline": Object {
       "fontSize": "14px",
       "lineHeight": "20px",
+    },
+    "title": Object {
+      "four": Object {
+        "fontSize": "56px",
+        "lineHeight": "56px",
+      },
+      "one": Object {
+        "fontSize": "120px",
+        "lineHeight": "120px",
+      },
+      "three": Object {
+        "fontSize": "64px",
+        "lineHeight": "64px",
+      },
+      "two": Object {
+        "fontSize": "96px",
+        "lineHeight": "96px",
+      },
     },
   },
   "zIndex": Object {

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -79,6 +79,24 @@ export const typography = {
       lineHeight: '24px',
     },
   },
+  title: {
+    one: {
+      fontSize: '120px',
+      lineHeight: '120px',
+    },
+    two: {
+      fontSize: '96px',
+      lineHeight: '96px',
+    },
+    three: {
+      fontSize: '64px',
+      lineHeight: '64px',
+    },
+    four: {
+      fontSize: '56px',
+      lineHeight: '56px',
+    },
+  },
   subHeadline: {
     fontSize: '14px',
     lineHeight: '20px',
@@ -92,6 +110,10 @@ export const typography = {
       fontSize: '14px',
       lineHeight: '20px',
     },
+  },
+  bodyLarge: {
+    fontSize: '20px',
+    lineHeight: '20px',
   },
 };
 

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -113,7 +113,7 @@ export const typography = {
   },
   bodyLarge: {
     fontSize: '20px',
-    lineHeight: '20px',
+    lineHeight: '28px',
   },
 };
 

--- a/packages/design-tokens/types/index.ts
+++ b/packages/design-tokens/types/index.ts
@@ -206,11 +206,18 @@ export interface Theme {
       three: Typography;
       four: Typography;
     };
+    title: {
+      one: Typography;
+      two: Typography;
+      three: Typography;
+      four: Typography;
+    };
     subHeadline: Typography;
     body: {
       one: Typography;
       two: Typography;
     };
+    bodyLarge: Typography;
   };
   fontStack: FontStack;
   fontWeight: FontWeight;

--- a/packages/design-tokens/utils/theme-prop-type.ts
+++ b/packages/design-tokens/utils/theme-prop-type.ts
@@ -164,11 +164,18 @@ export const themePropType = PropTypes.shape({
       three: typePropType,
       four: typePropType,
     }).isRequired,
+    title: PropTypes.shape({
+      one: typePropType,
+      two: typePropType,
+      three: typePropType,
+      four: typePropType,
+    }).isRequired,
     subHeadline: typePropType,
     body: PropTypes.shape({
       one: typePropType,
       two: typePropType,
     }).isRequired,
+    bodyLarge: typePropType,
   }).isRequired,
   fontStack: PropTypes.shape({
     default: PropTypes.string,


### PR DESCRIPTION
## Purpose

This PR introduces two new components, `Title` and `BodyLarge`, for cases when larger typography should be used—for example on landing pages.

It also slightly adjusts the tracking of the current `Headline` component.

## Approach and changes

* Adapted the `Headline` component tracking (patch)
* Added new design tokens for the new typography values (minor)
* Added a new `Title` component (minor)
* Added a new `BodyLarge` component (minor)
* Extras ✨ 
  * Fixed Storybook links and deprecation warnings
  * Added missing tests for the Body component
  * Improved typography docs

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
