### PR TITLE
Fix loading button stories and docs

### DIFF
--- a/packages/circuit-ui/components/Button/Button.docs.mdx
+++ b/packages/circuit-ui/components/Button/Button.docs.mdx
@@ -56,6 +56,12 @@ The button component supports 2 different sizes:
 
 <Story id="components-button--sizes" />
 
+### Loading
+
+When the button's action is inputting/saving information, you can indicate a loading state by setting the `isLoading` prop to `true` and passing a `loadingLabel` (for announcing the busy state to screen readers).
+
+<Story id="components-button--loading" />
+
 ## ButtonGroup
 
 Used when users have two opposite actions to be taken in a certain step of a flow. It is generally used aligned to the right,
@@ -64,9 +70,3 @@ with a primary button for the expected action and a secondary button on its left
 <Story id="components-button-buttongroup--base" />
 
 - **Do** use the same verb tenses for both actions
-
-## LoadingButton
-
-When the button's action is inputting/saving information or it takes more than 3 seconds to take the user to the next step/page, you can indicate a loading state with `LoadingButton`.
-
-<Story id="components-button-loadingbutton--base" />

--- a/packages/circuit-ui/components/Button/Button.stories.tsx
+++ b/packages/circuit-ui/components/Button/Button.stories.tsx
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
+import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { Plus } from '@sumup/icons';
-import { useState } from 'react';
 
 import { Stack } from '../../../../.storybook/components';
 import ButtonGroup from '../ButtonGroup';
@@ -107,24 +107,30 @@ export const Tracking = (args: ButtonProps) => (
   </Button>
 );
 
-export const Loading = (args: ButtonProps) => {
-  const [loading, setLoading] = useState(false);
+const ButtonWithLoadingState = (args: ButtonProps) => {
+  const [isLoading, setLoading] = useState(false);
 
   const handleClick = () => {
     setLoading(true);
     setTimeout(() => {
       setLoading(false);
-    }, 2000);
+    }, 3000);
   };
 
   return (
     <Button
-      isLoading={loading}
+      isLoading={isLoading}
       loadingLabel="Loading"
       onClick={handleClick}
       {...args}
-    >
-      Things take time
-    </Button>
+    />
   );
+};
+
+export const Loading = (args: ButtonProps) => (
+  <ButtonWithLoadingState>{args.children}</ButtonWithLoadingState>
+);
+
+Loading.args = {
+  children: 'Things take time',
 };

--- a/packages/circuit-ui/components/Button/Button.stories.tsx
+++ b/packages/circuit-ui/components/Button/Button.stories.tsx
@@ -107,7 +107,7 @@ export const Tracking = (args: ButtonProps) => (
   </Button>
 );
 
-const ButtonWithLoadingState = (args: ButtonProps) => {
+export const Loading = (args: ButtonProps) => {
   const [isLoading, setLoading] = useState(false);
 
   const handleClick = () => {
@@ -117,20 +117,10 @@ const ButtonWithLoadingState = (args: ButtonProps) => {
     }, 3000);
   };
 
-  return (
-    <Button
-      isLoading={isLoading}
-      loadingLabel="Loading"
-      onClick={handleClick}
-      {...args}
-    />
-  );
+  return <Button {...args} isLoading={isLoading} onClick={handleClick} />;
 };
-
-export const Loading = (args: ButtonProps) => (
-  <ButtonWithLoadingState {...args} />
-);
 
 Loading.args = {
   children: 'Things take time',
+  loadingLabel: 'Loading',
 };

--- a/packages/circuit-ui/components/Button/Button.stories.tsx
+++ b/packages/circuit-ui/components/Button/Button.stories.tsx
@@ -128,7 +128,7 @@ const ButtonWithLoadingState = (args: ButtonProps) => {
 };
 
 export const Loading = (args: ButtonProps) => (
-  <ButtonWithLoadingState>{args.children}</ButtonWithLoadingState>
+  <ButtonWithLoadingState {...args} />
 );
 
 Loading.args = {


### PR DESCRIPTION
## Purpose

- The docs were pointing to an unexisting story
- The story wasn't working because ~state needs to be handled separately from the exported story~ we were overriding the `isLoading` prop with story args

## Approach and changes

- Ensured the stories and docs work properly for the loading button

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
