### PR TITLE
Change Notify icon to NotifyCircle

### DIFF
--- a/.changeset/three-walls-drum.md
+++ b/.changeset/three-walls-drum.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Changed the "Notify" icon to "NotifyCircle" for the `NotificationInline`, `NotificationToast` and `Input` components.

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -1424,6 +1424,7 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
 
 .circuit-13 {
   display: inline-block;
+  position: relative;
   width: 16px;
   height: 16px;
   vertical-align: text-top;
@@ -1507,20 +1508,24 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
   <span
     class="circuit-12"
   >
-    <svg
+    <div
       class="circuit-13"
-      fill="none"
-      height="24"
-      role="presentation"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
+      color="danger"
     >
-      <path
-        d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
-        fill="currentColor"
-      />
-    </svg>
+      <svg
+        fill="none"
+        height="16"
+        role="presentation"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3 11a1 1 0 0 1-1.41 0L8 9.41 6.41 11A1 1 0 0 1 5 9.59L6.59 8 5 6.41A1 1 0 0 1 5 5a1 1 0 0 1 1.41 0L8 6.59 9.59 5A1 1 0 0 1 11 5a1 1 0 0 1 0 1.41L9.41 8 11 9.59A1 1 0 0 1 11 11z"
+          fill="currentColor"
+        />
+      </svg>
+    </div>
     The uploaded image exceeds the maximum allowed size. Please use an image with a size below 20MB.
   </span>
 </div>

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -15,7 +15,7 @@
 
 import { HTMLAttributes, RefObject, useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
-import { Alert, Confirm, Info, Notify } from '@sumup/icons';
+import { Alert, Confirm, Info, NotifyCircle } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { useAnimation } from '../../hooks/useAnimation';
@@ -93,7 +93,7 @@ const iconMap = {
   info: Info,
   confirm: Confirm,
   alert: Alert,
-  notify: Notify,
+  notify: NotifyCircle,
 };
 
 const inlineWrapperStyles = () => css`
@@ -155,15 +155,36 @@ const actionButtonStyles = ({ theme }: StyleProps & ButtonProps) =>
 
 const ActionButton = styled(Button)(actionButtonStyles);
 
-const StyledIcon = styled.span(
+const IconWrapper = styled.div(
   ({ theme, variant }: StyleProps & { variant: Variant }) =>
     css`
-      display: block;
+      position: relative;
       align-self: flex-start;
       flex-grow: 0;
       flex-shrink: 0;
       line-height: 0;
       color: ${theme.colors[colorMap[variant]]};
+    `,
+  // Adds a black background behind the SVG icon to color just the exclamation mark black.
+  ({ theme, variant }: StyleProps & { variant: Variant }) =>
+    variant === 'notify' &&
+    css`
+      &::before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: calc(100% - 4px);
+        height: calc(100% - 4px);
+        background: ${theme.colors.black};
+        border-radius: ${theme.borderRadius.circle};
+      }
+
+      svg {
+        position: relative;
+        z-index: 1;
+      }
     `,
 );
 
@@ -212,6 +233,8 @@ export function NotificationInline({
     });
   }, [isVisible, setAnimating]);
 
+  const Icon = iconMap[variant];
+
   return (
     <NotificationInlineWrapper
       ref={contentElement}
@@ -223,11 +246,9 @@ export function NotificationInline({
       {...props}
     >
       <ContentWrapper variant={variant}>
-        <StyledIcon
-          as={iconMap[variant]}
-          variant={variant}
-          role="presentation"
-        />
+        <IconWrapper variant={variant}>
+          <Icon role="presentation" />
+        </IconWrapper>
         <span css={hideVisually}>{iconLabel}</span>
         <Content>
           {headline && (

--- a/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
@@ -27,7 +27,7 @@ exports[`NotificationInline styles should render notification inline with alert 
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -87,21 +87,23 @@ exports[`NotificationInline styles should render notification inline with alert 
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="alert"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -147,7 +149,7 @@ exports[`NotificationInline styles should render notification inline with confir
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -207,21 +209,23 @@ exports[`NotificationInline styles should render notification inline with confir
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="confirm"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -267,7 +271,7 @@ exports[`NotificationInline styles should render notification inline with headli
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -336,21 +340,23 @@ exports[`NotificationInline styles should render notification inline with headli
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="info"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -401,7 +407,7 @@ exports[`NotificationInline styles should render notification inline with info s
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -461,21 +467,23 @@ exports[`NotificationInline styles should render notification inline with info s
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="info"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -521,7 +529,7 @@ exports[`NotificationInline styles should render notification inline with notify
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -534,6 +542,23 @@ exports[`NotificationInline styles should render notification inline with notify
   flex-shrink: 0;
   line-height: 0;
   color: #F5C625;
+}
+
+.circuit-2::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc(100% - 4px);
+  height: calc(100% - 4px);
+  background: #000;
+  border-radius: 100%;
+}
+
+.circuit-2 svg {
+  position: relative;
+  z-index: 1;
 }
 
 .circuit-3 {
@@ -581,23 +606,25 @@ exports[`NotificationInline styles should render notification inline with notify
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="notify"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            clip-rule="evenodd"
-            d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M11.994 1.006a10.994 10.994 0 1 0 .012 0zm-1 6a1 1 0 0 1 2 0v5a1 1 0 1 1-2 0zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -659,7 +686,7 @@ exports[`NotificationInline styles should render notification toast with an acti
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -833,21 +860,23 @@ exports[`NotificationInline styles should render notification toast with an acti
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="info"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -909,7 +938,7 @@ exports[`NotificationInline styles should render with default styles 1`] = `
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -969,21 +998,23 @@ exports[`NotificationInline styles should render with default styles 1`] = `
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="info"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -15,7 +15,7 @@
 
 import { HTMLAttributes, RefObject, useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
-import { Alert, Confirm, Info, Notify } from '@sumup/icons';
+import { Alert, Confirm, Info, NotifyCircle } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { useAnimation } from '../../hooks/useAnimation';
@@ -76,7 +76,7 @@ const iconMap = {
   info: Info,
   confirm: Confirm,
   alert: Alert,
-  notify: Notify,
+  notify: NotifyCircle,
 };
 
 type NotificationToastWrapperProps = {
@@ -119,15 +119,36 @@ const contentStyles = ({ theme }: StyleProps) => css`
 
 const Content = styled('div')(contentStyles);
 
-const StyledIcon = styled.span(
+const IconWrapper = styled.div(
   ({ theme, variant }: StyleProps & { variant: Variant }) =>
     css`
-      display: block;
+      position: relative;
       align-self: flex-start;
       flex-grow: 0;
       flex-shrink: 0;
       line-height: 0;
       color: ${theme.colors[colorMap[variant]]};
+    `,
+  // Adds a black background behind the SVG icon to color just the exclamation mark black.
+  ({ theme, variant }: StyleProps & { variant: Variant }) =>
+    variant === 'notify' &&
+    css`
+      &::before {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: calc(100% - 4px);
+        height: calc(100% - 4px);
+        background: ${theme.colors.black};
+        border-radius: ${theme.borderRadius.circle};
+      }
+
+      svg {
+        position: relative;
+        z-index: 1;
+      }
     `,
 );
 
@@ -175,6 +196,8 @@ export function NotificationToast({
     });
   }, [isVisible, setAnimating]);
 
+  const Icon = iconMap[variant];
+
   return (
     <NotificationToastWrapper
       ref={contentElement}
@@ -187,11 +210,9 @@ export function NotificationToast({
       {...props}
     >
       <ContentWrapper>
-        <StyledIcon
-          as={iconMap[variant]}
-          variant={variant}
-          role="presentation"
-        />
+        <IconWrapper variant={variant}>
+          <Icon role="presentation" />
+        </IconWrapper>
         <span css={hideVisually}>{iconLabel}</span>
         <Content>
           {headline && (

--- a/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`NotificationToast styles should render notification toast with alert st
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -218,21 +218,23 @@ exports[`NotificationToast styles should render notification toast with alert st
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="alert"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -333,7 +335,7 @@ exports[`NotificationToast styles should render notification toast with confirm 
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -508,21 +510,23 @@ exports[`NotificationToast styles should render notification toast with confirm 
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="confirm"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -623,7 +627,7 @@ exports[`NotificationToast styles should render notification toast with headline
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -807,21 +811,23 @@ exports[`NotificationToast styles should render notification toast with headline
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="info"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -927,7 +933,7 @@ exports[`NotificationToast styles should render notification toast with info sty
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -1102,21 +1108,23 @@ exports[`NotificationToast styles should render notification toast with info sty
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="info"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -1217,7 +1225,7 @@ exports[`NotificationToast styles should render notification toast with notify s
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -1230,6 +1238,23 @@ exports[`NotificationToast styles should render notification toast with notify s
   flex-shrink: 0;
   line-height: 0;
   color: #F5C625;
+}
+
+.circuit-2::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc(100% - 4px);
+  height: calc(100% - 4px);
+  background: #000;
+  border-radius: 100%;
+}
+
+.circuit-2 svg {
+  position: relative;
+  z-index: 1;
 }
 
 .circuit-3 {
@@ -1392,23 +1417,25 @@ exports[`NotificationToast styles should render notification toast with notify s
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="notify"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            clip-rule="evenodd"
-            d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
-            fill="currentColor"
-            fill-rule="evenodd"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M11.994 1.006a10.994 10.994 0 1 0 .012 0zm-1 6a1 1 0 0 1 2 0v5a1 1 0 1 1-2 0zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />
@@ -1509,7 +1536,7 @@ exports[`NotificationToast styles should render with default styles 1`] = `
 }
 
 .circuit-2 {
-  display: block;
+  position: relative;
   -webkit-align-self: flex-start;
   -ms-flex-item-align: flex-start;
   align-self: flex-start;
@@ -1684,21 +1711,23 @@ exports[`NotificationToast styles should render with default styles 1`] = `
       <div
         class="circuit-1"
       >
-        <svg
+        <div
           class="circuit-2"
-          fill="none"
-          height="24"
-          role="presentation"
-          variant="info"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
-            fill="currentColor"
-          />
-        </svg>
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 22.988a10.994 10.994 0 1 0-.012 0H12zm1-6a1 1 0 0 1-2 0v-5a1 1 0 0 1 2 0v5zm-1-11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
         <span
           class="circuit-3"
         />

--- a/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
+++ b/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
@@ -43,6 +43,15 @@ const validStyles = ({ theme, showValid }: StyleProps & ValidationHintProps) =>
     color: ${theme.colors.success};
   `;
 
+const warningStyles = ({
+  theme,
+  hasWarning,
+}: StyleProps & ValidationHintProps) =>
+  hasWarning &&
+  css`
+    color: ${theme.colors.n800};
+  `;
+
 const invalidStyles = ({ theme, invalid }: StyleProps & ValidationHintProps) =>
   invalid &&
   css`
@@ -54,6 +63,7 @@ const Wrapper = styled('span')<ValidationHintProps>(
   baseStyles,
   validStyles,
   invalidStyles,
+  warningStyles,
 );
 
 const IconWrapper = styled.div(
@@ -134,7 +144,11 @@ export const ValidationHint = ({
   const icon = getIcon(props);
 
   return (
-    <Wrapper invalid={props.invalid} showValid={props.showValid}>
+    <Wrapper
+      invalid={props.invalid}
+      showValid={props.showValid}
+      hasWarning={props.hasWarning}
+    >
       {icon}
       {validationHint}
     </Wrapper>

--- a/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
+++ b/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
@@ -49,7 +49,7 @@ const warningStyles = ({
 }: StyleProps & ValidationHintProps) =>
   hasWarning &&
   css`
-    color: ${theme.colors.n800};
+    color: ${theme.colors.n900};
   `;
 
 const invalidStyles = ({ theme, invalid }: StyleProps & ValidationHintProps) =>

--- a/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
+++ b/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
@@ -15,11 +15,12 @@
 
 import { HTMLAttributes } from 'react';
 import { css } from '@emotion/react';
-import { Confirm, Notify, Alert } from '@sumup/icons';
-import { Theme } from '@sumup/design-tokens';
+import { Confirm, NotifyCircle, Alert } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { typography } from '../../styles/style-mixins';
+
+type Color = 'danger' | 'warning' | 'success';
 
 export interface ValidationHintProps extends HTMLAttributes<HTMLSpanElement> {
   validationHint?: string;
@@ -55,16 +56,37 @@ const Wrapper = styled('span')<ValidationHintProps>(
   invalidStyles,
 );
 
-const iconStyles =
-  (color: 'danger' | 'warning' | 'success') => (theme: Theme) =>
+const IconWrapper = styled.div(
+  ({ theme, color }: StyleProps & { color: Color }) =>
     css`
       display: inline-block;
+      position: relative;
       width: ${theme.iconSizes.kilo};
       height: ${theme.iconSizes.kilo};
       vertical-align: text-top;
       margin-right: ${theme.spacings.bit};
       color: ${theme.colors[color]};
-    `;
+    `,
+  ({ theme, color }: StyleProps & { color: Color }) =>
+    color === 'warning' &&
+    css`
+      &::before {
+        content: '';
+        display: inline-block;
+        position: absolute;
+        top: 2px;
+        left: 2px;
+        width: calc(100% - 4px);
+        height: calc(100% - 4px);
+        background: ${theme.colors.black};
+        border-radius: ${theme.borderRadius.circle};
+      }
+      svg {
+        position: relative;
+        z-index: 1;
+      }
+    `,
+);
 
 const getIcon = (state: ValidationHintProps) => {
   switch (true) {
@@ -72,13 +94,25 @@ const getIcon = (state: ValidationHintProps) => {
       return null;
     }
     case state.invalid: {
-      return <Alert role="presentation" css={iconStyles('danger')} />;
+      return (
+        <IconWrapper color="danger">
+          <Alert role="presentation" size="16" />
+        </IconWrapper>
+      );
     }
     case state.hasWarning: {
-      return <Notify role="presentation" css={iconStyles('warning')} />;
+      return (
+        <IconWrapper color="warning">
+          <NotifyCircle role="presentation" size="16" />
+        </IconWrapper>
+      );
     }
     case state.showValid: {
-      return <Confirm role="presentation" css={iconStyles('success')} />;
+      return (
+        <IconWrapper color="success">
+          <Confirm role="presentation" size="16" />
+        </IconWrapper>
+      );
     }
     default: {
       return null;

--- a/packages/circuit-ui/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
+++ b/packages/circuit-ui/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
@@ -121,7 +121,7 @@ exports[`ValidationHint styles should render with warning styles 1`] = `
   color: #666;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
-  color: #333;
+  color: #1A1A1A;
 }
 
 .circuit-1 {

--- a/packages/circuit-ui/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
+++ b/packages/circuit-ui/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
@@ -121,6 +121,7 @@ exports[`ValidationHint styles should render with warning styles 1`] = `
   color: #666;
   -webkit-transition: color 120ms ease-in-out;
   transition: color 120ms ease-in-out;
+  color: #333;
 }
 
 .circuit-1 {

--- a/packages/circuit-ui/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
+++ b/packages/circuit-ui/components/ValidationHint/__snapshots__/ValidationHint.spec.tsx.snap
@@ -32,6 +32,7 @@ exports[`ValidationHint styles should render with invalid styles 1`] = `
 
 .circuit-1 {
   display: inline-block;
+  position: relative;
   width: 16px;
   height: 16px;
   vertical-align: text-top;
@@ -42,20 +43,24 @@ exports[`ValidationHint styles should render with invalid styles 1`] = `
 <span
   class="circuit-0"
 >
-  <svg
+  <div
     class="circuit-1"
-    fill="none"
-    height="24"
-    role="presentation"
-    viewBox="0 0 24 24"
-    width="24"
-    xmlns="http://www.w3.org/2000/svg"
+    color="danger"
   >
-    <path
-      d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
-      fill="currentColor"
-    />
-  </svg>
+    <svg
+      fill="none"
+      height="16"
+      role="presentation"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3 11a1 1 0 0 1-1.41 0L8 9.41 6.41 11A1 1 0 0 1 5 9.59L6.59 8 5 6.41A1 1 0 0 1 5 5a1 1 0 0 1 1.41 0L8 6.59 9.59 5A1 1 0 0 1 11 5a1 1 0 0 1 0 1.41L9.41 8 11 9.59A1 1 0 0 1 11 11z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
   This field is required
 </span>
 `;
@@ -74,6 +79,7 @@ exports[`ValidationHint styles should render with valid styles 1`] = `
 
 .circuit-1 {
   display: inline-block;
+  position: relative;
   width: 16px;
   height: 16px;
   vertical-align: text-top;
@@ -84,20 +90,24 @@ exports[`ValidationHint styles should render with valid styles 1`] = `
 <span
   class="circuit-0"
 >
-  <svg
+  <div
     class="circuit-1"
-    fill="none"
-    height="24"
-    role="presentation"
-    viewBox="0 0 24 24"
-    width="24"
-    xmlns="http://www.w3.org/2000/svg"
+    color="success"
   >
-    <path
-      d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
-      fill="currentColor"
-    />
-  </svg>
+    <svg
+      fill="none"
+      height="16"
+      role="presentation"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 6.62-4 5a.993.993 0 0 1-.72.38H7a1 1 0 0 1-.71-.29l-2-2a1.004 1.004 0 0 1 1.42-1.42L6.92 9.5l3.3-4.12a1 1 0 1 1 1.56 1.24z"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
   This field is required
 </span>
 `;
@@ -115,6 +125,7 @@ exports[`ValidationHint styles should render with warning styles 1`] = `
 
 .circuit-1 {
   display: inline-block;
+  position: relative;
   width: 16px;
   height: 16px;
   vertical-align: text-top;
@@ -122,25 +133,46 @@ exports[`ValidationHint styles should render with warning styles 1`] = `
   color: #F5C625;
 }
 
+.circuit-1::before {
+  content: '';
+  display: inline-block;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc(100% - 4px);
+  height: calc(100% - 4px);
+  background: #000;
+  border-radius: 100%;
+}
+
+.circuit-1 svg {
+  position: relative;
+  z-index: 1;
+}
+
 <span
   class="circuit-0"
 >
-  <svg
+  <div
     class="circuit-1"
-    fill="none"
-    height="24"
-    role="presentation"
-    viewBox="0 0 24 24"
-    width="24"
-    xmlns="http://www.w3.org/2000/svg"
+    color="warning"
   >
-    <path
-      clip-rule="evenodd"
-      d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
-      fill="currentColor"
-      fill-rule="evenodd"
-    />
-  </svg>
+    <svg
+      fill="none"
+      height="16"
+      role="presentation"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        clip-rule="evenodd"
+        d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zM7 5a1 1 0 0 1 2 0v3a1 1 0 0 1-2 0V5zm1 7.5A1.25 1.25 0 1 1 8 10a1.25 1.25 0 0 1 0 2.5z"
+        fill="currentColor"
+        fill-rule="evenodd"
+      />
+    </svg>
+  </div>
   This field is required
 </span>
 `;


### PR DESCRIPTION
## Purpose

Change the notify icon to  "notify_circle" icon for the yellow variant, and have the element inside in black.
## Approach and changes

_Describe how you solved the problem_

Updated NotificationInline, NotificationToast and ValidationHint components to use the NotifyCircle icon.
Update the warning text color to n80.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
