### PR TITLE
Remove deprecated zIndex.sidebar

### DIFF
--- a/packages/circuit-ui/components/Sidebar/Sidebar.js
+++ b/packages/circuit-ui/components/Sidebar/Sidebar.js
@@ -41,7 +41,7 @@ const baseStyles = ({ theme }) => css`
   transition: transform ${theme.transitions.default};
   position: absolute;
   transform: translateX(-100%);
-  z-index: ${theme.zIndex.sidebar};
+  z-index: ${theme.zIndex.navigation};
   ${theme.mq.giga} {
     transform: translateX(0);
     position: relative;

--- a/packages/circuit-ui/components/Sidebar/components/CloseButton/CloseButton.ts
+++ b/packages/circuit-ui/components/Sidebar/components/CloseButton/CloseButton.ts
@@ -34,7 +34,7 @@ const baseStyles = ({ theme }: StyleProps) => css`
   transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
   visibility: hidden;
   opacity: 0;
-  z-index: ${theme.zIndex.sidebar};
+  z-index: ${theme.zIndex.navigation};
   ${theme.mq.giga} {
     visibility: hidden;
   }

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -202,10 +202,6 @@ export const zIndex: ZIndex = {
   tooltip: 40,
   header: 600,
   backdrop: 700,
-  /**
-   * @deprecated Use `theme.zIndex.navigation` instead.
-   */
-  sidebar: 800,
   navigation: 800,
   modal: 1000,
   toast: 1100,

--- a/packages/design-tokens/types/index.ts
+++ b/packages/design-tokens/types/index.ts
@@ -189,10 +189,6 @@ export type ZIndex = {
   tooltip: number;
   header: number;
   backdrop: number;
-  /**
-   * @deprecated Use `theme.zIndex.navigation` instead.
-   */
-  sidebar: number;
   navigation: number;
   modal: number;
   toast: number;

--- a/packages/design-tokens/utils/theme-prop-type.ts
+++ b/packages/design-tokens/utils/theme-prop-type.ts
@@ -238,7 +238,6 @@ export const themePropType = PropTypes.shape({
     tooltip: PropTypes.number.isRequired,
     header: PropTypes.number.isRequired,
     backdrop: PropTypes.number.isRequired,
-    sidebar: PropTypes.number.isRequired,
     navigation: PropTypes.number.isRequired,
     modal: PropTypes.number.isRequired,
     toast: PropTypes.number.isRequired,


### PR DESCRIPTION
## Purpose

Remove the deprecated `zIndex.sidebar` token.

## Approach and changes

- remove the deprecated `zIndex.sidebar`
- replace its use in the legacy Sidebar component by `zIndex.navigation`
- ⚠️ Note: this PR does _not_ include a codemod, because migration should be straightforward using a search and replace for `zIndex.sidebar`. This is documented in the migration guide.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
