### PR TITLE
Fix NavLink onClick errors when disabled

### DIFF
--- a/.changeset/clean-laws-perform.md
+++ b/.changeset/clean-laws-perform.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Fixed a runtime error occurring when users click on a disabled NavItem with an onClick handler
+Fixed a runtime error that occurred when users click on a disabled item in the `Sidebar` with an `onClick` handler.

--- a/.changeset/clean-laws-perform.md
+++ b/.changeset/clean-laws-perform.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fix a runtime error occurring when users click on a disabled NavItem with an onClick handler

--- a/.changeset/clean-laws-perform.md
+++ b/.changeset/clean-laws-perform.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Fix a runtime error occurring when users click on a disabled NavItem with an onClick handler
+Fixed a runtime error occurring when users click on a disabled NavItem with an onClick handler

--- a/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.spec.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.spec.tsx
@@ -13,7 +13,13 @@
  * limitations under the License.
  */
 
-import { create, render, renderToHtml, axe } from '../../../../util/test-utils';
+import {
+  create,
+  screen,
+  render,
+  renderToHtml,
+  axe,
+} from '../../../../util/test-utils';
 import { NavList } from '../NavList';
 
 import { NavItem } from './NavItem';
@@ -62,6 +68,25 @@ describe('NavItem', () => {
       );
       const iconEl = getByTestId('icon');
       expect(iconEl).not.toBeNull();
+    });
+  });
+
+  describe('when disabled', () => {
+    it('should ignore clicks', () => {
+      const label = 'Disabled';
+      const mockOnClick = jest.fn();
+      render(
+        <NavItem
+          disabled={true}
+          onClick={mockOnClick}
+          secondary={false}
+          label={label}
+          selected={false}
+        />,
+      );
+
+      screen.getByText(label).click();
+      expect(mockOnClick).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.tsx
@@ -145,7 +145,6 @@ export function NavItem({
     >
       <NavLink
         as={Link}
-        // @ts-expect-error It's okay if onClick is undefined.
         onClick={!disabled ? handleClick : undefined}
         selected={selected}
         secondary={secondary}

--- a/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.tsx
@@ -146,7 +146,7 @@ export function NavItem({
       <NavLink
         as={Link}
         // @ts-expect-error It's okay if onClick is undefined.
-        onClick={!disabled && handleClick}
+        onClick={!disabled ? handleClick : undefined}
         selected={selected}
         secondary={secondary}
         visible={visible}


### PR DESCRIPTION
## Purpose

When using `NavLink` and setting `disabled={true}`, the onClick behavior causes a runtime error because React does not remove the `onClick` prop, which has the value `false`. Instead the prop is executed as a function with `.apply()` causing the runtime error, which is not defined on a boolean.

Next.js warns about this in the development console.

## Approach and changes

Apply the fix recommended by Next.js so that the `onClick` prop is `undefined` instead of `false`.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
