### PR TITLE
Add indeterminate prop to the Checkbox

### DIFF
--- a/.changeset/quiet-toes-joke.md
+++ b/.changeset/quiet-toes-joke.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Adds a style for the indeterminate state of a checkbox

--- a/.changeset/quiet-toes-joke.md
+++ b/.changeset/quiet-toes-joke.md
@@ -1,5 +1,5 @@
 ---
-'@sumup/circuit-ui': patch
+'@sumup/circuit-ui': minor
 ---
 
-Adds a style for the indeterminate state of a checkbox
+Added the `indeterminate` prop to the Checkbox component. Use it to display and control the collective state of a group of nested checkboxes.

--- a/packages/circuit-ui/components/Checkbox/Checkbox.mdx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.mdx
@@ -43,7 +43,7 @@ Disabled form fields can be confusing to users, so use them with caution. Consid
 > Please note that the indeterminate state is not supported in IE11.
 > It's also advised to use an `aria-checked="mixed"` for Assistive Technologies (in Safari).
 
-<Story id="forms-checkbox--indeterminate" />
+<Story id={Stories.Indeterminate} />
 
 ## State
 

--- a/packages/circuit-ui/components/Checkbox/Checkbox.mdx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.mdx
@@ -40,6 +40,9 @@ Disabled form fields can be confusing to users, so use them with caution. Consid
 
 ### Indeterminate
 
+> Please note that the indeterminate state is not supported in IE11.
+> It's also advised to use an `aria-checked="mixed"` for Assistive Technologies (in Safari).
+
 <Story id="forms-checkbox--indeterminate" />
 
 ## State

--- a/packages/circuit-ui/components/Checkbox/Checkbox.mdx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.mdx
@@ -38,6 +38,10 @@ Disabled form fields can be confusing to users, so use them with caution. Consid
 
 <Story of={Stories.Disabled} />
 
+### Indeterminate
+
+<Story id="forms-checkbox--indeterminate" />
+
 ## State
 
 The Checkbox can be used as a controlled or uncontrolled component.

--- a/packages/circuit-ui/components/Checkbox/Checkbox.mdx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.mdx
@@ -39,9 +39,6 @@ Disabled form fields can be confusing to users, so use them with caution. Consid
 <Story of={Stories.Disabled} />
 
 ### Indeterminate
-
-> It's advised to use an `aria-checked="mixed"` for Assistive Technologies (for Safari).
-
 <Story id={Stories.Indeterminate} />
 
 ## State

--- a/packages/circuit-ui/components/Checkbox/Checkbox.mdx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.mdx
@@ -39,7 +39,19 @@ Disabled form fields can be confusing to users, so use them with caution. Consid
 <Story of={Stories.Disabled} />
 
 ### Indeterminate
-<Story id={Stories.Indeterminate} />
+
+The indeterminate state of a checkbox can be used to display and control the collective state of a group of nested checkboxes.
+
+A checkbox is a binary input: either it is checked or it is not. A group of checkboxes, however, can be thought of as having three states: all unchecked, all checked or some checked. The mixed state can be represented by the `indeterminate` prop. It is purely presentational and should not be relied upon to submit data since a native form submission won't include an indeterminate checkbox.
+
+When building a checkbox group with a parent checkbox, make sure to adhere to the following best practices:
+
+- The checkbox group should be wrapped in a `fieldset` and labelled using the `legend` element.
+- Validation messages should be associated with the `fieldset` using `aria-describedby` and should be announced to screen readers using a live region.
+- Toggling the state of the parent checkbox should toggle the state of all child options to match the parent's state.
+- Toggling the state of a child option should update the parent's state.
+
+<Story of={Stories.Indeterminate} />
 
 ## State
 

--- a/packages/circuit-ui/components/Checkbox/Checkbox.mdx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.mdx
@@ -40,8 +40,7 @@ Disabled form fields can be confusing to users, so use them with caution. Consid
 
 ### Indeterminate
 
-> Please note that the indeterminate state is not supported in IE11.
-> It's also advised to use an `aria-checked="mixed"` for Assistive Technologies (in Safari).
+> It's advised to use an `aria-checked="mixed"` for Assistive Technologies (for Safari).
 
 <Story id={Stories.Indeterminate} />
 

--- a/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
@@ -57,6 +57,13 @@ describe('Checkbox', () => {
       expect(inputEl).toBeDisabled();
     });
 
+    it('should be optionally indeterminate', () => {
+      render(<Checkbox {...defaultProps} indeterminate />);
+      const inputEl: HTMLInputElement = screen.getByRole('checkbox');
+      expect(inputEl.indeterminate).toBe(true);
+      expect(inputEl).toHaveAttribute('aria-checked', 'mixed');
+    });
+
     it('should have a name', () => {
       render(<Checkbox {...defaultProps} />);
       const inputEl = screen.getByRole('checkbox');

--- a/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, SumUp Ltd.
+ * Copyright 2023, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -68,4 +68,20 @@ Disabled.args = {
   name: 'disabled',
   validationHint: 'Express shipping is unavailable in your region',
   disabled: true,
+};
+export const Indeterminate = (args: CheckboxProps) => (
+  <Checkbox
+    {...args}
+    ref={(el: HTMLInputElement) => {
+      if (el) {
+        // eslint-disable-next-line no-param-reassign
+        el.indeterminate = true;
+      }
+    }}
+  />
+);
+
+Indeterminate.args = {
+  name: 'indeterminate',
+  value: 'true',
 };

--- a/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, SumUp Ltd.
+ * Copyright 2019, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
+import { css } from '@emotion/react';
+import type { Theme } from '@sumup/design-tokens';
 
 import { Checkbox, CheckboxProps } from './Checkbox';
 
@@ -70,21 +72,95 @@ Disabled.args = {
   disabled: true,
 };
 
-export const Indeterminate = (args: CheckboxProps) => (
-  <Checkbox
-    {...args}
-    ref={(el: HTMLInputElement) => {
-      if (el) {
-        // eslint-disable-next-line no-param-reassign
-        el.indeterminate = true;
-      }
-    }}
-  />
-);
+const legendStyles = (theme: Theme) => css`
+  display: block;
+  margin-bottom: ${theme.spacings.bit};
+  font-size: ${theme.typography.body.two.fontSize};
+  line-height: ${theme.typography.body.two.lineHeight};
+`;
+
+const listStyles = css`
+  list-style: none;
+  margin-left: 26px;
+`;
+
+export const Indeterminate = (args: {
+  label: string;
+  name: string;
+  initialValues: CheckboxProps['value'][];
+  parent: CheckboxProps;
+  options: CheckboxProps[];
+}) => {
+  const { label, name, initialValues, parent, options } = args;
+  const [values, setValues] = useState(initialValues);
+
+  const handleOptionChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const eventValue = event.target.value;
+
+    setValues((prevValues) =>
+      prevValues.includes(eventValue)
+        ? prevValues.filter((v) => v !== eventValue)
+        : prevValues.concat(eventValue),
+    );
+  };
+
+  const handleParentChange = () => {
+    setValues((prevValues) =>
+      prevValues.length === options.length
+        ? []
+        : options.map((option) => option.value),
+    );
+  };
+
+  const someChecked = options.some((option) => values.includes(option.value));
+  const allChecked = options.every((option) => values.includes(option.value));
+
+  return (
+    <fieldset name={name}>
+      <legend css={legendStyles}>{label}</legend>
+      <Checkbox
+        {...parent}
+        onChange={handleParentChange}
+        name={name}
+        indeterminate={someChecked && !allChecked}
+        checked={allChecked}
+      />
+      <ul css={listStyles}>
+        {options.map((option) => (
+          <li key={option.label}>
+            <Checkbox
+              {...option}
+              onChange={handleOptionChange}
+              name={name}
+              checked={values.includes(option.value)}
+            />
+          </li>
+        ))}
+      </ul>
+    </fieldset>
+  );
+};
 
 Indeterminate.args = {
-  'name': 'indeterminate',
-  'value': 'any value',
-  'aria-checked': 'mixed',
-  'indeterminate': true,
+  label: 'Choose your favorite fruits',
+  name: 'indeterminate',
+  initialValues: ['mango'],
+  parent: {
+    label: 'All fruits',
+    value: 'all',
+  },
+  options: [
+    {
+      label: 'Apple',
+      value: 'apple',
+    },
+    {
+      label: 'Banana',
+      value: 'banana',
+    },
+    {
+      label: 'Mango',
+      value: 'mango',
+    },
+  ],
 };

--- a/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
@@ -82,6 +82,7 @@ export const Indeterminate = (args: CheckboxProps) => (
 );
 
 Indeterminate.args = {
-  name: 'indeterminate',
-  value: 'true',
+  'name': 'indeterminate',
+  'value': 'true',
+  'aria-checked': 'mixed',
 };

--- a/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
@@ -69,6 +69,7 @@ Disabled.args = {
   validationHint: 'Express shipping is unavailable in your region',
   disabled: true,
 };
+
 export const Indeterminate = (args: CheckboxProps) => (
   <Checkbox
     {...args}
@@ -83,6 +84,6 @@ export const Indeterminate = (args: CheckboxProps) => (
 
 Indeterminate.args = {
   'name': 'indeterminate',
-  'value': 'true',
+  'value': 'any value',
   'aria-checked': 'mixed',
 };

--- a/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
@@ -86,4 +86,5 @@ Indeterminate.args = {
   'name': 'indeterminate',
   'value': 'any value',
   'aria-checked': 'mixed',
+  'indeterminate': true,
 };

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -144,6 +144,14 @@ const inputBaseStyles = ({ theme }: StyleProps) => css`
     border-color: var(--cui-border-accent);
     background-color: var(--cui-bg-accent-strong);
   }
+
+  &:checked:disabled + label::before,
+  &:checked[disabled] + label::before,
+  &:indeterminate:disabled + label::before,
+  &:indeterminate[disabled] + label::before {
+    border-color: var(--cui-border-accent-disabled);
+    background-color: var(--cui-bg-accent-strong-disabled);
+  }
 `;
 
 const inputInvalidStyles = ({ invalid }: InputElProps) =>
@@ -164,6 +172,14 @@ const inputInvalidStyles = ({ invalid }: InputElProps) =>
       border-color: var(--cui-border-danger);
       background-color: var(--cui-bg-danger-strong);
     }
+
+    &:checked:disabled + label::before,
+    &:indeterminate:disabled + label::before,
+    &:checked[disabled] + label::before,
+    &:indeterminate[disabled] + label::before {
+      border-color: var(--cui-border-danger-disabled);
+      background-color: var(--cui-bg-danger-strong-disabled);
+    }
   `;
 
 const inputDisabledStyles = () =>
@@ -172,11 +188,11 @@ const inputDisabledStyles = () =>
     &[disabled] + label {
       pointer-events: none;
       color: var(--cui-fg-normal-disabled);
-
-      &::before {
-        border-color: var(--cui-border-normal-disabled);
-        background-color: var(--cui-bg-normal-disabled);
-      }
+    }
+    &:disabled + label::before,
+    &[disabled] + label::before {
+      border-color: var(--cui-border-normal-disabled);
+      background-color: var(--cui-bg-normal-disabled);
     }
 
     &:disabled:checked + label::before,

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -258,13 +258,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
     const localRef = useRef<HTMLInputElement>(null);
     useEffect(() => {
-      if (!localRef.current) {
-        return;
+      if (localRef.current) {
+        localRef.current.indeterminate = indeterminate;
       }
-
-      localRef.current.indeterminate = indeterminate;
       // Because it came from a props, we are keeping the `indeterminate` state even if the `checked` one is changed:
-    }, [props.defaultChecked, props.checked, indeterminate]);
+    }, [props.checked, indeterminate]);
 
     return (
       <CheckboxWrapper className={className} style={style} disabled={disabled}>

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -34,11 +34,12 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
    */
   label?: string;
   /**
-   * Triggers error styles on the component.
+   * Marks the input as invalid.
    */
   invalid?: boolean;
   /**
-   * Triggers indeterminate styles on the component.
+   * Marks the input as indeterminate. This is presentational only, the value
+   * of an indeterminate checkbox is not included in form submissions.
    */
   indeterminate?: boolean;
   /**
@@ -233,6 +234,15 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     },
     passedRef,
   ) => {
+    const localRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+      if (localRef.current) {
+        localRef.current.indeterminate = indeterminate;
+      }
+      // Because it came from a props, we are keeping the `indeterminate` state even if the `checked` one is changed:
+    }, [props.checked, indeterminate]);
+
     if (process.env.NODE_ENV !== 'production' && children) {
       deprecate(
         'Checkbox',
@@ -254,15 +264,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     const descriptionIds = `${
       descriptionId ? `${descriptionId} ` : ''
     }${validationHintId}`;
-    const handleChange = useClickEvent(onChange, tracking, 'checkbox');
 
-    const localRef = useRef<HTMLInputElement>(null);
-    useEffect(() => {
-      if (localRef.current) {
-        localRef.current.indeterminate = indeterminate;
-      }
-      // Because it came from a props, we are keeping the `indeterminate` state even if the `checked` one is changed:
-    }, [props.checked, indeterminate]);
+    const handleChange = useClickEvent(onChange, tracking, 'checkbox');
 
     return (
       <CheckboxWrapper className={className} style={style} disabled={disabled}>
@@ -277,7 +280,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           ref={applyMultipleRefs(passedRef, localRef)}
           aria-describedby={descriptionIds}
           onChange={handleChange}
-          {...(indeterminate && { 'aria-checked': 'mixed' })}
+          aria-checked={indeterminate ? 'mixed' : undefined}
         />
         <CheckboxLabel htmlFor={id}>
           {label || children}

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -263,7 +263,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       }
 
       localRef.current.indeterminate = indeterminate;
-    }, [indeterminate]);
+      // Because it came from a props, we are keeping the `indeterminate` state even if the `checked` one is changed:
+    }, [props.defaultChecked, props.checked, indeterminate]);
 
     return (
       <CheckboxWrapper className={className} style={style} disabled={disabled}>
@@ -275,7 +276,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           type="checkbox"
           disabled={disabled}
           invalid={invalid}
-          ref={applyMultipleRefs(localRef, passedRef)}
+          ref={applyMultipleRefs(passedRef, localRef)}
           aria-describedby={descriptionIds}
           onChange={handleChange}
           {...(indeterminate && { 'aria-checked': 'mixed' })}

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -25,6 +25,8 @@ import { FieldValidationHint, FieldWrapper } from '../FieldAtoms';
 import { deprecate } from '../../util/logger';
 import { AccessibilityError } from '../../util/errors';
 
+import { IndeterminateIcon } from './IndeterminateIcon';
+
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   /**
    * A clear and concise description of the input's purpose.
@@ -126,16 +128,19 @@ const inputBaseStyles = ({ theme }: StyleProps) => css`
     border-color: var(--cui-border-normal);
   }
 
-  &:checked:focus:not(:focus-visible) + label::before {
+  &:checked:focus:not(:focus-visible) + label::before,
+  &:indeterminate:focus:not(:focus-visible) + label::before {
     border-color: var(--cui-border-accent);
   }
 
-  &:checked + label > svg {
+  &:checked + label > svg[data-symbol='checked'],
+  &:indeterminate + label > svg[data-symbol='indeterminate'] {
     transform: translateY(-50%) scale(1, 1);
     opacity: 1;
   }
 
-  &:checked + label::before {
+  &:checked + label::before,
+  &:indeterminate + label::before {
     border-color: var(--cui-border-accent);
     background-color: var(--cui-bg-accent-strong);
   }
@@ -154,7 +159,8 @@ const inputInvalidStyles = ({ invalid }: InputElProps) =>
       border-color: var(--cui-border-danger-hovered);
     }
 
-    &:checked + label::before {
+    &:checked + label::before,
+    &:indeterminate + label::before {
       border-color: var(--cui-border-danger);
       background-color: var(--cui-bg-danger-strong);
     }
@@ -249,6 +255,7 @@ export const Checkbox = forwardRef(
         <CheckboxLabel htmlFor={id}>
           {label || children}
           <Checkmark aria-hidden="true" />
+          <IndeterminateIcon aria-hidden="true" />
         </CheckboxLabel>
         <FieldValidationHint
           id={validationHintId}

--- a/packages/circuit-ui/components/Checkbox/IndeterminateIcon.tsx
+++ b/packages/circuit-ui/components/Checkbox/IndeterminateIcon.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { SVGAttributes, ReactElement } from 'react';
+import type { SVGAttributes, ReactElement } from 'react';
 
 export const IndeterminateIcon = (
   props: SVGAttributes<SVGElement>,

--- a/packages/circuit-ui/components/Checkbox/IndeterminateIcon.tsx
+++ b/packages/circuit-ui/components/Checkbox/IndeterminateIcon.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SVGAttributes, ReactElement } from 'react';
+
+export const IndeterminateIcon = (
+  props: SVGAttributes<SVGElement>,
+): ReactElement => (
+  <svg
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <rect width="10" height="2" x="3" y="7" rx="1" />
+  </svg>
+);

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.mdx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.mdx
@@ -50,10 +50,10 @@ The CheckboxGroup can be used as a controlled or uncontrolled component.
 
 ```tsx
 import { useState, ChangeEvent } from 'react';
-import { CheckboxGroup } from '@sumup/circuit-ui';
+import { CheckboxGroup, CheckboxProps } from '@sumup/circuit-ui';
 
 function Controlled() {
-  const [value, setValue] = useState([]);
+  const [value, setValue] = useState<CheckboxProps['value'][]>([]);
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const eventValue = event.target.value;


### PR DESCRIPTION
## Purpose

Use another symbol when state is indeterminate.

Compliant with design:
<img width="99" alt="image" src="https://user-images.githubusercontent.com/1178625/152643227-bd1d33c7-8c63-4225-b7dd-44505cd08d19.png">

## Approach and changes

I tried to stay as close as possible of the checked state styling implementation.
I add a new SVG in the label for the indeterminate symbol.
And I put a new props on both SVGs to be able to select them with CSS.

There is now `indeterminate` property.
It takes visually precedence visually over the checked state.
Natively, the indeterminate state of the input would be set to false, when the checked state change. 
Here, because it came from a props, it stays on.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
