### PR TITLE
Fix CurrencyInput typings

### DIFF
--- a/.changeset/silent-kiwis-attack.md
+++ b/.changeset/silent-kiwis-attack.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Improved types in the `CurrencyInput`. The component's type (exposed via its `ref`) changed from `NumberFormat` to `NumberFormat<InputProps>`, now explicitly typing the wrapped Circuit UI `Input`.

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -47,7 +47,7 @@ export interface CurrencyInputProps
   /**
    * The ref to the HTML DOM element.
    */
-  ref?: Ref<NumberFormat>;
+  ref?: Ref<NumberFormat<InputProps>>;
   /**
    * The value of the input element.
    */
@@ -108,14 +108,14 @@ export const CurrencyInput = forwardRef(
         ? (prefixProps: { className?: string }) => (
             <CurrencyIcon {...prefixProps}>{currencySymbol}</CurrencyIcon>
           )
-        : null;
+        : undefined;
 
     const renderSuffix =
       currencyPosition === 'suffix'
         ? (suffixProps: { className?: string }) => (
             <CurrencyIcon {...suffixProps}>{currencySymbol}</CurrencyIcon>
           )
-        : null;
+        : undefined;
 
     return (
       <NumberFormat

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,9 +4715,9 @@
     "@types/react" "*"
 
 "@types/react-modal@^3.10.5":
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.12.1.tgz#fd1558762ed96020291b831190c85bc721aad3c1"
-  integrity sha512-pgq/jAnSJqHX7NXTFyUSXwlFOBUGngBXavFmAIKE7bkM7WNKyF/9XvmMr2+eIBOvR8waiA0Nj2qHfDZqMgeT6w==
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.13.1.tgz#5b9845c205fccc85d9a77966b6e16dc70a60825a"
+  integrity sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==
   dependencies:
     "@types/react" "*"
 
@@ -15780,9 +15780,9 @@ react-moment-proptypes@^1.6.0:
     moment ">=1.6.0"
 
 react-number-format@^4.4.1:
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.7.3.tgz#e1706204a23c40fa17365a19f5059aabfca1886f"
-  integrity sha512-4EvcANjstypQ5anhanmdEioGc49qbnErfS+yqbhatC0vzQ1okplkWNb0DIY7ABu4RhaxzttEz6pypEy8KsqgBQ==
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.9.1.tgz#62b3450b43c911f9227e770a8ea9fa606696e52e"
+  integrity sha512-v49XqXv7SpwYZKGkghNJjoDUr6lIUozlPLrObcxre7GfcLx7qD4TCvArn3GozN/Y4FVbLyEYCwJoBCiChdBh5A==
   dependencies:
     prop-types "^15.7.2"
 


### PR DESCRIPTION
Splits from #1344 

## Purpose

This fixes our CurrencyInput's typings after they were strengthened upstream in https://github.com/s-yadav/react-number-format/pull/577

## Approach and changes

- Bumped `react-number-format` (via Dependabot)
- Passed Input props to the new `NumberFormat` generic (used to only extend HTML input attributes)
- Fixed typings for `renderPrefix` and `renderSuffix`, which should be `undefined` if not rendered, not `null`

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
