### PR TITLE
Add noMargin to the NotificationFullscreen to fix deprecation warning

### DIFF
--- a/.changeset/itchy-bees-smoke.md
+++ b/.changeset/itchy-bees-smoke.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Added the `noMargin` prop to the `NotificationFullscreen`'s headline to prevent the deprecation warning.

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
@@ -83,6 +83,7 @@ export const NotificationFullscreen = ({
     <div css={wrapperStyles} {...props}>
       <Image {...image} css={imageStyles} />
       <Headline
+        noMargin
         css={spacing({ top: 'giga', bottom: 'byte' })}
         size="two"
         as={headlineElement}

--- a/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
@@ -49,6 +49,7 @@ exports[`NotificationFullscreen styles should render with default styles 1`] = `
   letter-spacing: -0.03em;
   font-size: 24px;
   line-height: 28px;
+  margin-bottom: 0;
   margin-top: 24px;
   margin-bottom: 8px;
 }
@@ -470,6 +471,7 @@ exports[`NotificationFullscreen styles should render with default styles with h1
   letter-spacing: -0.03em;
   font-size: 24px;
   line-height: 28px;
+  margin-bottom: 0;
   margin-top: 24px;
   margin-bottom: 8px;
 }


### PR DESCRIPTION
## Purpose

We were using a `Headline` in the `NotificationFullscreen` without the `noMargin` prop set.

## Approach and changes

Added `noMargin`. Spacing is already handled using the spacing mixin.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
