### PR TITLE
Remove the deprecated shadow style mixins

### DIFF
--- a/.changeset/pink-maps-do.md
+++ b/.changeset/pink-maps-do.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Removed the deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins. Use the `shadow()` style mixin instead.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -135,7 +135,7 @@ Read more about the new notification components in [the Notification section in 
 
 ### Others
 
-- The deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins were removed. Use the `shadow()` style mixin instead. There is no codemod for this change: migrate manually by searching you for the deprecated style mixins in your codebase, and verify the changes visually.
+- The deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins were removed. Use the `shadow()` style mixin instead. There is no codemod for this change: migrate manually by searching for the deprecated style mixins in your codebase, and verify the changes visually.
 
 ## From v4 to v4.1
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,6 +6,7 @@
     - [In design tokens](#in-design-tokens)
     - [In component variants](#in-component-variants)
   - [Notification components](#notification-components)
+  - [Others](#others)
 - [From v4 to v4.1](#from-v4-to-v41)
   - [Combined LoadingButton and Button](#combined-loadingbutton-and-button)
 - [From v3.x to v4](#from-v3x-to-v4)
@@ -131,6 +132,10 @@ Furthermore, some patterns that were previously not supported by Circuit UI are 
 - The new `NotificationFullscreen` can replace custom full-screen messages such as error pages or empty states, for more consistency across pages.
 
 Read more about the new notification components in [the Notification section in Storybook](https://circuit.sumup.com/?path=/docs/notification).
+
+### Others
+
+- The deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins were removed. Use the `shadow()` style mixin instead. There is no codemod for this change: migrate manually by searching you for the deprecated style mixins in your codebase, and verify the changes visually.
 
 ## From v4 to v4.1
 

--- a/packages/circuit-ui/components/Tabs/__snapshots__/Tabs.spec.js.snap
+++ b/packages/circuit-ui/components/Tabs/__snapshots__/Tabs.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Tabs styles should render with default styles 1`] = `
 .circuit-0 {
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07),0 4px 4px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   -ms-overflow-style: none;
   scrollbar-width: none;
   background: #FFF;
@@ -190,7 +190,7 @@ exports[`Tabs styles should render with default styles 1`] = `
 
 exports[`Tabs styles should render with stretched styles 1`] = `
 .circuit-0 {
-  box-shadow: 0 0 0 1px rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07),0 4px 4px 0 rgba(12, 15, 20, 0.07);
+  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   -ms-overflow-style: none;
   scrollbar-width: none;
   background: #FFF;

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.js
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.js
@@ -24,7 +24,7 @@ const DEFAULT_HEIGHT = '48px';
 
 const Wrapper = styled.div(
   ({ theme }) => css`
-    ${shadow()};
+    ${shadow(theme)};
     ${hideScrollbar()}
     background: ${theme.colors.white};
     height: ${DEFAULT_HEIGHT};

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.js
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.js
@@ -17,14 +17,14 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 
-import { shadowDouble, hideScrollbar } from '../../../../styles/style-mixins';
+import { shadow, hideScrollbar } from '../../../../styles/style-mixins';
 
 const MOBILE_AUTOSTRETCH_ITEMS_MAX = 3;
 const DEFAULT_HEIGHT = '48px';
 
 const Wrapper = styled.div(
   ({ theme }) => css`
-    ${shadowDouble({ theme })};
+    ${shadow()};
     ${hideScrollbar()}
     background: ${theme.colors.white};
     height: ${DEFAULT_HEIGHT};

--- a/packages/circuit-ui/styles/style-mixins.spec.tsx
+++ b/packages/circuit-ui/styles/style-mixins.spec.tsx
@@ -22,9 +22,6 @@ import {
   cx,
   spacing,
   shadow,
-  shadowSingle,
-  shadowDouble,
-  shadowTriple,
   typography,
   disableVisually,
   hideVisually,
@@ -156,33 +153,6 @@ describe('Style helpers', () => {
       const { styles } = shadow()({ theme: light });
       expect(styles).toMatchInlineSnapshot(
         '"box-shadow:0 3px 8px 0 rgba(0, 0, 0, 0.2);label:shadow;"',
-      );
-    });
-  });
-
-  describe('shadowSingle', () => {
-    it('should match the snapshot', () => {
-      const { styles } = shadowSingle({ theme: light });
-      expect(styles).toMatchInlineSnapshot(
-        '"box-shadow:0 0 0 1px rgba(12, 15, 20, 0.07),0 0 1px 0 rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07);;label:shadowSingle;"',
-      );
-    });
-  });
-
-  describe('shadowDouble', () => {
-    it('should match the snapshot', () => {
-      const { styles } = shadowDouble({ theme: light });
-      expect(styles).toMatchInlineSnapshot(
-        '"box-shadow:0 0 0 1px rgba(12, 15, 20, 0.07),0 2px 2px 0 rgba(12, 15, 20, 0.07),0 4px 4px 0 rgba(12, 15, 20, 0.07);;label:shadowDouble;"',
-      );
-    });
-  });
-
-  describe('shadowTriple', () => {
-    it('should match the snapshot', () => {
-      const { styles } = shadowTriple({ theme: light });
-      expect(styles).toMatchInlineSnapshot(
-        '"box-shadow:0 0 0 1px rgba(12, 15, 20, 0.07),0 4px 4px 0 rgba(12, 15, 20, 0.07),0 8px 8px 0 rgba(12, 15, 20, 0.07);;label:shadowTriple;"',
       );
     });
   });

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -141,39 +141,6 @@ export function shadow(
 }
 
 /**
- * @deprecated Use the `shadow` style mixin instead.
- */
-export const shadowSingle = (args: ThemeArgs): SerializedStyles => {
-  const theme = getTheme(args);
-  return css`
-    box-shadow: 0 0 0 1px ${theme.colors.shadow},
-      0 0 1px 0 ${theme.colors.shadow}, 0 2px 2px 0 ${theme.colors.shadow};
-  `;
-};
-
-/**
- * @deprecated Use the `shadow` style mixin instead.
- */
-export const shadowDouble = (args: ThemeArgs): SerializedStyles => {
-  const theme = getTheme(args);
-  return css`
-    box-shadow: 0 0 0 1px ${theme.colors.shadow},
-      0 2px 2px 0 ${theme.colors.shadow}, 0 4px 4px 0 ${theme.colors.shadow};
-  `;
-};
-
-/**
- * @deprecated Use the `shadow` style mixin instead.
- */
-export const shadowTriple = (args: ThemeArgs): SerializedStyles => {
-  const theme = getTheme(args);
-  return css`
-    box-shadow: 0 0 0 1px ${theme.colors.shadow},
-      0 4px 4px 0 ${theme.colors.shadow}, 0 8px 8px 0 ${theme.colors.shadow};
-  `;
-};
-
-/**
  * Sets the font size and line height matching the Body component.
  */
 export function typography(


### PR DESCRIPTION
## Purpose

Remove the deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins.

## Approach and changes

- Remove the deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins
- Migrate a remaining use of shadowDouble in the TabList component to the `shadow` style mixin.
- ⚠️ Note: this PR doesn't include a codemod. The change should be verified visually, and we expect the current use of deprecated shadow mixins to be flow.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
