### PR TITLE
Convert Tooltip to TypeScript

### DIFF
--- a/.changeset/green-ghosts-walk.md
+++ b/.changeset/green-ghosts-walk.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Convert `Tooltip` to TypeScript and remove Lodash dependency.

--- a/.changeset/green-ghosts-walk.md
+++ b/.changeset/green-ghosts-walk.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Convert `Tooltip` to TypeScript and remove Lodash dependency.
+Converted the `Tooltip` component to TypeScript and removed its Lodash dependency.

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -266,7 +266,6 @@ export const Checkbox = forwardRef(
           <Checkmark aria-hidden="true" />
         </CheckboxLabel>
         {!disabled && validationHint && (
-          // @ts-expect-error Reenable typechecks once Tooltip has been migrated to TypeScript
           <CheckboxTooltip position={'top'} align={'right'}>
             {validationHint}
           </CheckboxTooltip>

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -121,7 +121,7 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   left: 50%;
   left: calc(50% - (16px + 4px));
   bottom: 100%;

--- a/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
@@ -13,13 +13,16 @@
  * limitations under the License.
  */
 
-import Tooltip from '.';
+import { create, renderToHtml, axe } from '../../util/test-utils';
+
+import type { Position, Alignment } from './Tooltip';
+import { Tooltip } from './Tooltip';
 
 describe('Tooltip', () => {
   /**
    * Style tests.
    */
-  const positions = ['top', 'right', 'bottom', 'left'];
+  const positions: Position[] = ['top', 'right', 'bottom', 'left'];
   positions.forEach((position) => {
     it(`should render with position ${position}, when passed "${position}" for the position prop`, () => {
       const component = create(
@@ -29,7 +32,7 @@ describe('Tooltip', () => {
     });
   });
 
-  const alignments = ['right', 'left', 'top', 'bottom', 'center'];
+  const alignments: Alignment[] = ['right', 'left', 'top', 'bottom', 'center'];
   alignments.forEach((align) => {
     it(`should render with align ${align}, when passed "${align}" for the align prop`, () => {
       const component = create(
@@ -52,11 +55,7 @@ describe('Tooltip', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(
-      <Tooltip align={'center'} content="Tooltip">
-        Text
-      </Tooltip>,
-    );
+    const wrapper = renderToHtml(<Tooltip align={'center'}>Text</Tooltip>);
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -17,7 +17,7 @@ import styled from '@emotion/styled';
 import { Info } from '@sumup/icons';
 
 import docs from './Tooltip.docs.mdx';
-import Tooltip from './Tooltip';
+import { Tooltip } from './Tooltip';
 
 export default {
   title: 'Components/Tooltip',

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -139,7 +139,10 @@ const positionAndAlignStyles = ({
   ${getPositionStyles({ theme, position })};
 `;
 
-type TooltipProps = { position?: Position; align?: Alignment };
+export interface TooltipProps {
+  position?: Position;
+  align?: Alignment;
+}
 
 /**
  * A Tooltip component

--- a/packages/circuit-ui/components/Tooltip/__snapshots__/Tooltip.spec.tsx.snap
+++ b/packages/circuit-ui/components/Tooltip/__snapshots__/Tooltip.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`Tooltip should override alignment styles with position styles 1`] = `
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
@@ -71,7 +71,7 @@ exports[`Tooltip should render with align bottom, when passed "bottom" for the a
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   top: calc(50% - (16px + 4px));
   left: 100%;
@@ -119,7 +119,7 @@ exports[`Tooltip should render with align center, when passed "center" for the a
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
@@ -174,7 +174,7 @@ exports[`Tooltip should render with align left, when passed "left" for the align
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
@@ -229,7 +229,7 @@ exports[`Tooltip should render with align right, when passed "right" for the ali
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
@@ -284,7 +284,7 @@ exports[`Tooltip should render with align top, when passed "top" for the align p
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   bottom: 50%;
   bottom: calc(50% - (16px + 4px));
   left: 100%;
@@ -332,7 +332,7 @@ exports[`Tooltip should render with position bottom, when passed "bottom" for th
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   left: 50%;
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);
@@ -387,7 +387,7 @@ exports[`Tooltip should render with position left, when passed "left" for the po
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
@@ -442,7 +442,7 @@ exports[`Tooltip should render with position right, when passed "right" for the 
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
@@ -497,7 +497,7 @@ exports[`Tooltip should render with position top, when passed "top" for the posi
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   left: 50%;
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);

--- a/packages/circuit-ui/components/Tooltip/index.ts
+++ b/packages/circuit-ui/components/Tooltip/index.ts
@@ -13,6 +13,6 @@
  * limitations under the License.
  */
 
-import Tooltip from './Tooltip';
+import { Tooltip } from './Tooltip';
 
 export default Tooltip;

--- a/packages/circuit-ui/components/Tooltip/index.ts
+++ b/packages/circuit-ui/components/Tooltip/index.ts
@@ -15,4 +15,6 @@
 
 import { Tooltip } from './Tooltip';
 
+export type { TooltipProps } from './Tooltip';
+
 export default Tooltip;

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -146,6 +146,7 @@ export type { TagProps } from './components/Tag';
 export { default as Popover } from './components/Popover';
 export type { PopoverProps } from './components/Popover';
 export { default as Tooltip } from './components/Tooltip';
+export type { TooltipProps } from './components/Tooltip';
 export { default as BaseStyles } from './components/BaseStyles';
 export { ModalProvider } from './components/ModalContext';
 export type { ModalProviderProps } from './components/ModalContext';


### PR DESCRIPTION
## Purpose

`Tooltip` was relying on Lodash's `includes` function which caused our project
to include 9kB of additional JS in the client bundle. The PR removes the
dependency on `includes` and converts the component to TypeScript along the way.

## Approach and changes

* Convert component to TypeScript.
* Use type guards instead of Lodash `includes` and maps.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
