### PR TITLE
Clean up Checkbox styles

### DIFF
--- a/.changeset/lazy-zoos-tell.md
+++ b/.changeset/lazy-zoos-tell.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Refactored `Checkbox` styles. This is an internal change only, but you'll need to update your snapshots.

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -51,7 +51,7 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   ref?: Ref<HTMLInputElement>;
 }
 
-type LabelElProps = Pick<CheckboxProps, 'invalid' | 'disabled'>;
+type LabelElProps = Pick<CheckboxProps, 'disabled'>;
 
 const labelBaseStyles = ({ theme }: StyleProps) => css`
   color: ${theme.colors.bodyColor};
@@ -96,31 +96,12 @@ const labelBaseStyles = ({ theme }: StyleProps) => css`
   }
 `;
 
-const labelInvalidStyles = ({ theme, invalid }: StyleProps & LabelElProps) =>
-  invalid &&
-  css`
-    &:not(:focus)::before {
-      border-color: ${theme.colors.danger};
-      background-color: ${theme.colors.r100};
-    }
-  `;
-
-const labelDisabledStyles = ({ disabled, theme }: StyleProps & LabelElProps) =>
-  disabled &&
-  css`
-    ${disableVisually()};
-
-    &::before {
-      ${disableVisually()};
-      border-color: ${theme.colors.n700};
-      background-color: ${theme.colors.n200};
-    }
-  `;
+const labelDisabledStyles = ({ disabled }: LabelElProps) =>
+  disabled && disableVisually;
 
 const CheckboxLabel = styled('label')<LabelElProps>(
   labelBaseStyles,
   labelDisabledStyles,
-  labelInvalidStyles,
 );
 
 type WrapperElProps = Pick<CheckboxProps, 'noMargin'>;
@@ -198,6 +179,11 @@ const inputBaseStyles = ({ theme }: StyleProps) => css`
 const inputInvalidStyles = ({ theme, invalid }: StyleProps & InputElProps) =>
   invalid &&
   css`
+    & + label::before {
+      border-color: ${theme.colors.danger};
+      background-color: ${theme.colors.r100};
+    }
+
     &:hover + label::before,
     &:focus + label::before {
       border-color: ${theme.colors.r700};
@@ -209,9 +195,20 @@ const inputInvalidStyles = ({ theme, invalid }: StyleProps & InputElProps) =>
     }
   `;
 
+const inputDisabledStyles = ({ theme, disabled }: StyleProps & InputElProps) =>
+  disabled &&
+  css`
+    & + label::before {
+      ${disableVisually()}
+      border-color: ${theme.colors.n700};
+      background-color: ${theme.colors.n200};
+    }
+  `;
+
 const CheckboxInput = styled('input')<InputElProps>(
   inputBaseStyles,
   inputInvalidStyles,
+  inputDisabledStyles,
 );
 
 const tooltipStyles = ({ theme }: StyleProps) => css`
@@ -261,7 +258,7 @@ export const Checkbox = forwardRef(
           // Noop to silence React warning: https://github.com/facebook/react/issues/3070#issuecomment-73311114
           onChange={() => {}}
         />
-        <CheckboxLabel htmlFor={id} disabled={disabled} invalid={invalid}>
+        <CheckboxLabel htmlFor={id} disabled={disabled}>
           {children}
           <Checkmark aria-hidden="true" />
         </CheckboxLabel>

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -59,41 +59,6 @@ const labelBaseStyles = ({ theme }: StyleProps) => css`
   padding-left: 26px;
   position: relative;
   cursor: pointer;
-
-  &::before {
-    height: 18px;
-    width: 18px;
-    box-sizing: border-box;
-    box-shadow: 0;
-    background-color: ${theme.colors.white};
-    border: 1px solid ${theme.colors.n500};
-    border-radius: 3px;
-    content: '';
-    display: block;
-    position: absolute;
-    top: ${theme.spacings.kilo};
-    left: 0;
-    transform: translateY(-50%);
-    transition: border ${theme.transitions.default},
-      background-color ${theme.transitions.default};
-  }
-
-  svg {
-    height: 18px;
-    width: 18px;
-    padding: 2px;
-    box-sizing: border-box;
-    color: ${theme.colors.white};
-    display: block;
-    line-height: 0;
-    opacity: 0;
-    position: absolute;
-    top: ${theme.spacings.kilo};
-    left: 0;
-    transform: translateY(-50%) scale(0, 0);
-    transition: transform ${theme.transitions.default},
-      opacity ${theme.transitions.default};
-  }
 `;
 
 const labelDisabledStyles = ({ disabled }: LabelElProps) =>
@@ -146,6 +111,41 @@ type InputElProps = Omit<CheckboxProps, 'tracking'>;
 
 const inputBaseStyles = ({ theme }: StyleProps) => css`
   ${hideVisually()};
+
+  & + label::before {
+    height: 18px;
+    width: 18px;
+    box-sizing: border-box;
+    box-shadow: 0;
+    background-color: ${theme.colors.white};
+    border: 1px solid ${theme.colors.n500};
+    border-radius: 3px;
+    content: '';
+    display: block;
+    position: absolute;
+    top: ${theme.spacings.kilo};
+    left: 0;
+    transform: translateY(-50%);
+    transition: border ${theme.transitions.default},
+      background-color ${theme.transitions.default};
+  }
+
+  & + label svg {
+    height: 18px;
+    width: 18px;
+    padding: 2px;
+    box-sizing: border-box;
+    color: ${theme.colors.white};
+    display: block;
+    line-height: 0;
+    opacity: 0;
+    position: absolute;
+    top: ${theme.spacings.kilo};
+    left: 0;
+    transform: translateY(-50%) scale(0, 0);
+    transition: transform ${theme.transitions.default},
+      opacity ${theme.transitions.default};
+  }
 
   &:hover + label::before {
     border-color: ${theme.colors.n700};

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -21,6 +21,47 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   width: 1px;
 }
 
+.circuit-1+label::before {
+  height: 18px;
+  width: 18px;
+  box-sizing: border-box;
+  box-shadow: 0;
+  background-color: #FFF;
+  border: 1px solid #999;
+  border-radius: 3px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+}
+
+.circuit-1+label svg {
+  height: 18px;
+  width: 18px;
+  padding: 2px;
+  box-sizing: border-box;
+  color: #FFF;
+  display: block;
+  line-height: 0;
+  opacity: 0;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%) scale(0, 0);
+  -moz-transform: translateY(-50%) scale(0, 0);
+  -ms-transform: translateY(-50%) scale(0, 0);
+  transform: translateY(-50%) scale(0, 0);
+  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
+  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
+}
+
 .circuit-1:hover+label::before {
   border-color: #666;
 }
@@ -63,47 +104,6 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   padding-left: 26px;
   position: relative;
   cursor: pointer;
-}
-
-.circuit-2::before {
-  height: 18px;
-  width: 18px;
-  box-sizing: border-box;
-  box-shadow: 0;
-  background-color: #FFF;
-  border: 1px solid #999;
-  border-radius: 3px;
-  content: '';
-  display: block;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-}
-
-.circuit-2 svg {
-  height: 18px;
-  width: 18px;
-  padding: 2px;
-  box-sizing: border-box;
-  color: #FFF;
-  display: block;
-  line-height: 0;
-  opacity: 0;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%) scale(0, 0);
-  -moz-transform: translateY(-50%) scale(0, 0);
-  -ms-transform: translateY(-50%) scale(0, 0);
-  transform: translateY(-50%) scale(0, 0);
-  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
-  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
 }
 
 .circuit-3 {
@@ -204,6 +204,47 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   width: 1px;
 }
 
+.circuit-1+label::before {
+  height: 18px;
+  width: 18px;
+  box-sizing: border-box;
+  box-shadow: 0;
+  background-color: #FFF;
+  border: 1px solid #999;
+  border-radius: 3px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+}
+
+.circuit-1+label svg {
+  height: 18px;
+  width: 18px;
+  padding: 2px;
+  box-sizing: border-box;
+  color: #FFF;
+  display: block;
+  line-height: 0;
+  opacity: 0;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%) scale(0, 0);
+  -moz-transform: translateY(-50%) scale(0, 0);
+  -ms-transform: translateY(-50%) scale(0, 0);
+  transform: translateY(-50%) scale(0, 0);
+  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
+  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
+}
+
 .circuit-1:hover+label::before {
   border-color: #666;
 }
@@ -246,47 +287,6 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   padding-left: 26px;
   position: relative;
   cursor: pointer;
-}
-
-.circuit-2::before {
-  height: 18px;
-  width: 18px;
-  box-sizing: border-box;
-  box-shadow: 0;
-  background-color: #FFF;
-  border: 1px solid #999;
-  border-radius: 3px;
-  content: '';
-  display: block;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-}
-
-.circuit-2 svg {
-  height: 18px;
-  width: 18px;
-  padding: 2px;
-  box-sizing: border-box;
-  color: #FFF;
-  display: block;
-  line-height: 0;
-  opacity: 0;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%) scale(0, 0);
-  -moz-transform: translateY(-50%) scale(0, 0);
-  -ms-transform: translateY(-50%) scale(0, 0);
-  transform: translateY(-50%) scale(0, 0);
-  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
-  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
 }
 
 <div
@@ -342,6 +342,47 @@ exports[`Checkbox should render with default styles 1`] = `
   width: 1px;
 }
 
+.circuit-1+label::before {
+  height: 18px;
+  width: 18px;
+  box-sizing: border-box;
+  box-shadow: 0;
+  background-color: #FFF;
+  border: 1px solid #999;
+  border-radius: 3px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+}
+
+.circuit-1+label svg {
+  height: 18px;
+  width: 18px;
+  padding: 2px;
+  box-sizing: border-box;
+  color: #FFF;
+  display: block;
+  line-height: 0;
+  opacity: 0;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%) scale(0, 0);
+  -moz-transform: translateY(-50%) scale(0, 0);
+  -ms-transform: translateY(-50%) scale(0, 0);
+  transform: translateY(-50%) scale(0, 0);
+  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
+  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
+}
+
 .circuit-1:hover+label::before {
   border-color: #666;
 }
@@ -384,47 +425,6 @@ exports[`Checkbox should render with default styles 1`] = `
   padding-left: 26px;
   position: relative;
   cursor: pointer;
-}
-
-.circuit-2::before {
-  height: 18px;
-  width: 18px;
-  box-sizing: border-box;
-  box-shadow: 0;
-  background-color: #FFF;
-  border: 1px solid #999;
-  border-radius: 3px;
-  content: '';
-  display: block;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-}
-
-.circuit-2 svg {
-  height: 18px;
-  width: 18px;
-  padding: 2px;
-  box-sizing: border-box;
-  color: #FFF;
-  display: block;
-  line-height: 0;
-  opacity: 0;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%) scale(0, 0);
-  -moz-transform: translateY(-50%) scale(0, 0);
-  -ms-transform: translateY(-50%) scale(0, 0);
-  transform: translateY(-50%) scale(0, 0);
-  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
-  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
 }
 
 <div
@@ -477,6 +477,47 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+.circuit-1+label::before {
+  height: 18px;
+  width: 18px;
+  box-sizing: border-box;
+  box-shadow: 0;
+  background-color: #FFF;
+  border: 1px solid #999;
+  border-radius: 3px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+}
+
+.circuit-1+label svg {
+  height: 18px;
+  width: 18px;
+  padding: 2px;
+  box-sizing: border-box;
+  color: #FFF;
+  display: block;
+  line-height: 0;
+  opacity: 0;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%) scale(0, 0);
+  -moz-transform: translateY(-50%) scale(0, 0);
+  -ms-transform: translateY(-50%) scale(0, 0);
+  transform: translateY(-50%) scale(0, 0);
+  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
+  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
 }
 
 .circuit-1:hover+label::before {
@@ -534,47 +575,6 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   box-shadow: none;
 }
 
-.circuit-2::before {
-  height: 18px;
-  width: 18px;
-  box-sizing: border-box;
-  box-shadow: 0;
-  background-color: #FFF;
-  border: 1px solid #999;
-  border-radius: 3px;
-  content: '';
-  display: block;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-}
-
-.circuit-2 svg {
-  height: 18px;
-  width: 18px;
-  padding: 2px;
-  box-sizing: border-box;
-  color: #FFF;
-  display: block;
-  line-height: 0;
-  opacity: 0;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%) scale(0, 0);
-  -moz-transform: translateY(-50%) scale(0, 0);
-  -ms-transform: translateY(-50%) scale(0, 0);
-  transform: translateY(-50%) scale(0, 0);
-  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
-  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
-}
-
 <div
   class="circuit-0"
 >
@@ -627,6 +627,47 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   position: absolute;
   white-space: nowrap;
   width: 1px;
+}
+
+.circuit-1+label::before {
+  height: 18px;
+  width: 18px;
+  box-sizing: border-box;
+  box-shadow: 0;
+  background-color: #FFF;
+  border: 1px solid #999;
+  border-radius: 3px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+}
+
+.circuit-1+label svg {
+  height: 18px;
+  width: 18px;
+  padding: 2px;
+  box-sizing: border-box;
+  color: #FFF;
+  display: block;
+  line-height: 0;
+  opacity: 0;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%) scale(0, 0);
+  -moz-transform: translateY(-50%) scale(0, 0);
+  -ms-transform: translateY(-50%) scale(0, 0);
+  transform: translateY(-50%) scale(0, 0);
+  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
+  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
 }
 
 .circuit-1:hover+label::before {
@@ -688,47 +729,6 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   cursor: pointer;
 }
 
-.circuit-2::before {
-  height: 18px;
-  width: 18px;
-  box-sizing: border-box;
-  box-shadow: 0;
-  background-color: #FFF;
-  border: 1px solid #999;
-  border-radius: 3px;
-  content: '';
-  display: block;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-}
-
-.circuit-2 svg {
-  height: 18px;
-  width: 18px;
-  padding: 2px;
-  box-sizing: border-box;
-  color: #FFF;
-  display: block;
-  line-height: 0;
-  opacity: 0;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%) scale(0, 0);
-  -moz-transform: translateY(-50%) scale(0, 0);
-  -ms-transform: translateY(-50%) scale(0, 0);
-  transform: translateY(-50%) scale(0, 0);
-  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
-  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
-}
-
 <div
   class="circuit-0"
 >
@@ -785,6 +785,47 @@ exports[`Checkbox should render with noMargin styles when passed the noMargin pr
   width: 1px;
 }
 
+.circuit-1+label::before {
+  height: 18px;
+  width: 18px;
+  box-sizing: border-box;
+  box-shadow: 0;
+  background-color: #FFF;
+  border: 1px solid #999;
+  border-radius: 3px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+}
+
+.circuit-1+label svg {
+  height: 18px;
+  width: 18px;
+  padding: 2px;
+  box-sizing: border-box;
+  color: #FFF;
+  display: block;
+  line-height: 0;
+  opacity: 0;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%) scale(0, 0);
+  -moz-transform: translateY(-50%) scale(0, 0);
+  -ms-transform: translateY(-50%) scale(0, 0);
+  transform: translateY(-50%) scale(0, 0);
+  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
+  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
+}
+
 .circuit-1:hover+label::before {
   border-color: #666;
 }
@@ -827,47 +868,6 @@ exports[`Checkbox should render with noMargin styles when passed the noMargin pr
   padding-left: 26px;
   position: relative;
   cursor: pointer;
-}
-
-.circuit-2::before {
-  height: 18px;
-  width: 18px;
-  box-sizing: border-box;
-  box-shadow: 0;
-  background-color: #FFF;
-  border: 1px solid #999;
-  border-radius: 3px;
-  content: '';
-  display: block;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-}
-
-.circuit-2 svg {
-  height: 18px;
-  width: 18px;
-  padding: 2px;
-  box-sizing: border-box;
-  color: #FFF;
-  display: block;
-  line-height: 0;
-  opacity: 0;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%) scale(0, 0);
-  -moz-transform: translateY(-50%) scale(0, 0);
-  -ms-transform: translateY(-50%) scale(0, 0);
-  transform: translateY(-50%) scale(0, 0);
-  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
-  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
 }
 
 <div

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -515,6 +515,14 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   background-color: #3063E9;
 }
 
+.circuit-1+label::before {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+  border-color: #666;
+  background-color: #E6E6E6;
+}
+
 .circuit-2 {
   color: #1A1A1A;
   display: inline-block;
@@ -565,14 +573,6 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   transform: translateY(-50%) scale(0, 0);
   -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
   transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
-}
-
-.circuit-2::before {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-  border-color: #666;
-  background-color: #E6E6E6;
 }
 
 <div
@@ -665,6 +665,11 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   background-color: #3063E9;
 }
 
+.circuit-1+label::before {
+  border-color: #D23F47;
+  background-color: #F4CBCB;
+}
+
 .circuit-1:hover+label::before,
 .circuit-1:focus+label::before {
   border-color: #B22426;
@@ -722,11 +727,6 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   transform: translateY(-50%) scale(0, 0);
   -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
   transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
-}
-
-.circuit-2:not(:focus)::before {
-  border-color: #D23F47;
-  background-color: #F4CBCB;
 }
 
 <div


### PR DESCRIPTION
## Purpose

Group all checkbox styles (targeting the actual ☑️) under `input*Styles` style objects, instead of declaring half the rules in the `label*Styles` style objects.

Technically our checkbox is `label::before` but it makes more sense to keep styles in `inputStyles` (via `& + label::before`) since the input element holds the logic for the disabled/invalid states.

This also makes the CSS more readable and understandable: checkbox styles are in `input*Styles`, label styles are in `label*Styles`.

## Approach and changes

☝️ 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
