### PR TITLE
Remove modern syntax in NotificationInline

### DIFF
--- a/.changeset/ten-ghosts-move.md
+++ b/.changeset/ten-ghosts-move.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed modern syntax in the NotificationInline component that wasn't transpiled and could lead to build issues in apps that consume Circuit UI.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "start": "lerna run start --stream",
     "build": "lerna run build",
+    "clean": "lerna run clean",
     "test": "jest --watch",
     "test:ci": "mkdir -p __reports__ && jest --json --outputFile=__reports__/jest-results.json --ci --coverage --runInBand",
     "lint": "foundry run eslint . --ext .js,.jsx,.ts,.tsx",
@@ -30,7 +31,7 @@
     "check:licenses": "license-checker --production --summary --failOn=GPLv3",
     "check:svg-sizes": "./scripts/check-svg-sizes.sh",
     "copy-docs": "./scripts/copy-docs.sh",
-    "bootstrap": "yarn build && yarn copy-docs && cd packages/create-sumup-next-app/template && yarn --no-lockfile --ignore-scripts",
+    "bootstrap": "yarn clean && yarn build && yarn copy-docs && cd packages/create-sumup-next-app/template && yarn --no-lockfile --ignore-scripts",
     "release": "changeset publish"
   },
   "devDependencies": {

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -257,7 +257,7 @@ export function NotificationInline({
               as={isString(headline) ? 'h3' : headline.as}
               noMargin
             >
-              {isString(headline) ? headline : headline?.label}
+              {isString(headline) ? headline : headline.label}
             </Body>
           )}
           <Body noMargin>{body}</Body>

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/sumup-oss/circuit-ui/tree/main/packages/circuit-ui/README.md",
   "scripts": {
     "start": "tsc --watch",
+    "clean": "rm -rf dist",
     "build": "tsc && tsc --project tsconfig.cjs.json && yarn build:executable",
     "build:executable": "chmod +x ./dist/cjs/cli/index.js",
     "lint": "foundry run eslint . --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
## Purpose

Modern JavaScript syntax isn't transpiled in Circuit UI and can lead to build issues in apps that consume Circuit UI.

## Approach and changes

- Removed optional chaining in the NotificationInline component
- **Bonus**: Automatically clean up build artifacts before running `yarn bootstrap`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
