### PR TITLE
Rename Input component type and export from Circuit

### DIFF
--- a/.changeset/dirty-pumas-flash.md
+++ b/.changeset/dirty-pumas-flash.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Exported the Circuit Input component type as `InputElement`.

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -36,7 +36,7 @@ import ValidationHint from '../ValidationHint';
 import { ReturnType } from '../../types/return-type';
 import { deprecate } from '../../util/logger';
 
-export type HTMLCircuitInputElement = HTMLInputElement & HTMLTextAreaElement;
+export type InputElement = HTMLInputElement & HTMLTextAreaElement;
 type CircuitInputHTMLAttributes = InputHTMLAttributes<HTMLInputElement> &
   TextareaHTMLAttributes<HTMLTextAreaElement>;
 export interface InputProps extends CircuitInputHTMLAttributes {
@@ -115,7 +115,7 @@ export interface InputProps extends CircuitInputHTMLAttributes {
   /**
    * The ref to the HTML DOM element
    */
-  ref?: Ref<HTMLCircuitInputElement>;
+  ref?: Ref<InputElement>;
 }
 
 const containerStyles = () => css`
@@ -232,7 +232,7 @@ const inputSuffixStyles = ({ theme, hasSuffix }: StyleProps & InputElProps) =>
     padding-right: ${theme.spacings.exa};
   `;
 
-const InputElement = styled('input')<InputElProps>(
+const StyledInput = styled('input')<InputElProps>(
   typography('one'),
   inputBaseStyles,
   inputWarningStyles,
@@ -360,7 +360,7 @@ export const Input = forwardRef(
         </LabelText>
         <InputContainer>
           {prefix}
-          <InputElement
+          <StyledInput
             as={as}
             id={id}
             value={value}

--- a/packages/circuit-ui/components/Input/index.ts
+++ b/packages/circuit-ui/components/Input/index.ts
@@ -15,6 +15,6 @@
 
 import { Input } from './Input';
 
-export type { InputProps } from './Input';
+export type { InputProps, InputElement } from './Input';
 
 export default Input;

--- a/packages/circuit-ui/components/TextArea/TextArea.tsx
+++ b/packages/circuit-ui/components/TextArea/TextArea.tsx
@@ -17,7 +17,7 @@ import { forwardRef, useRef } from 'react';
 import { css } from '@emotion/react';
 
 import Input from '../Input';
-import { HTMLCircuitInputElement, InputProps } from '../Input/Input';
+import { InputElement, InputProps } from '../Input/Input';
 import { multiRefs } from '../../util/multiRefs';
 
 import { useAutoExpand } from './useAutoExpand';
@@ -43,9 +43,9 @@ const textAreaStyles = css`
 /**
  * TextArea component for forms.
  */
-export const TextArea = forwardRef<HTMLCircuitInputElement, TextAreaProps>(
+export const TextArea = forwardRef<InputElement, TextAreaProps>(
   (props, passedRef) => {
-    const localRef = useRef<HTMLCircuitInputElement>(null);
+    const localRef = useRef<InputElement>(null);
     const modifiedProps = useAutoExpand(localRef, props);
 
     return (

--- a/packages/circuit-ui/components/TextArea/useAutoExpand.spec.tsx
+++ b/packages/circuit-ui/components/TextArea/useAutoExpand.spec.tsx
@@ -18,7 +18,7 @@ import userEvent from '@testing-library/user-event';
 import React, { FormEvent } from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { HTMLCircuitInputElement } from '../Input/Input';
+import { InputElement } from '../Input/Input';
 
 import { useAutoExpand } from './useAutoExpand';
 
@@ -26,7 +26,7 @@ const createTextAreaRef = (props = {}) => {
   render(<textarea {...props} />);
   return {
     current: screen.getByRole('textbox'),
-  } as React.MutableRefObject<HTMLCircuitInputElement>;
+  } as React.MutableRefObject<InputElement>;
 };
 
 describe('useAutoExpand hook', () => {
@@ -182,7 +182,7 @@ describe('useAutoExpand hook', () => {
     test('should allow preventing resize from onInput handler', () => {
       const onInputHandler = jest
         .fn()
-        .mockImplementation((e: FormEvent<HTMLCircuitInputElement>) => {
+        .mockImplementation((e: FormEvent<InputElement>) => {
           e.preventDefault();
         });
 

--- a/packages/circuit-ui/components/TextArea/useAutoExpand.ts
+++ b/packages/circuit-ui/components/TextArea/useAutoExpand.ts
@@ -16,7 +16,7 @@
 
 import { FormEvent, RefObject, useCallback, useEffect } from 'react';
 
-import { HTMLCircuitInputElement } from '../Input/Input';
+import { InputElement } from '../Input/Input';
 import { useComponentSize } from '../../hooks/useComponentSize';
 
 import { TextAreaProps } from '.';
@@ -26,7 +26,7 @@ type ModifiedProps = Omit<TextAreaProps, 'minRows' | 'rows'> & {
 };
 
 export const useAutoExpand = (
-  ref: RefObject<HTMLCircuitInputElement>,
+  ref: RefObject<InputElement>,
   { minRows, rows = minRows, onInput, ...props }: TextAreaProps,
 ): ModifiedProps => {
   const autoExpand = rows === 'auto';
@@ -53,7 +53,7 @@ export const useAutoExpand = (
   );
 
   const inputHandler = useCallback(
-    (e: FormEvent<HTMLCircuitInputElement>) => {
+    (e: FormEvent<InputElement>) => {
       if (onInput) {
         onInput(e);
       }

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -45,7 +45,7 @@ export type { CheckboxProps } from './components/Checkbox';
 export { default as Label } from './components/Label';
 export type { LabelProps } from './components/Label';
 export { default as Input } from './components/Input';
-export type { InputProps } from './components/Input';
+export type { InputProps, InputElement } from './components/Input';
 export { default as RadioButton } from './components/RadioButton';
 export type { RadioButtonProps } from './components/RadioButton';
 export { default as RadioButtonGroup } from './components/RadioButtonGroup';


### PR DESCRIPTION
## Purpose

Follows up on the type changes in #1093.

## Approach and changes

- export the new Input element type (`HTMLInputElement & HTMLTextAreaElement`) from Circuit for use in applications
- rename the type from `CircuitHTMLInputElement` to `InputElement` (for consistency with other type names e.g. `InputProps`)

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
