### PR TITLE
Add z-index to Notification Toast ListWrapper

### DIFF
--- a/.changeset/smart-yaks-walk.md
+++ b/.changeset/smart-yaks-walk.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Added a `z-index` to the NotificationToasts so they always float above other content.
+Added a `z-index` to the NotificationToasts so they always float above other content. Requires updating to `@sumup/design-tokens@3.3.0`.

--- a/.changeset/smart-yaks-walk.md
+++ b/.changeset/smart-yaks-walk.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a z-index to the Toast ListWrapper.

--- a/.changeset/smart-yaks-walk.md
+++ b/.changeset/smart-yaks-walk.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Added a z-index to the Toast ListWrapper.
+Added a `z-index` to the NotificationToasts so they always float above other content.

--- a/.changeset/tame-pigs-worry.md
+++ b/.changeset/tame-pigs-worry.md
@@ -2,4 +2,4 @@
 '@sumup/design-tokens': minor
 ---
 
-Added new zIndex value for the toast.
+Added a new `zIndex.toast` value for the NotificationToast component in Circuit UI.

--- a/.changeset/tame-pigs-worry.md
+++ b/.changeset/tame-pigs-worry.md
@@ -1,0 +1,5 @@
+---
+'@sumup/design-tokens': minor
+---
+
+Added new zIndex value for the toast.

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -60,6 +60,7 @@ const listWrapperStyles = ({ theme }: StyleProps) => css`
   transform: translateX(-50%);
   display: flex;
   flex-direction: column-reverse;
+  z-index: ${theme.zIndex.toast};
 `;
 
 const ListWrapper = styled('ul')(listWrapperStyles);

--- a/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
@@ -242,6 +242,7 @@ Object {
     "navigation": 800,
     "popover": 30,
     "sidebar": 800,
+    "toast": 1100,
     "tooltip": 40,
   },
 }

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -208,4 +208,5 @@ export const zIndex: ZIndex = {
   sidebar: 800,
   navigation: 800,
   modal: 1000,
+  toast: 1100,
 };

--- a/packages/design-tokens/types/index.ts
+++ b/packages/design-tokens/types/index.ts
@@ -191,6 +191,7 @@ export type ZIndex = {
   sidebar: number;
   navigation: number;
   modal: number;
+  toast: number;
 };
 
 export interface Theme {

--- a/packages/design-tokens/utils/theme-prop-type.ts
+++ b/packages/design-tokens/utils/theme-prop-type.ts
@@ -237,5 +237,6 @@ export const themePropType = PropTypes.shape({
     sidebar: PropTypes.number.isRequired,
     navigation: PropTypes.number.isRequired,
     modal: PropTypes.number.isRequired,
+    toast: PropTypes.number.isRequired,
   } as { [key in keyof ZIndex]: Requireable<unknown> }).isRequired,
 } as { [key in keyof Theme]: Requireable<unknown> });


### PR DESCRIPTION

## Purpose

The Notification Toast didn't have a z-index value set, which caused stacking issues.

## Approach and changes

- Added a new z-index value for the toast to design-tokens.
- Add z-index to ToastContext ListWrapper.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
