### PR TITLE
Add alignment for NotificationBanner image

### DIFF
--- a/.changeset/poor-houses-collect.md
+++ b/.changeset/poor-houses-collect.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a prop to change the alignment of the NotificationBanner image.

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.spec.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.spec.tsx
@@ -55,6 +55,20 @@ describe('NotificationBanner', () => {
       });
       expect(container).toMatchSnapshot();
     });
+
+    it('should change the alignment of the image', () => {
+      const { container } = renderNotificationBanner({
+        ...baseProps,
+        variant: 'promotional',
+        image: {
+          ...baseProps.image,
+          align: 'bottom',
+        },
+      });
+      expect(container.querySelector('img')).toHaveStyle(
+        'object-position: bottom',
+      );
+    });
   });
 
   /**

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -57,6 +57,13 @@ type CloseProps =
     }
   | { onClose?: never; closeButtonLabel?: never };
 
+interface NotificationImageProps extends ImageProps {
+  /**
+   * Align the image to one side of its container. Default: `center`.
+   */
+  align?: 'top' | 'left' | 'bottom' | 'right';
+}
+
 interface BaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'action'> {
   /**
    * Use the `system` variant for system notification use cases, otherwise,
@@ -67,7 +74,7 @@ interface BaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'action'> {
    * Optional image to communicate message. The image container width is
    * adjustable.
    */
-  image?: ImageProps;
+  image?: NotificationImageProps;
   /**
    * Optional notification headline to communicate a message.
    */
@@ -172,12 +179,13 @@ const ResponsiveButton = styled(Button)(buttonStyles);
 const imageStyles = ({
   theme,
   image,
-}: { image: ImageProps } & StyleProps) => css`
+}: { image: NotificationImageProps } & StyleProps) => css`
   border-radius: 0 ${theme.borderRadius.mega} ${theme.borderRadius.mega} 0;
   min-width: 0;
   width: ${image.width || '200'}px;
   height: auto;
   object-fit: contain;
+  object-position: ${image.align || 'center'};
 `;
 
 const StyledImage = styled(Image)(imageStyles);
@@ -254,11 +262,7 @@ export function NotificationBanner({
         <ResponsiveButton {...action} />
       </Content>
       {image && image.src && (
-        <StyledImage
-          alt={image.alt}
-          src={image.src}
-          image={image}
-        ></StyledImage>
+        <StyledImage alt={image.alt} src={image.src} image={image} />
       )}
       {onClose && closeButtonLabel && (
         <StyledCloseButton

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -178,14 +178,15 @@ const ResponsiveButton = styled(Button)(buttonStyles);
 
 const imageStyles = ({
   theme,
-  image,
-}: { image: NotificationImageProps } & StyleProps) => css`
+  width,
+  align,
+}: NotificationImageProps & StyleProps) => css`
   border-radius: 0 ${theme.borderRadius.mega} ${theme.borderRadius.mega} 0;
   min-width: 0;
-  width: ${image.width || '200'}px;
+  width: ${width || 200}px;
   height: auto;
   object-fit: contain;
-  object-position: ${image.align || 'center'};
+  object-position: ${align || 'center'};
 `;
 
 const StyledImage = styled(Image)(imageStyles);
@@ -261,9 +262,7 @@ export function NotificationBanner({
         <ResponsiveBody noMargin>{body}</ResponsiveBody>
         <ResponsiveButton {...action} />
       </Content>
-      {image && image.src && (
-        <StyledImage alt={image.alt} src={image.src} image={image} />
-      )}
+      {image && image.src && <StyledImage {...image} />}
       {onClose && closeButtonLabel && (
         <StyledCloseButton
           notificationVariant={variant}

--- a/packages/circuit-ui/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
@@ -264,6 +264,7 @@ exports[`NotificationBanner styles should render a promotional banner 1`] = `
       alt="Update"
       class="circuit-8"
       src="/images/software_update.png"
+      width="100"
     />
   </div>
 </div>
@@ -533,6 +534,7 @@ exports[`NotificationBanner styles should render with default styles 1`] = `
       alt="Update"
       class="circuit-8"
       src="/images/software_update.png"
+      width="100"
     />
   </div>
 </div>

--- a/packages/circuit-ui/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
@@ -222,6 +222,7 @@ exports[`NotificationBanner styles should render a promotional banner 1`] = `
   width: 100px;
   height: auto;
   object-fit: contain;
+  object-position: center;
 }
 
 <div>
@@ -490,6 +491,7 @@ exports[`NotificationBanner styles should render with default styles 1`] = `
   width: 100px;
   height: auto;
   object-fit: contain;
+  object-position: center;
 }
 
 <div>


### PR DESCRIPTION
## Purpose

The refer-a-friend banner on the dashboard uses an illustration that needs to be aligned to the bottom of the banner: 

<img width="801" alt="Screenshot 2022-02-23 at 13 56 15" src="https://user-images.githubusercontent.com/11017722/155323521-f1b62db7-3e6d-40f0-8b88-ee020b662c8d.png">

## Approach and changes

- Add an `align` property to the NotificationBanner's `image` prop

I didn't add any documentation or stories since it's a pretty advanced use case. Let me know if you think I should add some.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
