### PR TITLE
NotificationBanner bugfix

### DIFF
--- a/.changeset/four-lies-itch.md
+++ b/.changeset/four-lies-itch.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed the `onClick` function from `Image` component in `NotificationBanner`.

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -253,7 +253,6 @@ export function NotificationBanner({
       </Content>
       {image && image.src && (
         <StyledImage
-          onClick={action.onClick}
           alt={image.alt}
           src={image.src}
           image={image}


### PR DESCRIPTION

## Purpose

Prevents the `onClick` function call in `Image` component in `NotificationBanner`.

## Approach and changes

Removed the `onClick` from `StyledImage`.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
