### PR TITLE
Rerender the Table when rows change

### DIFF
--- a/.changeset/cuddly-brooms-sip.md
+++ b/.changeset/cuddly-brooms-sip.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed a bug where deeply nested updates in the Table `rows` prop wouldn't update the Table.

--- a/.changeset/cuddly-brooms-sip.md
+++ b/.changeset/cuddly-brooms-sip.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Fixed a bug where deeply nested updates in the Table `rows` prop wouldn't update the Table.
+Fixed a bug where updating Table `rows wouldn't re-render the Table.

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -226,6 +226,16 @@ class Table extends Component<TableProps, TableState> {
 
   componentDidUpdate(prevProps: TableProps): void {
     if (this.props.rows !== prevProps.rows) {
+      // Preserve existing sorting
+      if (this.state.sortedRow && this.state.sortDirection) {
+        const sortedRows = this.getSortedRows(
+          this.state.sortDirection,
+          this.state.sortedRow,
+        );
+        this.setState({ rows: sortedRows });
+        return;
+      }
+
       this.setState({ rows: this.props.rows });
     }
 

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -15,7 +15,7 @@
 
 import { Component, createRef, HTMLAttributes, UIEvent } from 'react';
 import { css } from '@emotion/react';
-import { isNil, throttle } from 'lodash/fp';
+import { isEqual, isNil, throttle } from 'lodash/fp';
 
 import styled, { StyleProps } from '../../styles/styled';
 
@@ -194,7 +194,7 @@ const StyledTable = styled.table<TableElProps>`
 
 type TableState = {
   sortedRow?: number;
-  sortedRows?: Row[];
+  rows?: Row[];
   sortHover?: number;
   sortDirection?: Direction;
   scrollTop?: number;
@@ -207,7 +207,7 @@ type TableState = {
 class Table extends Component<TableProps, TableState> {
   state: TableState = {
     sortedRow: undefined,
-    sortedRows: undefined,
+    rows: undefined,
     sortHover: undefined,
     sortDirection: undefined,
     scrollTop: undefined,
@@ -217,12 +217,18 @@ class Table extends Component<TableProps, TableState> {
   private tableRef = createRef<HTMLDivElement>();
 
   componentDidMount(): void {
+    this.setState({ rows: this.props.rows });
+
     if (this.props.scrollable) {
       this.addVerticalScroll();
     }
   }
 
   componentDidUpdate(prevProps: TableProps): void {
+    if (!isEqual(this.props.rows, prevProps.rows)) {
+      this.setState({ rows: this.props.rows });
+    }
+
     if (!prevProps.scrollable && this.props.scrollable) {
       this.addVerticalScroll();
     }
@@ -285,7 +291,7 @@ class Table extends Component<TableProps, TableState> {
     this.setState({
       sortedRow: i,
       sortDirection: nextDirection,
-      sortedRows,
+      rows: sortedRows,
     });
 
   defaultSortBy = (i: number, rows: Row[], direction?: Direction): Row[] => {
@@ -311,10 +317,14 @@ class Table extends Component<TableProps, TableState> {
       onSortBy,
       ...props
     } = this.props;
-    const { sortDirection, sortHover, sortedRow, scrollTop, tableBodyHeight } =
-      this.state;
-
-    const rows = this.state.sortedRows || initialRows;
+    const {
+      sortDirection,
+      sortHover,
+      sortedRow,
+      scrollTop,
+      tableBodyHeight,
+      rows,
+    } = this.state;
 
     return (
       <TableContainer

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -15,7 +15,7 @@
 
 import { Component, createRef, HTMLAttributes, UIEvent } from 'react';
 import { css } from '@emotion/react';
-import { isEqual, isNil, throttle } from 'lodash/fp';
+import { isNil, throttle } from 'lodash/fp';
 
 import styled, { StyleProps } from '../../styles/styled';
 
@@ -225,7 +225,7 @@ class Table extends Component<TableProps, TableState> {
   }
 
   componentDidUpdate(prevProps: TableProps): void {
-    if (!isEqual(this.props.rows, prevProps.rows)) {
+    if (this.props.rows !== prevProps.rows) {
       this.setState({ rows: this.props.rows });
     }
 


### PR DESCRIPTION
Follows up on #1292

## Purpose

#1292 introduced a bug where if the Table's `rows` prop got an update, the table itself wouldn't get updated.

This is an issue when rows state is managed in userland, for example when table filtering is implemented.

## Approach and changes

- Set rows to stete on mount
- Update rows on update if necessary
- Preserve sort on update

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
