### PR TITLE
Only pass aria-pressed to elements with role=button

### DIFF
--- a/.changeset/new-zebras-build.md
+++ b/.changeset/new-zebras-build.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Set `aria-pressed` on a `ListItem` or `CardList.Item` (deprecated) only when it has a role of `button`. The attribute is invalid on any other role.

--- a/packages/circuit-ui/components/CardList/__snapshots__/CardList.spec.js.snap
+++ b/packages/circuit-ui/components/CardList/__snapshots__/CardList.spec.js.snap
@@ -146,29 +146,33 @@ exports[`CardList should render with default styles 1`] = `
   class="circuit-0 circuit-1"
 >
   <div
-    aria-selected="false"
+    aria-pressed="false"
     class="circuit-2 circuit-3"
+    role="button"
     tabindex="0"
   >
     List item 1
   </div>
   <div
-    aria-selected="true"
+    aria-pressed="true"
     class="circuit-4 circuit-3"
+    role="button"
     tabindex="0"
   >
     List item 2
   </div>
   <div
-    aria-selected="false"
+    aria-pressed="false"
     class="circuit-2 circuit-3"
+    role="button"
     tabindex="0"
   >
     List item 3
   </div>
   <div
-    aria-selected="false"
+    aria-pressed="false"
     class="circuit-2 circuit-3"
+    role="button"
     tabindex="0"
   >
     List item 4

--- a/packages/circuit-ui/components/CardList/components/Item/Item.js
+++ b/packages/circuit-ui/components/CardList/components/Item/Item.js
@@ -101,7 +101,8 @@ const createOnKeyDown = (onClick) => {
 
 const Item = (props) => (
   <BaseItem
-    aria-selected={props.selected}
+    role="button"
+    aria-pressed={props.selected}
     onKeyDown={createOnKeyDown(props.onClick)}
     {...props}
   />

--- a/packages/circuit-ui/components/CardList/components/Item/__snapshots__/Item.spec.js.snap
+++ b/packages/circuit-ui/components/CardList/components/Item/__snapshots__/Item.spec.js.snap
@@ -56,8 +56,9 @@ exports[`Item should render with all paddings 1`] = `
 }
 
 <div
-  aria-selected="false"
+  aria-pressed="false"
   class="circuit-0 circuit-1"
+  role="button"
   tabindex="0"
 >
   List item
@@ -120,8 +121,9 @@ exports[`Item should render with all paddings 2`] = `
 }
 
 <div
-  aria-selected="false"
+  aria-pressed="false"
   class="circuit-0 circuit-1"
+  role="button"
   tabindex="0"
 >
   List item
@@ -184,8 +186,9 @@ exports[`Item should render with all paddings 3`] = `
 }
 
 <div
-  aria-selected="false"
+  aria-pressed="false"
   class="circuit-0 circuit-1"
+  role="button"
   tabindex="0"
 >
   List item
@@ -248,8 +251,9 @@ exports[`Item should render with default styles 1`] = `
 }
 
 <div
-  aria-selected="false"
+  aria-pressed="false"
   class="circuit-0 circuit-1"
+  role="button"
   tabindex="0"
 >
   List item
@@ -312,8 +316,9 @@ exports[`Item should render with selected styles 1`] = `
 }
 
 <div
-  aria-selected="false"
+  aria-pressed="false"
   class="circuit-0 circuit-1"
+  role="button"
   tabindex="0"
 >
   List item

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
@@ -282,7 +282,7 @@ export const ListItemGroup = forwardRef(
               <StyledListItem
                 {...item}
                 isPlain={isPlain}
-                aria-pressed={item.selected}
+                aria-pressed={item.onClick ? item.selected : undefined}
               />
             </StyledLi>
           ))}

--- a/packages/circuit-ui/components/ListItemGroup/__snapshots__/ListItemGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/ListItemGroup/__snapshots__/ListItemGroup.spec.tsx.snap
@@ -324,7 +324,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom detail
       class="circuit-7"
     >
       <div
-        aria-pressed="true"
         class="circuit-8"
       >
         <div
@@ -346,7 +345,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom detail
       class="circuit-12"
     >
       <div
-        aria-pressed="false"
         class="circuit-13"
       >
         <div
@@ -368,7 +366,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom detail
       class="circuit-12"
     >
       <div
-        aria-pressed="false"
         class="circuit-13"
       >
         <div
@@ -685,7 +682,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom label 
       class="circuit-5"
     >
       <div
-        aria-pressed="true"
         class="circuit-6"
       >
         <div
@@ -707,7 +703,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom label 
       class="circuit-10"
     >
       <div
-        aria-pressed="false"
         class="circuit-11"
       >
         <div
@@ -729,7 +724,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom label 
       class="circuit-10"
     >
       <div
-        aria-pressed="false"
         class="circuit-11"
       >
         <div
@@ -1075,7 +1069,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a details line 
       class="circuit-7"
     >
       <div
-        aria-pressed="true"
         class="circuit-8"
       >
         <div
@@ -1097,7 +1090,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a details line 
       class="circuit-12"
     >
       <div
-        aria-pressed="false"
         class="circuit-13"
       >
         <div
@@ -1119,7 +1111,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a details line 
       class="circuit-12"
     >
       <div
-        aria-pressed="false"
         class="circuit-13"
       >
         <div
@@ -1449,7 +1440,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a hidden label 
       class="circuit-5"
     >
       <div
-        aria-pressed="true"
         class="circuit-6"
       >
         <div
@@ -1471,7 +1461,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a hidden label 
       class="circuit-10"
     >
       <div
-        aria-pressed="false"
         class="circuit-11"
       >
         <div
@@ -1493,7 +1482,6 @@ exports[`ListItemGroup styles should render a ListItemGroup with a hidden label 
       class="circuit-10"
     >
       <div
-        aria-pressed="false"
         class="circuit-11"
       >
         <div
@@ -1824,7 +1812,6 @@ exports[`ListItemGroup styles should render a plain variant ListItemGroup 1`] = 
       class="circuit-5"
     >
       <div
-        aria-pressed="true"
         class="circuit-6"
       >
         <div
@@ -1846,7 +1833,6 @@ exports[`ListItemGroup styles should render a plain variant ListItemGroup 1`] = 
       class="circuit-10"
     >
       <div
-        aria-pressed="false"
         class="circuit-11"
       >
         <div
@@ -1868,7 +1854,6 @@ exports[`ListItemGroup styles should render a plain variant ListItemGroup 1`] = 
       class="circuit-10"
     >
       <div
-        aria-pressed="false"
         class="circuit-11"
       >
         <div
@@ -2189,7 +2174,6 @@ exports[`ListItemGroup styles should render the inset variant ListItemGroup by d
       class="circuit-5"
     >
       <div
-        aria-pressed="true"
         class="circuit-6"
       >
         <div
@@ -2211,7 +2195,6 @@ exports[`ListItemGroup styles should render the inset variant ListItemGroup by d
       class="circuit-10"
     >
       <div
-        aria-pressed="false"
         class="circuit-11"
       >
         <div
@@ -2233,7 +2216,6 @@ exports[`ListItemGroup styles should render the inset variant ListItemGroup by d
       class="circuit-10"
     >
       <div
-        aria-pressed="false"
         class="circuit-11"
       >
         <div

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -69,7 +69,7 @@
     "@types/jest-axe": "^3.5.3",
     "@types/jscodeshift": "^0.11.0",
     "@types/lodash": "^4.14.165",
-    "@types/react": "^17.0.0",
+    "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.0",
     "@types/react-modal": "^3.10.5",
     "chalk": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4984,10 +4984,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.0":
-  version "17.0.38"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
-  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.39":
+  version "17.0.39"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
+  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -6081,9 +6081,9 @@ aws4@^1.8.0:
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 axe-core@4.2.1, axe-core@^3.5.5, axe-core@^4.0.2, axe-core@^4.2.0, axe-core@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
-  integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.1.tgz#7dbdc25989298f9ad006645cd396782443757413"
+  integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -15909,7 +15909,7 @@ react-moment-proptypes@^1.6.0:
   dependencies:
     moment ">=1.6.0"
 
-react-number-format@^4.4.1:
+react-number-format@^4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.9.1.tgz#62b3450b43c911f9227e770a8ea9fa606696e52e"
   integrity sha512-v49XqXv7SpwYZKGkghNJjoDUr6lIUozlPLrObcxre7GfcLx7qD4TCvArn3GozN/Y4FVbLyEYCwJoBCiChdBh5A==


### PR DESCRIPTION
This branches off #1412, where the issue was discovered in CI, in order to validate the fix.

## Purpose

`axe-core` was bumped in a dependabot PR and started to complain about aria attributes being set on the wrong roles (not all aria attributes are valid on every accessible roles). Instead of pinning the axe version, I've handled the errors.

## Approach and changes

- in `ListItemGroup`, only set `aria-pressed` if the ListItem has an `onClick` prop (which transforms it into a `<button>` element under the hood). If the ListItem is an anchor or a div, it should not have `aria-pressed` (which only goes with `role="button"` and created a toggle button)
- in `CardList` (deprecated), add `role="button"` to cards and replace `aria-selected` by `aria-pressed`. These cards are effectively buttons already since they have a button-like event handler attached, so it makes sense to make them buttons from the perspective of assistive technology, too. `aria-selected` is also incorrect in this context, hence the switch to `aria-pressed`. _(Note: a more robust solution would have been to refactor the component to actually render a `<button>`, much like the `ListItemGroup`, but since it's already deprecated I went for a quick fix instead.)_

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
