### PR TITLE
Add new semantic variant names to the Badge and Body components

### DIFF
--- a/.changeset/plenty-timers-whisper.md
+++ b/.changeset/plenty-timers-whisper.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Change the `Badge`'s promo variant's foreground color from white to `bodyColor` for better contrast.

--- a/.changeset/plenty-timers-whisper.md
+++ b/.changeset/plenty-timers-whisper.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Change the `Badge`'s promo variant's foreground color from white to `bodyColor` for better contrast.
+Changed the `Badge`'s promo variant's foreground color from white to `bodyColor` for better color contrast.

--- a/.changeset/plenty-timers-whisper.md
+++ b/.changeset/plenty-timers-whisper.md
@@ -1,5 +1,0 @@
----
-'@sumup/circuit-ui': patch
----
-
-Changed the `Badge`'s promo variant's foreground color from white to `bodyColor` for better color contrast.

--- a/.changeset/weak-geckos-sell.md
+++ b/.changeset/weak-geckos-sell.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added new semantic variant names to the `Body`, `BodyLarge` and `Badge` components, and deprecated legacy variants. Read more in the [migration guide](https://github.com/sumup-oss/circuit-ui/blob/main/MIGRATION.md#new-semantic-color-names).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,8 @@
 - [🤖 Codemods](#-codemods)
 - [From v4 to v5](#from-v4-to-v5)
   - [New semantic color names](#new-semantic-color-names)
+    - [In design tokens](#in-design-tokens)
+    - [In component variants](#in-component-variants)
   - [Notification components](#notification-components)
 - [From v4 to v4.1](#from-v4-to-v41)
   - [Combined LoadingButton and Button](#combined-loadingbutton-and-button)
@@ -78,6 +80,38 @@ Tip: Provide the `--transform`/`-t` argument at the end of the command, so that 
 Circuit UI v5 is not out yet, but there are already steps you can take to make migration easier in the future.
 
 ### New semantic color names
+
+#### In design tokens
+
+New semantic color names were introduced in `@sumup/design-tokens@3.4.0`. The legacy names were deprecated and will be removed in v5.
+
+| Legacy name | New name  |
+| ----------- | --------- |
+| `success`   | `confirm` |
+| `warning`   | `notify`  |
+| `danger`    | `alert`   |
+
+The new naming brings cross-platform consistency, as well as alignment with some existing components such as the notification icons.
+
+_🤖 semantic-color-names_
+
+#### In component variants
+
+Some `Body`, `BodyLarge` and `Badge` component variants were also renamed for consistency with the new design tokens:
+
+| Legacy variant                | New variant                   |
+| ----------------------------- | ----------------------------- |
+| `<Body variant="success" />`  | `<Body variant="confirm" />`  |
+| `<Body variant="error" />`    | `<Body variant="alert" />`    |
+| `<Badge variant="success" />` | `<Badge variant="confirm" />` |
+| `<Badge variant="warning" />` | `<Badge variant="notify" />`  |
+| `<Badge variant="danger" />`  | `<Badge variant="alert" />`   |
+
+_Note: the `Body` variants mapping above also apply to the `BodyLarge` component._
+
+The legacy variant names were deprecated and will be removed in v5.
+
+_🤖 semantic-variant-names_
 
 ### Notification components
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -128,7 +128,7 @@ Furthermore, some patterns that were previously not supported by Circuit UI are 
 
 - The new `NotificationToast` provider and hook should replace any custom implementation of a toast notifications system for improved accessibility.
 - The new `NotificationModal` can be used for building notification dialogs that are essential to user flows.
-- the new `NotificationFullscreen` can replace custom full-screen messages such as error pages or empty states, for more consistency across pages.
+- The new `NotificationFullscreen` can replace custom full-screen messages such as error pages or empty states, for more consistency across pages.
 
 Read more about the new notification components in [the Notification section in Storybook](https://circuit.sumup.com/?path=/docs/notification).
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,7 @@
 
 - [🤖 Codemods](#-codemods)
 - [From v4 to v5](#from-v4-to-v5)
+  - [New semantic color names](#new-semantic-color-names)
   - [Notification components](#notification-components)
 - [From v4 to v4.1](#from-v4-to-v41)
   - [Combined LoadingButton and Button](#combined-loadingbutton-and-button)
@@ -74,19 +75,28 @@ Tip: Provide the `--transform`/`-t` argument at the end of the command, so that 
 
 ## From v4 to v5
 
-The Circuit UI v5 is not released yet, and in order to handle the deprecations earlier the migration guide was updated.
+Circuit UI v5 is not out yet, but there are already steps you can take to make migration easier in the future.
+
+### New semantic color names
 
 ### Notification components
 
-The old Notification components were general purpose without clear guidelines when to use a specific Notification component. This has led to inconsistent usage in our apps.
+The legacy Circuit UI notification components (`Notification`, `NotificationList`, `NotificationCard` and `InlineMessage`) were general purpose, lacking clear guidelines on when to use which and leading to inconsistent usage in our apps.
 
-The deprecated `Notification`, `NotificationList` and `NotificationCard` components were replaced with the new refreshed Notification components (`NotificationBanner`, `NotificationFullscreen`, `NotificationModal`, `NotificationToast` and `NotificationInline`).
-This introduces semantic, accessible components that make it clear when each should be used and are flexible enough to cover all use cases.
+They were deprecated in v4.14.0 and replaced by semantic, accessible components that make it clear when each should be used and are flexible enough to cover all use cases (`NotificationBanner`, `NotificationFullscreen`, `NotificationModal`, `NotificationToast` and `NotificationInline`). The legacy components will be removed in v5.
 
-- The deprecated `InlineMessage` was replaced with the new `NotificationInline` component.
-- The deprecated `NotificationCard` component can be replaced with either `NotificationInline`, `NotificationBanner` or `NotificationToast` depending on use cases.
+To migrate to the new notifications, you'll need to:
 
-Refer to [the Notification section in Storybook](https://circuit.sumup.com/?path=/docs/notification) for usage examples of the new Notification components.
+- Replace the `InlineMessage` by the `NotificationInline` in your app
+- Replace uses of the `NotificationCard`, `NotificationList` and `Notification` (often used together) by either the `NotificationInline` or `NotificationBanner`, depending on the use cases.
+
+Furthermore, some patterns that were previously not supported by Circuit UI are now available:
+
+- The new `NotificationToast` provider and hook should replace any custom implementation of a toast notifications system for improved accessibility.
+- The new `NotificationModal` can be used for building notification dialogs that are essential to user flows.
+- the new `NotificationFullscreen` can replace custom full-screen messages such as error pages or empty states, for more consistency across pages.
+
+Read more about the new notification components in [the Notification section in Storybook](https://circuit.sumup.com/?path=/docs/notification).
 
 ## From v4 to v4.1
 

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/semantic-color-names.input.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/semantic-color-names.input.js
@@ -1,0 +1,10 @@
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
+const pStyles = ({ theme }) => css`
+  color: ${theme.colors.success};
+  color: ${theme.colors.warning};
+  color: ${theme.colors.danger};
+`;
+
+const Paragraph = styled.p(pStyles);

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/semantic-color-names.output.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/semantic-color-names.output.js
@@ -1,0 +1,10 @@
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+
+const pStyles = ({ theme }) => css`
+  color: ${theme.colors.confirm};
+  color: ${theme.colors.notify};
+  color: ${theme.colors.alert};
+`;
+
+const Paragraph = styled.p(pStyles);

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/semantic-variant-names.input.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/semantic-variant-names.input.js
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+import { Badge, Body, BodyLarge } from '@sumup/circuit-ui';
+
+/**
+ * Badge
+ */
+const BadgeComponent = () => (
+  <>
+    <Badge variant="success">success</Badge>
+    <Badge variant="warning">warning</Badge>
+    <Badge variant="danger">danger</Badge>
+  </>
+);
+
+const RedBadge = styled(Badge)`
+  // don't ever do this
+  color: red;
+`;
+const BadgeComponentStyled = () => (
+  <>
+    <RedBadge variant="success">success</RedBadge>
+    <RedBadge variant="warning">warning</RedBadge>
+    <RedBadge variant="danger">danger</RedBadge>
+  </>
+);
+
+/**
+ * Body and BodyLarge
+ */
+const BodyComponent = () => (
+  <>
+    <Body variant="success">success</Body>
+    <Body variant="error">error</Body>
+    <BodyLarge variant="success">success</BodyLarge>
+    <BodyLarge variant="error">error</BodyLarge>
+  </>
+);
+
+const RedBody = styled(Body)`
+  color: red;
+`;
+const RedBodyLarge = styled(BodyLarge)`
+  color: red;
+`;
+const BodyComponentStyled = () => (
+  <>
+    <RedBody variant="success">success</RedBody>
+    <RedBody variant="error">error</RedBody>
+    <RedBodyLarge variant="success">success</RedBodyLarge>
+    <RedBodyLarge variant="error">error</RedBodyLarge>
+  </>
+);

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/semantic-variant-names.output.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/semantic-variant-names.output.js
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+import { Badge, Body, BodyLarge } from '@sumup/circuit-ui';
+
+/**
+ * Badge
+ */
+const BadgeComponent = () => (
+  <>
+    <Badge variant="confirm">success</Badge>
+    <Badge variant="notify">warning</Badge>
+    <Badge variant="alert">danger</Badge>
+  </>
+);
+
+const RedBadge = styled(Badge)`
+  // don't ever do this
+  color: red;
+`;
+const BadgeComponentStyled = () => (
+  <>
+    <RedBadge variant="confirm">success</RedBadge>
+    <RedBadge variant="notify">warning</RedBadge>
+    <RedBadge variant="alert">danger</RedBadge>
+  </>
+);
+
+/**
+ * Body and BodyLarge
+ */
+const BodyComponent = () => (
+  <>
+    <Body variant="confirm">success</Body>
+    <Body variant="alert">error</Body>
+    <BodyLarge variant="confirm">success</BodyLarge>
+    <BodyLarge variant="alert">error</BodyLarge>
+  </>
+);
+
+const RedBody = styled(Body)`
+  color: red;
+`;
+const RedBodyLarge = styled(BodyLarge)`
+  color: red;
+`;
+const BodyComponentStyled = () => (
+  <>
+    <RedBody variant="confirm">success</RedBody>
+    <RedBody variant="alert">error</RedBody>
+    <RedBodyLarge variant="confirm">success</RedBodyLarge>
+    <RedBodyLarge variant="alert">error</RedBodyLarge>
+  </>
+);

--- a/packages/circuit-ui/cli/migrate/__tests__/migrate.spec.js
+++ b/packages/circuit-ui/cli/migrate/__tests__/migrate.spec.js
@@ -60,6 +60,10 @@ defineTest('icons-v2');
 // v4.1
 defineTest('component-names-v4-1');
 
+// v5
+defineTest('semantic-color-names');
+defineTest('semantic-variant-names');
+
 function defineTest(transformName, testFilePrefix, testOptions = {}) {
   const dirName = __dirname;
   const fixtureDir = path.join(dirName, '..', '__testfixtures__');

--- a/packages/circuit-ui/cli/migrate/semantic-color-names.ts
+++ b/packages/circuit-ui/cli/migrate/semantic-color-names.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2022, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform } from 'jscodeshift';
+
+import { findProperty } from './utils';
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const mappings = [
+    ['theme.colors.success', 'theme.colors.confirm'],
+    ['theme.colors.warning', 'theme.colors.notify'],
+    ['theme.colors.danger', 'theme.colors.alert'],
+  ];
+
+  mappings.forEach(([prevValue, nextValue]) =>
+    findProperty(j, root, prevValue).replaceWith(j.identifier(nextValue)),
+  );
+
+  return root.toSource();
+};
+
+export default transform;

--- a/packages/circuit-ui/cli/migrate/semantic-variant-names.ts
+++ b/packages/circuit-ui/cli/migrate/semantic-variant-names.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2022, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform, JSCodeshift, Collection } from 'jscodeshift';
+
+import { findLocalNames } from './utils';
+
+function transformFactory(
+  j: JSCodeshift,
+  root: Collection,
+  componentName: string,
+): void {
+  const components = findLocalNames(j, root, componentName);
+
+  if (!components) {
+    return;
+  }
+
+  const variantNames = [
+    { old: 'success', new: 'confirm' },
+    { old: 'warning', new: 'notify' },
+    { old: 'error', new: 'alert' }, // Body and BodyLarge
+    { old: 'danger', new: 'alert' }, // Badge
+  ];
+
+  components.forEach((component) => {
+    const jsxElement = root.findJSXElements(component);
+    variantNames.forEach((variantName) => {
+      // The babel and TypeScript parsers use different node types.
+      ['Literal', 'StringLiteral'].forEach((type) => {
+        jsxElement
+          .find(j.JSXAttribute, {
+            name: {
+              type: 'JSXIdentifier',
+              name: 'variant',
+            },
+            value: {
+              type,
+              value: variantName.old,
+            },
+          })
+          .replaceWith(() =>
+            j.jsxAttribute(
+              j.jsxIdentifier('variant'),
+              j.stringLiteral(variantName.new),
+            ),
+          );
+      });
+    });
+  });
+}
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  transformFactory(j, root, 'Badge');
+  transformFactory(j, root, 'Body');
+  transformFactory(j, root, 'BodyLarge');
+
+  return root.toSource();
+};
+
+export default transform;

--- a/packages/circuit-ui/components/Badge/Badge.spec.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.spec.tsx
@@ -31,8 +31,11 @@ describe('Badge', () => {
   const variants = [
     'neutral',
     'success',
+    'confirm',
     'warning',
+    'notify',
     'danger',
+    'alert',
     'promo',
   ] as const;
 

--- a/packages/circuit-ui/components/Badge/Badge.stories.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.stories.tsx
@@ -43,14 +43,14 @@ export const Variants = (args: BadgeProps) => {
       <Badge {...args} variant="neutral">
         Neutral
       </Badge>
-      <Badge {...args} variant="success">
-        Success
+      <Badge {...args} variant="confirm">
+        Confirm
       </Badge>
-      <Badge {...args} variant="warning">
-        Warning
+      <Badge {...args} variant="notify">
+        Notify
       </Badge>
-      <Badge {...args} variant="danger">
-        Danger
+      <Badge {...args} variant="alert">
+        Alert
       </Badge>
       <Badge {...args} variant="promo">
         Promo

--- a/packages/circuit-ui/components/Badge/Badge.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.tsx
@@ -60,7 +60,7 @@ const COLOR_MAP = {
     background: 'n200',
   },
   promo: {
-    text: 'bodyColor',
+    text: 'white',
     background: 'v500',
   },
 } as const;

--- a/packages/circuit-ui/components/Badge/Badge.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.tsx
@@ -80,31 +80,46 @@ const variantStyles = ({
   theme,
   variant = 'neutral',
 }: StyleProps & BadgeProps) => {
-  // TODO: remove the legacy variants and this mapping in v5
+  // TODO: remove the legacy variants and this switch statement in v5
   /* eslint-disable no-param-reassign */
   switch (variant) {
     case 'success':
-      deprecate(
-        'Badge',
-        "The Badge's `success` variant is deprecated.",
-        'Use the `confirm` variant instead.',
-      );
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        process.env.NODE_ENV !== 'test'
+      ) {
+        deprecate(
+          'Badge',
+          "The Badge's `success` variant is deprecated.",
+          'Use the `confirm` variant instead.',
+        );
+      }
       variant = 'confirm';
       break;
     case 'warning':
-      deprecate(
-        'Badge',
-        "The Badge's `warning` variant is deprecated.",
-        'Use the `notify` variant instead.',
-      );
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        process.env.NODE_ENV !== 'test'
+      ) {
+        deprecate(
+          'Badge',
+          "The Badge's `warning` variant is deprecated.",
+          'Use the `notify` variant instead.',
+        );
+      }
       variant = 'notify';
       break;
     case 'danger':
-      deprecate(
-        'Badge',
-        "The Badge's `danger` variant is deprecated.",
-        'Use the `alert` variant instead.',
-      );
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        process.env.NODE_ENV !== 'test'
+      ) {
+        deprecate(
+          'Badge',
+          "The Badge's `danger` variant is deprecated.",
+          'Use the `alert` variant instead.',
+        );
+      }
       variant = 'alert';
       break;
     default:

--- a/packages/circuit-ui/components/Badge/Badge.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.tsx
@@ -17,33 +17,41 @@ import { Ref, forwardRef, HTMLAttributes } from 'react';
 import { css } from '@emotion/react';
 
 import styled, { StyleProps } from '../../styles/styled';
+import { deprecate } from '../../util/logger';
 
 export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Choose from 4 style variants. Default: 'neutral'.
    */
-  variant?: 'neutral' | 'success' | 'warning' | 'danger' | 'promo';
+  variant?:
+    | 'neutral'
+    | 'success'
+    | 'confirm'
+    | 'warning'
+    | 'notify'
+    | 'danger'
+    | 'alert'
+    | 'promo';
   /**
    * Use the circular badge to indicate a count of items related to an element.
    */
   circle?: boolean;
   /**
-   * The ref to the HTML DOM element
+   * The ref to the HTML DOM element.
    */
   ref?: Ref<HTMLDivElement>;
 }
 
-// TODO: Will rename variants to match the new color names scheme in the next major version
 const COLOR_MAP = {
-  success: {
+  confirm: {
     text: 'white',
     background: 'g700',
   },
-  warning: {
+  notify: {
     text: 'bodyColor',
     background: 'y300',
   },
-  danger: {
+  alert: {
     text: 'white',
     background: 'r500',
   },
@@ -52,7 +60,7 @@ const COLOR_MAP = {
     background: 'n200',
   },
   promo: {
-    text: 'white',
+    text: 'bodyColor',
     background: 'v500',
   },
 } as const;
@@ -72,6 +80,38 @@ const variantStyles = ({
   theme,
   variant = 'neutral',
 }: StyleProps & BadgeProps) => {
+  // TODO: remove the legacy variants and this mapping in v5
+  /* eslint-disable no-param-reassign */
+  switch (variant) {
+    case 'success':
+      deprecate(
+        'Badge',
+        "The Badge's `success` variant is deprecated.",
+        'Use the `confirm` variant instead.',
+      );
+      variant = 'confirm';
+      break;
+    case 'warning':
+      deprecate(
+        'Badge',
+        "The Badge's `warning` variant is deprecated.",
+        'Use the `notify` variant instead.',
+      );
+      variant = 'notify';
+      break;
+    case 'danger':
+      deprecate(
+        'Badge',
+        "The Badge's `danger` variant is deprecated.",
+        'Use the `alert` variant instead.',
+      );
+      variant = 'alert';
+      break;
+    default:
+      break;
+  }
+  /* eslint-enable no-param-reassign */
+
   const currentColor = COLOR_MAP[variant];
   return css`
     background-color: ${theme.colors[currentColor.background]};

--- a/packages/circuit-ui/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/circuit-ui/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -159,7 +159,7 @@ exports[`Badge should render with promo styles 1`] = `
   text-align: center;
   letter-spacing: 0.25px;
   background-color: #CA58FF;
-  color: #1A1A1A;
+  color: #FFF;
 }
 
 <div

--- a/packages/circuit-ui/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/circuit-ui/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -34,6 +34,44 @@ exports[`Badge should have the correct circle styles 1`] = `
 />
 `;
 
+exports[`Badge should render with alert styles 1`] = `
+.circuit-0 {
+  border-radius: 999999px;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: 0.25px;
+  background-color: #D23F47;
+  color: #FFF;
+}
+
+<div
+  class="circuit-0"
+/>
+`;
+
+exports[`Badge should render with confirm styles 1`] = `
+.circuit-0 {
+  border-radius: 999999px;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: 0.25px;
+  background-color: #138849;
+  color: #FFF;
+}
+
+<div
+  class="circuit-0"
+/>
+`;
+
 exports[`Badge should render with danger styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
@@ -91,6 +129,25 @@ exports[`Badge should render with neutral styles 1`] = `
 />
 `;
 
+exports[`Badge should render with notify styles 1`] = `
+.circuit-0 {
+  border-radius: 999999px;
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: 0.25px;
+  background-color: #F6CC1B;
+  color: #1A1A1A;
+}
+
+<div
+  class="circuit-0"
+/>
+`;
+
 exports[`Badge should render with promo styles 1`] = `
 .circuit-0 {
   border-radius: 999999px;
@@ -102,7 +159,7 @@ exports[`Badge should render with promo styles 1`] = `
   text-align: center;
   letter-spacing: 0.25px;
   background-color: #CA58FF;
-  color: #FFF;
+  color: #1A1A1A;
 }
 
 <div

--- a/packages/circuit-ui/components/Body/Body.docs.mdx
+++ b/packages/circuit-ui/components/Body/Body.docs.mdx
@@ -21,7 +21,7 @@ The Body component comes in two sizes. Use the default `one` size in most cases.
 
 ### Variants
 
-The Body component accepts five different variants—`highlight`, `quote`, `success`, `error` and `subtle`—to tailor it according to the content we are presenting.
+The Body component accepts five different variants—`highlight`, `quote`, `confirm`, `alert` and `subtle`—to tailor it according to the content we are presenting.
 
 Different variants will render different HTML elements by default:
 
@@ -30,15 +30,15 @@ Different variants will render different HTML elements by default:
 | default     | `p`             |
 | `highlight` | `strong`        |
 | `quote`     | `blockquote`    |
-| `success`   | `p`             |
-| `error`     | `p`             |
+| `confirm`   | `p`             |
+| `alert`     | `p`             |
 | `subtle`    | `p`             |
 
 Use the `as` prop to render other HTML elements, for example for rendering a highlighted paragraph (`<Body variant="highlight" as="p" />`).
 
 <Story id="typography-body--variants" />
 
-**Important**: the `success` and `error` variants only change the text's color. Keep in mind that this is not sufficient to make them accessible. Refer to the Accessibility section below, especially "Do not rely on color alone" and "Make status messages accessible to screen readers using live regions".
+**Important**: the `confirm` and `alert` variants only change the text's color. Keep in mind that this is not sufficient to make them accessible. Refer to the Accessibility section below, especially "Do not rely on color alone" and "Make status messages accessible to screen readers using live regions".
 
 ---
 
@@ -81,17 +81,17 @@ Bear in mind that machine translation is often inaccurate: prefer professional t
 
 Color alone is not sufficient to differentiate text from the surrounding content ([1.4.1 Use of Color](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)).
 
-This is especially relevant when using the `success` and `error` variants.
+This is especially relevant when using the `confirm` and `alert` variants.
 
-For example, imagine a list of good and bad accessibility practices. It is not enough to use the `success` (green) variant for good practices and the `error` (red) variant for bad practices. Instead, use additional visual cues such as icons (with an accessible label), or break up the list into two separate ones with explicit labeling.
+For example, imagine a list of good and bad accessibility practices. It is not enough to use the `confirm` (green) variant for good practices and the `alert` (red) variant for bad practices. Instead, use additional visual cues such as icons (with an accessible label), or break up the list into two separate ones with explicit labeling.
 
 #### Make status messages accessible to screen readers using live regions
 
 When a change in content is not given focus (typically a message being added to the DOM to reflect a status update), the change needs to be announced to screen readers using a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) ([4.1.3 Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html), [3.3.1 Error Identification](https://www.w3.org/WAI/WCAG21/Understanding/error-identification)).
 
-For example, a form submission fails and a message saying "This username is already taken." using `<Body variant="error" />` appears. Without a live region, screen reader users would have no way of knowing that something happened and that they need to make changes to the form before submitting again. They will either have to step through the DOM to try and find the relevant error message, or they will give up and close the page.
+For example, a form submission fails and a message saying "This username is already taken." using `<Body variant="alert" />` appears. Without a live region, screen reader users would have no way of knowing that something happened and that they need to make changes to the form before submitting again. They will either have to step through the DOM to try and find the relevant error message, or they will give up and close the page.
 
-Live regions can be tricky to work with, therefore we recommend using existing components such as the [NotificationInline](Notifications/NotificationInline) or the [NotifiationToast](Notifications/NotificationToast) instead of implementing them from scratch.
+Live regions can be tricky to work with, therefore we recommend using existing components such as the [NotificationInline](Notifications/NotificationInline) or the [NotificationToast](Notifications/NotificationToast) instead of implementing them from scratch.
 
 ### Resources
 

--- a/packages/circuit-ui/components/Body/Body.spec.tsx
+++ b/packages/circuit-ui/components/Body/Body.spec.tsx
@@ -36,7 +36,9 @@ describe('Body', () => {
     'highlight',
     'quote',
     'success',
+    'confirm',
     'error',
+    'alert',
     'subtle',
   ] as BodyProps['variant'][];
   it.each(variants)('should render as a "%s" variant', (variant) => {

--- a/packages/circuit-ui/components/Body/Body.stories.tsx
+++ b/packages/circuit-ui/components/Body/Body.stories.tsx
@@ -47,7 +47,7 @@ export const Sizes = (args: BodyProps) =>
     </Body>
   ));
 
-const variants = ['highlight', 'quote', 'success', 'error', 'subtle'] as const;
+const variants = ['highlight', 'quote', 'confirm', 'alert', 'subtle'] as const;
 
 export const Variants = (args: BodyProps) =>
   variants.map((variant) => (

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -22,8 +22,14 @@ import { deprecate } from '../../util/logger';
 import { AsPropType } from '../../types/prop-types';
 
 type Size = 'one' | 'two';
-// TODO: Will rename variants to match the new color names scheme in the next major version
-type Variant = 'highlight' | 'quote' | 'success' | 'error' | 'subtle';
+type Variant =
+  | 'highlight'
+  | 'quote'
+  | 'success'
+  | 'confirm'
+  | 'error'
+  | 'alert'
+  | 'subtle';
 
 export interface BodyProps extends HTMLAttributes<HTMLParagraphElement> {
   /**
@@ -60,6 +66,40 @@ const sizeStyles = ({ theme, size = 'one' }: BodyProps & StyleProps) => css`
 `;
 
 const variantStyles = ({ theme, variant }: BodyProps & StyleProps) => {
+  // TODO: remove the legacy variants and this switch statement in v5
+  /* eslint-disable no-param-reassign */
+  switch (variant) {
+    case 'success':
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        process.env.NODE_ENV !== 'test'
+      ) {
+        deprecate(
+          'Body',
+          "The Body's `success` variant is deprecated.",
+          'Use the `confirm` variant instead.',
+        );
+      }
+      variant = 'confirm';
+      break;
+    case 'error':
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        process.env.NODE_ENV !== 'test'
+      ) {
+        deprecate(
+          'Body',
+          "The Body's `error` variant is deprecated.",
+          'Use the `alert` variant instead.',
+        );
+      }
+      variant = 'alert';
+      break;
+    default:
+      break;
+  }
+  /* eslint-enable no-param-reassign */
+
   switch (variant) {
     default: {
       return null;
@@ -76,12 +116,12 @@ const variantStyles = ({ theme, variant }: BodyProps & StyleProps) => {
         border-left: ${theme.borderWidth.mega} solid ${theme.colors.p500};
       `;
     }
-    case 'success': {
+    case 'confirm': {
       return css`
         color: ${theme.colors.confirm};
       `;
     }
-    case 'error': {
+    case 'alert': {
       return css`
         color: ${theme.colors.alert};
       `;

--- a/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
+++ b/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Body should render as a "alert" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  color: #D23F47;
+}
+
+<p
+  class="circuit-0"
+>
+  alert
+   Body
+</p>
+`;
+
+exports[`Body should render as a "confirm" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  margin-bottom: 16px;
+  font-size: 16px;
+  line-height: 24px;
+  color: #138849;
+}
+
+<p
+  class="circuit-0"
+>
+  confirm
+   Body
+</p>
+`;
+
 exports[`Body should render as a "error" variant 1`] = `
 .circuit-0 {
   font-weight: 400;

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.docs.mdx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.docs.mdx
@@ -13,7 +13,7 @@ The BodyLarge component is used to render content with large typography. Typical
 
 ### Variants
 
-The BodyLarge accepts five different variants—`highlight`, `quote`, `success`, `error` and `subtle`—to tailor it according to the content we are presenting.
+The BodyLarge accepts five different variants—`highlight`, `quote`, `confirm`, `alert` and `subtle`—to tailor it according to the content we are presenting.
 
 The `highlight` variant will render a `<strong>` element by default, while the `quote` variant will render a `blockquote`.
 

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.spec.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.spec.tsx
@@ -30,7 +30,9 @@ describe('BodyLarge', () => {
     'highlight',
     'quote',
     'success',
+    'confirm',
     'error',
+    'alert',
     'subtle',
   ] as BodyLargeProps['variant'][];
   it.each(variants)('should render as a "%s" variant', (variant) => {

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.stories.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.stories.tsx
@@ -36,7 +36,7 @@ export const Base = (args: BodyLargeProps) => (
   <BodyLarge {...args}>{content}</BodyLarge>
 );
 
-const variants = ['highlight', 'quote', 'success', 'error', 'subtle'] as const;
+const variants = ['highlight', 'quote', 'confirm', 'alert', 'subtle'] as const;
 
 export const Variants = (args: BodyLargeProps) =>
   variants.map((variant) => (

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.tsx
@@ -19,8 +19,16 @@ import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { AsPropType } from '../../types/prop-types';
+import { deprecate } from '../../util/logger';
 
-type Variant = 'highlight' | 'quote' | 'success' | 'error' | 'subtle';
+type Variant =
+  | 'highlight'
+  | 'quote'
+  | 'success'
+  | 'confirm'
+  | 'error'
+  | 'alert'
+  | 'subtle';
 
 export interface BodyLargeProps extends HTMLAttributes<HTMLParagraphElement> {
   /**
@@ -45,6 +53,40 @@ const baseStyles = ({ theme }: StyleProps) => css`
 `;
 
 const variantStyles = ({ theme, variant }: BodyLargeProps & StyleProps) => {
+  // TODO: remove the legacy variants and this switch statement in v5
+  /* eslint-disable no-param-reassign */
+  switch (variant) {
+    case 'success':
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        process.env.NODE_ENV !== 'test'
+      ) {
+        deprecate(
+          'BodyLarge',
+          "The BodyLarge's `success` variant is deprecated.",
+          'Use the `confirm` variant instead.',
+        );
+      }
+      variant = 'confirm';
+      break;
+    case 'error':
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        process.env.NODE_ENV !== 'test'
+      ) {
+        deprecate(
+          'BodyLarge',
+          "The BodyLarge's `error` variant is deprecated.",
+          'Use the `alert` variant instead.',
+        );
+      }
+      variant = 'alert';
+      break;
+    default:
+      break;
+  }
+  /* eslint-enable no-param-reassign */
+
   switch (variant) {
     default: {
       return null;
@@ -61,12 +103,12 @@ const variantStyles = ({ theme, variant }: BodyLargeProps & StyleProps) => {
         border-left: ${theme.borderWidth.mega} solid ${theme.colors.p500};
       `;
     }
-    case 'success': {
+    case 'confirm': {
       return css`
         color: ${theme.colors.confirm};
       `;
     }
-    case 'error': {
+    case 'alert': {
       return css`
         color: ${theme.colors.alert};
       `;

--- a/packages/circuit-ui/components/BodyLarge/__snapshots__/BodyLarge.spec.tsx.snap
+++ b/packages/circuit-ui/components/BodyLarge/__snapshots__/BodyLarge.spec.tsx.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BodyLarge should render as a "alert" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 28px;
+  color: #D23F47;
+}
+
+<p
+  class="circuit-0"
+>
+  alert
+   BodyLarge
+</p>
+`;
+
+exports[`BodyLarge should render as a "confirm" variant 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 28px;
+  color: #138849;
+}
+
+<p
+  class="circuit-0"
+>
+  confirm
+   BodyLarge
+</p>
+`;
+
 exports[`BodyLarge should render as a "error" variant 1`] = `
 .circuit-0 {
   font-weight: 400;

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
@@ -121,7 +121,7 @@ export const InlineMessage = ({
       'InlineMessage',
       'The InlineMessage component is deprecated.',
       'Use the `NotificationInline` component instead.',
-      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5',
+      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#notification-components',
     );
   }
   return <InlineMessageStyles {...props} />;

--- a/packages/circuit-ui/components/ListItem/__snapshots__/ListItem.spec.tsx.snap
+++ b/packages/circuit-ui/components/ListItem/__snapshots__/ListItem.spec.tsx.snap
@@ -1058,7 +1058,7 @@ exports[`ListItem styles should render a ListItem with a custom suffix 1`] = `
   text-align: center;
   letter-spacing: 0.25px;
   background-color: #CA58FF;
-  color: #1A1A1A;
+  color: #FFF;
 }
 
 <div

--- a/packages/circuit-ui/components/ListItem/__snapshots__/ListItem.spec.tsx.snap
+++ b/packages/circuit-ui/components/ListItem/__snapshots__/ListItem.spec.tsx.snap
@@ -1058,7 +1058,7 @@ exports[`ListItem styles should render a ListItem with a custom suffix 1`] = `
   text-align: center;
   letter-spacing: 0.25px;
   background-color: #CA58FF;
-  color: #FFF;
+  color: #1A1A1A;
 }
 
 <div

--- a/packages/circuit-ui/components/Notification/Notification.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.tsx
@@ -105,7 +105,7 @@ export const Notification = ({
       'Notification',
       'The Notification component is deprecated.',
       'Use one of the new notification components instead',
-      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5',
+      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#notification-components',
     );
   }
 

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.docs.mdx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.docs.mdx
@@ -5,10 +5,10 @@ import { NotificationBanner } from '@sumup/circuit-ui';
 
 <Status.Stable />
 
+The notification banner component prominently communicates and promotes high-level, site-wide information to the user.
+
 <Story id="notification-notificationbanner--base" />
 <Props />
-
-The notification banner component prominently communicates and promotes high-level, site-wide information to the user.
 
 ## When to use it
 

--- a/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
+++ b/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
@@ -57,7 +57,7 @@ export const NotificationCard = ({
       'NotificationCard',
       'The NotificationCard component is deprecated.',
       'Use one of the new notification components instead',
-      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5',
+      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#notification-components',
     );
   }
   return (

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.docs.mdx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.docs.mdx
@@ -5,10 +5,10 @@ import { NotificationFullscreen } from '@sumup/circuit-ui';
 
 <Status.Stable />
 
+The NotificationFullscreen component provides important information or feedback as part of a process flow.
+
 <Story id="notification-notificationfullscreen--base" />
 <Props />
-
-The NotificationFullscreen component provides important information or feedback as part of a process flow.
 
 ## When to use it
 

--- a/packages/circuit-ui/components/NotificationList/NotificationList.tsx
+++ b/packages/circuit-ui/components/NotificationList/NotificationList.tsx
@@ -81,7 +81,7 @@ export const NotificationList = ({
       'NotificationList',
       'The NotificationList component is deprecated.',
       'Use one of the new notification components instead',
-      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#from-v4-to-v5',
+      'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#notification-components',
     );
   }
   return (

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.docs.mdx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.docs.mdx
@@ -5,10 +5,10 @@ import { NotificationModal } from '@sumup/circuit-ui';
 
 <Status.Stable />
 
+The notification modal component communicates critical information while blocking everything else on the page, and needs the user's attention or action to proceed.
+
 <Story id="notification-notificationmodal--base" />
 <Props />
-
-The notification modal component communicates critical information while blocking everything else on the page, and needs the user's attention or action to proceed.
 
 ## When to use it
 

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
@@ -94,7 +94,7 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   text-align: center;
   letter-spacing: 0.25px;
   background-color: #CA58FF;
-  color: #FFF;
+  color: #1A1A1A;
 }
 
 .circuit-9 {

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
@@ -94,7 +94,7 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   text-align: center;
   letter-spacing: 0.25px;
   background-color: #CA58FF;
-  color: #1A1A1A;
+  color: #FFF;
 }
 
 .circuit-9 {


### PR DESCRIPTION
Follows up on #1431 

## Purpose

Adds the new semantic variant names (see #1431) to the `Badge`, `Body` and `BodyLarge` components.

## Approach and changes

- add the new variant names, remap legacy variant names to use them under the hood
- deprecate old variant names (via a warning in the console, I [tried to](https://www.typescriptlang.org/play?#code/PTAEEkDtQFgOgAygC4AsCmoBSBlAIgPYDGKAhgOagACAJugA4BO6Rpy6NoAlgM6ik06nZARQYAsACgQKAJ71MPWT3YBbOKACaBAK6hW0HT0y0GzVu06lIsgO4ZmUmbN37roI5lyESRHY2ZIZAAbWTgpKS4g9EYAM1IiTAAhAXJMAG8pUFAAN1JGLmtkAC4s7NBgACpKsvLK6jomFjYOD2MxTCICSFiuRlVc-MKg7kgVdAFa7MrgKYAfUAAiHh0iRJ4eRfmlrp6+1UWAbikAXwjJOiJg-M7ulVAAI1T0YtAUmjTjySeP9Dg8gpFUAAXiWKzW6A2R3OMgAKvJ0DgiAV6MhQLYuMFgqACLFYjF+KBIN0ALQPYLEADWUUotnykBp6Iw0FITjAjXMLU4TAICkYyFk3D4CXWxhoABp+JBOBwuCJGHxglxKeg2bkeF06OjMdjPKAeKgCLYOqAOc1LKNYqIoqB6Nd1mqlSrRuwsbx0GN0JLdCEopCpZwbS5-PoCHRwpIgA) deprecate the specific prop values using JSDoc but it didn't work)
- 💙 increase contrast of the `promo` Badge. [Old contrast](https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=CA58FF) (3.3:1, AA violation ⚠️), [new contrast](https://webaim.org/resources/contrastchecker/?fcolor=1A1A1A&bcolor=CA58FF) (5.26:1, AA pass ✅ )
- added an entry to the pre-v5 migration guide

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
