### PR TITLE
Fix Storybook Theme page

### DIFF
--- a/.storybook/components/BorderRadius.js
+++ b/.storybook/components/BorderRadius.js
@@ -17,9 +17,9 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { light } from '@sumup/design-tokens';
-import { Body } from '@sumup/circuit-ui';
+import { Body, spacing } from '@sumup/circuit-ui';
 
-const Box = styled('div')`
+const Box = styled.div`
   ${({ theme, size }) => css`
     width: ${theme.spacings.tera};
     height: ${theme.spacings.tera};
@@ -29,25 +29,11 @@ const Box = styled('div')`
   `};
 `;
 
-const Wrapper = styled('div')`
+const Wrapper = styled.div`
   ${({ theme }) => css`
     display: flex;
     align-items: center;
     margin-bottom: ${theme.spacings.mega};
-  `};
-`;
-
-const BorderRadiusSize = styled('span')`
-  ${({ theme }) => css`
-    color: ${theme.colors.n500};
-  `};
-`;
-
-const BorderRadiusName = styled(Body)`
-  ${({ theme }) => css`
-    margin-left: ${theme.spacings.kilo};
-    margin-bottom: ${theme.spacings.giga};
-    color: ${theme.colors.n500};
   `};
 `;
 
@@ -58,18 +44,20 @@ const BorderRadius = ({ size, ...props }) => (
       <Body as="span" noMargin>
         {size}
       </Body>
-      <BorderRadiusSize>
-        <BorderRadiusName size="two" as="span">
-          {light.borderRadius[size]}
-        </BorderRadiusName>
-      </BorderRadiusSize>
+      <Body
+        size="two"
+        as="span"
+        noMargin
+        variant="subtle"
+        css={spacing({ bottom: 'giga', left: 'kilo' })}
+      >
+        {light.borderRadius[size]}
+      </Body>
     </div>
   </Wrapper>
 );
 
 BorderRadius.propTypes = {
-  // eslint-disable-next-line
-  theme: PropTypes.object.isRequired,
   size: PropTypes.string.isRequired,
 };
 

--- a/.storybook/components/BorderWidth.js
+++ b/.storybook/components/BorderWidth.js
@@ -17,9 +17,9 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css, ThemeProvider } from '@emotion/react';
 import { light } from '@sumup/design-tokens';
-import { Body } from '@sumup/circuit-ui';
+import { Body, spacing } from '@sumup/circuit-ui';
 
-const Box = styled('div')`
+const Box = styled.div`
   ${({ theme, size }) => css`
     width: ${theme.spacings.tera};
     height: ${theme.spacings.tera};
@@ -30,25 +30,11 @@ const Box = styled('div')`
   `};
 `;
 
-const Wrapper = styled('div')`
+const Wrapper = styled.div`
   ${({ theme }) => css`
     display: flex;
     align-items: center;
     margin-bottom: ${theme.spacings.mega};
-  `};
-`;
-
-const BorderWidthSize = styled('span')`
-  ${({ theme }) => css`
-    color: ${theme.colors.n500};
-  `};
-`;
-
-const BorderWidthName = styled(Body)`
-  ${({ theme }) => css`
-    margin-left: ${theme.spacings.kilo};
-    margin-bottom: ${theme.spacings.giga};
-    color: ${theme.colors.n500};
   `};
 `;
 
@@ -60,19 +46,21 @@ const BorderWidth = ({ size }) => (
         <Body as="span" noMargin>
           {size}
         </Body>
-        <BorderWidthSize>
-          <BorderWidthName size="two" as="span">
-            {light.borderWidth[size]}
-          </BorderWidthName>
-        </BorderWidthSize>
+        <Body
+          variant="subtle"
+          size="two"
+          as="span"
+          css={spacing({ bottom: 'giga', left: 'kilo' })}
+          noMargin
+        >
+          {light.borderWidth[size]}
+        </Body>
       </div>
     </Wrapper>
   </ThemeProvider>
 );
 
 BorderWidth.propTypes = {
-  // eslint-disable-next-line
-  theme: PropTypes.object.isRequired,
   size: PropTypes.string.isRequired,
 };
 

--- a/.storybook/components/IconSize.js
+++ b/.storybook/components/IconSize.js
@@ -19,7 +19,7 @@ import { css, ThemeProvider } from '@emotion/react';
 import { light } from '@sumup/design-tokens';
 import { Body, spacing } from '@sumup/circuit-ui';
 
-const Box = styled('div')`
+const Box = styled.div`
   ${({ theme, size }) => css`
     width: ${theme.iconSizes[size]};
     height: ${theme.iconSizes[size]};
@@ -28,25 +28,11 @@ const Box = styled('div')`
   `};
 `;
 
-const Wrapper = styled('div')`
+const Wrapper = styled.div`
   ${({ theme }) => css`
     display: flex;
     align-items: center;
     margin-bottom: ${theme.spacings.mega};
-  `};
-`;
-
-const IconSizeSize = styled('span')`
-  ${({ theme }) => css`
-    color: ${theme.colors.n500};
-  `};
-`;
-
-const IconSizeName = styled(Body)`
-  ${({ theme }) => css`
-    margin-left: ${theme.spacings.kilo};
-    margin-bottom: ${theme.spacings.giga};
-    color: ${theme.colors.n500};
   `};
 `;
 
@@ -58,11 +44,15 @@ const IconSize = ({ size }) => (
         <Body as="span" noMargin css={spacing({ bottom: 'giga' })}>
           {size}
         </Body>
-        <IconSizeSize>
-          <IconSizeName size="two" as="span" noMargin>
-            {light.iconSizes[size]}
-          </IconSizeName>
-        </IconSizeSize>
+        <Body
+          variant="subtle"
+          size="two"
+          as="span"
+          noMargin
+          css={spacing({ bottom: 'giga', left: 'kilo' })}
+        >
+          {light.iconSizes[size]}
+        </Body>
       </div>
     </Wrapper>
   </ThemeProvider>

--- a/.storybook/components/Icons.js
+++ b/.storybook/components/Icons.js
@@ -153,9 +153,7 @@ const Icons = () => {
       </Filters>
 
       {isEmpty(activeIcons) ? (
-        <Body noMargin css={spacing({ bottom: 'giga' })}>
-          No icons found
-        </Body>
+        <Body noMargin>No icons found</Body>
       ) : (
         group('category', activeIcons).map(({ category, items }) => (
           <Category key={category}>

--- a/.storybook/components/Spacing.js
+++ b/.storybook/components/Spacing.js
@@ -59,8 +59,6 @@ const Spacing = ({ spacingName }) => (
 );
 
 Spacing.propTypes = {
-  // eslint-disable-next-line
-  theme: PropTypes.object.isRequired,
   spacingName: PropTypes.string.isRequired,
 };
 

--- a/.storybook/components/Type.js
+++ b/.storybook/components/Type.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Fragment, createElement } from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { css, ThemeProvider } from '@emotion/react';
+import { light } from '@sumup/design-tokens';
+
+import { Body } from '@sumup/circuit-ui';
+
+const TypePx = styled(Body)`
+  ${({ theme }) => css`
+    margin-left: ${theme.spacings.mega};
+    margin-bottom: ${theme.spacings.giga};
+    text-transform: lowercase;
+  `};
+`;
+
+const Type = ({ size, component, name, fontWeight, ...props }) => {
+  // The fontSize can be either on typography[name][size] (body, headline) or
+  // on typography[name] directly (subHeadline).
+  const { fontSize, lineHeight } =
+    light.typography[name][size] || light.typography[name];
+  const weight = light.fontWeight[fontWeight];
+
+  return (
+    <ThemeProvider theme={light}>
+      {createElement(component, {
+        children: (
+          <Fragment>
+            This is {name} {size ? `size ${size}` : ''}
+            <TypePx as="span" variant="subtle" size="two" noMargin>
+              {weight ? `${weight}` : `${fontSize}, ${lineHeight}`}
+            </TypePx>
+          </Fragment>
+        ),
+        size,
+        noMargin: true,
+        ...props,
+      })}
+    </ThemeProvider>
+  );
+};
+
+Type.propTypes = {
+  component: PropTypes.object.isRequired,
+  size: PropTypes.string,
+  fontWeight: PropTypes.string,
+  name: PropTypes.string.isRequired,
+};
+
+Type.defaultProps = {
+  fontWeight: null,
+};
+
+export default Type;

--- a/.storybook/components/index.js
+++ b/.storybook/components/index.js
@@ -25,6 +25,7 @@ export { default as Status } from './Statuses';
 export { default as Preview } from './Preview';
 export { default as Story } from './Story';
 export { default as Swatch } from './Swatch';
+export { default as Type } from './Type';
 export { default as Spacing } from './Spacing';
 export { default as MediaQueriesTable } from './MediaQueriesTable';
 export { default as BorderWidth } from './BorderWidth';

--- a/docs/features/theme.stories.mdx
+++ b/docs/features/theme.stories.mdx
@@ -1,6 +1,5 @@
 import {
   Meta,
-  Intro,
   Preview,
   Swatch,
   Spacing,
@@ -16,11 +15,7 @@ import { Headline, SubHeadline, Body } from '../../packages/circuit-ui';
 
 # Theme
 
-<Intro>
-
 The theme used throughout Circuit UI comes from SumUp's design token library, [`@sumup/design-tokens`](Packages/design-tokens), which is a required peer dependency of `@sumup/circuit-ui`. Refer to its [documentation](Packages/design-tokens) for usage instructions.
-
-</Intro>
 
 ## Colors
 


### PR DESCRIPTION
## Purpose

As title suggests.

## Approach and changes

- Reintroduces `Type` component, mistakenly removed in #1392 
- Addresses leftover deprecation warnings specific to the Theme page (because the page is using several custom Storybook components)

_Note: I'm also noticing that the theme information on the page is not fully up-to-date (for example z-indices). We'll look into tying this closer to the actual theme to avoid mismatches in the future_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
