### PR TITLE
Fix prop types of the InlineMessage component

### DIFF
--- a/.changeset/giant-bees-accept.md
+++ b/.changeset/giant-bees-accept.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the prop types of the InlineMessage to include the default HTML attributes."

--- a/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
+++ b/packages/circuit-ui/components/InlineMessage/InlineMessage.tsx
@@ -14,13 +14,15 @@
  */
 
 import { css } from '@emotion/react';
+import { HTMLAttributes } from 'react';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { deprecate } from '../../util/logger';
 
 type Variant = 'danger' | 'success' | 'warning';
 
-export interface InlineMessageProps {
+export interface InlineMessageProps
+  extends HTMLAttributes<HTMLParagraphElement> {
   /**
    * Indicates the color of the left border and text in the message.
    */
@@ -99,7 +101,7 @@ const successStyles = createLeftBorderStyles('success');
 const warningStyles = createLeftBorderStyles('warning');
 const dangerStyles = createLeftBorderStyles('danger');
 
-export const InlineMessageStyles = styled('p')<InlineMessageProps>(
+export const InlineMessageStyled = styled('p')<InlineMessageProps>(
   dangerStyles,
   successStyles,
   warningStyles,
@@ -110,9 +112,7 @@ export const InlineMessageStyles = styled('p')<InlineMessageProps>(
  * @deprecated — Use the new NotificationInline component instead.
  * An inline message displayed inside a Card.
  */
-export const InlineMessage = ({
-  ...props
-}: InlineMessageProps): JSX.Element => {
+export const InlineMessage = (props: InlineMessageProps): JSX.Element => {
   if (
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'
@@ -124,5 +124,5 @@ export const InlineMessage = ({
       'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#notification-components',
     );
   }
-  return <InlineMessageStyles {...props} />;
+  return <InlineMessageStyled {...props} />;
 };

--- a/packages/circuit-ui/components/Notification/Notification.tsx
+++ b/packages/circuit-ui/components/Notification/Notification.tsx
@@ -84,7 +84,7 @@ const StyledCloseButton =
   styled(CloseButton)<CloseButtonProps>(closeButtonStyles);
 
 /**
- * @deprecated
+ * @deprecated – Use one of the new notification components instead.
  * A Notification component for alerts, updates and notifications.
  */
 export const Notification = ({
@@ -104,7 +104,7 @@ export const Notification = ({
     deprecate(
       'Notification',
       'The Notification component is deprecated.',
-      'Use one of the new notification components instead',
+      'Use one of the new notification components instead.',
       'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#notification-components',
     );
   }

--- a/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
+++ b/packages/circuit-ui/components/NotificationCard/NotificationCard.tsx
@@ -42,7 +42,7 @@ const innerStyles = ({ theme }: StyleProps) => css`
 const NotificationCardInner = styled('div')(innerStyles);
 
 /**
- * @deprecated
+ * @deprecated – Use one of the new notification components instead.
  * NotificationCard displays a persistent Notification.
  */
 export const NotificationCard = ({
@@ -56,7 +56,7 @@ export const NotificationCard = ({
     deprecate(
       'NotificationCard',
       'The NotificationCard component is deprecated.',
-      'Use one of the new notification components instead',
+      'Use one of the new notification components instead.',
       'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#notification-components',
     );
   }

--- a/packages/circuit-ui/components/NotificationList/NotificationList.tsx
+++ b/packages/circuit-ui/components/NotificationList/NotificationList.tsx
@@ -66,7 +66,7 @@ const cardStyles = ({ theme }: StyleProps) => css`
 const NotificationListCard = styled('li')<NoTheme>(cardStyles, shadow());
 
 /**
- * @deprecated
+ * @deprecated – Use one of the new notification components instead.
  * NotificationList displays Notifications as Cards in a corner.
  */
 export const NotificationList = ({
@@ -80,7 +80,7 @@ export const NotificationList = ({
     deprecate(
       'NotificationList',
       'The NotificationList component is deprecated.',
-      'Use one of the new notification components instead',
+      'Use one of the new notification components instead.',
       'Refer to the migration guide: https://github.com/sumup-oss/circuit-ui/MIGRATION.md/#notification-components',
     );
   }


### PR DESCRIPTION
Addresses #ticket-number.

## Purpose

In #1437, the prop types for the InlineMessage were narrowed accidentally. Previously, the styled component was exported directly, which merged the custom prop types with the default HTML attributes of the element. In order to deprecate the component, it was wrapped in a function component that missed the default HTML attributes. This caused errors when passing `children` to the component.

## Approach and changes

- Extend the prop types with the default HTML attributes
- Polish some of the deprecation messages

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
