### PR TITLE
Deprecate InlineMessage and old Notification components

### DIFF
--- a/.changeset/honest-taxis-wave.md
+++ b/.changeset/honest-taxis-wave.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Deprecated `InlineMessage`, `Notification`, `NotificationList` and `NotificationCard` components.
+Deprecated the `InlineMessage`, `Notification`, `NotificationList`, and `NotificationCard` components. Use the new `NotificationBanner`, `NotificationInline`, and `NotificationToast` components instead.

--- a/.changeset/honest-taxis-wave.md
+++ b/.changeset/honest-taxis-wave.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Deprecated `InlineMessage`, `Notification`, `NotificationList` and `NotificationCard` components.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,7 @@
 # Migration <!-- omit in toc -->
 
 - [🤖 Codemods](#-codemods)
+- [From v4 to v5](#from-v4-to-v5)
 - [From v4 to v4.1](#from-v4-to-v41)
   - [Combined LoadingButton and Button](#combined-loadingbutton-and-button)
 - [From v3.x to v4](#from-v3x-to-v4)
@@ -97,6 +98,8 @@ A toast should be used to follow a user action (e.g. submitting a form) or it ca
 #### NotificationInline
 
 It is frequently used to provide additional guidance or to draw attention to a section of the interface (like positive feedback, confirmation about an action or errors in forms, cards or dialog boxes.)
+
+The deprecated `InlineMessage` was replaced with the new `NotificationInline` component.
 
 Refer to [the Notification section in Storybook](https://circuit.sumup.com/?path=/docs/notification) for a usage examples.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -70,6 +70,36 @@ Tip: Provide the `--transform`/`-t` argument at the end of the command, so that 
 > ./node_modules/.bin/circuit-ui migrate -l JavaScript -l TypeScript -t codemod-name
 > ```
 
+## From v4 to v5
+
+### Notification components
+
+The old Notification components were general purpose without clear guidelines when to use a specific Notification component. This has led to inconsistent usage in our apps.
+The deprecated `Notification`, `NotificationList` and `NotificationCard` components were replaced with the new refreshed Notification components (`NotificationBanner`, `NotificationFullscreen`, `NotificationModal`, `NotificationToast` and `NotificationInline`)
+This introduces semantic, accessible components that make it clear when each should be used and are flexible enough to cover all use cases.
+
+#### NotificationBanner
+
+The notification banner should be used to display the global system messages or for promotions and recommendations.
+
+#### NotificationFullscreen
+
+The NotificationFullscreen component provides important information or feedback as part of a process flow. It can be used as a confirmation/success screen, an empty screen state or as an error screen.
+
+#### NotificationModal
+
+Notification modal should be used as information that needs a user's immediate attention or to request a confirmation before performing a destructive action.
+
+#### NotificationToast
+
+A toast should be used to follow a user action (e.g. submitting a form) or it can appear without having been triggered explicitly (e.g. a toast message "You made a new sale" showing real-time sales in an app).
+
+#### NotificationInline
+
+It is frequently used to provide additional guidance or to draw attention to a section of the interface (like positive feedback, confirmation about an action or errors in forms, cards or dialog boxes.)
+
+Refer to [the Notification section in Storybook](https://circuit.sumup.com/?path=/docs/notification) for a usage examples.
+
 ## From v4 to v4.1
 
 ### Combined LoadingButton and Button

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,7 @@
 
 - [🤖 Codemods](#-codemods)
 - [From v4 to v5](#from-v4-to-v5)
+  - [Notification components](#notification-components)
 - [From v4 to v4.1](#from-v4-to-v41)
   - [Combined LoadingButton and Button](#combined-loadingbutton-and-button)
 - [From v3.x to v4](#from-v3x-to-v4)
@@ -73,35 +74,19 @@ Tip: Provide the `--transform`/`-t` argument at the end of the command, so that 
 
 ## From v4 to v5
 
+The Circuit UI v5 is not released yet, and in order to handle the deprecations earlier the migration guide was updated.
+
 ### Notification components
 
 The old Notification components were general purpose without clear guidelines when to use a specific Notification component. This has led to inconsistent usage in our apps.
-The deprecated `Notification`, `NotificationList` and `NotificationCard` components were replaced with the new refreshed Notification components (`NotificationBanner`, `NotificationFullscreen`, `NotificationModal`, `NotificationToast` and `NotificationInline`)
+
+The deprecated `Notification`, `NotificationList` and `NotificationCard` components were replaced with the new refreshed Notification components (`NotificationBanner`, `NotificationFullscreen`, `NotificationModal`, `NotificationToast` and `NotificationInline`).
 This introduces semantic, accessible components that make it clear when each should be used and are flexible enough to cover all use cases.
 
-#### NotificationBanner
+- The deprecated `InlineMessage` was replaced with the new `NotificationInline` component.
+- The deprecated `NotificationCard` component can be replaced with either `NotificationInline`, `NotificationBanner` or `NotificationToast` depending on use cases.
 
-The notification banner should be used to display the global system messages or for promotions and recommendations.
-
-#### NotificationFullscreen
-
-The NotificationFullscreen component provides important information or feedback as part of a process flow. It can be used as a confirmation/success screen, an empty screen state or as an error screen.
-
-#### NotificationModal
-
-Notification modal should be used as information that needs a user's immediate attention or to request a confirmation before performing a destructive action.
-
-#### NotificationToast
-
-A toast should be used to follow a user action (e.g. submitting a form) or it can appear without having been triggered explicitly (e.g. a toast message "You made a new sale" showing real-time sales in an app).
-
-#### NotificationInline
-
-It is frequently used to provide additional guidance or to draw attention to a section of the interface (like positive feedback, confirmation about an action or errors in forms, cards or dialog boxes.)
-
-The deprecated `InlineMessage` was replaced with the new `NotificationInline` component.
-
-Refer to [the Notification section in Storybook](https://circuit.sumup.com/?path=/docs/notification) for a usage examples.
+Refer to [the Notification section in Storybook](https://circuit.sumup.com/?path=/docs/notification) for a usage examples of the new Notification components.
 
 ## From v4 to v4.1
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -86,7 +86,7 @@ This introduces semantic, accessible components that make it clear when each sho
 - The deprecated `InlineMessage` was replaced with the new `NotificationInline` component.
 - The deprecated `NotificationCard` component can be replaced with either `NotificationInline`, `NotificationBanner` or `NotificationToast` depending on use cases.
 
-Refer to [the Notification section in Storybook](https://circuit.sumup.com/?path=/docs/notification) for a usage examples of the new Notification components.
+Refer to [the Notification section in Storybook](https://circuit.sumup.com/?path=/docs/notification) for usage examples of the new Notification components.
 
 ## From v4 to v4.1
 

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
@@ -99,12 +99,30 @@ const successStyles = createLeftBorderStyles('success');
 const warningStyles = createLeftBorderStyles('warning');
 const dangerStyles = createLeftBorderStyles('danger');
 
-/**
- * An inline message displayed inside a Card.
- */
-export const InlineMessage = styled('p')<InlineMessageProps>(
+export const InlineMessageStyles = styled('p')<InlineMessageProps>(
   dangerStyles,
   successStyles,
   warningStyles,
   marginStyles,
 );
+
+/**
+ * @deprecated
+ * An inline message displayed inside a Card.
+ */
+export const InlineMessage = ({
+  ...props
+}: InlineMessageProps): JSX.Element => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test'
+  ) {
+    deprecate(
+      'InlineMessage',
+      'The InlineMessage component is deprecated.',
+      'Use the `NotificationInline` component instead.',
+      'Read more at https://circuit.sumup.com/?path=/docs/notification-notificationinline--base',
+    );
+  }
+  return <InlineMessageStyles {...props}></InlineMessageStyles>;
+};

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
@@ -121,7 +121,7 @@ export const InlineMessage = ({
       'InlineMessage',
       'The InlineMessage component is deprecated.',
       'Use the `NotificationInline` component instead.',
-      'Read more at https://circuit.sumup.com/?path=/docs/notification-notificationinline--base',
+      'Read more at [migration guide](https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5) for usage examples',
     );
   }
   return <InlineMessageStyles {...props}></InlineMessageStyles>;

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
@@ -107,7 +107,7 @@ export const InlineMessageStyles = styled('p')<InlineMessageProps>(
 );
 
 /**
- * @deprecated
+ * @deprecated — Use the new NotificationInline component instead.
  * An inline message displayed inside a Card.
  */
 export const InlineMessage = ({
@@ -121,8 +121,8 @@ export const InlineMessage = ({
       'InlineMessage',
       'The InlineMessage component is deprecated.',
       'Use the `NotificationInline` component instead.',
-      'Read more at [migration guide](https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5) for usage examples',
+      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5',
     );
   }
-  return <InlineMessageStyles {...props}></InlineMessageStyles>;
+  return <InlineMessageStyles {...props} />;
 };

--- a/packages/circuit-ui/components/Notification/Notification.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.tsx
@@ -105,7 +105,7 @@ export const Notification = ({
       'Notification',
       'The Notification component is deprecated.',
       'Use the new Notification components instead',
-      'Read more at [migration guide] ',
+      'Read more at [migration guide](https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5) for usage examples',
     );
   }
 

--- a/packages/circuit-ui/components/Notification/Notification.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.tsx
@@ -104,8 +104,8 @@ export const Notification = ({
     deprecate(
       'Notification',
       'The Notification component is deprecated.',
-      'Use the new Notification components instead',
-      'Read more at [migration guide](https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5) for usage examples',
+      'Use one of the new notification components instead',
+      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5',
     );
   }
 

--- a/packages/circuit-ui/components/Notification/Notification.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.tsx
@@ -21,6 +21,7 @@ import { Theme } from '@sumup/design-tokens';
 import { ClickEvent } from '../../types/events';
 import styled, { StyleProps } from '../../styles/styled';
 import CloseButton, { CloseButtonProps } from '../CloseButton';
+import { deprecate } from '../../util/logger';
 
 type Variant = 'success' | 'error' | 'warning';
 
@@ -83,6 +84,7 @@ const StyledCloseButton =
   styled(CloseButton)<CloseButtonProps>(closeButtonStyles);
 
 /**
+ * @deprecated
  * A Notification component for alerts, updates and notifications.
  */
 export const Notification = ({
@@ -94,6 +96,18 @@ export const Notification = ({
   ...props
 }: NotificationProps): JSX.Element => {
   const Icon = icon || iconMap[variant];
+
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test'
+  ) {
+    deprecate(
+      'Notification',
+      'The Notification component is deprecated.',
+      'Use the new Notification components instead',
+      'Read more at [migration guide] ',
+    );
+  }
 
   return (
     <Container {...props}>

--- a/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
+++ b/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
@@ -56,8 +56,8 @@ export const NotificationCard = ({
     deprecate(
       'NotificationCard',
       'The NotificationCard component is deprecated.',
-      'Use the new Notification components instead',
-      'Read more at [migration guide](https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5) for usage examples',
+      'Use one of the new notification components instead',
+      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5',
     );
   }
   return (

--- a/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
+++ b/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
@@ -18,6 +18,7 @@ import { css } from '@emotion/react';
 
 import styled, { NoTheme, StyleProps } from '../../styles/styled';
 import { shadow } from '../../styles/style-mixins';
+import { deprecate } from '../../util/logger';
 
 export interface NotificationCardProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -41,13 +42,27 @@ const innerStyles = ({ theme }: StyleProps) => css`
 const NotificationCardInner = styled('div')(innerStyles);
 
 /**
+ * @deprecated
  * NotificationCard displays a persistent Notification.
  */
 export const NotificationCard = ({
   children,
   ...props
-}: NotificationCardProps): JSX.Element => (
-  <NotificationCardOuter {...props} aria-live="polite" role="status">
-    <NotificationCardInner>{children}</NotificationCardInner>
-  </NotificationCardOuter>
-);
+}: NotificationCardProps): JSX.Element => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test'
+  ) {
+    deprecate(
+      'NotificationCard',
+      'The NotificationCard component is deprecated.',
+      'Use the new Notification components instead',
+      'Read more at [migration guide] ',
+    );
+  }
+  return (
+    <NotificationCardOuter {...props} aria-live="polite" role="status">
+      <NotificationCardInner>{children}</NotificationCardInner>
+    </NotificationCardOuter>
+  );
+};

--- a/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
+++ b/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
@@ -57,7 +57,7 @@ export const NotificationCard = ({
       'NotificationCard',
       'The NotificationCard component is deprecated.',
       'Use the new Notification components instead',
-      'Read more at [migration guide] ',
+      'Read more at [migration guide](https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5) for usage examples',
     );
   }
   return (

--- a/packages/circuit-ui/components/NotificationList/NotificationList.tsx
+++ b/packages/circuit-ui/components/NotificationList/NotificationList.tsx
@@ -80,8 +80,8 @@ export const NotificationList = ({
     deprecate(
       'NotificationList',
       'The NotificationList component is deprecated.',
-      'Use the new Notification components instead',
-      'Read more at [migration guide](https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5) for usage examples',
+      'Use one of the new notification components instead',
+      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5',
     );
   }
   return (

--- a/packages/circuit-ui/components/NotificationList/NotificationList.tsx
+++ b/packages/circuit-ui/components/NotificationList/NotificationList.tsx
@@ -18,6 +18,7 @@ import { css } from '@emotion/react';
 
 import styled, { NoTheme, StyleProps } from '../../styles/styled';
 import { shadow } from '../../styles/style-mixins';
+import { deprecate } from '../../util/logger';
 
 export interface NotificationListProps
   extends Omit<HTMLAttributes<HTMLUListElement>, 'as'> {
@@ -65,15 +66,29 @@ const cardStyles = ({ theme }: StyleProps) => css`
 const NotificationListCard = styled('li')<NoTheme>(cardStyles, shadow());
 
 /**
+ * @deprecated
  * NotificationList displays Notifications as Cards in a corner.
  */
 export const NotificationList = ({
   children,
   ...props
-}: NotificationListProps): JSX.Element => (
-  <NotificationListWrapper {...props} aria-live="polite">
-    {Children.map(children, (child, i) => (
-      <NotificationListCard key={i}>{child}</NotificationListCard>
-    ))}
-  </NotificationListWrapper>
-);
+}: NotificationListProps): JSX.Element => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test'
+  ) {
+    deprecate(
+      'NotificationList',
+      'The NotificationList component is deprecated.',
+      'Use the new Notification components instead',
+      'Read more at [migration guide] ',
+    );
+  }
+  return (
+    <NotificationListWrapper {...props} aria-live="polite">
+      {Children.map(children, (child, i) => (
+        <NotificationListCard key={i}>{child}</NotificationListCard>
+      ))}
+    </NotificationListWrapper>
+  );
+};

--- a/packages/circuit-ui/components/NotificationList/NotificationList.tsx
+++ b/packages/circuit-ui/components/NotificationList/NotificationList.tsx
@@ -81,7 +81,7 @@ export const NotificationList = ({
       'NotificationList',
       'The NotificationList component is deprecated.',
       'Use the new Notification components instead',
-      'Read more at [migration guide] ',
+      'Read more at [migration guide](https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5) for usage examples',
     );
   }
   return (


### PR DESCRIPTION

## Purpose

The brand new Notification components were released. The remaining work was to deprecated the old Notification components.

## Approach and changes

- Update the migration guide with the changes to the Notification components.
- Deprecate InlineMessage, Notification, NotificationList and NotificationCard components.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
