### PR TITLE
Center the NotificationFullscreen headline

### DIFF
--- a/.changeset/chatty-teachers-change.md
+++ b/.changeset/chatty-teachers-change.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Centered the `NotificationFullscreen`'s headline when the copy wraps on two lines.

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
@@ -19,7 +19,7 @@ import { css } from '@emotion/react';
 import Body from '../Body';
 import Headline from '../Headline';
 import ButtonGroup, { ButtonGroupProps } from '../ButtonGroup';
-import { spacing } from '../../styles/style-mixins';
+import { spacing, cx } from '../../styles/style-mixins';
 import Image, { ImageProps } from '../Image';
 import { isString } from '../../util/type-check';
 
@@ -63,7 +63,7 @@ const imageStyles = css`
   object-fit: contain;
 `;
 
-const bodyStyles = css`
+const centeredStyles = css`
   text-align: center;
 `;
 
@@ -84,14 +84,14 @@ export const NotificationFullscreen = ({
       <Image {...image} css={imageStyles} />
       <Headline
         noMargin
-        css={spacing({ top: 'giga', bottom: 'byte' })}
+        css={cx(spacing({ top: 'giga', bottom: 'byte' }), centeredStyles)}
         size="two"
         as={headlineElement}
       >
         {headlineLabel}
       </Headline>
       {body && (
-        <Body css={bodyStyles} noMargin>
+        <Body css={centeredStyles} noMargin>
           {body}
         </Body>
       )}

--- a/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
@@ -52,6 +52,7 @@ exports[`NotificationFullscreen styles should render with default styles 1`] = `
   margin-bottom: 0;
   margin-top: 24px;
   margin-bottom: 8px;
+  text-align: center;
 }
 
 .circuit-3 {
@@ -474,6 +475,7 @@ exports[`NotificationFullscreen styles should render with default styles with h1
   margin-bottom: 0;
   margin-top: 24px;
   margin-bottom: 8px;
+  text-align: center;
 }
 
 .circuit-3 {


### PR DESCRIPTION
## Purpose

Center the NotificationFullscreen headline. It was previously left-aligned when thew headline wraps on multiple lines.

## Approach and changes

Reused the styled from the body for the headline.

**Before**

<img width="698" alt="Screenshot 2021-11-25 at 14 53 08" src="https://user-images.githubusercontent.com/35560568/143454769-738d1a15-4035-494d-9787-f2222c691d10.png">

**After**

<img width="698" alt="Screenshot 2021-11-25 at 14 53 15" src="https://user-images.githubusercontent.com/35560568/143454792-03b58203-96a2-4b24-b117-560a3a365c2e.png">

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
