### PR TITLE
Add Notification Inline

### DIFF
--- a/.changeset/nine-tigers-approve.md
+++ b/.changeset/nine-tigers-approve.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a new `NotificationInline` component that provides quick and contextual inline notification.

--- a/.changeset/nine-tigers-approve.md
+++ b/.changeset/nine-tigers-approve.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Added a new `NotificationInline` component that provides quick and contextual inline notification.
+Added a new `NotificationInline` component that provides quick and contextual inline notifications.

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.docs.mdx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.docs.mdx
@@ -1,0 +1,35 @@
+import { Status, Props, Story } from '../../../../.storybook/components';
+import { NotificationToast } from '@sumup/circuit-ui';
+
+# NotificationInline
+
+<Status.Stable />
+
+<Story id="notification-notificationinline--base" />
+<Props />
+
+The Notification Inline component non-disruptively provides quick and contextual inline notification and it is integrated within the content section.
+Inline notifications are frequently used to provide additional guidance to the user, like positive feedback, confirmation about an action or errors in forms, cards or dialog boxes.
+
+## Usage guidelines
+
+- Be concise, specific and short in the message and always provide a body copy.
+- Be descriptive and give users clear next steps.
+- Inline notifications are part of the content and should be placed near their related part of the content.
+- Do not cover other content with inline notifications.
+- If needed an optional headline or an action button can be included.
+
+## Component variations
+
+### Notification Inline variants
+
+<Story id="notification-notificationinline--variants" />
+
+- Use the 'Info' variant for informational, neutral messages.
+- Use the 'Confirm' variant the successful messages.
+- Use the 'Notify' variant for warning messages, and other information a user should be aware of.
+- Use the 'Alert' variant for error messages.
+
+### Inline with headline and action button
+
+<Story id="notification-notificationinline--dismissable" />

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.docs.mdx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.docs.mdx
@@ -22,14 +22,20 @@ Inline notifications are frequently used to provide additional guidance to the u
 - Use the 'Notify' variant for warning messages, and other information a user should be aware of.
 - Use the 'Alert' variant for error messages. Be descriptive and give users clear next steps.
 
-### Inline with headline and action button
+### Dismissable inline notification
+
+The close button is optional and can be excluded if the notification should not be dismissable. As accessibility requirement you need to provide a closeButtonLabel.
 
 <Story id="notification-notificationinline--dismissable" />
 
-## Accessibility guidelines
+### Inline with headline and action button
+
+If needed an optional headline can be included above the body copy. The action button is optional and it enables the user to take a specific action in relation to the message.
+
+<Story id="notification-notificationinline--with-headline-and-action" />
+
+## Accessibility
 
 - Be concise, specific and short in the message.
 - Inline notifications are part of the content and should be placed near their related part of the content.
 - Do not cover other content with inline notifications.
-- In case you need to provide an action button, use NotificationInline component. Toast messages should not contain any interactive elements. Screen readers will announce raw text within the toast as it appears, without structure and without moving focus to the toast element.
-- Inline notifications should not be added to the page dynamically. For this use case, use Toast notifications, since only dynamic alerts include aria live attributes.

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.docs.mdx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.docs.mdx
@@ -11,14 +11,6 @@ import { NotificationToast } from '@sumup/circuit-ui';
 The Notification Inline component non-disruptively provides quick and contextual inline notification and it is integrated within the content section.
 Inline notifications are frequently used to provide additional guidance to the user, like positive feedback, confirmation about an action or errors in forms, cards or dialog boxes.
 
-## Usage guidelines
-
-- Be concise, specific and short in the message and always provide a body copy.
-- Be descriptive and give users clear next steps.
-- Inline notifications are part of the content and should be placed near their related part of the content.
-- Do not cover other content with inline notifications.
-- If needed an optional headline or an action button can be included.
-
 ## Component variations
 
 ### Notification Inline variants
@@ -28,8 +20,16 @@ Inline notifications are frequently used to provide additional guidance to the u
 - Use the 'Info' variant for informational, neutral messages.
 - Use the 'Confirm' variant the successful messages.
 - Use the 'Notify' variant for warning messages, and other information a user should be aware of.
-- Use the 'Alert' variant for error messages.
+- Use the 'Alert' variant for error messages. Be descriptive and give users clear next steps.
 
 ### Inline with headline and action button
 
 <Story id="notification-notificationinline--dismissable" />
+
+## Accessibility guidelines
+
+- Be concise, specific and short in the message.
+- Inline notifications are part of the content and should be placed near their related part of the content.
+- Do not cover other content with inline notifications.
+- In case you need to provide an action button, use NotificationInline component. Toast messages should not contain any interactive elements. Screen readers will announce raw text within the toast as it appears, without structure and without moving focus to the toast element.
+- Inline notifications should not be added to the page dynamically. For this use case, use Toast notifications, since only dynamic alerts include aria live attributes.

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable react/display-name */
+import React from 'react';
+
+import { act, axe, render, userEvent, waitFor } from '../../util/test-utils';
+
+import {
+  NotificationInline,
+  NotificationInlineProps,
+} from './NotificationInline';
+
+describe('NotificationInline', () => {
+  const renderNotificationInline = (props: NotificationInlineProps) =>
+    render(<NotificationInline {...props} />);
+
+  const baseProps: NotificationInlineProps = {
+    iconLabel: '',
+    body: 'This is an inline message',
+  };
+  describe('styles', () => {
+    it('should render with default styles', () => {
+      const { baseElement } = renderNotificationInline(baseProps);
+      expect(baseElement).toMatchSnapshot();
+    });
+
+    it('should render the notification inline', async () => {
+      const { getByText } = renderNotificationInline({
+        ...baseProps,
+      });
+
+      const toastEl = getByText('This is an inline message');
+
+      await waitFor(() => {
+        expect(toastEl).toBeVisible();
+      });
+    });
+
+    const variants: NotificationInlineProps['variant'][] = [
+      'info',
+      'confirm',
+      'notify',
+      'alert',
+    ];
+
+    it.each(variants)(
+      'should render notification inline with %s styles',
+      (variant) => {
+        const { baseElement } = renderNotificationInline({
+          ...baseProps,
+          variant,
+        });
+        expect(baseElement).toMatchSnapshot();
+      },
+    );
+
+    it('should render notification inline with headline', () => {
+      const { baseElement } = renderNotificationInline({
+        ...baseProps,
+        headline: 'Information',
+      });
+      expect(baseElement).toMatchSnapshot();
+    });
+
+    it('should render notification toast with an action button', () => {
+      const { baseElement } = renderNotificationInline({
+        ...baseProps,
+        action: {
+          onClick: jest.fn(),
+          children: 'Click here',
+        },
+      });
+      expect(baseElement).toMatchSnapshot();
+    });
+  });
+  describe('business logic', () => {
+    it('should click on a call to action button', () => {
+      const props = {
+        ...baseProps,
+        action: {
+          onClick: jest.fn(),
+          children: 'Click here',
+        },
+      };
+      const { getByRole } = renderNotificationInline(props);
+
+      act(() => {
+        userEvent.click(getByRole('button'));
+      });
+
+      expect(props.action.onClick).toHaveBeenCalledTimes(1);
+    });
+    it('should close the notification inline when the onClose method is called', () => {
+      const props = {
+        ...baseProps,
+        onClose: jest.fn(),
+        closeButtonLabel: 'Close notification',
+      };
+      const { getByRole } = renderNotificationInline(props);
+
+      act(() => {
+        userEvent.click(getByRole('button', { name: /close/i }));
+      });
+
+      expect(props.onClose).toHaveBeenCalled();
+    });
+  });
+  /**
+   * Accessibility tests.
+   */
+  describe('accessibility', () => {
+    it('should meet accessibility guidelines', async () => {
+      const { container } = renderNotificationInline(baseProps);
+      const actual = await axe(container);
+      expect(actual).toHaveNoViolations();
+    });
+  });
+});

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
@@ -28,7 +28,6 @@ describe('NotificationInline', () => {
     render(<NotificationInline {...props} />);
 
   const baseProps: NotificationInlineProps = {
-    iconLabel: '',
     body: 'This is an inline message',
   };
   describe('styles', () => {

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
@@ -22,13 +22,13 @@ import {
   NotificationInline,
   NotificationInlineProps,
 } from './NotificationInline';
-// import docs from './NotificationInline.docs.mdx';
+import docs from './NotificationInline.docs.mdx';
 
 export default {
   title: 'Notification/NotificationInline',
-  // parameters: {
-  //   docs: { page: docs },
-  // },
+  parameters: {
+    docs: { page: docs },
+  },
   component: NotificationInline,
 };
 

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
@@ -42,12 +42,12 @@ const StackInlineMessages = styled.div`
   gap: 1rem;
 `;
 
-export const Variants = (toast: NotificationInlineProps) => (
+export const Variants = (args: NotificationInlineProps) => (
   <StackInlineMessages>
     {variants.map((variant) => (
       <NotificationInline
         key={variant}
-        {...toast}
+        {...args}
         isVisible={true}
         variant={variant}
       />
@@ -57,16 +57,14 @@ export const Variants = (toast: NotificationInlineProps) => (
 
 Variants.args = {
   body: 'This is a toast message',
-  iconLabel: '',
 } as NotificationInlineProps;
 
-export const Base = (toast: NotificationInlineProps) => (
-  <NotificationInline {...toast} isVisible={true} />
+export const Base = (args: NotificationInlineProps) => (
+  <NotificationInline {...args} isVisible={true} />
 );
 
 Base.args = {
   headline: 'Information',
-  iconLabel: '',
   body: 'You successfully updated your data.',
   variant: 'info',
   action: {
@@ -88,7 +86,6 @@ export const Dismissable = (args: NotificationInlineProps): JSX.Element => {
 };
 
 Dismissable.args = {
-  iconLabel: '',
   body: 'You successfully updated your data.',
   variant: 'info',
 } as NotificationInlineProps;

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable array-callback-return */
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from '@emotion/styled';
+import { action } from '@storybook/addon-actions';
+import { useState } from 'react';
+
+import {
+  NotificationInline,
+  NotificationInlineProps,
+} from './NotificationInline';
+// import docs from './NotificationInline.docs.mdx';
+
+export default {
+  title: 'Notification/NotificationInline',
+  // parameters: {
+  //   docs: { page: docs },
+  // },
+  component: NotificationInline,
+};
+
+const variants = ['info', 'confirm', 'notify', 'alert'] as const;
+
+const StackInlineMessages = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+`;
+
+export const Variants = (toast: NotificationInlineProps) => (
+  <StackInlineMessages>
+    {variants.map((variant) => (
+      <NotificationInline
+        key={variant}
+        {...toast}
+        isVisible={true}
+        variant={variant}
+      />
+    ))}
+  </StackInlineMessages>
+);
+
+Variants.args = {
+  body: 'This is a toast message',
+  iconLabel: '',
+} as NotificationInlineProps;
+
+export const Base = (toast: NotificationInlineProps) => (
+  <NotificationInline {...toast} isVisible={true} />
+);
+
+Base.args = {
+  headline: 'Information',
+  iconLabel: '',
+  body: 'You successfully updated your data.',
+  variant: 'info',
+  action: {
+    onClick: action('Action clicked'),
+    children: 'Click here',
+  },
+} as NotificationInlineProps;
+
+export const Dismissable = (args: NotificationInlineProps): JSX.Element => {
+  const [isVisible, setVisible] = useState(args.isVisible);
+  return (
+    <NotificationInline
+      {...args}
+      isVisible={isVisible}
+      onClose={() => setVisible(false)}
+      closeButtonLabel="Close notification"
+    />
+  );
+};
+
+Dismissable.args = {
+  iconLabel: '',
+  body: 'You successfully updated your data.',
+  variant: 'info',
+} as NotificationInlineProps;

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
@@ -80,6 +80,18 @@ export const Dismissable = (args: NotificationInlineProps): JSX.Element => {
 };
 
 Dismissable.args = {
+  body: 'You successfully updated your data.',
+  variant: 'info',
+} as NotificationInlineProps;
+
+export const WithHeadlineAndAction = (
+  args: NotificationInlineProps,
+): JSX.Element => {
+  const [isVisible, setVisible] = useState(args.isVisible);
+  return <NotificationInline {...args} isVisible={isVisible} />;
+};
+
+WithHeadlineAndAction.args = {
   headline: 'Information',
   body: 'You successfully updated your data.',
   variant: 'info',

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable array-callback-return */
 /**
  * Copyright 2021, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,6 +41,15 @@ const StackInlineMessages = styled.div`
   gap: 1rem;
 `;
 
+export const Base = (args: NotificationInlineProps) => (
+  <NotificationInline {...args} isVisible={true} />
+);
+
+Base.args = {
+  body: 'You successfully updated your data.',
+  variant: 'info',
+} as NotificationInlineProps;
+
 export const Variants = (args: NotificationInlineProps) => (
   <StackInlineMessages>
     {variants.map((variant) => (
@@ -56,21 +64,7 @@ export const Variants = (args: NotificationInlineProps) => (
 );
 
 Variants.args = {
-  body: 'This is a toast message',
-} as NotificationInlineProps;
-
-export const Base = (args: NotificationInlineProps) => (
-  <NotificationInline {...args} isVisible={true} />
-);
-
-Base.args = {
-  headline: 'Information',
-  body: 'You successfully updated your data.',
-  variant: 'info',
-  action: {
-    onClick: action('Action clicked'),
-    children: 'Click here',
-  },
+  body: 'This is an inline message',
 } as NotificationInlineProps;
 
 export const Dismissable = (args: NotificationInlineProps): JSX.Element => {
@@ -86,6 +80,11 @@ export const Dismissable = (args: NotificationInlineProps): JSX.Element => {
 };
 
 Dismissable.args = {
+  headline: 'Information',
   body: 'You successfully updated your data.',
   variant: 'info',
+  action: {
+    onClick: action('Action clicked'),
+    children: 'Click here',
+  },
 } as NotificationInlineProps;

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -76,7 +76,7 @@ export type BaseProps = HTMLAttributes<HTMLDivElement> & {
   /**
    * A clear and concise description of the icon and the Toast's purpose. If the toast body is self-explanatory pass an empty string.
    */
-  iconLabel: string;
+  iconLabel?: string;
 };
 
 export type NotificationInlineProps = BaseProps & CloseProps;
@@ -186,7 +186,7 @@ export function NotificationInline({
   action,
   onClose,
   closeButtonLabel,
-  iconLabel,
+  iconLabel = '',
   isVisible = true,
   tracking,
   ...props

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -1,0 +1,255 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HTMLAttributes, RefObject, useEffect, useRef, useState } from 'react';
+import { css } from '@emotion/react';
+import { Alert, Confirm, Info, Notify } from '@sumup/icons';
+
+import styled, { StyleProps } from '../../styles/styled';
+import { useAnimation } from '../../hooks/useAnimation';
+import Body from '../Body';
+import { TrackingProps } from '../../hooks/useClickEvent';
+import CloseButton from '../CloseButton';
+import { hideVisually } from '../../styles/style-mixins';
+import Button, { ButtonProps } from '../Button';
+import { ClickEvent } from '../../types/events';
+
+const TRANSITION_DURATION = 200;
+const DEFAULT_HEIGHT = 'auto';
+
+type Variant = 'info' | 'confirm' | 'notify' | 'alert';
+
+type Action = ButtonProps;
+
+type CloseProps =
+  | {
+      /**
+       * Renders a close button in the top right corner and calls the provided function
+       * when the button is clicked.
+       */
+      onClose: (event: ClickEvent) => void;
+      /**
+       * Text label for the close button for screen readers.
+       * Important for accessibility.
+       */
+      closeButtonLabel: string;
+    }
+  | { onClose?: never; closeButtonLabel?: never };
+
+export type BaseProps = HTMLAttributes<HTMLDivElement> & {
+  /**
+   * Notification inline variants. Defaults to `info`.
+   */
+  variant?: Variant;
+  /**
+   * Notification inline headline to provide information (optional)
+   */
+  headline?: string;
+  /**
+   * A body copy to provide information
+   */
+  body: string;
+  /**
+   * An optional call-to-action button.
+   */
+  action?: Action;
+  /**
+   * Whether the notification inline is visible.
+   */
+  isVisible?: boolean;
+  /**
+   * Additional data that is dispatched with the tracking event.
+   */
+  tracking?: TrackingProps;
+  /**
+   * A clear and concise description of the icon and the Toast's purpose. If the toast body is self-explanatory pass an empty string.
+   */
+  iconLabel: string;
+};
+
+export type NotificationInlineProps = BaseProps & CloseProps;
+
+// TODO: update the design token colors to be info/confirm/alert/notify, then remove this mapping
+const colorMap = {
+  info: 'p500',
+  confirm: 'success',
+  alert: 'danger',
+  notify: 'warning',
+} as const;
+
+const iconMap = {
+  info: Info,
+  confirm: Confirm,
+  alert: Alert,
+  notify: Notify,
+};
+
+type NotificationInlineWrapperProps = HTMLAttributes<HTMLDivElement> & {
+  variant: Variant;
+};
+
+const inlineWrapperStyles = ({
+  theme,
+  variant,
+}: NotificationInlineWrapperProps & StyleProps) => css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  position: relative;
+  background-color: ${theme.colors.bodyBg};
+  padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+  border-radius: ${theme.borderRadius.byte};
+  border: ${theme.borderWidth.mega} solid ${theme.colors[colorMap[variant]]};
+  overflow: hidden;
+  transition: opacity 200ms ease-in-out, height 200ms ease-in-out,
+    visibility 200ms ease-in-out;
+`;
+
+const NotificationInlineWrapper =
+  styled('div')<NotificationInlineWrapperProps>(inlineWrapperStyles);
+
+const contentStyles = ({ theme }: StyleProps) => css`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding-right: ${theme.spacings.peta};
+  padding-left: ${theme.spacings.mega};
+`;
+
+const Content = styled('div')(contentStyles);
+
+const actionButtonStyles = ({ theme }: StyleProps & ButtonProps) =>
+  css`
+    font-weight: bold;
+    text-decoration-line: underline;
+    color: ${theme.colors.black};
+    padding-bottom: calc(${theme.spacings.kilo} - ${theme.borderWidth.kilo});
+
+    &:hover {
+      color: ${theme.colors.n800};
+    }
+
+    &:active,
+    &[aria-expanded='true'],
+    &[aria-pressed='true'] {
+      color: ${theme.colors.n700};
+    }
+  `;
+
+const ActionButton = styled(Button)(actionButtonStyles);
+
+const StyledIcon = styled.span(
+  ({ theme, variant }: StyleProps & { variant: Variant }) =>
+    css`
+      display: block;
+      align-self: flex-start;
+      flex-grow: 0;
+      flex-shrink: 0;
+      line-height: 0;
+      color: ${theme.colors[colorMap[variant]]};
+    `,
+);
+
+const closeButtonStyles = ({ theme }: StyleProps) => css`
+  flex-grow: 0;
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: -${theme.spacings.bit};
+  margin-bottom: -${theme.spacings.bit};
+  margin-left: auto;
+`;
+
+const StyledCloseButton = styled(CloseButton)(closeButtonStyles);
+
+export function NotificationInline({
+  variant = 'info',
+  body,
+  headline,
+  action,
+  onClose,
+  closeButtonLabel,
+  iconLabel,
+  isVisible = true,
+  tracking,
+  ...props
+}: NotificationInlineProps): JSX.Element {
+  const contentElement = useRef(null);
+  const [isOpen, setOpen] = useState(isVisible);
+  const [height, setHeight] = useState(getHeight(contentElement));
+  const [, setAnimating] = useAnimation();
+  useEffect(() => {
+    setAnimating({
+      duration: 200,
+      onStart: () => {
+        setHeight(getHeight(contentElement));
+        // Delaying the state update until the next animation frame ensures that
+        // the browsers renders the new height before the animation starts.
+        window.requestAnimationFrame(() => {
+          setOpen(isVisible);
+        });
+      },
+      onEnd: () => {
+        setHeight(DEFAULT_HEIGHT);
+      },
+    });
+  }, [isVisible, setAnimating]);
+
+  return (
+    <NotificationInlineWrapper
+      ref={contentElement}
+      style={{
+        opacity: isOpen ? 1 : 0,
+        height: isOpen ? height : 0,
+        visibility: isOpen ? 'visible' : 'hidden',
+      }}
+      variant={variant}
+      {...props}
+    >
+      <StyledIcon as={iconMap[variant]} variant={variant} role="presentation" />
+      <span css={hideVisually}>{iconLabel}</span>
+      <Content>
+        {headline && (
+          <Body variant={'highlight'} as="h3" noMargin>
+            {headline}
+          </Body>
+        )}
+        <Body noMargin>{body}</Body>
+        {action && <ActionButton {...action} variant={'tertiary'} />}
+      </Content>
+
+      {onClose && closeButtonLabel && (
+        <StyledCloseButton
+          label={closeButtonLabel}
+          size="kilo"
+          onClick={onClose}
+          tracking={
+            tracking
+              ? { component: 'notification-close', ...tracking }
+              : undefined
+          }
+        />
+      )}
+    </NotificationInlineWrapper>
+  );
+}
+
+NotificationInline.TIMEOUT = TRANSITION_DURATION;
+
+export function getHeight(element: RefObject<HTMLElement>): string {
+  if (!element || !element.current) {
+    return DEFAULT_HEIGHT;
+  }
+  return `${element.current.scrollHeight}px`;
+}

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -113,8 +113,9 @@ const inlineWrapperStyles = ({
   border-radius: ${theme.borderRadius.byte};
   border: ${theme.borderWidth.mega} solid ${theme.colors[colorMap[variant]]};
   overflow: hidden;
-  transition: opacity 200ms ease-in-out, height 200ms ease-in-out,
-    visibility 200ms ease-in-out;
+  transition: opacity ${TRANSITION_DURATION}ms ease-in-out,
+    height ${TRANSITION_DURATION}ms ease-in-out,
+    visibility ${TRANSITION_DURATION}ms ease-in-out;
 `;
 
 const NotificationInlineWrapper =
@@ -191,7 +192,7 @@ export function NotificationInline({
   const [, setAnimating] = useAnimation();
   useEffect(() => {
     setAnimating({
-      duration: 200,
+      duration: TRANSITION_DURATION,
       onStart: () => {
         setHeight(getHeight(contentElement));
         // Delaying the state update until the next animation frame ensures that

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -97,6 +97,7 @@ const iconMap = {
 };
 
 const inlineWrapperStyles = () => css`
+  display: inline-flex;
   overflow: hidden;
   will-change: height;
   transition: opacity ${TRANSITION_DURATION}ms ease-in-out,

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -96,30 +96,34 @@ const iconMap = {
   notify: Notify,
 };
 
-type NotificationInlineWrapperProps = HTMLAttributes<HTMLDivElement> & {
-  variant: Variant;
-};
-
-const inlineWrapperStyles = ({
-  theme,
-  variant,
-}: NotificationInlineWrapperProps & StyleProps) => css`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  position: relative;
-  background-color: ${theme.colors.bodyBg};
-  padding: ${theme.spacings.kilo} ${theme.spacings.mega};
-  border-radius: ${theme.borderRadius.byte};
-  border: ${theme.borderWidth.mega} solid ${theme.colors[colorMap[variant]]};
+const inlineWrapperStyles = () => css`
   overflow: hidden;
+  will-change: height;
   transition: opacity ${TRANSITION_DURATION}ms ease-in-out,
     height ${TRANSITION_DURATION}ms ease-in-out,
     visibility ${TRANSITION_DURATION}ms ease-in-out;
 `;
 
-const NotificationInlineWrapper =
-  styled('div')<NotificationInlineWrapperProps>(inlineWrapperStyles);
+const NotificationInlineWrapper = styled('div')(inlineWrapperStyles);
+
+type ContentWrapperProps = {
+  variant: Variant;
+};
+
+const contentWrapperStyles = ({
+  theme,
+  variant,
+}: ContentWrapperProps & StyleProps) => css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  background-color: ${theme.colors.bodyBg};
+  padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+  border-radius: ${theme.borderRadius.byte};
+  border: ${theme.borderWidth.mega} solid ${theme.colors[colorMap[variant]]};
+`;
+
+const ContentWrapper = styled('div')<ContentWrapperProps>(contentWrapperStyles);
 
 const contentStyles = ({ theme }: StyleProps) => css`
   display: flex;
@@ -190,6 +194,7 @@ export function NotificationInline({
   const [isOpen, setOpen] = useState(isVisible);
   const [height, setHeight] = useState(getHeight(contentElement));
   const [, setAnimating] = useAnimation();
+
   useEffect(() => {
     setAnimating({
       duration: TRANSITION_DURATION,
@@ -215,33 +220,38 @@ export function NotificationInline({
         height: isOpen ? height : 0,
         visibility: isOpen ? 'visible' : 'hidden',
       }}
-      variant={variant}
       {...props}
     >
-      <StyledIcon as={iconMap[variant]} variant={variant} role="presentation" />
-      <span css={hideVisually}>{iconLabel}</span>
-      <Content>
-        {headline && (
-          <Body variant={'highlight'} as="h3" noMargin>
-            {headline}
-          </Body>
-        )}
-        <Body noMargin>{body}</Body>
-        {action && <ActionButton {...action} variant={'tertiary'} />}
-      </Content>
-
-      {onClose && closeButtonLabel && (
-        <StyledCloseButton
-          label={closeButtonLabel}
-          size="kilo"
-          onClick={onClose}
-          tracking={
-            tracking
-              ? { component: 'notification-close', ...tracking }
-              : undefined
-          }
+      <ContentWrapper variant={variant}>
+        <StyledIcon
+          as={iconMap[variant]}
+          variant={variant}
+          role="presentation"
         />
-      )}
+        <span css={hideVisually}>{iconLabel}</span>
+        <Content>
+          {headline && (
+            <Body variant={'highlight'} as="h3" noMargin>
+              {headline}
+            </Body>
+          )}
+          <Body noMargin>{body}</Body>
+          {action && <ActionButton {...action} variant={'tertiary'} />}
+        </Content>
+
+        {onClose && closeButtonLabel && (
+          <StyledCloseButton
+            label={closeButtonLabel}
+            size="kilo"
+            onClick={onClose}
+            tracking={
+              tracking
+                ? { component: 'notification-close', ...tracking }
+                : undefined
+            }
+          />
+        )}
+      </ContentWrapper>
     </NotificationInlineWrapper>
   );
 }

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -97,7 +97,6 @@ const iconMap = {
 };
 
 const inlineWrapperStyles = () => css`
-  display: inline-flex;
   overflow: hidden;
   will-change: height;
   transition: opacity ${TRANSITION_DURATION}ms ease-in-out,

--- a/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
@@ -2,6 +2,13 @@
 
 exports[`NotificationInline styles should render notification inline with alert styles 1`] = `
 .circuit-0 {
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -13,17 +20,13 @@ exports[`NotificationInline styles should render notification inline with alert 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
   background-color: #FFF;
   padding: 12px 16px;
   border-radius: 8px;
   border: 2px solid #D23F47;
-  overflow: hidden;
-  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
 }
 
-.circuit-1 {
+.circuit-2 {
   display: block;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
@@ -39,7 +42,7 @@ exports[`NotificationInline styles should render notification inline with alert 
   color: #D23F47;
 }
 
-.circuit-2 {
+.circuit-3 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -51,7 +54,7 @@ exports[`NotificationInline styles should render notification inline with alert 
   width: 1px;
 }
 
-.circuit-3 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -65,241 +68,6 @@ exports[`NotificationInline styles should render notification inline with alert 
   align-items: flex-start;
   padding-right: 40px;
   padding-left: 16px;
-}
-
-.circuit-4 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 0;
-}
-
-<body>
-  <div>
-    <div
-      class="circuit-0"
-      style="opacity: 1; height: 0px; visibility: visible;"
-    >
-      <svg
-        class="circuit-1"
-        fill="none"
-        height="24"
-        role="presentation"
-        variant="alert"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
-          fill="currentColor"
-        />
-      </svg>
-      <span
-        class="circuit-2"
-      />
-      <div
-        class="circuit-3"
-      >
-        <p
-          class="circuit-4"
-        >
-          This is an inline message
-        </p>
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`NotificationInline styles should render notification inline with confirm styles 1`] = `
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  background-color: #FFF;
-  padding: 12px 16px;
-  border-radius: 8px;
-  border: 2px solid #138849;
-  overflow: hidden;
-  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-}
-
-.circuit-1 {
-  display: block;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  line-height: 0;
-  color: #138849;
-}
-
-.circuit-2 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  padding-right: 40px;
-  padding-left: 16px;
-}
-
-.circuit-4 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 0;
-}
-
-<body>
-  <div>
-    <div
-      class="circuit-0"
-      style="opacity: 1; height: 0px; visibility: visible;"
-    >
-      <svg
-        class="circuit-1"
-        fill="none"
-        height="24"
-        role="presentation"
-        variant="confirm"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
-          fill="currentColor"
-        />
-      </svg>
-      <span
-        class="circuit-2"
-      />
-      <div
-        class="circuit-3"
-      >
-        <p
-          class="circuit-4"
-        >
-          This is an inline message
-        </p>
-      </div>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`NotificationInline styles should render notification inline with headline 1`] = `
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: relative;
-  background-color: #FFF;
-  padding: 12px 16px;
-  border-radius: 8px;
-  border: 2px solid #3063E9;
-  overflow: hidden;
-  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-}
-
-.circuit-1 {
-  display: block;
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: flex-start;
-  align-self: flex-start;
-  -webkit-box-flex: 0;
-  -webkit-flex-grow: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  line-height: 0;
-  color: #3063E9;
-}
-
-.circuit-2 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  padding-right: 40px;
-  padding-left: 16px;
-}
-
-.circuit-4 {
-  font-weight: 400;
-  margin-bottom: 16px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 0;
-  font-weight: 700;
 }
 
 .circuit-5 {
@@ -316,45 +84,51 @@ exports[`NotificationInline styles should render notification inline with headli
       class="circuit-0"
       style="opacity: 1; height: 0px; visibility: visible;"
     >
-      <svg
-        class="circuit-1"
-        fill="none"
-        height="24"
-        role="presentation"
-        variant="info"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-          fill="currentColor"
-        />
-      </svg>
-      <span
-        class="circuit-2"
-      />
       <div
-        class="circuit-3"
+        class="circuit-1"
       >
-        <h3
+        <svg
+          class="circuit-2"
+          fill="none"
+          height="24"
+          role="presentation"
+          variant="alert"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
+            fill="currentColor"
+          />
+        </svg>
+        <span
+          class="circuit-3"
+        />
+        <div
           class="circuit-4"
         >
-          Information
-        </h3>
-        <p
-          class="circuit-5"
-        >
-          This is an inline message
-        </p>
+          <p
+            class="circuit-5"
+          >
+            This is an inline message
+          </p>
+        </div>
       </div>
     </div>
   </div>
 </body>
 `;
 
-exports[`NotificationInline styles should render notification inline with info styles 1`] = `
+exports[`NotificationInline styles should render notification inline with confirm styles 1`] = `
 .circuit-0 {
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -366,17 +140,133 @@ exports[`NotificationInline styles should render notification inline with info s
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
   background-color: #FFF;
   padding: 12px 16px;
   border-radius: 8px;
-  border: 2px solid #3063E9;
+  border: 2px solid #138849;
+}
+
+.circuit-2 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #138849;
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
   overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-5 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <div
+        class="circuit-1"
+      >
+        <svg
+          class="circuit-2"
+          fill="none"
+          height="24"
+          role="presentation"
+          variant="confirm"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
+            fill="currentColor"
+          />
+        </svg>
+        <span
+          class="circuit-3"
+        />
+        <div
+          class="circuit-4"
+        >
+          <p
+            class="circuit-5"
+          >
+            This is an inline message
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationInline styles should render notification inline with headline 1`] = `
+.circuit-0 {
+  overflow: hidden;
+  will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
   transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
 }
 
 .circuit-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #3063E9;
+}
+
+.circuit-2 {
   display: block;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
@@ -392,7 +282,7 @@ exports[`NotificationInline styles should render notification inline with info s
   color: #3063E9;
 }
 
-.circuit-2 {
+.circuit-3 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -404,7 +294,7 @@ exports[`NotificationInline styles should render notification inline with info s
   width: 1px;
 }
 
-.circuit-3 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -420,7 +310,16 @@ exports[`NotificationInline styles should render notification inline with info s
   padding-left: 16px;
 }
 
-.circuit-4 {
+.circuit-5 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+  font-weight: 700;
+}
+
+.circuit-6 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -434,40 +333,56 @@ exports[`NotificationInline styles should render notification inline with info s
       class="circuit-0"
       style="opacity: 1; height: 0px; visibility: visible;"
     >
-      <svg
-        class="circuit-1"
-        fill="none"
-        height="24"
-        role="presentation"
-        variant="info"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-          fill="currentColor"
-        />
-      </svg>
-      <span
-        class="circuit-2"
-      />
       <div
-        class="circuit-3"
+        class="circuit-1"
       >
-        <p
+        <svg
+          class="circuit-2"
+          fill="none"
+          height="24"
+          role="presentation"
+          variant="info"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+            fill="currentColor"
+          />
+        </svg>
+        <span
+          class="circuit-3"
+        />
+        <div
           class="circuit-4"
         >
-          This is an inline message
-        </p>
+          <h3
+            class="circuit-5"
+          >
+            Information
+          </h3>
+          <p
+            class="circuit-6"
+          >
+            This is an inline message
+          </p>
+        </div>
       </div>
     </div>
   </div>
 </body>
 `;
 
-exports[`NotificationInline styles should render notification inline with notify styles 1`] = `
+exports[`NotificationInline styles should render notification inline with info styles 1`] = `
 .circuit-0 {
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -479,17 +394,133 @@ exports[`NotificationInline styles should render notification inline with notify
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
   background-color: #FFF;
   padding: 12px 16px;
   border-radius: 8px;
-  border: 2px solid #F5C625;
+  border: 2px solid #3063E9;
+}
+
+.circuit-2 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #3063E9;
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
   overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-5 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <div
+        class="circuit-1"
+      >
+        <svg
+          class="circuit-2"
+          fill="none"
+          height="24"
+          role="presentation"
+          variant="info"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+            fill="currentColor"
+          />
+        </svg>
+        <span
+          class="circuit-3"
+        />
+        <div
+          class="circuit-4"
+        >
+          <p
+            class="circuit-5"
+          >
+            This is an inline message
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationInline styles should render notification inline with notify styles 1`] = `
+.circuit-0 {
+  overflow: hidden;
+  will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
   transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
 }
 
 .circuit-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #F5C625;
+}
+
+.circuit-2 {
   display: block;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
@@ -505,7 +536,7 @@ exports[`NotificationInline styles should render notification inline with notify
   color: #F5C625;
 }
 
-.circuit-2 {
+.circuit-3 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -517,7 +548,7 @@ exports[`NotificationInline styles should render notification inline with notify
   width: 1px;
 }
 
-.circuit-3 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -533,7 +564,7 @@ exports[`NotificationInline styles should render notification inline with notify
   padding-left: 16px;
 }
 
-.circuit-4 {
+.circuit-5 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -547,34 +578,38 @@ exports[`NotificationInline styles should render notification inline with notify
       class="circuit-0"
       style="opacity: 1; height: 0px; visibility: visible;"
     >
-      <svg
-        class="circuit-1"
-        fill="none"
-        height="24"
-        role="presentation"
-        variant="notify"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          clip-rule="evenodd"
-          d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
-          fill="currentColor"
-          fill-rule="evenodd"
-        />
-      </svg>
-      <span
-        class="circuit-2"
-      />
       <div
-        class="circuit-3"
+        class="circuit-1"
       >
-        <p
+        <svg
+          class="circuit-2"
+          fill="none"
+          height="24"
+          role="presentation"
+          variant="notify"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </svg>
+        <span
+          class="circuit-3"
+        />
+        <div
           class="circuit-4"
         >
-          This is an inline message
-        </p>
+          <p
+            class="circuit-5"
+          >
+            This is an inline message
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -599,6 +634,13 @@ exports[`NotificationInline styles should render notification toast with an acti
 }
 
 .circuit-0 {
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -610,17 +652,13 @@ exports[`NotificationInline styles should render notification toast with an acti
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
   background-color: #FFF;
   padding: 12px 16px;
   border-radius: 8px;
   border: 2px solid #3063E9;
-  overflow: hidden;
-  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
 }
 
-.circuit-1 {
+.circuit-2 {
   display: block;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
@@ -636,7 +674,7 @@ exports[`NotificationInline styles should render notification toast with an acti
   color: #3063E9;
 }
 
-.circuit-2 {
+.circuit-3 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -648,7 +686,7 @@ exports[`NotificationInline styles should render notification toast with an acti
   width: 1px;
 }
 
-.circuit-3 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -664,7 +702,7 @@ exports[`NotificationInline styles should render notification toast with an acti
   padding-left: 16px;
 }
 
-.circuit-4 {
+.circuit-5 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -672,7 +710,7 @@ exports[`NotificationInline styles should render notification toast with an acti
   margin-bottom: 0;
 }
 
-.circuit-5 {
+.circuit-6 {
   font-size: 16px;
   line-height: 24px;
   display: -webkit-inline-box;
@@ -710,47 +748,47 @@ exports[`NotificationInline styles should render notification toast with an acti
   padding-bottom: calc(12px - 1px);
 }
 
-.circuit-5:focus {
+.circuit-6:focus {
   outline: 0;
   box-shadow: 0 0 0 4px #AFD0FE;
 }
 
-.circuit-5:focus::-moz-focus-inner {
+.circuit-6:focus::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-5:focus:not(:focus-visible) {
+.circuit-6:focus:not(:focus-visible) {
   box-shadow: none;
 }
 
-.circuit-5:disabled,
-.circuit-5[disabled] {
+.circuit-6:disabled,
+.circuit-6[disabled] {
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
 }
 
-.circuit-5:hover {
+.circuit-6:hover {
   color: #234BC3;
 }
 
-.circuit-5:active,
-.circuit-5[aria-expanded='true'],
-.circuit-5[aria-pressed='true'] {
+.circuit-6:active,
+.circuit-6[aria-expanded='true'],
+.circuit-6[aria-pressed='true'] {
   color: #1A368E;
 }
 
-.circuit-5:hover {
+.circuit-6:hover {
   color: #333;
 }
 
-.circuit-5:active,
-.circuit-5[aria-expanded='true'],
-.circuit-5[aria-pressed='true'] {
+.circuit-6:active,
+.circuit-6[aria-expanded='true'],
+.circuit-6[aria-pressed='true'] {
   color: #666;
 }
 
-.circuit-6 {
+.circuit-7 {
   display: block;
   border-radius: 100%;
   border: 2px solid currentColor;
@@ -767,7 +805,7 @@ exports[`NotificationInline styles should render notification toast with an acti
   transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
 }
 
-.circuit-8 {
+.circuit-9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -792,48 +830,52 @@ exports[`NotificationInline styles should render notification toast with an acti
       class="circuit-0"
       style="opacity: 1; height: 0px; visibility: visible;"
     >
-      <svg
-        class="circuit-1"
-        fill="none"
-        height="24"
-        role="presentation"
-        variant="info"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-          fill="currentColor"
-        />
-      </svg>
-      <span
-        class="circuit-2"
-      />
       <div
-        class="circuit-3"
+        class="circuit-1"
       >
-        <p
+        <svg
+          class="circuit-2"
+          fill="none"
+          height="24"
+          role="presentation"
+          variant="info"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+            fill="currentColor"
+          />
+        </svg>
+        <span
+          class="circuit-3"
+        />
+        <div
           class="circuit-4"
         >
-          This is an inline message
-        </p>
-        <button
-          class="circuit-5"
-        >
-          <span
+          <p
+            class="circuit-5"
+          >
+            This is an inline message
+          </p>
+          <button
             class="circuit-6"
           >
             <span
-              class="circuit-2"
-            />
-          </span>
-          <span
-            class="circuit-8"
-          >
-            Click here
-          </span>
-        </button>
+              class="circuit-7"
+            >
+              <span
+                class="circuit-3"
+              />
+            </span>
+            <span
+              class="circuit-9"
+            >
+              Click here
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -842,6 +884,13 @@ exports[`NotificationInline styles should render notification toast with an acti
 
 exports[`NotificationInline styles should render with default styles 1`] = `
 .circuit-0 {
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -853,17 +902,13 @@ exports[`NotificationInline styles should render with default styles 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  position: relative;
   background-color: #FFF;
   padding: 12px 16px;
   border-radius: 8px;
   border: 2px solid #3063E9;
-  overflow: hidden;
-  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
-  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
 }
 
-.circuit-1 {
+.circuit-2 {
   display: block;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
@@ -879,7 +924,7 @@ exports[`NotificationInline styles should render with default styles 1`] = `
   color: #3063E9;
 }
 
-.circuit-2 {
+.circuit-3 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -891,7 +936,7 @@ exports[`NotificationInline styles should render with default styles 1`] = `
   width: 1px;
 }
 
-.circuit-3 {
+.circuit-4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -907,7 +952,7 @@ exports[`NotificationInline styles should render with default styles 1`] = `
   padding-left: 16px;
 }
 
-.circuit-4 {
+.circuit-5 {
   font-weight: 400;
   margin-bottom: 16px;
   font-size: 16px;
@@ -921,32 +966,36 @@ exports[`NotificationInline styles should render with default styles 1`] = `
       class="circuit-0"
       style="opacity: 1; height: 0px; visibility: visible;"
     >
-      <svg
-        class="circuit-1"
-        fill="none"
-        height="24"
-        role="presentation"
-        variant="info"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-          fill="currentColor"
-        />
-      </svg>
-      <span
-        class="circuit-2"
-      />
       <div
-        class="circuit-3"
+        class="circuit-1"
       >
-        <p
+        <svg
+          class="circuit-2"
+          fill="none"
+          height="24"
+          role="presentation"
+          variant="info"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+            fill="currentColor"
+          />
+        </svg>
+        <span
+          class="circuit-3"
+        />
+        <div
           class="circuit-4"
         >
-          This is an inline message
-        </p>
+          <p
+            class="circuit-5"
+          >
+            This is an inline message
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
@@ -2,6 +2,10 @@
 
 exports[`NotificationInline styles should render notification inline with alert styles 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -122,6 +126,10 @@ exports[`NotificationInline styles should render notification inline with alert 
 
 exports[`NotificationInline styles should render notification inline with confirm styles 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -242,6 +250,10 @@ exports[`NotificationInline styles should render notification inline with confir
 
 exports[`NotificationInline styles should render notification inline with headline 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -376,6 +388,10 @@ exports[`NotificationInline styles should render notification inline with headli
 
 exports[`NotificationInline styles should render notification inline with info styles 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -496,6 +512,10 @@ exports[`NotificationInline styles should render notification inline with info s
 
 exports[`NotificationInline styles should render notification inline with notify styles 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -634,6 +654,10 @@ exports[`NotificationInline styles should render notification toast with an acti
 }
 
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -884,6 +908,10 @@ exports[`NotificationInline styles should render notification toast with an acti
 
 exports[`NotificationInline styles should render with default styles 1`] = `
 .circuit-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;

--- a/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
@@ -1,0 +1,954 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationInline styles should render notification inline with alert styles 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #D23F47;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #D23F47;
+}
+
+.circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-4 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        role="presentation"
+        variant="alert"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="circuit-2"
+      />
+      <div
+        class="circuit-3"
+      >
+        <p
+          class="circuit-4"
+        >
+          This is an inline message
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationInline styles should render notification inline with confirm styles 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #138849;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #138849;
+}
+
+.circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-4 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        role="presentation"
+        variant="confirm"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="circuit-2"
+      />
+      <div
+        class="circuit-3"
+      >
+        <p
+          class="circuit-4"
+        >
+          This is an inline message
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationInline styles should render notification inline with headline 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #3063E9;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #3063E9;
+}
+
+.circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-4 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+  font-weight: 700;
+}
+
+.circuit-5 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        role="presentation"
+        variant="info"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="circuit-2"
+      />
+      <div
+        class="circuit-3"
+      >
+        <h3
+          class="circuit-4"
+        >
+          Information
+        </h3>
+        <p
+          class="circuit-5"
+        >
+          This is an inline message
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationInline styles should render notification inline with info styles 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #3063E9;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #3063E9;
+}
+
+.circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-4 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        role="presentation"
+        variant="info"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="circuit-2"
+      />
+      <div
+        class="circuit-3"
+      >
+        <p
+          class="circuit-4"
+        >
+          This is an inline message
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationInline styles should render notification inline with notify styles 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #F5C625;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #F5C625;
+}
+
+.circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-4 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        role="presentation"
+        variant="notify"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+          fill="currentColor"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="circuit-2"
+      />
+      <div
+        class="circuit-3"
+      >
+        <p
+          class="circuit-4"
+        >
+          This is an inline message
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationInline styles should render notification toast with an action button 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #3063E9;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #3063E9;
+}
+
+.circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-4 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+.circuit-5 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  background-color: transparent;
+  border-color: transparent;
+  color: #3063E9;
+  padding-left: 0;
+  padding-right: 0;
+  position: relative;
+  overflow: hidden;
+  font-weight: bold;
+  text-decoration-line: underline;
+  color: #000;
+  padding-bottom: calc(12px - 1px);
+}
+
+.circuit-5:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-5:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-5:disabled,
+.circuit-5[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-5:hover {
+  color: #234BC3;
+}
+
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
+  color: #1A368E;
+}
+
+.circuit-5:hover {
+  color: #333;
+}
+
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
+  color: #666;
+}
+
+.circuit-6 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        role="presentation"
+        variant="info"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="circuit-2"
+      />
+      <div
+        class="circuit-3"
+      >
+        <p
+          class="circuit-4"
+        >
+          This is an inline message
+        </p>
+        <button
+          class="circuit-5"
+        >
+          <span
+            class="circuit-6"
+          >
+            <span
+              class="circuit-2"
+            />
+          </span>
+          <span
+            class="circuit-8"
+          >
+            Click here
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationInline styles should render with default styles 1`] = `
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  background-color: #FFF;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid #3063E9;
+  overflow: hidden;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: #3063E9;
+}
+
+.circuit-2 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-4 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <svg
+        class="circuit-1"
+        fill="none"
+        height="24"
+        role="presentation"
+        variant="info"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="circuit-2"
+      />
+      <div
+        class="circuit-3"
+      >
+        <p
+          class="circuit-4"
+        >
+          This is an inline message
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+`;

--- a/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
@@ -2,10 +2,6 @@
 
 exports[`NotificationInline styles should render notification inline with alert styles 1`] = `
 .circuit-0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -126,10 +122,6 @@ exports[`NotificationInline styles should render notification inline with alert 
 
 exports[`NotificationInline styles should render notification inline with confirm styles 1`] = `
 .circuit-0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -250,10 +242,6 @@ exports[`NotificationInline styles should render notification inline with confir
 
 exports[`NotificationInline styles should render notification inline with headline 1`] = `
 .circuit-0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -388,10 +376,6 @@ exports[`NotificationInline styles should render notification inline with headli
 
 exports[`NotificationInline styles should render notification inline with info styles 1`] = `
 .circuit-0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -512,10 +496,6 @@ exports[`NotificationInline styles should render notification inline with info s
 
 exports[`NotificationInline styles should render notification inline with notify styles 1`] = `
 .circuit-0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -654,10 +634,6 @@ exports[`NotificationInline styles should render notification toast with an acti
 }
 
 .circuit-0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
@@ -908,10 +884,6 @@ exports[`NotificationInline styles should render notification toast with an acti
 
 exports[`NotificationInline styles should render with default styles 1`] = `
 .circuit-0 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
   overflow: hidden;
   will-change: height;
   -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;

--- a/packages/circuit-ui/components/NotificationInline/index.tsx
+++ b/packages/circuit-ui/components/NotificationInline/index.tsx
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NotificationInline } from './NotificationInline';
+
+export type { NotificationInlineProps } from './NotificationInline';
+
+export default NotificationInline;

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.docs.mdx
@@ -69,6 +69,7 @@ Live region must always exist on the page at render, before the toast is generat
 Toast messages should not contain any interactive elements.
 Screen readers will announce raw text within the toast as it appears, without structure and without moving focus to the toast element.
 For example, if a toast read “You successfully updated your data” followed by an "Undo" button, screen readers would announce “You successfully updated your data. Undo”, not allowing keyboard users to interact with the button.
+In case you need to provide an action button, use NotificationInline component.
 
 To match the content, the role and aria-live level is adapted. The role is set to `"status"`, and it has `aria-live="polite"` meaning the screen reader will wait before announcing the update.
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -160,7 +160,7 @@ export function NotificationToast({
 
   useEffect(() => {
     setAnimating({
-      duration: 200,
+      duration: TRANSITION_DURATION,
       onStart: () => {
         setHeight(getHeight(contentElement));
         // Delaying the state update until the next animation frame ensures that


### PR DESCRIPTION
Addresses #792.

## Purpose

Introduces the new NotificationInline component.
The Notification Inline component non-disruptively provides quick and contextual inline notification and it is integrated within the content section.
<img width="802" alt="Screenshot 2022-01-14 at 15 08 07" src="https://user-images.githubusercontent.com/57903317/149528398-69476d2f-b02f-485e-a63b-25bcc0337997.png">


It comes in 4 variants, "info", "confirm", "notify" and "alert".
To communicate a message always provide a body copy, and if needed an optional headline can be included above the body copy and an action button.
Inline notifications are part of the content and should be placed near their related part of the content.
Inline notifications can be dismissed by clicking on a close button in the top-right corner.

## Approach and changes

Refer to the Storybook for further implementation and usage guidelines, and to the threads below for more details and discussion on the implementation.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
