### PR TITLE
Fix item selection in SidePanel storybook

### DIFF
--- a/packages/circuit-ui/components/SidePanel/SidePanel.stories.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.stories.tsx
@@ -153,12 +153,12 @@ const ComponentWithSidePanel = (props) => {
         variant: 'navigation',
         selected: item.key === selectedItem,
         onClick: () => {
-          setSelectedItem(item.key);
           setSidePanel({
             ...props,
             children: <DefaultChildren label={item.label} showMoreInfo />,
             onClose: () => setSelectedItem(null),
           });
+          setSelectedItem(item.key);
         },
       }))}
       label="Select an item to open its details in a side panel"


### PR DESCRIPTION
## Purpose

Selecting items from the ListItemGroup in the SidePanel Base story works only for the first selection.

## Approach and changes

Moving `setSelectedItem` after `setSidePanel` ensures that `onClose: () => setSelectedItem(null)` is executed before `setSelectedItem(item.key)`.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
