### PR TITLE
Adds optional stretch styles to ButtonGroup

### DIFF
--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
@@ -47,6 +47,10 @@ export interface ButtonGroupProps {
     primary: Action;
     secondary?: Action;
   };
+  /**
+   * Option to stretch the buttons in ButtonGroup
+   */
+  stretch?: boolean;
 }
 
 const getInlineStyles = ({ theme }: StyleProps) => css`
@@ -144,20 +148,32 @@ const ActionsWrapper = styled('div')<ButtonGroupProps>(actionWrapperStyles);
  */
 export const ButtonGroup = forwardRef(
   (
-    { children, actions, ...props }: ButtonGroupProps,
+    { children, actions, stretch, ...props }: ButtonGroupProps,
     ref: ButtonGroupProps['ref'],
   ) => {
     if (actions) {
       return (
         <ActionsWrapper {...props}>
           {actions.secondary && (
-            <SecondaryButton {...actions.secondary} variant="secondary" />
+            <SecondaryButton
+              {...actions.secondary}
+              variant="secondary"
+              {...(stretch && { css: { minWidth: '100%' } })}
+            />
           )}
 
-          <Button {...actions.primary} variant="primary" />
+          <Button
+            {...actions.primary}
+            variant="primary"
+            {...(stretch && { css: { minWidth: '100%' } })}
+          />
 
           {actions.secondary && (
-            <TertiaryButton {...actions.secondary} variant="tertiary" />
+            <TertiaryButton
+              {...actions.secondary}
+              variant="tertiary"
+              {...(stretch && { css: { minWidth: '100%' } })}
+            />
           )}
         </ActionsWrapper>
       );


### PR DESCRIPTION
## Purpose

_Adds optional stretch styles to ButtonGroup_
<img width="697" alt="Screenshot 2022-03-09 at 10 26 04" src="https://user-images.githubusercontent.com/98822962/157412463-9d8e80d8-8bb9-4b70-9520-81fa5e0939f5.png">

## Approach and changes

_Passing stretch down to Button did not give the correct style. I made an optional css style that give each button `min-width: 100%`_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
