### PR TITLE
Fix Badge colors

### DIFF
--- a/packages/circuit-ui/components/Badge/Badge.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.tsx
@@ -36,34 +36,28 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
 const COLOR_MAP = {
   success: {
     text: 'white',
-    default: 'g700',
-    hover: 'g900',
+    background: 'g700',
   },
   warning: {
     text: 'bodyColor',
-    default: 'y300',
-    hover: 'y500',
+    background: 'y300',
   },
   danger: {
     text: 'white',
-    default: 'r500',
-    hover: 'r700',
+    background: 'r500',
   },
   neutral: {
     text: 'bodyColor',
-    default: 'n200',
-    hover: 'n300',
+    background: 'n200',
   },
   promo: {
     text: 'white',
-    default: 'v500',
-    hover: 'v700',
+    background: 'v500',
   },
 } as const;
 
 const baseStyles = ({ theme }: StyleProps) => css`
   border-radius: ${theme.borderRadius.pill};
-  color: ${theme.colors.white};
   display: inline-block;
   padding: 2px ${theme.spacings.byte};
   font-size: 14px;
@@ -78,11 +72,8 @@ const variantStyles = ({
   variant = 'neutral',
 }: StyleProps & BadgeProps) => {
   const currentColor = COLOR_MAP[variant];
-  if (!currentColor) {
-    return null;
-  }
   return css`
-    background-color: ${theme.colors[currentColor.default]};
+    background-color: ${theme.colors[currentColor.background]};
     color: ${theme.colors[currentColor.text]};
   `;
 };

--- a/packages/circuit-ui/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/circuit-ui/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -3,7 +3,6 @@
 exports[`Badge should have the correct circle styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -38,7 +37,6 @@ exports[`Badge should have the correct circle styles 1`] = `
 exports[`Badge should render with danger styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -58,7 +56,6 @@ exports[`Badge should render with danger styles 1`] = `
 exports[`Badge should render with default styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -78,7 +75,6 @@ exports[`Badge should render with default styles 1`] = `
 exports[`Badge should render with neutral styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -98,7 +94,6 @@ exports[`Badge should render with neutral styles 1`] = `
 exports[`Badge should render with promo styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -118,7 +113,6 @@ exports[`Badge should render with promo styles 1`] = `
 exports[`Badge should render with success styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -138,7 +132,6 @@ exports[`Badge should render with success styles 1`] = `
 exports[`Badge should render with warning styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;

--- a/packages/circuit-ui/components/ListItem/__snapshots__/ListItem.spec.tsx.snap
+++ b/packages/circuit-ui/components/ListItem/__snapshots__/ListItem.spec.tsx.snap
@@ -815,7 +815,6 @@ exports[`ListItem styles should render a ListItem with a custom prefix 1`] = `
 
 .circuit-2 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;
@@ -1051,7 +1050,6 @@ exports[`ListItem styles should render a ListItem with a custom suffix 1`] = `
 
 .circuit-6 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
@@ -86,7 +86,6 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
 
 .circuit-8 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;

--- a/packages/circuit-ui/components/Table/__snapshots__/Table.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/__snapshots__/Table.spec.tsx.snap
@@ -2390,7 +2390,6 @@ tbody .circuit-4:last-child td {
 
 .circuit-24 {
   border-radius: 999999px;
-  color: #FFF;
   display: inline-block;
   padding: 2px 8px;
   font-size: 14px;


### PR DESCRIPTION
## Purpose

I noticed that the `Badge` component still includes a color mapping for a hover state.

The Badge's hover state was removed when we determined that it shouldn't be interactive.

## Approach and changes

- removes the hover color mapping
- rename the `default` color key to `background` for clarity

## Definition of done

(internal change only)

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
