### PR TITLE
Export NotificationInline component

### DIFF
--- a/.changeset/selfish-students-march.md
+++ b/.changeset/selfish-students-march.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Exported `NotificationInline` component.

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -98,6 +98,8 @@ export { useNotificationToast } from './components/NotificationToast';
 export type { NotificationToastProps } from './components/NotificationToast';
 export { ToastProvider } from './components/ToastContext';
 export type { ToastProviderProps } from './components/ToastContext';
+export { default as NotificationInline } from './components/NotificationInline';
+export type { NotificationInlineProps } from './components/NotificationInline';
 
 // Layout
 export { default as Grid } from './components/Grid';


### PR DESCRIPTION


## Purpose

We forgot to export the NotificationInline component along in https://github.com/sumup-oss/circuit-ui/pull/1332.

## Approach and changes

Updated index.tsx file to export the NotificationInline.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
