### PR TITLE
Add notification toast

### DIFF
--- a/.changeset/curly-buttons-compete.md
+++ b/.changeset/curly-buttons-compete.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Added a new `NotificationToast` component that provides quick and contextual feedback based on the outcome of an action.
+Added a new `NotificationToast` component that provides quick and contextual feedback to the user.

--- a/.changeset/curly-buttons-compete.md
+++ b/.changeset/curly-buttons-compete.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a new `NotificationToast` component that provides quick and contextual feedback based on the outcome of an action.

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
@@ -83,5 +83,55 @@ export function App({ name }) {
 By their nature as small quick messages, or interruptions, toasts map to [live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions),
 and screen readers are gonna automatically announce the raw text within without any need to move the user's focus.
 Live region must always exist on the page at render, before the toast is generated.
-To ensure that the toast is always anounced as a whole, `aria-atomic` is set to `"true"`.
-The `aria-role` is adapted to `"status"`, as a most generic one that provides an updated status. It has a `aria-live="polite"` meaning the screen reader will wait before announcing the update.
+To ensure that the toast is always announced as a whole, `aria-atomic` should be set to `"true"` (default value is `"false"`).
+
+### Role
+
+The `aria-role` can be adapted based on the context.
+For the most generic use cases that provides an updated status, the role can be set to `"status"`. It has a `aria-live="polite"` meaning the screen reader will wait before announcing the update.
+If it is an important message, typically time-sensitive, like an error, use `role="alert"`. It has `aria-live="assertive"` which means it will interrupt whatever the user is doing.
+The third role that can be given to the toast messages is `"log"`. It should be used when the order of the messages matters. It has a `aria-live="polite"`.
+
+Since the screen readers are gonna announce the raw text within toast messages, without structure, keyboard users won’t be able to move to the interactive elements with a clear path.
+For example, there is a toast message with the text “You successfully updated your data.”, followed by a link or button with the text "Back".
+Screen readers are gonna communicate a message as “You successfully updated your data. Back.”, meaning that the semantics of the link "Back" is not announced.
+People using a screen reader may think that the "Back" is an interactive element, but they will not know which element to search for.
+In this case you will need a modal or dialog with a `role="dialog"`.
+Ideally, the toast messages should not contain any interactive elements.
+
+### Best practices
+
+There are several WCAG 2.0 and 2.1 level AA accessibility guidelines that can be applied to toast messages.
+
+#### Color
+
+The standard color ratio requirement for text is 4.5:1 and for any interactive content 3.0:1.
+
+#### Consistent identification
+
+Based on the WCAG guideline [3.2.4](https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html) each component should be consistent with another.
+
+#### Location
+
+Following consistent identificaton, toast messages should be also placed consistently. Generally toast messages usually appear at the start or end of the DOM. If you place them somewhere else, it can cause difficulties for screen reader users to locate them.
+
+#### Keyboard access and focus order
+
+For any interactive element, user should be able to tab and shift through them by using the keyboard, which means they require a keyboard focus indicator.
+Follow more in the WCAG guideline [2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html)
+
+Using the keyboard, if the toast message has any interactive elements, then it should always show up in the same place in the focus order, in a way that makes sense to a user.
+This is related to the WCAG guideline [2.4.3](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
+
+#### Timing adjustable
+
+This is the one that is most relevant to the toast messages.
+Based on the WCAG guideline [2.2.1](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html), user should be able to choose how long they want the toast messages to be displayed.
+
+#### Resources
+
+For more information follow up:
+
+- [ARIA Roles](https://www.w3.org/TR/aria-in-html/#aria-roles])
+- [Defining toast messages](https://adrianroselli.com/2020/01/defining-toast-messages.html)
+- [Status messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html)

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
@@ -8,7 +8,7 @@ import { NotificationToast } from '@sumup/circuit-ui';
 <Story id="notification-notificationtoast--base" />
 <Props />
 
-The notification toast component non-disruptively provides quick, contextual or feedback based on outcome of an action.
+The notification toast component non-disruptively provides quick, contextual or feedback based on the outcome of an action.
 
 ## When to use it
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
@@ -10,37 +10,25 @@ import { NotificationToast } from '@sumup/circuit-ui';
 
 The notification toast component non-disruptively provides quick and contextual feedback to the user. It can be based on the outcome of an action (i.e. saving a form) or it can pop up without having been triggered explicitly (i.e. a toast message "You made a new sale" showing real time sales in an app).
 
-## When to use it
-
-The notification toast should be used for a feedback on micro actions (i.e. successfully/unsuccessfully saving some information).
-
 ## Usage guidelines
 
-- Be concise, specific and short in the message and always provide a body copy. If needed an optional headline can be included above the body copy.
-- The notification toast floats above the content, positioned at the bottom of the screen, centralized horizontally within the content area.
-- For multiple stacked toasts, the new toast slides on top of the previous one. The timeout of the stacked toasts follows chronological order.
-- The auto-dismiss duration is adjustable (default minimum duration is 3000 ms).
-- Toasts can also be dismissed by clicking on a close button in the top-right corner.
+- Be concise, specific and short in the message and always provide a body copy.
+- If needed an optional headline can be included above the body copy.
 
-## Variants
+## Component variations
+
+### Toast variants
 
 <Story id="notification-notificationtoast--variants" />
 
-### Info
+- Use the 'Info' variant for informational, neutral messages.
+- Use the 'Confirm' variant the successful messages.
+- Use the 'Notify' variant for warning messages, and other information a user should be aware of.
+- Use the 'Alert' variant for error messages.
 
-Use the 'Info' variant for informational, neutral messages.
+### Toast with headline
 
-### Confirm
-
-Use the 'Confirm' variant the successful messages.
-
-### Notify
-
-Use the 'Notify' variant for warning messages, and other information a user should be aware of.
-
-### Alert
-
-Use the 'Alert' variant for error messages.
+<Story id="notification-notificationtoast--with-headline" />
 
 ## Usage in code
 
@@ -78,11 +66,9 @@ export function App({}) {
 By their nature as small quick messages, or interruptions, toasts map to [live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
 Live region must always exist on the page at render, before the toast is generated.
 
-Ideally, the toast messages should not contain any interactive elements.
-The screen readers are gonna announce the raw text within toast messages, without structure and any need to move the user's focus.
-Keyboard users won’t be able to move to the interactive elements with a clear path.
-For example, there is a toast message with the text “You successfully updated your data.”, followed by a link or button with the text "Back".
-Screen readers are gonna communicate a message as “You successfully updated your data. Back.”, and the semantics of the link "Back" is not announced.
+Toast messages should not contain any interactive elements.
+Screen readers will announce raw text within the toast as it appears, without structure and without moving focus to the toast element.
+For example, if a toast read “You successfully updated your data” followed by an "Undo" button, screen readers would announce “You successfully updated your data. Undo”, not allowing keyboard users to interact with the button.
 
 To match the content, the role and aria-live level is adapted. The role is set to `"status"`, and it has `aria-live="polite"` meaning the screen reader will wait before announcing the update.
 
@@ -93,24 +79,18 @@ This component adheres to the following principles from the Web Content Accessib
 #### Toast duration
 
 The auto-dimiss duration of the toast is adjustable.
-Based on how fast the average American reads, a good lenght of time to keep the toast message up is 5 seconds plus 1 extra second for every 120 words.
+Based on how fast the [average American reads](https://sheribyrnehaber.medium.com/designing-toast-messages-for-accessibility-fb610ac364be), a good lenght of time to keep the toast message up is 5 seconds plus 1 extra second for every 120 words.
 The shortest default that should be used as a best practice is 6 seconds.
 
 #### Consistent identification
 
-Based on the WCAG guideline [3.2.4](https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html) each component should be consistent with another.
+Based on the WCAG guideline [3.2.4](https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html) each component should be identified consistently.
+However you choose to implement your messages, for example, deciding whether the information icon has alt-text or the toast message contains the word information, each type should be consistent with one another.
 
 #### Location
 
-Following consistent identificaton, toast messages should be also placed consistently. Generally toast messages usually appear at the start or end of the DOM. If you place them somewhere else, it can cause difficulties for screen reader users to locate them.
-
-#### Keyboard access and focus order
-
-For any interactive element, user should be able to tab and shift through them by using the keyboard, which means they require a keyboard focus indicator.
-Follow more in the WCAG guideline [2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html)
-
-Using the keyboard, if the toast message has any interactive elements, then it should always show up in the same place in the focus order, in a way that makes sense to a user.
-This is related to the WCAG guideline [2.4.3](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
+Following consistent identificaton, toast messages should be also placed consistently. Generally toast messages usually appear at the start or end of the DOM.
+If you place them somewhere else, they can confuse screen reader users as they navigate through the page.
 
 #### Resources
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
@@ -8,20 +8,19 @@ import { NotificationToast } from '@sumup/circuit-ui';
 <Story id="notification-notificationtoast--base" />
 <Props />
 
-The notification toast component non-disruptively provides quick, contextual or feedback based on the outcome of an action.
+The notification toast component non-disruptively provides quick and contextual feedback to the user. It can be based on the outcome of an action (i.e. saving a form) or it can pop up without having been triggered explicitly (i.e. a toast message "You made a new sale" showing real time sales in an app).
 
 ## When to use it
 
-The notification toast should be used for a feedback on micro actions (i.e. successful/unsuccessful saving on the page).
+The notification toast should be used for a feedback on micro actions (i.e. successfully/unsuccessfully saving some information).
 
 ## Usage guidelines
 
-- To communicate a message always provide a body copy, and if needed an optional headline can be included above the body copy.
-- The notification toast floats above the content, positioned at the bottom of the screen, centralized horizontally withing the content area.
-- For a multiple stacked toasts, the new toast slides on top of the previous one. The timeout of the stacked toasts follow chronological order.
+- Be concise, specific and short in the message and always provide a body copy. If needed an optional headline can be included above the body copy.
+- The notification toast floats above the content, positioned at the bottom of the screen, centralized horizontally within the content area.
+- For multiple stacked toasts, the new toast slides on top of the previous one. The timeout of the stacked toasts follows chronological order.
 - The auto-dismiss duration is adjustable (default minimum duration is 3000 ms).
-- Toasts can also be dismissed by clicking on a close button in the top-right corner. You need to provide closeButtonLabel.
-- **Do** Be concise, specific and short in the message.
+- Toasts can also be dismissed by clicking on a close button in the top-right corner.
 
 ## Variants
 
@@ -29,19 +28,19 @@ The notification toast should be used for a feedback on micro actions (i.e. succ
 
 ### Info
 
-Use 'Info' variant for the informational, neutral messages.
+Use the 'Info' variant for informational, neutral messages.
 
 ### Confirm
 
-Use 'Confirm' variant for the successful messages.
+Use the 'Confirm' variant the successful messages.
 
 ### Notify
 
-Use 'Notify' variant for a warning messages, information to be aware of.
+Use the 'Notify' variant for warning messages, and other information a user should be aware of.
 
 ### Alert
 
-Use 'Alert' variant for error messages.
+Use the 'Alert' variant for error messages.
 
 ## Usage in code
 
@@ -49,28 +48,24 @@ First, wrap your application in the `ToastProvider` which keeps track of the ope
 
 ```tsx
 // _app.tsx for Next.js or App.js for CRA
-import { ToastProvider, BaseStyles } from '@sumup/circuit-ui';
+import { ToastProvider } from '@sumup/circuit-ui';
 
 export default function App() {
-  return (
-      <BaseStyles />
-      <ToastProvider>{/* Your content goes here... */}</ToastProvider>
-  );
+  return <ToastProvider>{/* Your content goes here... */}</ToastProvider>;
 }
 ```
 
 Then, use the `useNotificationToast` hook to open a toast from a component:
 
 ```tsx
-import { useNotificationToast, Button, Body } from '@sumup/circuit-ui';
+import { useNotificationToast, Button } from '@sumup/circuit-ui';
 
-export function App({ name }) {
+export function App({}) {
   const { setToast } = useNotificationToast();
 
   const handleClick = () => {
     setToast({
       body: 'This is a toast message',
-      closeButtonLabel: 'Close modal',
     });
   };
 
@@ -80,32 +75,26 @@ export function App({ name }) {
 
 ## Accessibility
 
-By their nature as small quick messages, or interruptions, toasts map to [live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions),
-and screen readers are gonna automatically announce the raw text within without any need to move the user's focus.
+By their nature as small quick messages, or interruptions, toasts map to [live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
 Live region must always exist on the page at render, before the toast is generated.
-To ensure that the toast is always announced as a whole, `aria-atomic` should be set to `"true"` (default value is `"false"`).
 
-### Role
-
-The `aria-role` can be adapted based on the context.
-For the most generic use cases that provides an updated status, the role can be set to `"status"`. It has a `aria-live="polite"` meaning the screen reader will wait before announcing the update.
-If it is an important message, typically time-sensitive, like an error, use `role="alert"`. It has `aria-live="assertive"` which means it will interrupt whatever the user is doing.
-The third role that can be given to the toast messages is `"log"`. It should be used when the order of the messages matters. It has a `aria-live="polite"`.
-
-Since the screen readers are gonna announce the raw text within toast messages, without structure, keyboard users won’t be able to move to the interactive elements with a clear path.
-For example, there is a toast message with the text “You successfully updated your data.”, followed by a link or button with the text "Back".
-Screen readers are gonna communicate a message as “You successfully updated your data. Back.”, meaning that the semantics of the link "Back" is not announced.
-People using a screen reader may think that the "Back" is an interactive element, but they will not know which element to search for.
-In this case you will need a modal or dialog with a `role="dialog"`.
 Ideally, the toast messages should not contain any interactive elements.
+The screen readers are gonna announce the raw text within toast messages, without structure and any need to move the user's focus.
+Keyboard users won’t be able to move to the interactive elements with a clear path.
+For example, there is a toast message with the text “You successfully updated your data.”, followed by a link or button with the text "Back".
+Screen readers are gonna communicate a message as “You successfully updated your data. Back.”, and the semantics of the link "Back" is not announced.
+
+To match the content, the role and aria-live level is adapted. The role is set to `"status"`, and it has `aria-live="polite"` meaning the screen reader will wait before announcing the update.
 
 ### Best practices
 
-There are several WCAG 2.0 and 2.1 level AA accessibility guidelines that can be applied to toast messages.
+This component adheres to the following principles from the Web Content Accessibility Guidelines (WCAG):
 
-#### Color
+#### Toast duration
 
-The standard color ratio requirement for text is 4.5:1 and for any interactive content 3.0:1.
+The auto-dimiss duration of the toast is adjustable.
+Based on how fast the average American reads, a good lenght of time to keep the toast message up is 5 seconds plus 1 extra second for every 120 words.
+The shortest default that should be used as a best practice is 6 seconds.
 
 #### Consistent identification
 
@@ -122,11 +111,6 @@ Follow more in the WCAG guideline [2.1.1](https://www.w3.org/WAI/WCAG21/Understa
 
 Using the keyboard, if the toast message has any interactive elements, then it should always show up in the same place in the focus order, in a way that makes sense to a user.
 This is related to the WCAG guideline [2.4.3](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html).
-
-#### Timing adjustable
-
-This is the one that is most relevant to the toast messages.
-Based on the WCAG guideline [2.2.1](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html), user should be able to choose how long they want the toast messages to be displayed.
 
 #### Resources
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
@@ -1,0 +1,87 @@
+import { Status, Props, Story } from '../../../../.storybook/components';
+import { NotificationToast } from '@sumup/circuit-ui';
+
+# NotificationToast
+
+<Status.Stable />
+
+<Story id="notification-notificationtoast--base" />
+<Props />
+
+The notification toast component non-disruptively provides quick, contextual or feedback based on outcome of an action.
+
+## When to use it
+
+The notification toast should be used for a feedback on micro actions (i.e. successful/unsuccessful saving on the page).
+
+## Usage guidelines
+
+- To communicate a message always provide a body copy, and if needed an optional headline can be included above the body copy.
+- The notification toast floats above the content, positioned at the bottom of the screen, centralized horizontally withing the content area.
+- For a multiple stacked toasts, the new toast slides on top of the previous one. The timeout of the stacked toasts follow chronological order.
+- The auto-dismiss duration is adjustable (default minimum duration is 3000 ms).
+- Toasts can also be dismissed by clicking on a close button in the top-right corner. You need to provide closeButtonLabel.
+- **Do** Be concise, specific and short in the message.
+
+## Variants
+
+<Story id="notification-notificationtoast--variants" />
+
+### Info
+
+Use 'Info' variant for the informational, neutral messages.
+
+### Confirm
+
+Use 'Confirm' variant for the successful messages.
+
+### Notify
+
+Use 'Notify' variant for a warning messages, information to be aware of.
+
+### Alert
+
+Use 'Alert' variant for error messages.
+
+## Usage in code
+
+First, wrap your application in the `ToastProvider` which keeps track of the open toasts and ensures the accessibility of the toast.
+
+```tsx
+// _app.tsx for Next.js or App.js for CRA
+import { ToastProvider, BaseStyles } from '@sumup/circuit-ui';
+
+export default function App() {
+  return (
+      <BaseStyles />
+      <ToastProvider>{/* Your content goes here... */}</ToastProvider>
+  );
+}
+```
+
+Then, use the `useNotificationToast` hook to open a toast from a component:
+
+```tsx
+import { useNotificationToast, Button, Body } from '@sumup/circuit-ui';
+
+export function App({ name }) {
+  const { setToast } = useNotificationToast();
+
+  const handleClick = () => {
+    setToast({
+      body: 'This is a toast message',
+      closeButtonLabel: 'Close modal',
+    });
+  };
+
+  return <Button onClick={handleClick}>Open toast</Button>;
+}
+```
+
+## Accessibility
+
+By their nature as small quick messages, or interruptions, toasts map to [live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions),
+and screen readers are gonna automatically announce the raw text within without any need to move the user's focus.
+Live region must always exist on the page at render, before the toast is generated.
+To ensure that the toast is always anounced as a whole, `aria-atomic` is set to `"true"`.
+The `aria-role` is adapted to `"status"`, as a most generic one that provides an updated status. It has a `aria-live="polite"` meaning the screen reader will wait before announcing the update.

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable react/display-name */
+import React from 'react';
+
+import { act, axe, fireEvent, render, waitFor } from '../../util/test-utils';
+import Button from '../Button';
+import { ToastProvider } from '../ToastContext';
+
+import {
+  NotificationToast,
+  NotificationToastProps,
+  useNotificationToast,
+} from './NotificationToast';
+
+describe('NotificationToast', () => {
+  const renderNotificationToast = (props: NotificationToastProps) =>
+    render(<NotificationToast {...props} />);
+
+  const baseNotificationToast: NotificationToastProps = {
+    closeButtonLabel: 'Close toast',
+    onClose: jest.fn(),
+    body: 'This is a toast message',
+  };
+  describe('styles', () => {
+    it('should render with default styles', () => {
+      const { baseElement } = renderNotificationToast(baseNotificationToast);
+      expect(baseElement).toMatchSnapshot();
+    });
+
+    it('should render the toast', async () => {
+      const App = () => {
+        const { setToast } = useNotificationToast();
+        return (
+          <Button type="button" onClick={() => setToast(baseNotificationToast)}>
+            Open toast
+          </Button>
+        );
+      };
+
+      const { findByRole, getByText } = render(
+        <ToastProvider>
+          <App />
+        </ToastProvider>,
+      );
+
+      act(() => {
+        fireEvent.click(getByText('Open toast'));
+      });
+
+      const toastEl = await findByRole('status');
+
+      await waitFor(() => {
+        expect(toastEl).toBeVisible();
+      });
+    });
+    const variants: NotificationToastProps['variant'][] = [
+      'info',
+      'confirm',
+      'notify',
+      'alert',
+    ];
+
+    it.each(variants)(
+      'should render notification toast with %s styles',
+      (variant) => {
+        const actual = renderNotificationToast({
+          ...baseNotificationToast,
+          variant,
+        });
+        expect(actual).toMatchSnapshot();
+      },
+    );
+  });
+  describe('business logic', () => {
+    it('should close the toast when the onClose method is called', async () => {
+      const App = () => {
+        const { setToast } = useNotificationToast();
+        return (
+          <Button type="button" onClick={() => setToast(baseNotificationToast)}>
+            Open toast
+          </Button>
+        );
+      };
+
+      const { findByRole, getByText } = render(
+        <ToastProvider>
+          <App />
+        </ToastProvider>,
+      );
+
+      act(() => {
+        fireEvent.click(getByText('Open toast'));
+      });
+
+      const toastEl = await findByRole('status');
+
+      await waitFor(() => {
+        expect(toastEl).toBeVisible();
+      });
+
+      const closeButton = await findByRole('button', { name: /Close toast/ });
+
+      act(() => {
+        fireEvent.click(closeButton);
+      });
+
+      expect(baseNotificationToast.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+  it('should autodismiss toast after the duration has expired', async () => {
+    const App = () => {
+      const { setToast } = useNotificationToast();
+      return (
+        <Button
+          type="button"
+          onClick={() => setToast({ ...baseNotificationToast, duration: 30 })}
+        >
+          Open toast
+        </Button>
+      );
+    };
+
+    const { findByRole } = render(
+      <ToastProvider>
+        <App />
+      </ToastProvider>,
+    );
+
+    const toastEl = await findByRole('status');
+
+    await waitFor(() => {
+      expect(toastEl).toBeVisible();
+    });
+
+    await waitFor(() => {
+      expect(baseNotificationToast.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+  /**
+   * Accessibility tests.
+   */
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const { container } = renderNotificationToast(baseNotificationToast);
+      const actual = await axe(container);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
@@ -31,8 +31,9 @@ describe('NotificationToast', () => {
     render(<NotificationToast {...props} />);
 
   const baseNotificationToast: NotificationToastProps = {
-    closeButtonLabel: 'Close toast',
     onClose: jest.fn(),
+    iconLabel: '',
+    isVisible: false,
     body: 'This is a toast message',
   };
   describe('styles', () => {
@@ -77,16 +78,16 @@ describe('NotificationToast', () => {
     it.each(variants)(
       'should render notification toast with %s styles',
       (variant) => {
-        const actual = renderNotificationToast({
+        const { baseElement } = renderNotificationToast({
           ...baseNotificationToast,
           variant,
         });
-        expect(actual).toMatchSnapshot();
+        expect(baseElement).toMatchSnapshot();
       },
     );
   });
   describe('business logic', () => {
-    it('should close the toast when the onClose method is called', async () => {
+    it('should close the toast when the onClose method is called', () => {
       const App = () => {
         const { setToast } = useNotificationToast();
         return (
@@ -96,7 +97,7 @@ describe('NotificationToast', () => {
         );
       };
 
-      const { findByRole, getByText } = render(
+      const { getByText } = render(
         <ToastProvider>
           <App />
         </ToastProvider>,
@@ -106,48 +107,48 @@ describe('NotificationToast', () => {
         fireEvent.click(getByText('Open toast'));
       });
 
-      const toastEl = await findByRole('status');
+      expect(getByText('This is a toast message')).toBeVisible();
 
-      await waitFor(() => {
-        expect(toastEl).toBeVisible();
-      });
-
-      const closeButton = await findByRole('button', { name: /Close toast/ });
+      const closeButton = getByText('-');
 
       act(() => {
         fireEvent.click(closeButton);
       });
 
-      expect(baseNotificationToast.onClose).toHaveBeenCalledTimes(1);
+      expect(baseNotificationToast.onClose).toHaveBeenCalled();
     });
-  });
-  it('should autodismiss toast after the duration has expired', async () => {
-    const App = () => {
-      const { setToast } = useNotificationToast();
-      return (
-        <Button
-          type="button"
-          onClick={() => setToast({ ...baseNotificationToast, duration: 30 })}
-        >
-          Open toast
-        </Button>
+
+    it('should autodismiss toast after the duration has expired', async () => {
+      const App = () => {
+        const { setToast } = useNotificationToast();
+        return (
+          <Button
+            type="button"
+            onClick={() => setToast({ ...baseNotificationToast })}
+          >
+            Open toast
+          </Button>
+        );
+      };
+
+      const { getByText } = render(
+        <ToastProvider>
+          <App />
+        </ToastProvider>,
       );
-    };
 
-    const { findByRole } = render(
-      <ToastProvider>
-        <App />
-      </ToastProvider>,
-    );
+      act(() => {
+        fireEvent.click(getByText('Open toast'));
+      });
 
-    const toastEl = await findByRole('status');
+      expect(getByText('This is a toast message')).toBeVisible();
 
-    await waitFor(() => {
-      expect(toastEl).toBeVisible();
-    });
-
-    await waitFor(() => {
-      expect(baseNotificationToast.onClose).toHaveBeenCalledTimes(1);
+      await waitFor(
+        () => {
+          expect(baseNotificationToast.onClose).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 3000 },
+      );
     });
   });
   /**

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
@@ -85,6 +85,14 @@ describe('NotificationToast', () => {
         expect(baseElement).toMatchSnapshot();
       },
     );
+
+    it('should render notification toast with headline', () => {
+      const { baseElement } = renderNotificationToast({
+        ...baseNotificationToast,
+        headline: 'Information',
+      });
+      expect(baseElement).toMatchSnapshot();
+    });
   });
   describe('business logic', () => {
     it('should close the toast when the onClose method is called', () => {

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-import { action } from '@storybook/addon-actions';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import Button from '../Button';
+import Body from '../Body';
 import { ToastProvider } from '../ToastContext';
 
 import {
@@ -26,14 +26,13 @@ import {
 } from './NotificationToast';
 
 export default {
-  title: 'Notification/NotificatinToast',
+  title: 'Notification/NotificationToast',
   component: NotificationToast,
 };
 
 export const Base = (toast: NotificationToastProps): JSX.Element => {
-  const Toast = () => {
+  const App = () => {
     const { setToast } = useNotificationToast();
-
     return (
       <Button type="button" onClick={() => setToast(toast)}>
         Open toast
@@ -42,39 +41,34 @@ export const Base = (toast: NotificationToastProps): JSX.Element => {
   };
   return (
     <ToastProvider>
-      <Toast />
+      <App />
     </ToastProvider>
   );
 };
 
 Base.args = {
-  closeButtonLabel: 'Close Notification Toast',
-  headline: 'Toast',
+  closeButtonLabel: 'Close',
   body: 'This is a toast message',
-  action: {
-    onClick: action('Action clicked'),
-    children: 'Click here',
-  },
-};
+} as NotificationToastProps;
 
 const variants = ['info', 'confirm', 'notify', 'alert'] as const;
 
-export const Variants = (args: NotificationToastProps) => {
-  const initialToast = {
-    id: 'initial',
-    component: NotificationToast,
-    ...args,
+export const Variants = (toast: NotificationToastProps): JSX.Element => {
+  const App = () => {
+    const { setToast } = useNotificationToast();
+    useEffect(() => {
+      variants.forEach((variant) => {
+        setToast({ ...toast, variant });
+      });
+    }, [setToast]);
+
+    return <Body noMargin>Your app</Body>;
   };
-
-  return variants.map((variant) => (
-    <ToastProvider
-      initialState={[initialToast]}
-      key={variant}
-      variant={variant}
-    ></ToastProvider>
-  ));
+  return (
+    <ToastProvider>
+      <App />
+    </ToastProvider>
+  );
 };
 
-Variants.args = {
-  body: 'There is updated firmware available for your card reader',
-};
+Variants.args = Base.args;

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -35,10 +35,18 @@ export default {
 };
 
 const TOASTS = [
-  { body: 'An update is available.', variant: 'info' },
-  { body: 'Unexpected error occurred.', variant: 'alert' },
-  { body: 'Sorry. There was a problem with your request.', variant: 'notify' },
-  { body: 'You successfully updated your data.', variant: 'confirm' },
+  { body: 'An update is available.', variant: 'info', iconLabel: '' },
+  { body: 'Unexpected error occurred.', variant: 'alert', iconLabel: '' },
+  {
+    body: 'There was a problem with your request.',
+    variant: 'notify',
+    iconLabel: 'warning',
+  },
+  {
+    body: 'You successfully updated your data.',
+    variant: 'confirm',
+    iconLabel: '',
+  },
 ] as NotificationToastProps[];
 
 export const Base = (toast: NotificationToastProps): JSX.Element => {
@@ -65,8 +73,34 @@ export const Base = (toast: NotificationToastProps): JSX.Element => {
   );
 };
 
-Base.args = {
-  closeButtonLabel: 'Close',
+export const WithHeadline = (toast: NotificationToastProps): JSX.Element => {
+  const App = () => {
+    const { setToast } = useNotificationToast();
+    return (
+      <Button
+        type="button"
+        onClick={() =>
+          setToast({
+            ...toast,
+          })
+        }
+      >
+        Open toast
+      </Button>
+    );
+  };
+  return (
+    <ToastProvider>
+      <App />
+    </ToastProvider>
+  );
+};
+
+WithHeadline.args = {
+  headline: 'Information',
+  iconLabel: '',
+  body: 'You successfully updated your data.',
+  variant: 'info',
 } as NotificationToastProps;
 
 const variants = ['info', 'confirm', 'notify', 'alert'] as const;
@@ -94,5 +128,5 @@ export const Variants = (toast: NotificationToastProps) => (
 
 Variants.args = {
   body: 'This is a toast message',
-  closeButtonLabel: 'Close',
+  iconLabel: '',
 } as NotificationToastProps;

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable array-callback-return */
 /**
  * Copyright 2021, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +14,9 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from 'react';
+import styled from '@emotion/styled';
 
 import Button from '../Button';
-import Body from '../Body';
 import { ToastProvider } from '../ToastContext';
 
 import {
@@ -24,17 +24,36 @@ import {
   NotificationToastProps,
   useNotificationToast,
 } from './NotificationToast';
+import docs from './NotificationToast.docs.mdx';
 
 export default {
   title: 'Notification/NotificationToast',
+  parameters: {
+    docs: { page: docs },
+  },
   component: NotificationToast,
 };
+
+const TOASTS = [
+  { body: 'An update is available.', variant: 'info' },
+  { body: 'Unexpected error occurred.', variant: 'alert' },
+  { body: 'Sorry. There was a problem with your request.', variant: 'notify' },
+  { body: 'You successfully updated your data.', variant: 'confirm' },
+] as NotificationToastProps[];
 
 export const Base = (toast: NotificationToastProps): JSX.Element => {
   const App = () => {
     const { setToast } = useNotificationToast();
     return (
-      <Button type="button" onClick={() => setToast(toast)}>
+      <Button
+        type="button"
+        onClick={() =>
+          setToast({
+            ...toast,
+            ...TOASTS[Math.floor(Math.random() * TOASTS.length)],
+          })
+        }
+      >
         Open toast
       </Button>
     );
@@ -48,27 +67,32 @@ export const Base = (toast: NotificationToastProps): JSX.Element => {
 
 Base.args = {
   closeButtonLabel: 'Close',
-  body: 'This is a toast message',
 } as NotificationToastProps;
 
 const variants = ['info', 'confirm', 'notify', 'alert'] as const;
 
-export const Variants = (toast: NotificationToastProps): JSX.Element => {
-  const App = () => {
-    const { setToast } = useNotificationToast();
-    useEffect(() => {
-      variants.forEach((variant) => {
-        setToast({ ...toast, variant });
-      });
-    }, [setToast]);
+const StackToasts = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+`;
 
-    return <Body noMargin>Your app</Body>;
-  };
-  return (
-    <ToastProvider>
-      <App />
-    </ToastProvider>
-  );
-};
+export const Variants = (toast: NotificationToastProps) => (
+  <StackToasts>
+    {variants.map((variant) => (
+      <NotificationToast
+        key={variant}
+        {...toast}
+        isVisible={true}
+        variant={variant}
+      />
+    ))}
+  </StackToasts>
+);
 
-Variants.args = Base.args;
+Variants.args = {
+  body: 'This is a toast message',
+  closeButtonLabel: 'Close',
+} as NotificationToastProps;

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -73,36 +73,6 @@ export const Base = (toast: NotificationToastProps): JSX.Element => {
   );
 };
 
-export const WithHeadline = (toast: NotificationToastProps): JSX.Element => {
-  const App = () => {
-    const { setToast } = useNotificationToast();
-    return (
-      <Button
-        type="button"
-        onClick={() =>
-          setToast({
-            ...toast,
-          })
-        }
-      >
-        Open toast
-      </Button>
-    );
-  };
-  return (
-    <ToastProvider>
-      <App />
-    </ToastProvider>
-  );
-};
-
-WithHeadline.args = {
-  headline: 'Information',
-  iconLabel: '',
-  body: 'You successfully updated your data.',
-  variant: 'info',
-} as NotificationToastProps;
-
 const variants = ['info', 'confirm', 'notify', 'alert'] as const;
 
 const StackToasts = styled.div`
@@ -129,4 +99,15 @@ export const Variants = (toast: NotificationToastProps) => (
 Variants.args = {
   body: 'This is a toast message',
   iconLabel: '',
+} as NotificationToastProps;
+
+export const WithHeadline = (toast: NotificationToastProps) => (
+  <NotificationToast {...toast} isVisible={true} />
+);
+
+WithHeadline.args = {
+  headline: 'Information',
+  iconLabel: '',
+  body: 'You successfully updated your data.',
+  variant: 'info',
 } as NotificationToastProps;

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { action } from '@storybook/addon-actions';
+import React from 'react';
+
+import Button from '../Button';
+import { ToastProvider } from '../ToastContext';
+
+import {
+  NotificationToast,
+  NotificationToastProps,
+  useNotificationToast,
+} from './NotificationToast';
+
+export default {
+  title: 'Notification/NotificatinToast',
+  component: NotificationToast,
+};
+
+export const Base = (toast: NotificationToastProps): JSX.Element => {
+  const Toast = () => {
+    const { setToast } = useNotificationToast();
+
+    return (
+      <Button type="button" onClick={() => setToast(toast)}>
+        Open toast
+      </Button>
+    );
+  };
+  return (
+    <ToastProvider>
+      <Toast />
+    </ToastProvider>
+  );
+};
+
+Base.args = {
+  closeButtonLabel: 'Close Notification Toast',
+  headline: 'Toast',
+  body: 'This is a toast message',
+  action: {
+    onClick: action('Action clicked'),
+    children: 'Click here',
+  },
+};
+
+const variants = ['info', 'confirm', 'notify', 'alert'] as const;
+
+export const Variants = (args: NotificationToastProps) => {
+  const initialToast = {
+    id: 'initial',
+    component: NotificationToast,
+    ...args,
+  };
+
+  return variants.map((variant) => (
+    <ToastProvider
+      initialState={[initialToast]}
+      key={variant}
+      variant={variant}
+    ></ToastProvider>
+  ));
+};
+
+Variants.args = {
+  body: 'There is updated firmware available for your card reader',
+};

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -59,7 +59,7 @@ export type NotificationToastProps = HTMLAttributes<HTMLDivElement> &
      */
     onClose?: (event: ClickEvent) => void;
     /**
-     * A clear and concise description of the icon and the Toast's purpose.
+     * A clear and concise description of the icon and the Toast's purpose. If the toast body is self-explanatory pass an empty string.
      */
     iconLabel: string;
   };

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -1,0 +1,250 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <NotificationToast />
+ *   animation -> reference NotificationBanner
+ *
+ * useNotificationToast()
+ *   ToastContext
+ *   createUseToast
+ *   useStack
+ */
+import { ReactNode, RefObject, useEffect, useRef, useState } from 'react';
+import { css } from '@emotion/react';
+import { Alert, Confirm, Info, Notify } from '@sumup/icons';
+
+import Button, { ButtonProps } from '../Button';
+import styled, { StyleProps } from '../../styles/styled';
+import { useAnimation } from '../../hooks/useAnimation';
+import Body from '../Body';
+import { TrackingProps } from '../../hooks/useClickEvent';
+import CloseButton from '../CloseButton';
+import { ClickEvent } from '../../types/events';
+import { BaseToastProps, createUseToast } from '../ToastContext';
+
+const TRANSITION_DURATION = 200;
+const DEFAULT_HEIGHT = 'auto';
+
+type Variant = 'info' | 'confirm' | 'notify' | 'alert';
+
+type Action = ButtonProps & {
+  variant: 'tertiary';
+};
+
+export type NotificationToastProps = BaseToastProps & {
+  /**
+   * Notification toast variants.
+   * Use the `info` variant for the informational messages (default), 'confirm' for successfull message,
+   * 'notify' for warning messages and 'alert' for error messages.
+   */
+  variant: Variant;
+  /**
+   * Notification toast headline to provide information (optional)
+   */
+  headline?: string | ReactNode;
+  /**
+   * An body copy to provide notification toast information
+   */
+  body: string | ReactNode;
+  /**
+   * An optional call-to-action button.
+   */
+  action?: Action;
+  /**
+   * Whether the notification toast is visible.
+   */
+  isVisible?: boolean;
+  /**
+   * Additional data that is dispatched with the tracking event.
+   */
+  tracking?: TrackingProps;
+  /**
+   * Renders a close button in the top right corner and calls the provided function
+   * when the button is clicked.
+   */
+  onClose?: (event: ClickEvent) => void;
+  /**
+   * Text label for the close button for screen readers.
+   * Important for accessibility.
+   */
+  closeButtonLabel: string;
+};
+
+// TODO: update the design token colors to be info/confirm/alert/notify, then remove this mapping
+const colorMap = {
+  info: 'p500',
+  confirm: 'success',
+  alert: 'danger',
+  notify: 'warning',
+} as const;
+
+const iconMap = {
+  info: Info,
+  confirm: Confirm,
+  alert: Alert,
+  notify: Notify,
+};
+
+const toastWrapperStyles = ({
+  theme,
+  variant,
+}: Pick<NotificationToastProps, 'variant'> & StyleProps) => css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  position: relative;
+  background-color: ${theme.colors.bodyBg};
+  padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+  border-radius: ${theme.borderRadius.byte};
+  border: ${theme.borderWidth.mega} solid ${theme.colors[colorMap[variant]]};
+  overflow: hidden;
+  transition: opacity 200ms ease-in-out, height 200ms ease-in-out,
+    visibility 200ms ease-in-out;
+`;
+
+const NotificationToastWrapper = styled('div')(toastWrapperStyles);
+
+const contentStyles = ({ theme }: StyleProps) => css`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding-right: ${theme.spacings.peta};
+  padding-left: ${theme.spacings.mega};
+`;
+
+const Content = styled('div')(contentStyles);
+
+const actionButtonStyles = ({ theme }: StyleProps & ButtonProps) =>
+  css`
+    font-weight: bold;
+    text-decoration-line: underline;
+    color: ${theme.colors.black};
+    padding-bottom: calc(${theme.spacings.kilo} - ${theme.borderWidth.kilo});
+
+    &:hover {
+      color: ${theme.colors.n800};
+    }
+
+    &:active,
+    &[aria-expanded='true'],
+    &[aria-pressed='true'] {
+      color: ${theme.colors.n700};
+    }
+  `;
+
+const ActionButton = styled(Button)(actionButtonStyles);
+
+const StyledIcon = styled.span(
+  ({ theme, variant }: StyleProps & { variant: Variant }) =>
+    css`
+      display: block;
+      align-self: flex-start;
+      flex-grow: 0;
+      flex-shrink: 0;
+      line-height: 0;
+      color: ${theme.colors[colorMap[variant]]};
+    `,
+);
+
+const closeButtonStyles = ({ theme }: StyleProps) => css`
+  flex-grow: 0;
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: -${theme.spacings.bit};
+  margin-bottom: -${theme.spacings.bit};
+`;
+
+const StyledCloseButton = styled(CloseButton)(closeButtonStyles);
+
+export function NotificationToast({
+  variant = 'info',
+  body,
+  headline,
+  action,
+  onClose,
+  closeButtonLabel,
+  isVisible,
+  tracking,
+
+  ...props
+}: NotificationToastProps): JSX.Element {
+  const contentElement = useRef(null);
+  const [isOpen, setOpen] = useState(isVisible);
+  const [height, setHeight] = useState(getHeight(contentElement));
+  const [, setAnimating] = useAnimation();
+  useEffect(() => {
+    setAnimating({
+      duration: 200,
+      onStart: () => {
+        setHeight(getHeight(contentElement));
+        // Delaying the state update until the next animation frame ensures that
+        // the browsers renders the new height before the animation starts.
+        window.requestAnimationFrame(() => {
+          setOpen(isVisible);
+        });
+      },
+      onEnd: () => {
+        setHeight(DEFAULT_HEIGHT);
+      },
+    });
+  }, [isVisible, setAnimating]);
+
+  return (
+    <NotificationToastWrapper
+      ref={contentElement}
+      style={{
+        opacity: isOpen ? 1 : 0,
+        height: isOpen ? height : 0,
+        visibility: isOpen ? 'visible' : 'hidden',
+      }}
+      variant={variant}
+      {...props}
+    >
+      <StyledIcon as={iconMap[variant]} variant={variant} />
+      <Content>
+        {headline && (
+          <Body variant={'highlight'} as="h3" noMargin>
+            {headline}
+          </Body>
+        )}
+        <Body noMargin>{body}</Body>
+        {action && <ActionButton {...action} variant={'tertiary'} />}
+      </Content>
+
+      <StyledCloseButton
+        label={closeButtonLabel}
+        size="kilo"
+        onClick={onClose}
+        tracking={
+          tracking
+            ? { component: 'notification-close', ...tracking }
+            : undefined
+        }
+      />
+    </NotificationToastWrapper>
+  );
+}
+
+NotificationToast.TIMEOUT = TRANSITION_DURATION;
+
+export function getHeight(element: RefObject<HTMLElement>): string {
+  if (!element || !element.current) {
+    return DEFAULT_HEIGHT;
+  }
+  return `${element.current.scrollHeight}px`;
+}
+
+export const useNotificationToast = createUseToast(NotificationToast);

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -13,16 +13,14 @@
  * limitations under the License.
  */
 
-/**
- * <NotificationToast />
- *   animation -> reference NotificationBanner
- *
- * useNotificationToast()
- *   ToastContext
- *   createUseToast
- *   useStack
- */
-import { ReactNode, RefObject, useEffect, useRef, useState } from 'react';
+import {
+  HTMLAttributes,
+  ReactNode,
+  RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { css } from '@emotion/react';
 import { Alert, Confirm, Info, Notify } from '@sumup/icons';
 
@@ -44,44 +42,43 @@ type Action = ButtonProps & {
   variant: 'tertiary';
 };
 
-export type NotificationToastProps = BaseToastProps & {
-  /**
-   * Notification toast variants.
-   * Use the `info` variant for the informational messages (default), 'confirm' for successfull message,
-   * 'notify' for warning messages and 'alert' for error messages.
-   */
-  variant: Variant;
-  /**
-   * Notification toast headline to provide information (optional)
-   */
-  headline?: string | ReactNode;
-  /**
-   * An body copy to provide notification toast information
-   */
-  body: string | ReactNode;
-  /**
-   * An optional call-to-action button.
-   */
-  action?: Action;
-  /**
-   * Whether the notification toast is visible.
-   */
-  isVisible?: boolean;
-  /**
-   * Additional data that is dispatched with the tracking event.
-   */
-  tracking?: TrackingProps;
-  /**
-   * Renders a close button in the top right corner and calls the provided function
-   * when the button is clicked.
-   */
-  onClose?: (event: ClickEvent) => void;
-  /**
-   * Text label for the close button for screen readers.
-   * Important for accessibility.
-   */
-  closeButtonLabel: string;
-};
+export type NotificationToastProps = HTMLAttributes<HTMLDivElement> &
+  BaseToastProps & {
+    /**
+     * Notification toast variants. Defaults to `info`.
+     */
+    variant?: Variant;
+    /**
+     * Notification toast headline to provide information (optional)
+     */
+    headline?: string | ReactNode;
+    /**
+     * An body copy to provide notification toast information
+     */
+    body: string | ReactNode;
+    /**
+     * An optional call-to-action button.
+     */
+    action?: Action;
+    /**
+     * Whether the notification toast is visible.
+     */
+    isVisible?: boolean;
+    /**
+     * Additional data that is dispatched with the tracking event.
+     */
+    tracking?: TrackingProps;
+    /**
+     * Renders a close button in the top right corner and calls the provided function
+     * when the button is clicked.
+     */
+    onClose?: (event: ClickEvent) => void;
+    /**
+     * Text label for the close button for screen readers.
+     * Important for accessibility.
+     */
+    closeButtonLabel: string;
+  };
 
 // TODO: update the design token colors to be info/confirm/alert/notify, then remove this mapping
 const colorMap = {
@@ -98,10 +95,14 @@ const iconMap = {
   notify: Notify,
 };
 
+type NotificationToastWrapperProps = HTMLAttributes<HTMLDivElement> & {
+  variant: Variant;
+};
+
 const toastWrapperStyles = ({
   theme,
   variant,
-}: Pick<NotificationToastProps, 'variant'> & StyleProps) => css`
+}: NotificationToastWrapperProps & StyleProps) => css`
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -115,7 +116,9 @@ const toastWrapperStyles = ({
     visibility 200ms ease-in-out;
 `;
 
-const NotificationToastWrapper = styled('div')(toastWrapperStyles);
+const NotificationToastWrapper = styled('div')<NotificationToastWrapperProps>(
+  toastWrapperStyles,
+);
 
 const contentStyles = ({ theme }: StyleProps) => css`
   display: flex;
@@ -178,7 +181,7 @@ export function NotificationToast({
   closeButtonLabel,
   isVisible,
   tracking,
-
+  duration, // this is the auto-dismiss duration, not the animation duration. We shouldn't pass it to the wrapper along with ...props
   ...props
 }: NotificationToastProps): JSX.Element {
   const contentElement = useRef(null);

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -100,9 +100,8 @@ const toastWrapperStyles = ({
     visibility 200ms ease-in-out;
 `;
 
-const NotificationToastWrapper = styled('div')<NotificationToastWrapperProps>(
-  toastWrapperStyles,
-);
+const NotificationToastWrapper =
+  styled('div')<NotificationToastWrapperProps>(toastWrapperStyles);
 
 const contentStyles = ({ theme }: StyleProps) => css`
   display: flex;

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -13,14 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  HTMLAttributes,
-  ReactNode,
-  RefObject,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { HTMLAttributes, RefObject, useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import { Alert, Confirm, Info, Notify } from '@sumup/icons';
 
@@ -31,6 +24,7 @@ import { TrackingProps } from '../../hooks/useClickEvent';
 import CloseButton from '../CloseButton';
 import { ClickEvent } from '../../types/events';
 import { BaseToastProps, createUseToast } from '../ToastContext';
+import { hideVisually } from '../../styles/style-mixins';
 
 const TRANSITION_DURATION = 200;
 const DEFAULT_HEIGHT = 'auto';
@@ -46,29 +40,28 @@ export type NotificationToastProps = HTMLAttributes<HTMLDivElement> &
     /**
      * Notification toast headline to provide information (optional)
      */
-    headline?: string | ReactNode;
+    headline?: string;
     /**
-     * An body copy to provide notification toast information
+     * A body copy to provide notification toast information
      */
-    body: string | ReactNode;
+    body: string;
     /**
      * Whether the notification toast is visible.
      */
-    isVisible?: boolean;
+    isVisible: boolean;
     /**
      * Additional data that is dispatched with the tracking event.
      */
     tracking?: TrackingProps;
     /**
-     * Renders a close button in the top right corner and calls the provided function
-     * when the button is clicked.
+     * Close button is always rendered in the top right corner
+     * onClose is called when the toast is auto-dismissed or the close button is clicked.
      */
     onClose?: (event: ClickEvent) => void;
     /**
-     * Text label for the close button for screen readers.
-     * Important for accessibility.
+     * A clear and concise description of the icon and the Toast's purpose.
      */
-    closeButtonLabel: string;
+    iconLabel: string;
   };
 
 // TODO: update the design token colors to be info/confirm/alert/notify, then remove this mapping
@@ -149,7 +142,7 @@ export function NotificationToast({
   body,
   headline,
   onClose,
-  closeButtonLabel,
+  iconLabel,
   isVisible,
   tracking,
   duration, // this is the auto-dismiss duration, not the animation duration. We shouldn't pass it to the wrapper along with ...props
@@ -187,7 +180,8 @@ export function NotificationToast({
       variant={variant}
       {...props}
     >
-      <StyledIcon as={iconMap[variant]} variant={variant} />
+      <StyledIcon as={iconMap[variant]} variant={variant} role="presentation" />
+      <span css={hideVisually}>{iconLabel}</span>
       <Content>
         {headline && (
           <Body variant={'highlight'} as="h3" noMargin>
@@ -198,7 +192,8 @@ export function NotificationToast({
       </Content>
 
       <StyledCloseButton
-        label={closeButtonLabel}
+        label="-" // We need to pass a label here to prevent CloseButton from throwing an error
+        aria-hidden="true"
         size="kilo"
         onClick={onClose}
         tracking={
@@ -206,6 +201,7 @@ export function NotificationToast({
             ? { component: 'notification-close', ...tracking }
             : undefined
         }
+        tabIndex={-1}
       />
     </NotificationToastWrapper>
   );

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -24,7 +24,6 @@ import {
 import { css } from '@emotion/react';
 import { Alert, Confirm, Info, Notify } from '@sumup/icons';
 
-import Button, { ButtonProps } from '../Button';
 import styled, { StyleProps } from '../../styles/styled';
 import { useAnimation } from '../../hooks/useAnimation';
 import Body from '../Body';
@@ -37,10 +36,6 @@ const TRANSITION_DURATION = 200;
 const DEFAULT_HEIGHT = 'auto';
 
 type Variant = 'info' | 'confirm' | 'notify' | 'alert';
-
-type Action = ButtonProps & {
-  variant: 'tertiary';
-};
 
 export type NotificationToastProps = HTMLAttributes<HTMLDivElement> &
   BaseToastProps & {
@@ -56,10 +51,6 @@ export type NotificationToastProps = HTMLAttributes<HTMLDivElement> &
      * An body copy to provide notification toast information
      */
     body: string | ReactNode;
-    /**
-     * An optional call-to-action button.
-     */
-    action?: Action;
     /**
      * Whether the notification toast is visible.
      */
@@ -130,26 +121,6 @@ const contentStyles = ({ theme }: StyleProps) => css`
 
 const Content = styled('div')(contentStyles);
 
-const actionButtonStyles = ({ theme }: StyleProps & ButtonProps) =>
-  css`
-    font-weight: bold;
-    text-decoration-line: underline;
-    color: ${theme.colors.black};
-    padding-bottom: calc(${theme.spacings.kilo} - ${theme.borderWidth.kilo});
-
-    &:hover {
-      color: ${theme.colors.n800};
-    }
-
-    &:active,
-    &[aria-expanded='true'],
-    &[aria-pressed='true'] {
-      color: ${theme.colors.n700};
-    }
-  `;
-
-const ActionButton = styled(Button)(actionButtonStyles);
-
 const StyledIcon = styled.span(
   ({ theme, variant }: StyleProps & { variant: Variant }) =>
     css`
@@ -168,6 +139,7 @@ const closeButtonStyles = ({ theme }: StyleProps) => css`
   align-self: flex-start;
   margin-top: -${theme.spacings.bit};
   margin-bottom: -${theme.spacings.bit};
+  margin-left: auto;
 `;
 
 const StyledCloseButton = styled(CloseButton)(closeButtonStyles);
@@ -176,7 +148,6 @@ export function NotificationToast({
   variant = 'info',
   body,
   headline,
-  action,
   onClose,
   closeButtonLabel,
   isVisible,
@@ -224,7 +195,6 @@ export function NotificationToast({
           </Body>
         )}
         <Body noMargin>{body}</Body>
-        {action && <ActionButton {...action} variant={'tertiary'} />}
       </Content>
 
       <StyledCloseButton

--- a/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
@@ -1,0 +1,2694 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationToast styles should render notification toast with alert styles 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": @keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #D23F47;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #D23F47;
+}
+
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-3 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-4 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:disabled,
+.circuit-4[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-4:active,
+.circuit-4[aria-expanded='true'],
+.circuit-4[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-5 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-6 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<body>
+    <div>
+      <div
+        class="circuit-0"
+        style="opacity: 0; height: 0px; visibility: hidden;"
+      >
+        <svg
+          class="circuit-1"
+          fill="none"
+          height="24"
+          variant="alert"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
+            fill="currentColor"
+          />
+        </svg>
+        <div
+          class="circuit-2"
+        >
+          <p
+            class="circuit-3"
+          >
+            This is a toast message
+          </p>
+        </div>
+        <button
+          class="circuit-4"
+          title="Close toast"
+          type="button"
+        >
+          <span
+            class="circuit-5"
+          >
+            <span
+              class="circuit-6"
+            />
+          </span>
+          <span
+            class="circuit-7"
+          >
+            <svg
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+            <span
+              class="circuit-6"
+            >
+              Close toast
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </body>,
+  "container": @keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #D23F47;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #D23F47;
+}
+
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-3 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-4 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:disabled,
+.circuit-4[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-4:active,
+.circuit-4[aria-expanded='true'],
+.circuit-4[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-5 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-6 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<div>
+    <div
+      class="circuit-0"
+      style="opacity: 0; height: 0px; visibility: hidden;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        variant="alert"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
+          fill="currentColor"
+        />
+      </svg>
+      <div
+        class="circuit-2"
+      >
+        <p
+          class="circuit-3"
+        >
+          This is a toast message
+        </p>
+      </div>
+      <button
+        class="circuit-4"
+        title="Close toast"
+        type="button"
+      >
+        <span
+          class="circuit-5"
+        >
+          <span
+            class="circuit-6"
+          />
+        </span>
+        <span
+          class="circuit-7"
+        >
+          <svg
+            fill="none"
+            height="16"
+            role="presentation"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+          <span
+            class="circuit-6"
+          >
+            Close toast
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`NotificationToast styles should render notification toast with confirm styles 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": @keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #138849;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #138849;
+}
+
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-3 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-4 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:disabled,
+.circuit-4[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-4:active,
+.circuit-4[aria-expanded='true'],
+.circuit-4[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-5 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-6 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<body>
+    <div>
+      <div
+        class="circuit-0"
+        style="opacity: 0; height: 0px; visibility: hidden;"
+      >
+        <svg
+          class="circuit-1"
+          fill="none"
+          height="24"
+          variant="confirm"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
+            fill="currentColor"
+          />
+        </svg>
+        <div
+          class="circuit-2"
+        >
+          <p
+            class="circuit-3"
+          >
+            This is a toast message
+          </p>
+        </div>
+        <button
+          class="circuit-4"
+          title="Close toast"
+          type="button"
+        >
+          <span
+            class="circuit-5"
+          >
+            <span
+              class="circuit-6"
+            />
+          </span>
+          <span
+            class="circuit-7"
+          >
+            <svg
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+            <span
+              class="circuit-6"
+            >
+              Close toast
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </body>,
+  "container": @keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #138849;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #138849;
+}
+
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-3 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-4 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:disabled,
+.circuit-4[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-4:active,
+.circuit-4[aria-expanded='true'],
+.circuit-4[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-5 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-6 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<div>
+    <div
+      class="circuit-0"
+      style="opacity: 0; height: 0px; visibility: hidden;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        variant="confirm"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
+          fill="currentColor"
+        />
+      </svg>
+      <div
+        class="circuit-2"
+      >
+        <p
+          class="circuit-3"
+        >
+          This is a toast message
+        </p>
+      </div>
+      <button
+        class="circuit-4"
+        title="Close toast"
+        type="button"
+      >
+        <span
+          class="circuit-5"
+        >
+          <span
+            class="circuit-6"
+          />
+        </span>
+        <span
+          class="circuit-7"
+        >
+          <svg
+            fill="none"
+            height="16"
+            role="presentation"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+          <span
+            class="circuit-6"
+          >
+            Close toast
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`NotificationToast styles should render notification toast with info styles 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": @keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #3063E9;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #3063E9;
+}
+
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-3 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-4 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:disabled,
+.circuit-4[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-4:active,
+.circuit-4[aria-expanded='true'],
+.circuit-4[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-5 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-6 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<body>
+    <div>
+      <div
+        class="circuit-0"
+        style="opacity: 0; height: 0px; visibility: hidden;"
+      >
+        <svg
+          class="circuit-1"
+          fill="none"
+          height="24"
+          variant="info"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+            fill="currentColor"
+          />
+        </svg>
+        <div
+          class="circuit-2"
+        >
+          <p
+            class="circuit-3"
+          >
+            This is a toast message
+          </p>
+        </div>
+        <button
+          class="circuit-4"
+          title="Close toast"
+          type="button"
+        >
+          <span
+            class="circuit-5"
+          >
+            <span
+              class="circuit-6"
+            />
+          </span>
+          <span
+            class="circuit-7"
+          >
+            <svg
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+            <span
+              class="circuit-6"
+            >
+              Close toast
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </body>,
+  "container": @keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #3063E9;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #3063E9;
+}
+
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-3 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-4 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:disabled,
+.circuit-4[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-4:active,
+.circuit-4[aria-expanded='true'],
+.circuit-4[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-5 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-6 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<div>
+    <div
+      class="circuit-0"
+      style="opacity: 0; height: 0px; visibility: hidden;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        variant="info"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+          fill="currentColor"
+        />
+      </svg>
+      <div
+        class="circuit-2"
+      >
+        <p
+          class="circuit-3"
+        >
+          This is a toast message
+        </p>
+      </div>
+      <button
+        class="circuit-4"
+        title="Close toast"
+        type="button"
+      >
+        <span
+          class="circuit-5"
+        >
+          <span
+            class="circuit-6"
+          />
+        </span>
+        <span
+          class="circuit-7"
+        >
+          <svg
+            fill="none"
+            height="16"
+            role="presentation"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+          <span
+            class="circuit-6"
+          >
+            Close toast
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`NotificationToast styles should render notification toast with notify styles 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": @keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #F5C625;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #F5C625;
+}
+
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-3 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-4 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:disabled,
+.circuit-4[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-4:active,
+.circuit-4[aria-expanded='true'],
+.circuit-4[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-5 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-6 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<body>
+    <div>
+      <div
+        class="circuit-0"
+        style="opacity: 0; height: 0px; visibility: hidden;"
+      >
+        <svg
+          class="circuit-1"
+          fill="none"
+          height="24"
+          variant="notify"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </svg>
+        <div
+          class="circuit-2"
+        >
+          <p
+            class="circuit-3"
+          >
+            This is a toast message
+          </p>
+        </div>
+        <button
+          class="circuit-4"
+          title="Close toast"
+          type="button"
+        >
+          <span
+            class="circuit-5"
+          >
+            <span
+              class="circuit-6"
+            />
+          </span>
+          <span
+            class="circuit-7"
+          >
+            <svg
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+            <span
+              class="circuit-6"
+            >
+              Close toast
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </body>,
+  "container": @keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #F5C625;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #F5C625;
+}
+
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-3 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-4 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:disabled,
+.circuit-4[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-4:active,
+.circuit-4[aria-expanded='true'],
+.circuit-4[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-5 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-6 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<div>
+    <div
+      class="circuit-0"
+      style="opacity: 0; height: 0px; visibility: hidden;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        variant="notify"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+          fill="currentColor"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <div
+        class="circuit-2"
+      >
+        <p
+          class="circuit-3"
+        >
+          This is a toast message
+        </p>
+      </div>
+      <button
+        class="circuit-4"
+        title="Close toast"
+        type="button"
+      >
+        <span
+          class="circuit-5"
+        >
+          <span
+            class="circuit-6"
+          />
+        </span>
+        <span
+          class="circuit-7"
+        >
+          <svg
+            fill="none"
+            height="16"
+            role="presentation"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+          <span
+            class="circuit-6"
+          >
+            Close toast
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`NotificationToast styles should render with default styles 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #3063E9;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #3063E9;
+}
+
+.circuit-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-3 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-4 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:disabled,
+.circuit-4[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-4:active,
+.circuit-4[aria-expanded='true'],
+.circuit-4[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-5 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-6 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 0; height: 0px; visibility: hidden;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        variant="info"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+          fill="currentColor"
+        />
+      </svg>
+      <div
+        class="circuit-2"
+      >
+        <p
+          class="circuit-3"
+        >
+          This is a toast message
+        </p>
+      </div>
+      <button
+        class="circuit-4"
+        title="Close toast"
+        type="button"
+      >
+        <span
+          class="circuit-5"
+        >
+          <span
+            class="circuit-6"
+          />
+        </span>
+        <span
+          class="circuit-7"
+        >
+          <svg
+            fill="none"
+            height="16"
+            role="presentation"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+          <span
+            class="circuit-6"
+          >
+            Close toast
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
@@ -566,6 +566,303 @@ exports[`NotificationToast styles should render notification toast with confirm 
 </body>
 `;
 
+exports[`NotificationToast styles should render notification toast with headline 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #3063E9;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #3063E9;
+}
+
+.circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-4 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+  font-weight: 700;
+}
+
+.circuit-5 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-6 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-6:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-6:disabled,
+.circuit-6[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-6:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-6:active,
+.circuit-6[aria-expanded='true'],
+.circuit-6[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-7 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 0; height: 0px; visibility: hidden;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        role="presentation"
+        variant="info"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="circuit-2"
+      />
+      <div
+        class="circuit-3"
+      >
+        <h3
+          class="circuit-4"
+        >
+          Information
+        </h3>
+        <p
+          class="circuit-5"
+        >
+          This is a toast message
+        </p>
+      </div>
+      <button
+        aria-hidden="true"
+        class="circuit-6"
+        tabindex="-1"
+        title="-"
+        type="button"
+      >
+        <span
+          class="circuit-7"
+        >
+          <span
+            class="circuit-2"
+          />
+        </span>
+        <span
+          class="circuit-9"
+        >
+          <svg
+            fill="none"
+            height="16"
+            role="presentation"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+          <span
+            class="circuit-2"
+          >
+            -
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`NotificationToast styles should render notification toast with info styles 1`] = `
 @keyframes animation-0 {
   0% {

--- a/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NotificationToast styles should render notification toast with alert styles 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": @keyframes animation-0 {
+@keyframes animation-0 {
   0% {
     -webkit-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
@@ -58,6 +56,18 @@ Object {
 }
 
 .circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -73,7 +83,7 @@ Object {
   padding-left: 16px;
 }
 
-.circuit-3 {
+.circuit-4 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -81,7 +91,7 @@ Object {
   margin-bottom: 0;
 }
 
-.circuit-4 {
+.circuit-5 {
   font-size: 16px;
   line-height: 24px;
   display: -webkit-inline-box;
@@ -128,39 +138,39 @@ Object {
   margin-left: auto;
 }
 
-.circuit-4:focus {
+.circuit-5:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-4:focus::-moz-focus-inner {
+.circuit-5:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-4:focus:not(:focus-visible) {
+.circuit-5:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-4:disabled,
-.circuit-4[disabled] {
+.circuit-5:disabled,
+.circuit-5[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
-.circuit-4:hover {
+.circuit-5:hover {
   background-color: #F5F5F5;
   border-color: #666;
 }
 
-.circuit-4:active,
-.circuit-4[aria-expanded='true'],
-.circuit-4[aria-pressed='true'] {
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
   background-color: #E6E6E6;
   border-color: #333;
 }
 
-.circuit-5 {
+.circuit-6 {
   display: block;
   border-radius: 100%;
   border: 2px solid currentColor;
@@ -177,19 +187,7 @@ Object {
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
 }
 
-.circuit-6 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-7 {
+.circuit-8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -209,280 +207,7 @@ Object {
 }
 
 <body>
-    <div>
-      <div
-        class="circuit-0"
-        style="opacity: 0; height: 0px; visibility: hidden;"
-      >
-        <svg
-          class="circuit-1"
-          fill="none"
-          height="24"
-          variant="alert"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
-            fill="currentColor"
-          />
-        </svg>
-        <div
-          class="circuit-2"
-        >
-          <p
-            class="circuit-3"
-          >
-            This is a toast message
-          </p>
-        </div>
-        <button
-          class="circuit-4"
-          title="Close toast"
-          type="button"
-        >
-          <span
-            class="circuit-5"
-          >
-            <span
-              class="circuit-6"
-            />
-          </span>
-          <span
-            class="circuit-7"
-          >
-            <svg
-              fill="none"
-              height="16"
-              role="presentation"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
-                fill="currentColor"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <span
-              class="circuit-6"
-            >
-              Close toast
-            </span>
-          </span>
-        </button>
-      </div>
-    </div>
-  </body>,
-  "container": @keyframes animation-0 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  background-color: #FFF;
-  padding: 12px 16px;
-  border-radius: 8px;
-  border: 2px solid #D23F47;
-  overflow: hidden;
-  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-}
-
-.circuit-1 {
-  display: block;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  line-height: 0;
-  color: #D23F47;
-}
-
-.circuit-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  padding-right: 40px;
-  padding-left: 16px;
-}
-
-.circuit-3 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 0;
-}
-
-.circuit-4 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #FFF;
-  border-color: #999;
-  color: #000;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-  padding: calc(8px - 1px);
-  border-color: transparent!important;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-  margin-top: -4px;
-  margin-bottom: -4px;
-  margin-left: auto;
-}
-
-.circuit-4:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-4:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-4:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-4:disabled,
-.circuit-4[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-4:hover {
-  background-color: #F5F5F5;
-  border-color: #666;
-}
-
-.circuit-4:active,
-.circuit-4[aria-expanded='true'],
-.circuit-4[aria-pressed='true'] {
-  background-color: #E6E6E6;
-  border-color: #333;
-}
-
-.circuit-5 {
-  display: block;
-  border-radius: 100%;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  -webkit-animation: animation-0 1s infinite linear;
-  animation: animation-0 1s infinite linear;
-  transform-origin: 50% 50%;
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-6 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-7 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  opacity: 1;
-  visibility: inherit;
-  -webkit-transform: scale3d(1, 1, 1);
-  -moz-transform: scale3d(1, 1, 1);
-  -ms-transform: scale3d(1, 1, 1);
-  transform: scale3d(1, 1, 1);
-  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-<div>
+  <div>
     <div
       class="circuit-0"
       style="opacity: 0; height: 0px; visibility: hidden;"
@@ -491,6 +216,7 @@ Object {
         class="circuit-1"
         fill="none"
         height="24"
+        role="presentation"
         variant="alert"
         viewBox="0 0 24 24"
         width="24"
@@ -501,29 +227,34 @@ Object {
           fill="currentColor"
         />
       </svg>
-      <div
+      <span
         class="circuit-2"
+      />
+      <div
+        class="circuit-3"
       >
         <p
-          class="circuit-3"
+          class="circuit-4"
         >
           This is a toast message
         </p>
       </div>
       <button
-        class="circuit-4"
-        title="Close toast"
+        aria-hidden="true"
+        class="circuit-5"
+        tabindex="-1"
+        title="-"
         type="button"
       >
         <span
-          class="circuit-5"
+          class="circuit-6"
         >
           <span
-            class="circuit-6"
+            class="circuit-2"
           />
         </span>
         <span
-          class="circuit-7"
+          class="circuit-8"
         >
           <svg
             fill="none"
@@ -541,72 +272,19 @@ Object {
             />
           </svg>
           <span
-            class="circuit-6"
+            class="circuit-2"
           >
-            Close toast
+            -
           </span>
         </span>
       </button>
     </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+  </div>
+</body>
 `;
 
 exports[`NotificationToast styles should render notification toast with confirm styles 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": @keyframes animation-0 {
+@keyframes animation-0 {
   0% {
     -webkit-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
@@ -661,6 +339,18 @@ Object {
 }
 
 .circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -676,7 +366,7 @@ Object {
   padding-left: 16px;
 }
 
-.circuit-3 {
+.circuit-4 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -684,7 +374,7 @@ Object {
   margin-bottom: 0;
 }
 
-.circuit-4 {
+.circuit-5 {
   font-size: 16px;
   line-height: 24px;
   display: -webkit-inline-box;
@@ -731,39 +421,39 @@ Object {
   margin-left: auto;
 }
 
-.circuit-4:focus {
+.circuit-5:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-4:focus::-moz-focus-inner {
+.circuit-5:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-4:focus:not(:focus-visible) {
+.circuit-5:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-4:disabled,
-.circuit-4[disabled] {
+.circuit-5:disabled,
+.circuit-5[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
-.circuit-4:hover {
+.circuit-5:hover {
   background-color: #F5F5F5;
   border-color: #666;
 }
 
-.circuit-4:active,
-.circuit-4[aria-expanded='true'],
-.circuit-4[aria-pressed='true'] {
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
   background-color: #E6E6E6;
   border-color: #333;
 }
 
-.circuit-5 {
+.circuit-6 {
   display: block;
   border-radius: 100%;
   border: 2px solid currentColor;
@@ -780,19 +470,7 @@ Object {
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
 }
 
-.circuit-6 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-7 {
+.circuit-8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -812,280 +490,7 @@ Object {
 }
 
 <body>
-    <div>
-      <div
-        class="circuit-0"
-        style="opacity: 0; height: 0px; visibility: hidden;"
-      >
-        <svg
-          class="circuit-1"
-          fill="none"
-          height="24"
-          variant="confirm"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
-            fill="currentColor"
-          />
-        </svg>
-        <div
-          class="circuit-2"
-        >
-          <p
-            class="circuit-3"
-          >
-            This is a toast message
-          </p>
-        </div>
-        <button
-          class="circuit-4"
-          title="Close toast"
-          type="button"
-        >
-          <span
-            class="circuit-5"
-          >
-            <span
-              class="circuit-6"
-            />
-          </span>
-          <span
-            class="circuit-7"
-          >
-            <svg
-              fill="none"
-              height="16"
-              role="presentation"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
-                fill="currentColor"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <span
-              class="circuit-6"
-            >
-              Close toast
-            </span>
-          </span>
-        </button>
-      </div>
-    </div>
-  </body>,
-  "container": @keyframes animation-0 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  background-color: #FFF;
-  padding: 12px 16px;
-  border-radius: 8px;
-  border: 2px solid #138849;
-  overflow: hidden;
-  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-}
-
-.circuit-1 {
-  display: block;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  line-height: 0;
-  color: #138849;
-}
-
-.circuit-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  padding-right: 40px;
-  padding-left: 16px;
-}
-
-.circuit-3 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 0;
-}
-
-.circuit-4 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #FFF;
-  border-color: #999;
-  color: #000;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-  padding: calc(8px - 1px);
-  border-color: transparent!important;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-  margin-top: -4px;
-  margin-bottom: -4px;
-  margin-left: auto;
-}
-
-.circuit-4:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-4:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-4:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-4:disabled,
-.circuit-4[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-4:hover {
-  background-color: #F5F5F5;
-  border-color: #666;
-}
-
-.circuit-4:active,
-.circuit-4[aria-expanded='true'],
-.circuit-4[aria-pressed='true'] {
-  background-color: #E6E6E6;
-  border-color: #333;
-}
-
-.circuit-5 {
-  display: block;
-  border-radius: 100%;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  -webkit-animation: animation-0 1s infinite linear;
-  animation: animation-0 1s infinite linear;
-  transform-origin: 50% 50%;
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-6 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-7 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  opacity: 1;
-  visibility: inherit;
-  -webkit-transform: scale3d(1, 1, 1);
-  -moz-transform: scale3d(1, 1, 1);
-  -ms-transform: scale3d(1, 1, 1);
-  transform: scale3d(1, 1, 1);
-  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-<div>
+  <div>
     <div
       class="circuit-0"
       style="opacity: 0; height: 0px; visibility: hidden;"
@@ -1094,6 +499,7 @@ Object {
         class="circuit-1"
         fill="none"
         height="24"
+        role="presentation"
         variant="confirm"
         viewBox="0 0 24 24"
         width="24"
@@ -1104,29 +510,34 @@ Object {
           fill="currentColor"
         />
       </svg>
-      <div
+      <span
         class="circuit-2"
+      />
+      <div
+        class="circuit-3"
       >
         <p
-          class="circuit-3"
+          class="circuit-4"
         >
           This is a toast message
         </p>
       </div>
       <button
-        class="circuit-4"
-        title="Close toast"
+        aria-hidden="true"
+        class="circuit-5"
+        tabindex="-1"
+        title="-"
         type="button"
       >
         <span
-          class="circuit-5"
+          class="circuit-6"
         >
           <span
-            class="circuit-6"
+            class="circuit-2"
           />
         </span>
         <span
-          class="circuit-7"
+          class="circuit-8"
         >
           <svg
             fill="none"
@@ -1144,72 +555,19 @@ Object {
             />
           </svg>
           <span
-            class="circuit-6"
+            class="circuit-2"
           >
-            Close toast
+            -
           </span>
         </span>
       </button>
     </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+  </div>
+</body>
 `;
 
 exports[`NotificationToast styles should render notification toast with info styles 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": @keyframes animation-0 {
+@keyframes animation-0 {
   0% {
     -webkit-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
@@ -1264,6 +622,18 @@ Object {
 }
 
 .circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1279,7 +649,7 @@ Object {
   padding-left: 16px;
 }
 
-.circuit-3 {
+.circuit-4 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -1287,7 +657,7 @@ Object {
   margin-bottom: 0;
 }
 
-.circuit-4 {
+.circuit-5 {
   font-size: 16px;
   line-height: 24px;
   display: -webkit-inline-box;
@@ -1334,39 +704,39 @@ Object {
   margin-left: auto;
 }
 
-.circuit-4:focus {
+.circuit-5:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-4:focus::-moz-focus-inner {
+.circuit-5:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-4:focus:not(:focus-visible) {
+.circuit-5:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-4:disabled,
-.circuit-4[disabled] {
+.circuit-5:disabled,
+.circuit-5[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
-.circuit-4:hover {
+.circuit-5:hover {
   background-color: #F5F5F5;
   border-color: #666;
 }
 
-.circuit-4:active,
-.circuit-4[aria-expanded='true'],
-.circuit-4[aria-pressed='true'] {
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
   background-color: #E6E6E6;
   border-color: #333;
 }
 
-.circuit-5 {
+.circuit-6 {
   display: block;
   border-radius: 100%;
   border: 2px solid currentColor;
@@ -1383,19 +753,7 @@ Object {
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
 }
 
-.circuit-6 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-7 {
+.circuit-8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1415,280 +773,7 @@ Object {
 }
 
 <body>
-    <div>
-      <div
-        class="circuit-0"
-        style="opacity: 0; height: 0px; visibility: hidden;"
-      >
-        <svg
-          class="circuit-1"
-          fill="none"
-          height="24"
-          variant="info"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-            fill="currentColor"
-          />
-        </svg>
-        <div
-          class="circuit-2"
-        >
-          <p
-            class="circuit-3"
-          >
-            This is a toast message
-          </p>
-        </div>
-        <button
-          class="circuit-4"
-          title="Close toast"
-          type="button"
-        >
-          <span
-            class="circuit-5"
-          >
-            <span
-              class="circuit-6"
-            />
-          </span>
-          <span
-            class="circuit-7"
-          >
-            <svg
-              fill="none"
-              height="16"
-              role="presentation"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
-                fill="currentColor"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <span
-              class="circuit-6"
-            >
-              Close toast
-            </span>
-          </span>
-        </button>
-      </div>
-    </div>
-  </body>,
-  "container": @keyframes animation-0 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  background-color: #FFF;
-  padding: 12px 16px;
-  border-radius: 8px;
-  border: 2px solid #3063E9;
-  overflow: hidden;
-  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-}
-
-.circuit-1 {
-  display: block;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  line-height: 0;
-  color: #3063E9;
-}
-
-.circuit-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  padding-right: 40px;
-  padding-left: 16px;
-}
-
-.circuit-3 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 0;
-}
-
-.circuit-4 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #FFF;
-  border-color: #999;
-  color: #000;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-  padding: calc(8px - 1px);
-  border-color: transparent!important;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-  margin-top: -4px;
-  margin-bottom: -4px;
-  margin-left: auto;
-}
-
-.circuit-4:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-4:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-4:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-4:disabled,
-.circuit-4[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-4:hover {
-  background-color: #F5F5F5;
-  border-color: #666;
-}
-
-.circuit-4:active,
-.circuit-4[aria-expanded='true'],
-.circuit-4[aria-pressed='true'] {
-  background-color: #E6E6E6;
-  border-color: #333;
-}
-
-.circuit-5 {
-  display: block;
-  border-radius: 100%;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  -webkit-animation: animation-0 1s infinite linear;
-  animation: animation-0 1s infinite linear;
-  transform-origin: 50% 50%;
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-6 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-7 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  opacity: 1;
-  visibility: inherit;
-  -webkit-transform: scale3d(1, 1, 1);
-  -moz-transform: scale3d(1, 1, 1);
-  -ms-transform: scale3d(1, 1, 1);
-  transform: scale3d(1, 1, 1);
-  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-<div>
+  <div>
     <div
       class="circuit-0"
       style="opacity: 0; height: 0px; visibility: hidden;"
@@ -1697,6 +782,7 @@ Object {
         class="circuit-1"
         fill="none"
         height="24"
+        role="presentation"
         variant="info"
         viewBox="0 0 24 24"
         width="24"
@@ -1707,29 +793,34 @@ Object {
           fill="currentColor"
         />
       </svg>
-      <div
+      <span
         class="circuit-2"
+      />
+      <div
+        class="circuit-3"
       >
         <p
-          class="circuit-3"
+          class="circuit-4"
         >
           This is a toast message
         </p>
       </div>
       <button
-        class="circuit-4"
-        title="Close toast"
+        aria-hidden="true"
+        class="circuit-5"
+        tabindex="-1"
+        title="-"
         type="button"
       >
         <span
-          class="circuit-5"
+          class="circuit-6"
         >
           <span
-            class="circuit-6"
+            class="circuit-2"
           />
         </span>
         <span
-          class="circuit-7"
+          class="circuit-8"
         >
           <svg
             fill="none"
@@ -1747,72 +838,19 @@ Object {
             />
           </svg>
           <span
-            class="circuit-6"
+            class="circuit-2"
           >
-            Close toast
+            -
           </span>
         </span>
       </button>
     </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+  </div>
+</body>
 `;
 
 exports[`NotificationToast styles should render notification toast with notify styles 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": @keyframes animation-0 {
+@keyframes animation-0 {
   0% {
     -webkit-transform: rotate(0deg);
     -moz-transform: rotate(0deg);
@@ -1867,6 +905,18 @@ Object {
 }
 
 .circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1882,7 +932,7 @@ Object {
   padding-left: 16px;
 }
 
-.circuit-3 {
+.circuit-4 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -1890,7 +940,7 @@ Object {
   margin-bottom: 0;
 }
 
-.circuit-4 {
+.circuit-5 {
   font-size: 16px;
   line-height: 24px;
   display: -webkit-inline-box;
@@ -1937,39 +987,39 @@ Object {
   margin-left: auto;
 }
 
-.circuit-4:focus {
+.circuit-5:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-4:focus::-moz-focus-inner {
+.circuit-5:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-4:focus:not(:focus-visible) {
+.circuit-5:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-4:disabled,
-.circuit-4[disabled] {
+.circuit-5:disabled,
+.circuit-5[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
-.circuit-4:hover {
+.circuit-5:hover {
   background-color: #F5F5F5;
   border-color: #666;
 }
 
-.circuit-4:active,
-.circuit-4[aria-expanded='true'],
-.circuit-4[aria-pressed='true'] {
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
   background-color: #E6E6E6;
   border-color: #333;
 }
 
-.circuit-5 {
+.circuit-6 {
   display: block;
   border-radius: 100%;
   border: 2px solid currentColor;
@@ -1986,19 +1036,7 @@ Object {
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
 }
 
-.circuit-6 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-7 {
+.circuit-8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2018,282 +1056,7 @@ Object {
 }
 
 <body>
-    <div>
-      <div
-        class="circuit-0"
-        style="opacity: 0; height: 0px; visibility: hidden;"
-      >
-        <svg
-          class="circuit-1"
-          fill="none"
-          height="24"
-          variant="notify"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <div
-          class="circuit-2"
-        >
-          <p
-            class="circuit-3"
-          >
-            This is a toast message
-          </p>
-        </div>
-        <button
-          class="circuit-4"
-          title="Close toast"
-          type="button"
-        >
-          <span
-            class="circuit-5"
-          >
-            <span
-              class="circuit-6"
-            />
-          </span>
-          <span
-            class="circuit-7"
-          >
-            <svg
-              fill="none"
-              height="16"
-              role="presentation"
-              viewBox="0 0 16 16"
-              width="16"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                clip-rule="evenodd"
-                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
-                fill="currentColor"
-                fill-rule="evenodd"
-              />
-            </svg>
-            <span
-              class="circuit-6"
-            >
-              Close toast
-            </span>
-          </span>
-        </button>
-      </div>
-    </div>
-  </body>,
-  "container": @keyframes animation-0 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  background-color: #FFF;
-  padding: 12px 16px;
-  border-radius: 8px;
-  border: 2px solid #F5C625;
-  overflow: hidden;
-  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-}
-
-.circuit-1 {
-  display: block;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  line-height: 0;
-  color: #F5C625;
-}
-
-.circuit-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  padding-right: 40px;
-  padding-left: 16px;
-}
-
-.circuit-3 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 0;
-}
-
-.circuit-4 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #FFF;
-  border-color: #999;
-  color: #000;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-  padding: calc(8px - 1px);
-  border-color: transparent!important;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-  margin-top: -4px;
-  margin-bottom: -4px;
-  margin-left: auto;
-}
-
-.circuit-4:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-4:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-4:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-4:disabled,
-.circuit-4[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-4:hover {
-  background-color: #F5F5F5;
-  border-color: #666;
-}
-
-.circuit-4:active,
-.circuit-4[aria-expanded='true'],
-.circuit-4[aria-pressed='true'] {
-  background-color: #E6E6E6;
-  border-color: #333;
-}
-
-.circuit-5 {
-  display: block;
-  border-radius: 100%;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  -webkit-animation: animation-0 1s infinite linear;
-  animation: animation-0 1s infinite linear;
-  transform-origin: 50% 50%;
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-6 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-7 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  opacity: 1;
-  visibility: inherit;
-  -webkit-transform: scale3d(1, 1, 1);
-  -moz-transform: scale3d(1, 1, 1);
-  -ms-transform: scale3d(1, 1, 1);
-  transform: scale3d(1, 1, 1);
-  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-<div>
+  <div>
     <div
       class="circuit-0"
       style="opacity: 0; height: 0px; visibility: hidden;"
@@ -2302,6 +1065,7 @@ Object {
         class="circuit-1"
         fill="none"
         height="24"
+        role="presentation"
         variant="notify"
         viewBox="0 0 24 24"
         width="24"
@@ -2314,29 +1078,34 @@ Object {
           fill-rule="evenodd"
         />
       </svg>
-      <div
+      <span
         class="circuit-2"
+      />
+      <div
+        class="circuit-3"
       >
         <p
-          class="circuit-3"
+          class="circuit-4"
         >
           This is a toast message
         </p>
       </div>
       <button
-        class="circuit-4"
-        title="Close toast"
+        aria-hidden="true"
+        class="circuit-5"
+        tabindex="-1"
+        title="-"
         type="button"
       >
         <span
-          class="circuit-5"
+          class="circuit-6"
         >
           <span
-            class="circuit-6"
+            class="circuit-2"
           />
         </span>
         <span
-          class="circuit-7"
+          class="circuit-8"
         >
           <svg
             fill="none"
@@ -2354,66 +1123,15 @@ Object {
             />
           </svg>
           <span
-            class="circuit-6"
+            class="circuit-2"
           >
-            Close toast
+            -
           </span>
         </span>
       </button>
     </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+  </div>
+</body>
 `;
 
 exports[`NotificationToast styles should render with default styles 1`] = `
@@ -2472,6 +1190,18 @@ exports[`NotificationToast styles should render with default styles 1`] = `
 }
 
 .circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2487,7 +1217,7 @@ exports[`NotificationToast styles should render with default styles 1`] = `
   padding-left: 16px;
 }
 
-.circuit-3 {
+.circuit-4 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -2495,7 +1225,7 @@ exports[`NotificationToast styles should render with default styles 1`] = `
   margin-bottom: 0;
 }
 
-.circuit-4 {
+.circuit-5 {
   font-size: 16px;
   line-height: 24px;
   display: -webkit-inline-box;
@@ -2542,39 +1272,39 @@ exports[`NotificationToast styles should render with default styles 1`] = `
   margin-left: auto;
 }
 
-.circuit-4:focus {
+.circuit-5:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-4:focus::-moz-focus-inner {
+.circuit-5:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-4:focus:not(:focus-visible) {
+.circuit-5:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-4:disabled,
-.circuit-4[disabled] {
+.circuit-5:disabled,
+.circuit-5[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
-.circuit-4:hover {
+.circuit-5:hover {
   background-color: #F5F5F5;
   border-color: #666;
 }
 
-.circuit-4:active,
-.circuit-4[aria-expanded='true'],
-.circuit-4[aria-pressed='true'] {
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
   background-color: #E6E6E6;
   border-color: #333;
 }
 
-.circuit-5 {
+.circuit-6 {
   display: block;
   border-radius: 100%;
   border: 2px solid currentColor;
@@ -2591,19 +1321,7 @@ exports[`NotificationToast styles should render with default styles 1`] = `
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
 }
 
-.circuit-6 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-7 {
+.circuit-8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2632,6 +1350,7 @@ exports[`NotificationToast styles should render with default styles 1`] = `
         class="circuit-1"
         fill="none"
         height="24"
+        role="presentation"
         variant="info"
         viewBox="0 0 24 24"
         width="24"
@@ -2642,29 +1361,34 @@ exports[`NotificationToast styles should render with default styles 1`] = `
           fill="currentColor"
         />
       </svg>
-      <div
+      <span
         class="circuit-2"
+      />
+      <div
+        class="circuit-3"
       >
         <p
-          class="circuit-3"
+          class="circuit-4"
         >
           This is a toast message
         </p>
       </div>
       <button
-        class="circuit-4"
-        title="Close toast"
+        aria-hidden="true"
+        class="circuit-5"
+        tabindex="-1"
+        title="-"
         type="button"
       >
         <span
-          class="circuit-5"
+          class="circuit-6"
         >
           <span
-            class="circuit-6"
+            class="circuit-2"
           />
         </span>
         <span
-          class="circuit-7"
+          class="circuit-8"
         >
           <svg
             fill="none"
@@ -2682,9 +1406,9 @@ exports[`NotificationToast styles should render with default styles 1`] = `
             />
           </svg>
           <span
-            class="circuit-6"
+            class="circuit-2"
           >
-            Close toast
+            -
           </span>
         </span>
       </button>

--- a/packages/circuit-ui/components/NotificationToast/index.tsx
+++ b/packages/circuit-ui/components/NotificationToast/index.tsx
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { useNotificationToast } from './NotificationToast';
+
+export type { NotificationToastProps } from './NotificationToast';

--- a/packages/circuit-ui/components/ToastContext/ToastContext.spec.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.spec.tsx
@@ -25,9 +25,7 @@ import type { ToastComponent } from './types';
 jest.mock('@sumup/collector');
 
 const Toast: ToastComponent = ({ onClose }) => (
-  <div role="dialog">
-    <button onClick={onClose}>Close</button>
-  </div>
+  <button onClick={onClose}>Close</button>
 );
 Toast.TIMEOUT = 200;
 
@@ -60,14 +58,10 @@ describe('ToastContext', () => {
     it('should open a toast when the context function is called', () => {
       const Trigger = () => {
         const { setToast } = useContext(ToastContext);
-        return (
-          <>
-            <button onClick={() => setToast(toast)}>Open toast</button>
-          </>
-        );
+        return <button onClick={() => setToast(toast)}>Open toast</button>;
       };
 
-      const { getByRole, getByText } = render(
+      const { queryByRole, getByText } = render(
         <ToastProvider>
           <Trigger />
         </ToastProvider>,
@@ -77,17 +71,13 @@ describe('ToastContext', () => {
         fireEvent.click(getByText('Open toast'));
       });
 
-      expect(getByRole('dialog')).toBeVisible();
+      expect(queryByRole('status')).toBeVisible();
     });
 
     it('should close the toast when the onClose method is called', () => {
       const Trigger = () => {
         const { setToast } = useContext(ToastContext);
-        return (
-          <>
-            <button onClick={() => setToast(toast)}>Open toast</button>
-          </>
-        );
+        return <button onClick={() => setToast(toast)}>Open toast</button>;
       };
 
       const { queryByRole } = render(
@@ -100,7 +90,6 @@ describe('ToastContext', () => {
         jest.runAllTimers();
       });
 
-      expect(queryByRole('dialog')).toBeNull();
       expect(onClose).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/circuit-ui/components/ToastContext/ToastContext.spec.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.spec.tsx
@@ -57,7 +57,7 @@ describe('ToastContext', () => {
       tracking: { label: 'test-toast' },
     };
 
-    it('should open and close a toast when the context functions are called', () => {
+    it('should open a toast when the context function is called', () => {
       const Trigger = () => {
         const { setToast } = useContext(ToastContext);
         return (

--- a/packages/circuit-ui/components/ToastContext/ToastContext.spec.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.spec.tsx
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable react/display-name */
+import React, { useContext } from 'react';
+import * as Collector from '@sumup/collector';
+
+import { render, act, userEvent, fireEvent } from '../../util/test-utils';
+
+import { ToastProvider, ToastContext } from './ToastContext';
+import type { ToastComponent } from './types';
+
+jest.mock('@sumup/collector');
+
+const Toast: ToastComponent = ({ onClose }) => (
+  <div role="dialog">
+    <button onClick={onClose}>Close</button>
+  </div>
+);
+Toast.TIMEOUT = 200;
+
+describe('ToastContext', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+    jest.resetModules();
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('ToastProvider', () => {
+    const dispatch = jest.fn();
+    // @ts-expect-error TypeScript doesn't allow assigning to the read-only
+    // useClickTrigger
+    Collector.useClickTrigger = jest.fn(() => dispatch);
+
+    const onClose = jest.fn();
+    const toast = {
+      id: 'initial',
+      component: Toast,
+      onClose,
+      tracking: { label: 'test-toast' },
+    };
+    const initialState = [toast];
+
+    it('should render the initial toasts', () => {
+      const { getByRole } = render(
+        <ToastProvider initialState={initialState}>
+          <div />
+        </ToastProvider>,
+      );
+
+      expect(getByRole('dialog')).toBeVisible();
+    });
+
+    it('should open and close a toast when the context functions are called', () => {
+      const Trigger = () => {
+        const { setToast, removeToast } = useContext(ToastContext);
+        return (
+          <>
+            <button onClick={() => setToast(toast)}>Open toast</button>
+            <button onClick={() => removeToast(toast)}>Close toast</button>
+          </>
+        );
+      };
+
+      const { getByRole, queryByRole, getByText } = render(
+        <ToastProvider>
+          <Trigger />
+        </ToastProvider>,
+      );
+
+      act(() => {
+        fireEvent.click(getByText('Open toast'));
+      });
+
+      expect(getByRole('dialog')).toBeVisible();
+
+      act(() => {
+        fireEvent.click(getByText('Close toast'));
+        jest.runAllTimers();
+      });
+
+      expect(queryByRole('dialog')).toBeNull();
+    });
+
+    it('should close the toast when the onClose method is called', () => {
+      const { queryByRole } = render(
+        <ToastProvider initialState={initialState}>
+          <div />
+        </ToastProvider>,
+      );
+
+      act(() => {
+        userEvent.click(queryByRole('button'));
+        jest.runAllTimers();
+      });
+
+      expect(queryByRole('dialog')).toBeNull();
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(dispatch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/circuit-ui/components/ToastContext/ToastContext.spec.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.spec.tsx
@@ -56,30 +56,18 @@ describe('ToastContext', () => {
       onClose,
       tracking: { label: 'test-toast' },
     };
-    const initialState = [toast];
-
-    it('should render the initial toasts', () => {
-      const { getByRole } = render(
-        <ToastProvider initialState={initialState}>
-          <div />
-        </ToastProvider>,
-      );
-
-      expect(getByRole('dialog')).toBeVisible();
-    });
 
     it('should open and close a toast when the context functions are called', () => {
       const Trigger = () => {
-        const { setToast, removeToast } = useContext(ToastContext);
+        const { setToast } = useContext(ToastContext);
         return (
           <>
             <button onClick={() => setToast(toast)}>Open toast</button>
-            <button onClick={() => removeToast(toast)}>Close toast</button>
           </>
         );
       };
 
-      const { getByRole, queryByRole, getByText } = render(
+      const { getByRole, getByText } = render(
         <ToastProvider>
           <Trigger />
         </ToastProvider>,
@@ -90,22 +78,23 @@ describe('ToastContext', () => {
       });
 
       expect(getByRole('dialog')).toBeVisible();
-
-      act(() => {
-        fireEvent.click(getByText('Close toast'));
-        jest.runAllTimers();
-      });
-
-      expect(queryByRole('dialog')).toBeNull();
     });
 
     it('should close the toast when the onClose method is called', () => {
+      const Trigger = () => {
+        const { setToast } = useContext(ToastContext);
+        return (
+          <>
+            <button onClick={() => setToast(toast)}>Open toast</button>
+          </>
+        );
+      };
+
       const { queryByRole } = render(
-        <ToastProvider initialState={initialState}>
-          <div />
+        <ToastProvider>
+          <Trigger />
         </ToastProvider>,
       );
-
       act(() => {
         userEvent.click(queryByRole('button'));
         jest.runAllTimers();
@@ -113,7 +102,6 @@ describe('ToastContext', () => {
 
       expect(queryByRole('dialog')).toBeNull();
       expect(onClose).toHaveBeenCalledTimes(1);
-      expect(dispatch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -107,10 +107,10 @@ export function ToastProvider<TProps extends BaseToastProps>({
     [dispatch, sendEvent],
   );
 
-  const context = useMemo(() => ({ setToast, removeToast }), [
-    setToast,
-    removeToast,
-  ]);
+  const context = useMemo(
+    () => ({ setToast, removeToast }),
+    [setToast, removeToast],
+  );
 
   useEffect(() => {
     const toastToDismiss = toasts[0];

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -130,7 +130,7 @@ export function ToastProvider<TProps extends BaseToastProps>({
   return (
     <ToastContext.Provider value={context}>
       {children}
-      <ListWrapper>
+      <ListWrapper role="status" aria-live="polite" aria-atomic="true">
         {toasts.map((toast) => {
           const {
             id,

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -117,7 +117,9 @@ export function ToastProvider<TProps extends BaseToastProps>({
     if (!toastToDismiss) {
       return undefined;
     }
-    const duration = toastToDismiss.duration || 3000;
+    const duration = toastToDismiss.duration
+      ? Math.max(toastToDismiss.duration, 3000)
+      : 3000;
     const timeoutId = setTimeout(() => {
       context.removeToast(toastToDismiss);
     }, duration);
@@ -130,7 +132,7 @@ export function ToastProvider<TProps extends BaseToastProps>({
   return (
     <ToastContext.Provider value={context}>
       {children}
-      <ListWrapper role="status" aria-live="polite" aria-atomic="true">
+      <ListWrapper role="status" aria-live="polite" aria-atomic="false">
         {toasts.map((toast) => {
           const {
             id,

--- a/packages/circuit-ui/components/ToastContext/createUseToast.spec.tsx
+++ b/packages/circuit-ui/components/ToastContext/createUseToast.spec.tsx
@@ -54,19 +54,4 @@ describe('createUseToast', () => {
     });
     expect(setToast).toHaveBeenCalledWith(expected);
   });
-
-  it('should remove the toast when removeToast is called', () => {
-    const { result } = renderHook(() => useToast(), { wrapper });
-
-    actHook(() => {
-      result.current.setToast({});
-    });
-
-    actHook(() => {
-      result.current.removeToast();
-    });
-
-    const expected = expect.any(Object);
-    expect(removeToast).toHaveBeenCalledWith(expected);
-  });
 });

--- a/packages/circuit-ui/components/ToastContext/createUseToast.spec.tsx
+++ b/packages/circuit-ui/components/ToastContext/createUseToast.spec.tsx
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable react/display-name */
+import React from 'react';
+
+import { renderHook, actHook } from '../../util/test-utils';
+
+import { createUseToast } from './createUseToast';
+import { ToastContext } from './ToastContext';
+import type { ToastComponent } from './types';
+
+const Toast: ToastComponent = ({ onClose }) => (
+  <div role="dialog">
+    <button onClick={onClose}>Close</button>
+  </div>
+);
+Toast.TIMEOUT = 200;
+
+describe('createUseToast', () => {
+  const useToast = createUseToast(Toast);
+
+  const setToast = jest.fn();
+  const removeToast = jest.fn();
+
+  const wrapper = ({ children }) => (
+    <ToastContext.Provider value={{ setToast, removeToast }}>
+      {children}
+    </ToastContext.Provider>
+  );
+
+  it('should add the toast when setToast is called', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    actHook(() => {
+      result.current.setToast({});
+    });
+
+    const expected = expect.objectContaining({
+      component: expect.any(Function),
+      id: expect.any(String),
+    });
+    expect(setToast).toHaveBeenCalledWith(expected);
+  });
+
+  it('should remove the toast when removeToast is called', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    actHook(() => {
+      result.current.setToast({});
+    });
+
+    actHook(() => {
+      result.current.removeToast();
+    });
+
+    const expected = expect.any(Object);
+    expect(removeToast).toHaveBeenCalledWith(expected);
+  });
+});

--- a/packages/circuit-ui/components/ToastContext/createUseToast.ts
+++ b/packages/circuit-ui/components/ToastContext/createUseToast.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useContext, useMemo, useRef } from 'react';
+
+import { uniqueId } from '../../util/id';
+
+import { ToastContext } from './ToastContext';
+import type { BaseToastProps, ToastComponent } from './types';
+
+export function createUseToast<T extends BaseToastProps>(
+  component: ToastComponent<T>,
+) {
+  return (): {
+    setToast: (props: T) => void;
+    removeToast: () => void;
+  } => {
+    const id = useMemo(uniqueId, []);
+    const toastRef = useRef<T | null>(null);
+    const context = useContext(ToastContext);
+    // const [toasts, setToasts] = useState([]);
+
+    const setToast = useCallback(
+      (props: T): void => {
+        toastRef.current = props;
+        context.setToast({ ...props, id, component });
+        console.log(id);
+      },
+      [context, id],
+    );
+
+    const removeToast = useCallback((): void => {
+      if (toastRef.current) {
+        context.removeToast({ ...toastRef.current, id, component });
+        toastRef.current = null;
+      }
+    }, [context, id]);
+
+    return { setToast, removeToast };
+  };
+}

--- a/packages/circuit-ui/components/ToastContext/createUseToast.ts
+++ b/packages/circuit-ui/components/ToastContext/createUseToast.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useContext } from 'react';
+import { useContext, useMemo } from 'react';
 
 import { uniqueId } from '../../util/id';
 
@@ -28,14 +28,14 @@ export function createUseToast<T extends BaseToastProps>(
   } => {
     const context = useContext(ToastContext);
 
-    const setToast = useCallback(
-      (props: T): void => {
-        const id = uniqueId('toast_');
-        context.setToast({ ...props, id, component });
-      },
+    return useMemo(
+      () => ({
+        setToast: (props: T): void => {
+          const id = uniqueId('toast_');
+          context.setToast({ ...props, id, component });
+        },
+      }),
       [context],
     );
-
-    return { setToast };
   };
 }

--- a/packages/circuit-ui/components/ToastContext/createUseToast.ts
+++ b/packages/circuit-ui/components/ToastContext/createUseToast.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useContext, useMemo, useRef } from 'react';
+import { useCallback, useContext } from 'react';
 
 import { uniqueId } from '../../util/id';
 
@@ -25,29 +25,17 @@ export function createUseToast<T extends BaseToastProps>(
 ) {
   return (): {
     setToast: (props: T) => void;
-    removeToast: () => void;
   } => {
-    const id = useMemo(uniqueId, []);
-    const toastRef = useRef<T | null>(null);
     const context = useContext(ToastContext);
-    // const [toasts, setToasts] = useState([]);
 
     const setToast = useCallback(
       (props: T): void => {
-        toastRef.current = props;
+        const id = uniqueId('toast_');
         context.setToast({ ...props, id, component });
-        console.log(id);
       },
-      [context, id],
+      [context],
     );
 
-    const removeToast = useCallback((): void => {
-      if (toastRef.current) {
-        context.removeToast({ ...toastRef.current, id, component });
-        toastRef.current = null;
-      }
-    }, [context, id]);
-
-    return { setToast, removeToast };
+    return { setToast };
   };
 }

--- a/packages/circuit-ui/components/ToastContext/index.ts
+++ b/packages/circuit-ui/components/ToastContext/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { ToastProvider } from './ToastContext';
+export { createUseToast } from './createUseToast';
+
+export type { ToastProviderProps } from './ToastContext';
+
+export type { BaseToastProps, ToastComponent } from './types';

--- a/packages/circuit-ui/components/ToastContext/types.ts
+++ b/packages/circuit-ui/components/ToastContext/types.ts
@@ -30,7 +30,7 @@ export interface BaseToastProps {
   /**
    * TODO: Add description for prop
    */
-  duration: number;
+  duration?: number;
 }
 
 export type ToastComponent<TProps extends BaseToastProps = BaseToastProps> = ((

--- a/packages/circuit-ui/components/ToastContext/types.ts
+++ b/packages/circuit-ui/components/ToastContext/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ClickEvent } from '../../types/events';
+import { TrackingProps } from '../../hooks/useClickEvent';
+
+type OnClose = (event?: ClickEvent) => void;
+
+export interface BaseToastProps {
+  /**
+   * Callback function that is called when the Toast is closed.
+   */
+  onClose?: OnClose;
+  /**
+   * Additional data that is dispatched with the tracking event.
+   */
+  tracking?: TrackingProps;
+  /**
+   * TODO: Add description for prop
+   */
+  duration: number;
+}
+
+export type ToastComponent<TProps extends BaseToastProps = BaseToastProps> = ((
+  props: TProps,
+) => JSX.Element) & { TIMEOUT?: number };

--- a/packages/circuit-ui/components/ToastContext/types.ts
+++ b/packages/circuit-ui/components/ToastContext/types.ts
@@ -28,7 +28,7 @@ export interface BaseToastProps {
    */
   tracking?: TrackingProps;
   /**
-   * TODO: Add description for prop
+   * Toast duration, defaults to 3000 ms.
    */
   duration?: number;
 }

--- a/packages/circuit-ui/hooks/useStack/useStack.ts
+++ b/packages/circuit-ui/hooks/useStack/useStack.ts
@@ -72,10 +72,7 @@ export function useStack<T extends StackItem>(
   const [state, dispatch] = useReducer(reducer, initialStack);
 
   useEffect(() => {
-    console.log('hello useStack useEffect');
     const itemToRemove = state.find((item) => item.timeout);
-    console.log(itemToRemove);
-
     if (!itemToRemove) {
       return;
     }

--- a/packages/circuit-ui/hooks/useStack/useStack.ts
+++ b/packages/circuit-ui/hooks/useStack/useStack.ts
@@ -72,7 +72,9 @@ export function useStack<T extends StackItem>(
   const [state, dispatch] = useReducer(reducer, initialStack);
 
   useEffect(() => {
+    console.log('hello useStack useEffect');
     const itemToRemove = state.find((item) => item.timeout);
+    console.log(itemToRemove);
 
     if (!itemToRemove) {
       return;

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -94,6 +94,10 @@ export { default as NotificationList } from './components/NotificationList';
 export type { NotificationListProps } from './components/NotificationList';
 export { default as NotificationFullscreen } from './components/NotificationFullscreen';
 export type { NotificationFullscreenProps } from './components/NotificationFullscreen';
+export { useNotificationToast } from './components/NotificationToast';
+export type { NotificationToastProps } from './components/NotificationToast';
+export { ToastProvider } from './components/ToastContext';
+export type { ToastProviderProps } from './components/ToastContext';
 
 // Layout
 export { default as Grid } from './components/Grid';


### PR DESCRIPTION
Addresses #792.

## Purpose

Introduces the new NotificationToast component.
The notification toast component non-disruptively provides quick, contextual or feedback based on the outcome of an action.
<img width="1175" alt="Screenshot 2021-12-07 at 16 33 16" src="https://user-images.githubusercontent.com/57903317/145058765-f0a19500-d6fd-460a-b1c2-579332f73b22.png">

It comes in 4 variants, "info", "confirm", "notify" and "alert".
To communicate a message always provide a body copy, and if needed an optional headline can be included above the body copy.
The notification toast floats above the content, positioned at the bottom of the screen, centralized horizontally withing the content area.
The auto-dismiss duration is adjustable (default minimum duration is 3000 ms).
Toasts can also be dismissed by clicking on a close button in the top-right corner. You need to provide closeButtonLabel.

## Approach and changes

Refer to the Storybook for further implementation and usage guidelines, and to the threads below for more details and discussion on the implementation.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
