### PR TITLE
Add missing closeButtonLabel to the NotificationModal story

### DIFF
--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
@@ -65,4 +65,5 @@ Base.args = {
       onClick: action('secondary'),
     },
   },
+  closeButtonLabel: 'Close',
 };


### PR DESCRIPTION
## Purpose

As title suggests

## Approach and changes

- add the missing `closeButtonLabel` to the story's default args (required unless `preventClose` is set)

*Note: it looks like the [conditional types](https://github.com/sumup-oss/circuit-ui/blob/d08ad5652a606649f417b25e37cdc9c9e12a531d/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx#L35) aren't working since we were not getting a TS error for this. I'll look into it, any experience using TS conditional types welcome* 🙌

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
