### PR TITLE
Export TOP_NAVIGATION_HEIGHT and SIDE_PANEL_WIDTH constants

### DIFF
--- a/.changeset/dull-swans-fetch.md
+++ b/.changeset/dull-swans-fetch.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Exported `TOP_NAVIGATION_HEIGHT` and `SIDE_PANEL_WIDTH` constants.

--- a/packages/circuit-ui/components/SidePanel/SidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.tsx
@@ -31,8 +31,8 @@ export const HTML_OPEN_CLASS_NAME = 'ReactModal__SidePanel__Html--open';
 export const PORTAL_CLASS_NAME = 'ReactModalPortal__SidePanel';
 export const TRANSITION_DURATION_DESKTOP = 200;
 export const TRANSITION_DURATION_MOBILE = 240;
-export const DESKTOP_WIDTH = 400;
-export const BODY_MAX_WIDTH = 480;
+export const SIDE_PANEL_WIDTH = '400px';
+export const BODY_MAX_WIDTH = '480px';
 
 export type SidePanelProps = ReactModalProps &
   Pick<
@@ -101,7 +101,7 @@ const ContentContainer = styled.div(
 
 const contentStyles = ({ theme }: StyleProps) => css`
   width: 100%;
-  max-width: ${BODY_MAX_WIDTH}px;
+  max-width: ${BODY_MAX_WIDTH};
   padding: 0 ${theme.spacings.mega};
 
   ${theme.mq.mega} {

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
@@ -36,7 +36,7 @@ import { TOP_NAVIGATION_HEIGHT } from '../TopNavigation/TopNavigation';
 import {
   SidePanel,
   SidePanelProps,
-  DESKTOP_WIDTH,
+  SIDE_PANEL_WIDTH,
   TRANSITION_DURATION_DESKTOP,
   TRANSITION_DURATION_MOBILE,
 } from './SidePanel';
@@ -132,7 +132,7 @@ const primaryContentStyles = ({
 const primaryContentResizedStyles = ({ isResized }: PrimaryContentProps) =>
   isResized &&
   css`
-    width: calc(100% - ${DESKTOP_WIDTH}px);
+    width: calc(100% - ${SIDE_PANEL_WIDTH});
   `;
 
 const PrimaryContent = styled.div(

--- a/packages/circuit-ui/components/SidePanel/components/DesktopSidePanel/DesktopSidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/DesktopSidePanel/DesktopSidePanel.tsx
@@ -19,7 +19,7 @@ import ReactModal, { Props as ReactModalProps } from 'react-modal';
 import { StackContext } from '../../../StackContext';
 import {
   SidePanelProps,
-  DESKTOP_WIDTH,
+  SIDE_PANEL_WIDTH,
   PORTAL_CLASS_NAME,
   TRANSITION_DURATION_DESKTOP,
 } from '../../SidePanel';
@@ -85,7 +85,7 @@ export const DesktopSidePanel = ({
                 top: ${top};
                 right: 0;
                 bottom: 0;
-                width: ${DESKTOP_WIDTH}px;
+                width: ${SIDE_PANEL_WIDTH};
                 z-index: ${theme.zIndex.absolute};
               }
             `}

--- a/packages/circuit-ui/components/SidePanel/index.ts
+++ b/packages/circuit-ui/components/SidePanel/index.ts
@@ -14,9 +14,8 @@
  */
 
 export { SidePanelProvider } from './SidePanelContext';
-
 export { useSidePanel } from './useSidePanel';
+export { SIDE_PANEL_WIDTH } from './SidePanel';
 
 export type { SidePanelProviderProps } from './SidePanelContext';
-
 export type { SidePanelHookProps } from './useSidePanel';

--- a/packages/circuit-ui/components/TopNavigation/index.ts
+++ b/packages/circuit-ui/components/TopNavigation/index.ts
@@ -13,6 +13,6 @@
  * limitations under the License.
  */
 
-export { TopNavigation } from './TopNavigation';
+export { TopNavigation, TOP_NAVIGATION_HEIGHT } from './TopNavigation';
 
 export type { TopNavigationProps } from './TopNavigation';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -114,7 +114,10 @@ export type { HamburgerProps } from './components/Hamburger';
 export { default as Header } from './components/Header';
 export { default as Pagination } from './components/Pagination';
 export type { PaginationProps } from './components/Pagination';
-export { TopNavigation } from './components/TopNavigation';
+export {
+  TopNavigation,
+  TOP_NAVIGATION_HEIGHT,
+} from './components/TopNavigation';
 export type { TopNavigationProps } from './components/TopNavigation';
 export { SideNavigation } from './components/SideNavigation';
 export type {
@@ -164,7 +167,11 @@ export { default as ListItem } from './components/ListItem';
 export type { ListItemProps } from './components/ListItem';
 export { default as ListItemGroup } from './components/ListItemGroup';
 export type { ListItemGroupProps } from './components/ListItemGroup';
-export { SidePanelProvider, useSidePanel } from './components/SidePanel';
+export {
+  SidePanelProvider,
+  useSidePanel,
+  SIDE_PANEL_WIDTH,
+} from './components/SidePanel';
 export type {
   SidePanelProviderProps,
   SidePanelHookProps,


### PR DESCRIPTION
## Purpose

Export `TOP_NAVIGATION_HEIGHT` and `SIDE_PANEL_WIDTH` constants in order to avoid having to redefine them when they are needed in user code.

## Approach and changes

Converted the side panel constant to a string including both the number and the unit as discussed in Slack.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
