### PR TITLE
Remove direct dependency on chalk

### DIFF
--- a/packages/circuit-ui/cli/migrate/icons-v2.ts
+++ b/packages/circuit-ui/cli/migrate/icons-v2.ts
@@ -281,7 +281,7 @@ function handleIconRenamed(
   }
 
   if (productName) {
-    console.log(
+    console.warn(
       [
         `The "${oldIconName}" icon has been renamed to "${newIconName}",`,
         `and should only be used in the context of the ${productName}`,
@@ -316,7 +316,7 @@ function handleIconRemoved(
   if (legacyIconImport) {
     const defaultMessage =
       'Copy it locally to finish the migration, and request a new icon from the Design System team.';
-    console.log(
+    console.error(
       [
         `The "${oldIconName}" icon has been removed.`,
         customMessage || defaultMessage,
@@ -368,7 +368,7 @@ function handleIconDefaultSize(
           ];
 
           if (hasSize16 && !hasSmallIcon) {
-            console.log(
+            console.error(
               [
                 `The 16px size of the "${i.local}" icon has been removed.`,
                 ...actionMessage,
@@ -376,7 +376,7 @@ function handleIconDefaultSize(
             );
           }
           if (hasImplicitSize16 && !hasSmallIcon) {
-            console.log(
+            console.error(
               [
                 `The default size of the "${i.local}" icon changed from 16px to 24px.`,
                 ...actionMessage,

--- a/packages/circuit-ui/cli/migrate/icons-v2.ts
+++ b/packages/circuit-ui/cli/migrate/icons-v2.ts
@@ -21,7 +21,6 @@ import {
   StringLiteral,
   JSXIdentifier,
 } from 'jscodeshift';
-import chalk from 'chalk';
 
 import { findImportsByPath, findStyledComponentNames } from './utils';
 
@@ -283,16 +282,14 @@ function handleIconRenamed(
 
   if (productName) {
     console.log(
-      chalk.yellow(
-        [
-          `The "${oldIconName}" icon has been renamed to "${newIconName}",`,
-          `and should only be used in the context of the ${productName}`,
-          'product/feature.',
-          'If you have doubts about your use of the icon, file an issue or',
-          'contact the Design System team.',
-          `\nin ${filePath}`,
-        ].join(' '),
-      ),
+      [
+        `The "${oldIconName}" icon has been renamed to "${newIconName}",`,
+        `and should only be used in the context of the ${productName}`,
+        'product/feature.',
+        'If you have doubts about your use of the icon, file an issue or',
+        'contact the Design System team.',
+        `\nin ${filePath}`,
+      ].join(' '),
     );
   }
 
@@ -320,13 +317,11 @@ function handleIconRemoved(
     const defaultMessage =
       'Copy it locally to finish the migration, and request a new icon from the Design System team.';
     console.log(
-      chalk.red(
-        [
-          `The "${oldIconName}" icon has been removed.`,
-          customMessage || defaultMessage,
-          `\nin ${filePath}`,
-        ].join(' '),
-      ),
+      [
+        `The "${oldIconName}" icon has been removed.`,
+        customMessage || defaultMessage,
+        `\nin ${filePath}`,
+      ].join(' '),
     );
   }
 }
@@ -374,22 +369,18 @@ function handleIconDefaultSize(
 
           if (hasSize16 && !hasSmallIcon) {
             console.log(
-              chalk.red(
-                [
-                  `The 16px size of the "${i.local}" icon has been removed.`,
-                  ...actionMessage,
-                ].join(' '),
-              ),
+              [
+                `The 16px size of the "${i.local}" icon has been removed.`,
+                ...actionMessage,
+              ].join(' '),
             );
           }
           if (hasImplicitSize16 && !hasSmallIcon) {
             console.log(
-              chalk.red(
-                [
-                  `The default size of the "${i.local}" icon changed from 16px to 24px.`,
-                  ...actionMessage,
-                ].join(' '),
-              ),
+              [
+                `The default size of the "${i.local}" icon changed from 16px to 24px.`,
+                ...actionMessage,
+              ].join(' '),
             );
           }
           return false;

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.9.2",
-    "chalk": "^4.1.2",
     "cross-spawn": "^7.0.3",
     "jscodeshift": "^0.13.0",
     "lodash": "^4.17.11",
@@ -73,7 +72,6 @@
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.0",
     "@types/react-modal": "^3.10.5",
-    "chalk": "^4.1.2",
     "component-playground": "^3.2.1",
     "cross-env": "^7.0.2",
     "css-loader": "^6.6.0",


### PR DESCRIPTION
As mentioned in #1458 

## Purpose

Removes Circuit's direct dependency on `chalk`. The package was only being used in one codemod for the [v2 icons migration (part of Circuit UI v4)](https://github.com/sumup-oss/circuit-ui/blob/main/MIGRATION.md#new-brand-icons).

> But won't that make the v4 migration's DX less good?

It will remove coloring from the console output, yes. However:

1. most apps should be migrated by now
2. someone could still migrate to `4.0.0` to use the codemod with coloring, before migrating to the latest v4

Alternatively, we could also wait for v5 to be released before applying this change, since we don't support migrations that skip major versions. So by removing chalk only in v5, all v4 versions would include A v3-to-v4 codemod with colors. Happy to hear your thoughts here.

## Approach and changes

☝️ 

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
