### PR TITLE
Add Share_16 icon

### DIFF
--- a/.changeset/chilled-cameras-hug.md
+++ b/.changeset/chilled-cameras-hug.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': minor
+---
+
+Add a 16px Share Icon

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -201,6 +201,11 @@
       "size": "24"
     },
     {
+      "name": "share",
+      "category": "Action",
+      "size": "16"
+    },
+    {
       "name": "upload",
       "category": "Action",
       "size": "24"

--- a/packages/icons/web/v2/share_16.svg
+++ b/packages/icons/web/v2/share_16.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#share_16_svg__a)">
+        <path d="M13 6a3 3 0 1 0-2.977-2.63l-4.94 2.47a3 3 0 1 0 0 4.319l4.94 2.47a3 3 0 1 0 .895-1.789l-4.94-2.47a3.031 3.031 0 0 0 0-.74l4.94-2.47C11.456 5.68 12.19 6 13 6Z" fill="#000"/>
+    </g>
+    <defs>
+        <clipPath id="share_16_svg__a">
+            <path fill="#fff" d="M0 0h16v16H0z"/>
+        </clipPath>
+    </defs>
+</svg>

--- a/packages/icons/web/v2/share_16.svg
+++ b/packages/icons/web/v2/share_16.svg
@@ -1,10 +1,3 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <g clip-path="url(#share_16_svg__a)">
-        <path d="M13 6a3 3 0 1 0-2.977-2.63l-4.94 2.47a3 3 0 1 0 0 4.319l4.94 2.47a3 3 0 1 0 .895-1.789l-4.94-2.47a3.031 3.031 0 0 0 0-.74l4.94-2.47C11.456 5.68 12.19 6 13 6Z" fill="#000"/>
-    </g>
-    <defs>
-        <clipPath id="share_16_svg__a">
-            <path fill="#fff" d="M0 0h16v16H0z"/>
-        </clipPath>
-    </defs>
+    <path d="M13 6a3 3 0 1 0-2.977-2.63l-4.94 2.47a3 3 0 1 0 0 4.319l4.94 2.47a3 3 0 1 0 .895-1.789l-4.94-2.47c.03-.246.03-.494 0-.74l4.94-2.47C11.456 5.68 12.19 6 13 6Z" fill="currentColor"/>
 </svg>


### PR DESCRIPTION
## Purpose

_Add a new Share icon size that is needed for the new Z-Reports_

<img width="231" alt="Screenshot 2022-03-02 at 19 55 27" src="https://user-images.githubusercontent.com/98822962/156429337-54965894-1512-49be-8f71-fa5620eb3b6f.png">

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
