### PR TITLE
Increase the NotificationToast duration

### DIFF
--- a/.changeset/perfect-sheep-develop.md
+++ b/.changeset/perfect-sheep-develop.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Increased the NotificationToast's duration to 6 seconds to match accessibility criteria.

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
@@ -159,7 +159,7 @@ describe('NotificationToast', () => {
         () => {
           expect(baseNotificationToast.onClose).toHaveBeenCalledTimes(1);
         },
-        { timeout: 3000 },
+        { timeout: 6000 },
       );
     });
   });

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -120,8 +120,8 @@ export function ToastProvider<TProps extends BaseToastProps>({
       return undefined;
     }
     const duration = toastToDismiss.duration
-      ? Math.max(toastToDismiss.duration, 3000)
-      : 3000;
+      ? Math.max(toastToDismiss.duration, 6000)
+      : 6000;
     const timeoutId = setTimeout(() => {
       context.removeToast(toastToDismiss);
     }, duration);


### PR DESCRIPTION

## Purpose

Based on how fast the [average American reads](https://sheribyrnehaber.medium.com/designing-toast-messages-for-accessibility-fb610ac364be), a good lenght of time to keep the toast message up is 5 seconds plus 1 extra second for every 120 words.
The shortest default that should be used as a best practice is 6 seconds.

## Approach and changes

Increased the toast duration to 6 seconds.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
