### PR TITLE
Add accessibility docs for the List component

### DIFF
--- a/packages/circuit-ui/components/Body/Body.docs.mdx
+++ b/packages/circuit-ui/components/Body/Body.docs.mdx
@@ -40,6 +40,8 @@ Use the `as` prop to render other HTML elements, for example for rendering a hig
 
 **Important**: the `success` and `error` variants only change the text's color. Keep in mind that this is not sufficient to make them accessible. Refer to the Accessibility section below, especially "Do not rely on color alone" and "Make status messages accessible to screen readers using live regions".
 
+---
+
 ## Accessibility
 
 ### Best practices

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.docs.mdx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.docs.mdx
@@ -19,6 +19,8 @@ The `highlight` variant will render a `<strong>` element by default, while the `
 
 <Story id="typography-bodylarge--variants" />
 
+---
+
 ## Accessibility
 
 All accessibility guidelines for the [Body component](Typography/Body) also apply to the BodyLarge component.

--- a/packages/circuit-ui/components/Headline/Headline.docs.mdx
+++ b/packages/circuit-ui/components/Headline/Headline.docs.mdx
@@ -19,6 +19,8 @@ Use the `four` size for card headers and `three` for page titles in web applicat
 
 <Story id="typography-headline--sizes" />
 
+---
+
 ## Accessibility
 
 Headings are a fundamental aspect of creating accessible interfaces. Sighted users rely on them to easily find what they want on a page, while assistive technology allows users to jump between them for easier access to the page's different sections.

--- a/packages/circuit-ui/components/List/List.docs.mdx
+++ b/packages/circuit-ui/components/List/List.docs.mdx
@@ -4,7 +4,7 @@ import { Status, Props, Story } from '../../../../.storybook/components';
 
 <Status.Stable />
 
-The List component is used to group pieces of content—called "list items"—together.
+The List component is used to group pieces of content—the list items—together.
 
 <Story id="typography-list--base" />
 <Props />
@@ -36,9 +36,11 @@ Instead of relying on nested lists, consider splitting the content into separate
 
 <Story id="typography-list--nested" />
 
+---
+
 ## Accessibility
 
-Lists are fundamental elements for structuring content. They can group pieces of content, give an overview of them, and make parsing and accessing them easier.
+Lists are fundamental elements for content structure. They group related pieces of content, and make parsing and accessing them easier.
 
 ### Best practices
 
@@ -48,9 +50,9 @@ Keep the text in each list item concise. If you need to display more (structured
 
 #### Use tables for two-dimensional data
 
-In order to display two-dimensional data, consider using a table instead of a list. This makes parsing easier for sighted users and allows screen reader users to move vertically and horizontally across the data.
+In order to display two-dimensional data, consider using a table instead of a list. This makes parsing easier for sighted users, and allows screen reader users to move vertically and horizontally across the data.
 
-So instead of structuring content inside a list item:
+For example, instead of structuring content inside a list item:
 
 ```html
 <ul>
@@ -83,17 +85,96 @@ Consider displaying the data in a table (you can use the [`Table` component](Com
 </table>
 ```
 
-See also the section on definition lists below.
-
 #### Description lists
 
-- not supported by this component
-- not recommended (except for term/definition key-pair values?): screen reader discrepancies
+##### What are descriptions lists?
 
-#### Using lists for non-text UI elements
+One of the most obscure HTML elements, [description lists](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl) (`dl`) were initially intended for displaying glossary-like name-value pairs: a term (`dt`) and its definition (`dd`). Newer versions of the HTML spec also allow other name-value pairs, such as metadata labels and values, or questions and answers:
 
-- for lists of cards, e.g. a list of articles
-- not everything should be a list (can be quite noisy for SR users). think of how it is announced to screen readers and whether it makes sense for the list to be announced
+```html
+<dl>
+  <!-- term and definition -->
+  <dt>Circuit</dt>
+  <dd>A closed, usually circular line that goes around an object or area.</dd>
+  <!-- metadata label and value -->
+  <dt>Account number</dt>
+  <dd>12345</dd>
+  <!-- question and answer -->
+  <dt>How do I find my account number?</dt>
+  <dd>You can find your account number under "Profile details".</dd>
+</dl>
+```
+
+##### Avoid using description lists
+
+Description lists are intentionally not supported by the List component. They are not consistently announced by screen readers, and can confuse users.
+
+For example, consider this simple description list, containing 2 metadata label-value pairs:
+
+<details>
+  <summary>Show the rendered description list</summary>
+  <dl>
+    <dt>Account number</dt>
+    <dd>12345</dd>
+    <dt>Sign-up date</dt>
+    <dd>21.12.2021</dd>
+  </dl>
+</details>
+
+```html
+<dl>
+  <dt>Account number</dt>
+  <dd>12345</dd>
+  <dt>Sign-up date</dt>
+  <dd>21.12.2021</dd>
+</dl>
+```
+
+Here's the screen reader output on three major [screen reader / browser combinations](https://webaim.org/projects/screenreadersurvey9/#browsercombos), when arrowing through the list:
+
+| OS         | Browser | Screen reader | Output                                                                                                     |
+| ---------- | ------- | ------------- | ---------------------------------------------------------------------------------------------------------- |
+| Windows 10 | Chrome  | JAWS          | Definition list of 2 items. Account number. 12345. Sign-up date. 21.12.2021.                               |
+| Windows 10 | Chrome  | NVDA          | List with 4 items. Account number. 12345. Sign-up date. 21.12.2021.                                        |
+| macOS      | Safari  | VoiceOver     | Description list 2 items. Account number, 1 of 4. 12345, 2 of 4. Sign-up date, 3 of 4. 21.12.2021, 4 of 4. |
+
+As you can see, there are inconsistencies between outputs:
+
+- The description list has 2 name-value pairs, but NVDA on Chrome announces it as a "list with 4 items"
+- VoiceOver on macOS Safari correctly announces "2 items", but goes on to announce each item's position on a total of 4 items ("Account number, 1 of 4")
+- JAWS on Chrome announces a "definition list" (the initial name of the `dl` element), although this description list doesn't contain definitions
+- Other screen reader / browser combinations (such as NVDA on Firefox or VoiceOver on Chrome) have yet other behaviors
+
+This can be very confusing to users, so we recommend against using description lists at this time. Instead, use an unordered list or a table.
+
+#### Using lists for other UI elements
+
+In some cases, a list shouldn't only have text as list items, but another UI element such as a card (e.g. for a list of articles on a news website).
+
+The List componnt doesn't support this use case. Instead, use an HTML unordered list element:
+
+```jsx
+function ArticleList(articles) {
+  return (
+    <ul
+      css={css`
+        list-style: none;
+      `}
+      role="list"
+    >
+      {articles.map((article, i) => (
+        <li key={i}>
+          <ArticleCard article={article} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+**Warning**: if you remove the list's markers using `list-style: none;`, you'll need to add `role="list"` to the `ul` element. This is because [VoiceOver on Webkit removes list semantics when list markers are hidden](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html), both on iOS and macOS.
+
+Bear in mind that not every group of elements should necessarily be a list. Lists can be quite verbose for screen-reader users, and using them excessively can be counter-productive. Imagine your list being announced as a "list of n items" and each subsequent item as "item m of n", and whether this improves or hinders user experience.
 
 ### Resources
 

--- a/packages/circuit-ui/components/List/List.docs.mdx
+++ b/packages/circuit-ui/components/List/List.docs.mdx
@@ -4,42 +4,99 @@ import { Status, Props, Story } from '../../../../.storybook/components';
 
 <Status.Stable />
 
-At its core, the list component allows you to easily display a related content grouped together and organized vertically. They should be used to present simple pieces of information. For more complex sets of data, consider using a Data Table.
+The List component is used to group pieces of content—called "list items"—together.
 
 <Story id="typography-list--base" />
 <Props />
 
-## When to use it
-
-Use it when you want to display a list of text-only related items.
-
-## Usage guidelines
-
-- **Do** break up chunks of related content and make the information easier for users to scan
-- **Do** use sentence casing
-- **Do** arrange List items in a logical way. Try to sort items into smaller meaningful categories.
-  Specific lists might be more useful in some contexts. If sorting is not possible, organize in alphabetical
-  or numerical order
-- **Do not** show more than 2 columns on mobile view
-
-## Component Variants
+## Component variations
 
 ### Variants
 
-Use an ordered list to imply sequence and order. Ordered lists are commonly used when providing a set of instructions.
+The List component comes in two variants, `ordered` or `unordered`.
 
-Use an unordered list to present content of equal status or value.
+- Use an ordered list to imply sequence or order (e.g. when providing a set of instructions).
+- Use an unordered list when the order of the items is meaningless.
 
 <Story id="typography-list--variants" />
 
 ### Sizes
 
-The size of the list should be the same as the surrounding content.
+The List component has two available sizes, `one` and `two`, matching the [`Body` component](Typography/Body)'s sizes.
+
+For consistency, the list's size should be the same as the surrounding content's size.
 
 <Story id="typography-list--sizes" />
 
-### Nested
+### Nested lists
 
-Nested lists are indented.
+Lists can be nested to display a hierarchy, e.g. in a table of contents. The nested list will be visually indented.
+
+Instead of relying on nested lists, consider splitting the content into separate sections, labeled by headings (refer to the Accessibility section below).
 
 <Story id="typography-list--nested" />
+
+## Accessibility
+
+Lists are fundamental elements for structuring content. They can group pieces of content, give an overview of them, and make parsing and accessing them easier.
+
+### Best practices
+
+#### Keep list items concise
+
+Keep the text in each list item concise. If you need to display more (structured) content, consider splitting it into sections instead, labeled by headings.
+
+#### Use tables for two-dimensional data
+
+In order to display two-dimensional data, consider using a table instead of a list. This makes parsing easier for sighted users and allows screen reader users to move vertically and horizontally across the data.
+
+So instead of structuring content inside a list item:
+
+```html
+<ul>
+  <li>Germany (Capital: Berlin)</li>
+  <li>Ireland (Capital: Dublin)</li>
+  <li>Canada (Capital: Ottawa)</li>
+</ul>
+```
+
+Consider displaying the data in a table (you can use the [`Table` component](Components/Table)):
+
+```html
+<table>
+  <tr>
+    <th>Country</th>
+    <th>Capital</th>
+  </tr>
+  <tr>
+    <td>Germany</td>
+    <td>Berlin</td>
+  </tr>
+  <tr>
+    <td>Ireland</td>
+    <td>Dublin</td>
+  </tr>
+  <tr>
+    <td>Canada</td>
+    <td>Ottawa</td>
+  </tr>
+</table>
+```
+
+See also the section on definition lists below.
+
+#### Description lists
+
+- not supported by this component
+- not recommended (except for term/definition key-pair values?): screen reader discrepancies
+
+#### Using lists for non-text UI elements
+
+- for lists of cards, e.g. a list of articles
+- not everything should be a list (can be quite noisy for SR users). think of how it is announced to screen readers and whether it makes sense for the list to be announced
+
+### Resources
+
+#### Related WCAG success criteria
+
+- 1.3.1: [Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html)

--- a/packages/circuit-ui/components/List/List.docs.mdx
+++ b/packages/circuit-ui/components/List/List.docs.mdx
@@ -151,7 +151,7 @@ This can be very confusing to users, so we recommend against using description l
 
 In some cases, a list shouldn't only have text as list items, but another UI element such as a card (e.g. for a list of articles on a news website).
 
-The List componnt doesn't support this use case. Instead, use an HTML unordered list element:
+The List component doesn't support this use case. Instead, use an HTML unordered list element:
 
 ```jsx
 function ArticleList(articles) {

--- a/packages/circuit-ui/components/List/List.stories.tsx
+++ b/packages/circuit-ui/components/List/List.stories.tsx
@@ -15,6 +15,7 @@
 
 import { Fragment } from 'react';
 
+import Body from '../Body';
 import { spacing } from '../../styles/style-mixins';
 
 import docs from './List.docs.mdx';
@@ -60,23 +61,30 @@ const sizes: ListProps['size'][] = ['one', 'two'];
 
 export const Sizes = (args: ListProps) =>
   sizes.map((size) => (
-    <List
-      key={size}
-      {...args}
-      size={size}
-      noMargin
-      css={spacing({ bottom: 'giga' })}
-    >
-      <ListItems />
-    </List>
+    <>
+      <Body size={size}>
+        Use List size {size} with Body {size} text.
+      </Body>
+      <List
+        key={size}
+        {...args}
+        size={size}
+        noMargin
+        css={spacing({ bottom: 'giga' })}
+      >
+        <ListItems />
+      </List>
+    </>
   ));
 
 export const Nested = (args: ListProps) => (
   <List {...args} noMargin>
-    <ListItems />
-    <List {...args} noMargin>
-      <li>Sometimes a nested list</li>
-    </List>
+    <li>
+      This is a list
+      <List {...args} noMargin>
+        <li>Sometimes a nested list</li>
+      </List>
+    </li>
     <li>And the list goes on</li>
   </List>
 );

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -26,11 +26,11 @@ type Variant = 'ordered' | 'unordered';
 
 export interface ListProps extends OlHTMLAttributes<HTMLOListElement> {
   /**
-   * A Circuit UI body text size.
+   * A Circuit UI Body size. Should match surrounding text.
    */
   size?: Size;
   /**
-   * Whether the list should be presented as an <ol> or <ul>. Defaults to <ul>.
+   * Whether the list should be presented as an ordered or unordered list. Defaults to `unordered`.
    */
   variant?: Variant;
   /**
@@ -38,7 +38,7 @@ export interface ListProps extends OlHTMLAttributes<HTMLOListElement> {
    */
   noMargin?: boolean;
   /**
-   The ref to the HTML DOM element
+   The ref to the HTML DOM element.
    */
   ref?: Ref<HTMLOListElement & HTMLUListElement>;
 }
@@ -109,7 +109,7 @@ const marginStyles = ({ noMargin }: ListProps) => {
   `;
 };
 
-const BaseList = styled('ol', {
+const BaseList = styled('ul', {
   shouldForwardProp: (prop) => isPropValid(prop) && prop !== 'size',
 })<ListProps>(baseStyles, sizeStyles, marginStyles);
 

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.docs.mdx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.docs.mdx
@@ -9,6 +9,8 @@ The SubHeadline component helps break up larger related chunks of content in the
 <Story id="typography-subheadline--base" />
 <Props />
 
+---
+
 ## Accessibility
 
 All accessibility guidelines for the [Headline component](Typography/Headline) also apply to the SubHeadline component.

--- a/packages/circuit-ui/components/Title/Title.docs.mdx
+++ b/packages/circuit-ui/components/Title/Title.docs.mdx
@@ -17,6 +17,8 @@ The Title component comes in four sizes. In most cases, use the [Headline compon
 
 <Story id="typography-title--sizes" />
 
+---
+
 ## Accessibility
 
 All accessibility guidelines for the [Headline component](Typography/Headline) also apply to the Title component.


### PR DESCRIPTION
## Purpose

As title suggests 🙂 

## Approach and changes

- Add a11y docs for the List
  - includes guidelines on using HTML lists (ul, ol, dl) without the component as well
- Add a separator before the a11y section on docs page, to mark the separation in a clearer way
- Improve List stories and prop descriptions

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
