### PR TITLE
Initialise Table rows on first render

### DIFF
--- a/.changeset/happy-needles-end.md
+++ b/.changeset/happy-needles-end.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the initialization of the Table `rows` on the first render.

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -107,11 +107,11 @@ const shadowStyles = ({
     border: ${theme.borderWidth.kilo} solid ${theme.colors.n300};
   `;
 
-const TableContainer = styled.div<TableContainerElProps>`
-  ${tableContainerBaseStyles};
-  ${tableContainerScrollableStyles};
-  ${shadowStyles};
-`;
+const TableContainer = styled.div<TableContainerElProps>(
+  tableContainerBaseStyles,
+  tableContainerScrollableStyles,
+  shadowStyles,
+);
 
 /**
  * Scroll container styles.
@@ -141,10 +141,10 @@ const scrollableStyles = ({ scrollable, height }: ScrollContainerElProps) =>
     overflow-y: auto;
   `;
 
-const ScrollContainer = styled.div<ScrollContainerElProps>`
-  ${containerStyles};
-  ${scrollableStyles};
-`;
+const ScrollContainer = styled.div<ScrollContainerElProps>(
+  containerStyles,
+  scrollableStyles,
+);
 
 /**
  * Table styles.
@@ -186,11 +186,11 @@ const borderCollapsedStyles = ({ borderCollapsed }: TableElProps) =>
     border-collapse: collapse;
   `;
 
-const StyledTable = styled.table<TableElProps>`
-  ${baseStyles};
-  ${responsiveStyles};
-  ${borderCollapsedStyles};
-`;
+const StyledTable = styled.table<TableElProps>(
+  baseStyles,
+  responsiveStyles,
+  borderCollapsedStyles,
+);
 
 type TableState = {
   sortedRow?: number;

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -207,7 +207,7 @@ type TableState = {
 class Table extends Component<TableProps, TableState> {
   state: TableState = {
     sortedRow: undefined,
-    rows: undefined,
+    rows: this.props.rows,
     sortHover: undefined,
     sortDirection: undefined,
     scrollTop: undefined,
@@ -217,8 +217,6 @@ class Table extends Component<TableProps, TableState> {
   private tableRef = createRef<HTMLDivElement>();
 
   componentDidMount(): void {
-    this.setState({ rows: this.props.rows });
-
     if (this.props.scrollable) {
       this.addVerticalScroll();
     }

--- a/packages/circuit-ui/components/Table/__snapshots__/Table.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/__snapshots__/Table.spec.tsx.snap
@@ -128,8 +128,8 @@ tbody .circuit-4:last-child td {
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -144,7 +144,7 @@ tbody .circuit-4:last-child td {
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -158,8 +158,7 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-8 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-10 {
@@ -910,8 +909,8 @@ tbody .circuit-4:last-child td {
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -926,7 +925,7 @@ tbody .circuit-4:last-child td {
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -940,8 +939,7 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-8 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-10 {
@@ -1442,8 +1440,8 @@ tbody .circuit-4:last-child td {
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -1458,7 +1456,7 @@ tbody .circuit-4:last-child td {
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -1472,8 +1470,7 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-8 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-10 {
@@ -1968,8 +1965,8 @@ tbody .circuit-4:last-child td {
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -1984,7 +1981,7 @@ tbody .circuit-4:last-child td {
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -1998,8 +1995,7 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-8 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-10 {
@@ -2648,8 +2644,8 @@ tbody .circuit-4:last-child td {
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -2664,7 +2660,7 @@ tbody .circuit-4:last-child td {
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -2678,8 +2674,7 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-8 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-10 {
@@ -3175,8 +3170,8 @@ tbody .circuit-4:last-child td {
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -3191,7 +3186,7 @@ tbody .circuit-4:last-child td {
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -3205,8 +3200,7 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-8 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-10 {
@@ -3701,8 +3695,8 @@ tbody .circuit-4:last-child td {
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -3717,7 +3711,7 @@ tbody .circuit-4:last-child td {
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -3731,8 +3725,7 @@ tbody .circuit-4:last-child td {
 }
 
 .circuit-8 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-10 {

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
@@ -30,8 +30,8 @@ const baseStyles = ({ theme }: StyleProps) => css`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: ${theme.spacings.giga};
   position: absolute;
   left: 0;
   top: 50%;
@@ -42,7 +42,7 @@ const baseStyles = ({ theme }: StyleProps) => css`
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 
@@ -55,11 +55,10 @@ const baseStyles = ({ theme }: StyleProps) => css`
   }
 `;
 
-const Wrapper = styled.button(baseStyles);
+const Button = styled.button(baseStyles);
 
-const iconStyles = () => css`
-  margin-top: -3px;
-  margin-bottom: -3px;
+const iconStyles = css`
+  margin: -2px 0;
 `;
 
 const Label = styled('span')(hideVisually);
@@ -72,11 +71,11 @@ const SortArrow = ({
   direction,
   ...props
 }: SortArrowProps): JSX.Element => (
-  <Wrapper role="button" title={label} {...props}>
+  <Button role="button" title={label} {...props}>
     {direction !== 'ascending' && <ChevronUp size="16" css={iconStyles} />}
     {direction !== 'descending' && <ChevronDown size="16" css={iconStyles} />}
     <Label>{label}</Label>
-  </Wrapper>
+  </Button>
 );
 
 export default SortArrow;

--- a/packages/circuit-ui/components/Table/components/SortArrow/__snapshots__/SortArrow.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/SortArrow/__snapshots__/SortArrow.spec.tsx.snap
@@ -13,8 +13,8 @@ exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -29,7 +29,7 @@ exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -43,8 +43,7 @@ exports[`SortArrow Style tests should render with ascending arrow styles 1`] = `
 }
 
 .circuit-1 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-2 {
@@ -98,8 +97,8 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -114,7 +113,7 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -128,8 +127,7 @@ exports[`SortArrow Style tests should render with both arrows styles 1`] = `
 }
 
 .circuit-1 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-3 {
@@ -196,8 +194,8 @@ exports[`SortArrow Style tests should render with descending arrow styles 1`] = 
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -212,7 +210,7 @@ exports[`SortArrow Style tests should render with descending arrow styles 1`] = 
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -226,8 +224,7 @@ exports[`SortArrow Style tests should render with descending arrow styles 1`] = 
 }
 
 .circuit-1 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-2 {

--- a/packages/circuit-ui/components/Table/components/TableHead/__snapshots__/TableHead.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableHead/__snapshots__/TableHead.spec.tsx.snap
@@ -74,8 +74,8 @@ tbody .circuit-1:last-child td {
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -90,7 +90,7 @@ tbody .circuit-1:last-child td {
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -104,8 +104,7 @@ tbody .circuit-1:last-child td {
 }
 
 .circuit-5 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-7 {
@@ -287,8 +286,8 @@ tbody .circuit-1:last-child td {
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -303,7 +302,7 @@ tbody .circuit-1:last-child td {
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -317,8 +316,7 @@ tbody .circuit-1:last-child td {
 }
 
 .circuit-5 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-7 {

--- a/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
@@ -164,8 +164,8 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -180,7 +180,7 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -194,8 +194,7 @@ exports[`TableHeader Style tests should render with sortable styles 1`] = `
 }
 
 .circuit-2 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-4 {
@@ -326,8 +325,8 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -342,7 +341,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -356,8 +355,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 }
 
 .circuit-2 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-3 {
@@ -475,8 +473,8 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   -ms-flex-pack: center;
   -webkit-justify-content: center;
   justify-content: center;
-  height: 40px;
-  width: 20px;
+  height: 36px;
+  width: 24px;
   position: absolute;
   left: 0;
   top: 50%;
@@ -491,7 +489,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
   border: 0;
   background: none;
   outline: 0;
-  padding: 0;
+  padding: 2px 4px;
   margin: 0;
   cursor: pointer;
 }
@@ -505,8 +503,7 @@ exports[`TableHeader Style tests sortable + sorted should render with sortable +
 }
 
 .circuit-2 {
-  margin-top: -3px;
-  margin-bottom: -3px;
+  margin: -2px 0;
 }
 
 .circuit-3 {


### PR DESCRIPTION
Follow-up to #1306.

## Purpose

#1306 initialized the `rows` state to `undefined` and updated it in `componentDidMount`. This meant that on the initial render, the Table rows would be empty.﻿ This breaks server-side rendering (SSR) where `compontDidMount` is never called and could cause a layout shift even when client-side rendering.

## Approach and changes

- Initialize the `rows` state from props
- [Boy scout rule](https://deviq.com/principles/boy-scout-rule):
  - refactored some code to adhere to our conventional syntax for composing style functions
  - fixed the styles of the sort button to center-align in

| _Before_                                                                                                         | _After_                                                                                                         |
|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![Before](https://user-images.githubusercontent.com/11017722/145086241-08f8f847-dba6-4d83-a576-b786d7082183.png) | ![After](https://user-images.githubusercontent.com/11017722/145086138-b7ab4a4b-ea6e-43bb-ab50-13ec4e15be69.png) |


## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
