### PR TITLE
chore: add missing packages to getting started commands

### DIFF
--- a/docs/introduction/getting-started.stories.mdx
+++ b/docs/introduction/getting-started.stories.mdx
@@ -29,9 +29,9 @@ Circuit UI relies on some mandatory peer dependencies, namely [@sumup/collector]
 
 ```sh
 # With yarn:
-yarn add @sumup/collector @sumup/design-tokens @sumup/icons react react-dom @emotion/react @emotion/styled
+yarn add @sumup/collector @sumup/design-tokens @sumup/icons @sumup/intl react react-dom @emotion/react @emotion/styled
 # With npm:
-npm install --save @sumup/collector @sumup/design-tokens @sumup/icons react react-dom @emotion/react @emotion/styled
+npm install --save @sumup/collector @sumup/design-tokens @sumup/icons @sumup/intl react react-dom @emotion/react @emotion/styled
 ```
 
 ### Configuring the theme


### PR DESCRIPTION
## Purpose

This adds `@sumup/intl` peer dependency in the yarn and npm commands of the Getting Started page.

