### PR TITLE
Handle rendering the Storybook Intro component as a div

### DIFF
--- a/.storybook/components/Intro.tsx
+++ b/.storybook/components/Intro.tsx
@@ -13,20 +13,37 @@
  * limitations under the License.
  */
 
-import { ThemeProvider } from '@emotion/react';
-import { BodyLarge, spacing } from '@sumup/circuit-ui';
+import { css, ThemeProvider } from '@emotion/react';
+import { BodyLarge, spacing, cx } from '@sumup/circuit-ui';
 import { light } from '@sumup/design-tokens';
 
 import type { BodyLargeProps } from '@sumup/circuit-ui';
+import type { Theme } from '@sumup/design-tokens';
+
+/**
+ * We need this to force children to have bodyLarge typography when the Intro
+ * is rendered as a div.
+ */
+const childrenBodyLargeStyles = (theme: Theme) => css`
+  > * {
+    font-size: ${theme.typography.bodyLarge.fontSize} !important;
+    line-height: ${theme.typography.bodyLarge.lineHeight} !important;
+  }
+`;
 
 function Intro({
   children,
+  ...props
 }: {
   children: BodyLargeProps['children'];
 }): JSX.Element {
   return (
     <ThemeProvider theme={light}>
-      <BodyLarge variant="subtle" css={spacing({ bottom: 'giga' })}>
+      <BodyLarge
+        variant="subtle"
+        css={cx(childrenBodyLargeStyles, spacing({ bottom: 'giga' }))}
+        {...props}
+      >
         {children}
       </BodyLarge>
     </ThemeProvider>

--- a/docs/features/icons.stories.mdx
+++ b/docs/features/icons.stories.mdx
@@ -1,9 +1,13 @@
-import { Meta, Icons } from '../../.storybook/components';
+import { Intro, Meta, Icons } from '../../.storybook/components';
 
 <Meta title="Features/Icons" />
 
 # Icons
 
+<Intro as="div">
+
 The icons used throughout Circuit UI come from SumUp's icon library, [`@sumup/icons`](Packages/icons), which is a required peer dependency of `@sumup/circuit-ui`. Refer to its [documentation](Packages/icons) for usage instructions.
+
+</Intro>
 
 <Icons />

--- a/docs/features/theme.stories.mdx
+++ b/docs/features/theme.stories.mdx
@@ -1,4 +1,5 @@
 import {
+  Intro,
   Meta,
   Preview,
   Swatch,
@@ -15,7 +16,11 @@ import { Headline, SubHeadline, Body } from '../../packages/circuit-ui';
 
 # Theme
 
+<Intro as="div">
+
 The theme used throughout Circuit UI comes from SumUp's design token library, [`@sumup/design-tokens`](Packages/design-tokens), which is a required peer dependency of `@sumup/circuit-ui`. Refer to its [documentation](Packages/design-tokens) for usage instructions.
+
+</Intro>
 
 ## Colors
 


### PR DESCRIPTION
Follows up on https://github.com/sumup-oss/circuit-ui/pull/1393#discussion_r795044551

## Purpose

Extends the Storybook `Intro` component (internal only) to render as a `div` on pages such as `Theme` and `Icons`, where the intro includes markdown links and therefore will have the following markup:

```html
<!--
MDX:
<Intro as="div">

Intro [with a link](#)

</Intro>
-->

<div> <!-- 👈 Intro -->
  <p> <!-- 👈 generated by the newline in MDX -->
    Intro <a href="#">with a link</a>
  </p>
</div>
```

## Approach and changes

- override children typography styles (paragraphs in Storybook are given `body` size one styles) with `bodyLarge` typography
- use `<Intro as="div">` in Theme and Icons pages

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
