### PR TITLE
Throw dev-time error for noMargin prop

### DIFF
--- a/.changeset/dull-lions-shave.md
+++ b/.changeset/dull-lions-shave.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-Added `UNSAFE_DISABLE_NO_MARGIN_ERRORS` environment variable to silence noMargin errors in development when it is set to `true`.
+Threw a runtime error when the `noMargin` prop isn't passed to components requiring it. Setting the `UNSAFE_DISABLE_NO_MARGIN_ERRORS` environment variable to `true` will temporarily turn off the errors.

--- a/.changeset/dull-lions-shave.md
+++ b/.changeset/dull-lions-shave.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Added `UNSAFE_DISABLE_NO_MARGIN_ERRORS` environment variable to silence noMargin errors in development when it is set to `true`.

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -58,7 +58,15 @@ function createWebpackConfig(config) {
     }
     return rule;
   });
-
+  // Expose environment variables to Storybook
+  config.plugins = [
+    ...config.plugins,
+    new webpack.DefinePlugin({
+      'process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS': JSON.stringify(
+        process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS,
+      ),
+    }),
+  ];
   // Emotion 11
   config.resolve.alias = {
     ...config.resolve.alias,

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -7,6 +7,7 @@
     - [...in component variants](#in-component-variants)
   - [New notification components](#new-notification-components)
   - [Required accessible labels](#required-accessible-labels)
+  - [noMargin prop dev-time error](#nomargin-prop-dev-time-error)
   - [Other changes](#other-changes)
 - [From v4 to v4.1](#from-v4-to-v41)
   - [Combined LoadingButton and Button](#combined-loadingbutton-and-button)
@@ -143,6 +144,22 @@ In [Circuit UI v3](#accessibility), components requiring accessible labels start
 In v5, the workaround was removed, meaning that all components that require accessible labels expect to receive them.
 
 Before migrating, make sure that you add appropriate and localized labels for all occurrences flagged by the error mechanism. After that, stop setting the `UNSAFE_DISABLE_ACCESSIBILITY_ERRORS` environment variable.
+
+### noMargin prop dev-time error
+
+Since it require large scale changes in the apps, the noMargin prop is not removed in the v5, instead the components throw runtime errors in development at missing noMargin prop. Production and testing builds are not affected.
+
+During the migration you can use an escape hatch to continue running the app in development without throwing the noMargin prop errors.
+
+In your app, expose the `UNSAFE_DISABLE_NO_MARGIN_ERRORS` environment variable. You can use the [Webpack `DefinePlugin`](https://webpack.js.org/plugins/define-plugin/) ([here's an example](https://github.com/sumup-oss/circuit-ui/blob/main/.storybook/main.js#L45-L53) in the Circuit UI Storybook config) or, if your app uses Next.js, you can declare the variable in your `next.config.js` ([Next.js documentation](https://nextjs.org/docs/api-reference/next.config.js/environment-variables)).
+
+Now, if you want to turn off the noMargin errors temporarily, run the development app with the environment variable set to `true`:
+
+```sh
+UNSAFE_DISABLE_NO_MARGIN_ERRORS=true yarn dev # or yarn start
+```
+
+Keep in mind that this escape hatch is not meant as a way to permanently avoid the errors, but as a temporary workaround while the noMargin prop is still required.
 
 ### Other changes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -151,7 +151,7 @@ Since it require large scale changes in the apps, the noMargin prop is not remov
 
 During the migration you can use an escape hatch to continue running the app in development without throwing the noMargin prop errors.
 
-In your app, expose the `UNSAFE_DISABLE_NO_MARGIN_ERRORS` environment variable. You can use the [Webpack `DefinePlugin`](https://webpack.js.org/plugins/define-plugin/) ([here's an example](https://github.com/sumup-oss/circuit-ui/blob/main/.storybook/main.js#L45-L53) in the Circuit UI Storybook config) or, if your app uses Next.js, you can declare the variable in your `next.config.js` ([Next.js documentation](https://nextjs.org/docs/api-reference/next.config.js/environment-variables)).
+In your app, expose the `UNSAFE_DISABLE_NO_MARGIN_ERRORS` environment variable. You can use the [Webpack `DefinePlugin`](https://webpack.js.org/plugins/define-plugin/) (see the [Circuit UI Storybook Webpack config](https://github.com/sumup-oss/circuit-ui/blob/main/.storybook/main.js) as an example) or, if your app uses Next.js, you can declare the variable in your `next.config.js` ([Next.js documentation](https://nextjs.org/docs/api-reference/next.config.js/environment-variables)).
 
 Now, if you want to turn off the noMargin errors temporarily, run the development app with the environment variable set to `true`:
 

--- a/packages/circuit-ui/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
+++ b/packages/circuit-ui/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
@@ -3,10 +3,8 @@
 exports[`Anchor styles should render with custom styles 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   display: inline-block;
   -webkit-text-decoration: underline;
   text-decoration: underline;
@@ -67,10 +65,8 @@ exports[`Anchor styles should render with custom styles 1`] = `
 exports[`Anchor styles should render with default styles 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   display: inline-block;
   -webkit-text-decoration: underline;
   text-decoration: underline;

--- a/packages/circuit-ui/components/Body/Body.spec.tsx
+++ b/packages/circuit-ui/components/Body/Body.spec.tsx
@@ -22,13 +22,17 @@ describe('Body', () => {
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(<Body>Body</Body>);
+    const actual = create(<Body noMargin>Body</Body>);
     expect(actual).toMatchSnapshot();
   });
 
   const sizes: BodyProps['size'][] = ['one', 'two'];
   it.each(sizes)('should render with size "%s"', (size) => {
-    const actual = create(<Body size={size}>{size} Body</Body>);
+    const actual = create(
+      <Body noMargin size={size}>
+        {size} Body
+      </Body>,
+    );
     expect(actual).toMatchSnapshot();
   });
 
@@ -42,12 +46,16 @@ describe('Body', () => {
     'subtle',
   ] as BodyProps['variant'][];
   it.each(variants)('should render as a "%s" variant', (variant) => {
-    const actual = create(<Body variant={variant}>{variant} Body</Body>);
+    const actual = create(
+      <Body noMargin variant={variant}>
+        {variant} Body
+      </Body>,
+    );
     expect(actual).toMatchSnapshot();
   });
 
-  it('should render with no margin styles when passed the noMargin prop', () => {
-    const actual = create(<Body noMargin>noMargin Body</Body>);
+  it('should render with default spacing when there is no noMargin prop', () => {
+    const actual = create(<Body>noMargin Body</Body>);
     expect(actual).toMatchSnapshot();
   });
 
@@ -56,19 +64,31 @@ describe('Body', () => {
    */
   const elements = ['p', 'article', 'div'] as const;
   it.each(elements)('should render as a "%s" element', (as) => {
-    const { container } = render(<Body as={as}>{as} Body</Body>);
+    const { container } = render(
+      <Body noMargin as={as}>
+        {as} Body
+      </Body>,
+    );
     const actual = container.querySelector(as);
     expect(actual).toBeVisible();
   });
 
   it('should render the "highlight" variant as a "strong" element', () => {
-    const { container } = render(<Body variant="highlight">Highlight</Body>);
+    const { container } = render(
+      <Body noMargin variant="highlight">
+        Highlight
+      </Body>,
+    );
     const actual = container.querySelector('strong');
     expect(actual).toBeVisible();
   });
 
   it('should render the "quote" variant as a "blockquote" element', () => {
-    const { container } = render(<Body variant="quote">Quote</Body>);
+    const { container } = render(
+      <Body noMargin variant="quote">
+        Quote
+      </Body>,
+    );
     const actual = container.querySelector('blockquote');
     expect(actual).toBeVisible();
   });
@@ -77,7 +97,7 @@ describe('Body', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<Body>Body</Body>);
+    const wrapper = renderToHtml(<Body noMargin>Body</Body>);
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/Body/Body.spec.tsx
+++ b/packages/circuit-ui/components/Body/Body.spec.tsx
@@ -54,7 +54,7 @@ describe('Body', () => {
     expect(actual).toMatchSnapshot();
   });
 
-  it('should render with default spacing when there is no noMargin prop', () => {
+  it('should render with outer spacing when there is no noMargin prop', () => {
     const actual = create(<Body>noMargin Body</Body>);
     expect(actual).toMatchSnapshot();
   });

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -57,7 +57,6 @@ export interface BodyProps extends HTMLAttributes<HTMLParagraphElement> {
 
 const baseStyles = ({ theme }: StyleProps) => css`
   font-weight: ${theme.fontWeight.regular};
-  margin-bottom: ${theme.spacings.mega};
 `;
 
 const sizeStyles = ({ theme, size = 'one' }: BodyProps & StyleProps) => css`
@@ -134,26 +133,23 @@ const variantStyles = ({ theme, variant }: BodyProps & StyleProps) => {
   }
 };
 
-const marginStyles = ({ noMargin }: BodyProps & StyleProps) => {
+const marginStyles = ({ theme, noMargin }: BodyProps & StyleProps) => {
   if (!noMargin) {
     if (
+      process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      deprecate(
-        'Body',
-        'The default outer spacing in the Body component is deprecated.',
-        'Use the `noMargin` prop to silence this warning.',
-        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      throw new Error(
+        'The Body component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
-
-    return null;
+    return css`
+      margin-bottom: ${theme.spacings.mega};
+    `;
   }
 
-  return css`
-    margin-bottom: 0;
-  `;
+  return null;
 };
 
 const StyledBody = styled('p', {

--- a/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
+++ b/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
@@ -114,21 +114,6 @@ exports[`Body should render as a "success" variant 1`] = `
 </p>
 `;
 
-exports[`Body should render with default spacing when there is no noMargin prop 1`] = `
-.circuit-0 {
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 16px;
-}
-
-<p
-  class="circuit-0"
->
-  noMargin Body
-</p>
-`;
-
 exports[`Body should render with default styles 1`] = `
 .circuit-0 {
   font-weight: 400;
@@ -140,6 +125,21 @@ exports[`Body should render with default styles 1`] = `
   class="circuit-0"
 >
   Body
+</p>
+`;
+
+exports[`Body should render with outer spacing when there is no noMargin prop 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 24px;
+  margin-bottom: 16px;
+}
+
+<p
+  class="circuit-0"
+>
+  noMargin Body
 </p>
 `;
 

--- a/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
+++ b/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
@@ -5,7 +5,6 @@ exports[`Body should render as a "alert" variant 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   color: #D23F47;
 }
 
@@ -22,7 +21,6 @@ exports[`Body should render as a "confirm" variant 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   color: #138849;
 }
 
@@ -39,7 +37,6 @@ exports[`Body should render as a "error" variant 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   color: #D23F47;
 }
 
@@ -56,7 +53,6 @@ exports[`Body should render as a "highlight" variant 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   font-weight: 700;
 }
 
@@ -73,7 +69,6 @@ exports[`Body should render as a "quote" variant 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   font-style: italic;
   padding-left: 12px;
   border-left: 2px solid #3063E9;
@@ -92,7 +87,6 @@ exports[`Body should render as a "subtle" variant 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   color: #666;
 }
 
@@ -109,7 +103,6 @@ exports[`Body should render as a "success" variant 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   color: #138849;
 }
 
@@ -121,26 +114,12 @@ exports[`Body should render as a "success" variant 1`] = `
 </p>
 `;
 
-exports[`Body should render with default styles 1`] = `
+exports[`Body should render with default spacing when there is no noMargin prop 1`] = `
 .circuit-0 {
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
   margin-bottom: 16px;
-}
-
-<p
-  class="circuit-0"
->
-  Body
-</p>
-`;
-
-exports[`Body should render with no margin styles when passed the noMargin prop 1`] = `
-.circuit-0 {
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 24px;
 }
 
 <p
@@ -150,12 +129,25 @@ exports[`Body should render with no margin styles when passed the noMargin prop 
 </p>
 `;
 
+exports[`Body should render with default styles 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+<p
+  class="circuit-0"
+>
+  Body
+</p>
+`;
+
 exports[`Body should render with size "one" 1`] = `
 .circuit-0 {
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
 }
 
 <p
@@ -171,7 +163,6 @@ exports[`Body should render with size "two" 1`] = `
   font-weight: 400;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 16px;
 }
 
 <p

--- a/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
+++ b/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
@@ -3,9 +3,9 @@
 exports[`Body should render as a "alert" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   color: #D23F47;
 }
 
@@ -20,9 +20,9 @@ exports[`Body should render as a "alert" variant 1`] = `
 exports[`Body should render as a "confirm" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   color: #138849;
 }
 
@@ -37,9 +37,9 @@ exports[`Body should render as a "confirm" variant 1`] = `
 exports[`Body should render as a "error" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   color: #D23F47;
 }
 
@@ -54,9 +54,9 @@ exports[`Body should render as a "error" variant 1`] = `
 exports[`Body should render as a "highlight" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   font-weight: 700;
 }
 
@@ -71,9 +71,9 @@ exports[`Body should render as a "highlight" variant 1`] = `
 exports[`Body should render as a "quote" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   font-style: italic;
   padding-left: 12px;
   border-left: 2px solid #3063E9;
@@ -90,9 +90,9 @@ exports[`Body should render as a "quote" variant 1`] = `
 exports[`Body should render as a "subtle" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   color: #666;
 }
 
@@ -107,9 +107,9 @@ exports[`Body should render as a "subtle" variant 1`] = `
 exports[`Body should render as a "success" variant 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   color: #138849;
 }
 
@@ -124,9 +124,9 @@ exports[`Body should render as a "success" variant 1`] = `
 exports[`Body should render with default styles 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 <p
@@ -139,10 +139,8 @@ exports[`Body should render with default styles 1`] = `
 exports[`Body should render with no margin styles when passed the noMargin prop 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 <p
@@ -155,9 +153,9 @@ exports[`Body should render with no margin styles when passed the noMargin prop 
 exports[`Body should render with size "one" 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 <p
@@ -171,9 +169,9 @@ exports[`Body should render with size "one" 1`] = `
 exports[`Body should render with size "two" 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 16px;
 }
 
 <p

--- a/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.js.snap
+++ b/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.js.snap
@@ -226,9 +226,7 @@ exports[`Carousel styles should render with children as a function 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   font-weight: 700;
-  margin-bottom: 0;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -906,9 +904,7 @@ exports[`Carousel styles should render with children as a node 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   font-weight: 700;
-  margin-bottom: 0;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -1585,9 +1581,7 @@ exports[`Carousel styles should render with default paused styles 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   font-weight: 700;
-  margin-bottom: 0;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
@@ -2235,9 +2229,7 @@ exports[`Carousel styles should render with default styles 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   font-weight: 700;
-  margin-bottom: 0;
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;

--- a/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.js.snap
+++ b/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.js.snap
@@ -224,9 +224,9 @@ exports[`Carousel styles should render with children as a function 1`] = `
 
 .circuit-41 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   font-weight: 700;
   margin-bottom: 0;
   -webkit-flex: none;
@@ -904,9 +904,9 @@ exports[`Carousel styles should render with children as a node 1`] = `
 
 .circuit-41 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   font-weight: 700;
   margin-bottom: 0;
   -webkit-flex: none;
@@ -1583,9 +1583,9 @@ exports[`Carousel styles should render with default paused styles 1`] = `
 
 .circuit-41 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   font-weight: 700;
   margin-bottom: 0;
   -webkit-flex: none;
@@ -2233,9 +2233,9 @@ exports[`Carousel styles should render with default styles 1`] = `
 
 .circuit-41 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   font-weight: 700;
   margin-bottom: 0;
   -webkit-flex: none;

--- a/packages/circuit-ui/components/Carousel/components/Status/Status.js
+++ b/packages/circuit-ui/components/Carousel/components/Status/Status.js
@@ -21,8 +21,6 @@ import Body from '../../../Body';
 import { typography } from '../../../../styles/style-mixins';
 
 const textStyles = ({ theme }) => css`
-  margin-bottom: 0;
-
   ${theme.mq.untilKilo} {
     ${typography('two')(theme)};
   }
@@ -30,7 +28,7 @@ const textStyles = ({ theme }) => css`
 const StyledText = styled(Body)(textStyles);
 
 const Status = ({ step, total, ...props }) => (
-  <StyledText variant="highlight" {...props}>
+  <StyledText noMargin variant="highlight" {...props}>
     {step + 1} / {total}
   </StyledText>
 );

--- a/packages/circuit-ui/components/Carousel/components/Status/__snapshots__/Status.spec.js.snap
+++ b/packages/circuit-ui/components/Carousel/components/Status/__snapshots__/Status.spec.js.snap
@@ -5,9 +5,7 @@ exports[`Status styles should render with default styles 1`] = `
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
   font-weight: 700;
-  margin-bottom: 0;
 }
 
 @media (max-width: 479px) {

--- a/packages/circuit-ui/components/Carousel/components/Status/__snapshots__/Status.spec.js.snap
+++ b/packages/circuit-ui/components/Carousel/components/Status/__snapshots__/Status.spec.js.snap
@@ -3,9 +3,9 @@
 exports[`Status styles should render with default styles 1`] = `
 .circuit-1 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
   font-weight: 700;
   margin-bottom: 0;
 }

--- a/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
@@ -36,33 +36,37 @@ describe('Checkbox', () => {
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(<Checkbox {...defaultProps} />);
+    const actual = create(<Checkbox noMargin {...defaultProps} />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with checked styles when passed the checked prop', () => {
-    const actual = create(<Checkbox checked {...defaultProps} />);
+    const actual = create(<Checkbox noMargin checked {...defaultProps} />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with disabled styles when passed the disabled prop', () => {
-    const actual = create(<Checkbox disabled {...defaultProps} />);
+    const actual = create(<Checkbox noMargin disabled {...defaultProps} />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with invalid styles when passed the invalid prop', () => {
-    const actual = create(<Checkbox invalid {...defaultProps} />);
+    const actual = create(<Checkbox noMargin invalid {...defaultProps} />);
     expect(actual).toMatchSnapshot();
   });
 
-  it('should render with noMargin styles when passed the noMargin prop', () => {
-    const actual = create(<Checkbox noMargin {...defaultProps} />);
+  it('should render with default spacing when there is no noMargin prop', () => {
+    const actual = create(<Checkbox {...defaultProps} />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with a tooltip when passed a validation hint', () => {
     const actual = create(
-      <Checkbox validationHint="This field is required." {...defaultProps} />,
+      <Checkbox
+        noMargin
+        validationHint="This field is required."
+        {...defaultProps}
+      />,
     );
     expect(actual).toMatchSnapshot();
   });
@@ -72,7 +76,9 @@ describe('Checkbox', () => {
    */
   it('should be unchecked by default', () => {
     const { getByLabelText } = render(
-      <Checkbox {...defaultProps}>Label</Checkbox>,
+      <Checkbox noMargin {...defaultProps}>
+        Label
+      </Checkbox>,
     );
     const inputEl = getByLabelText('Label', {
       exact: false,
@@ -82,7 +88,9 @@ describe('Checkbox', () => {
 
   it('should call the change handler when clicked', () => {
     const { getByLabelText } = render(
-      <Checkbox {...defaultProps}>Label</Checkbox>,
+      <Checkbox noMargin {...defaultProps}>
+        Label
+      </Checkbox>,
     );
     const inputEl = getByLabelText('Label', {
       exact: false,
@@ -101,7 +109,7 @@ describe('Checkbox', () => {
      */
     it('should accept a working ref', () => {
       const tref = createRef<HTMLInputElement>();
-      const { container } = render(<Checkbox ref={tref} />);
+      const { container } = render(<Checkbox noMargin ref={tref} />);
       const checkbox = container.querySelector('input');
       expect(tref.current).toBe(checkbox);
     });
@@ -113,7 +121,9 @@ describe('Checkbox', () => {
   it('should meet accessibility guidelines', async () => {
     const wrapper = renderToHtml(
       <div>
-        <Checkbox {...defaultProps}>Label</Checkbox>
+        <Checkbox noMargin {...defaultProps}>
+          Label
+        </Checkbox>
       </div>,
     );
     const actual = await axe(wrapper);

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -70,15 +70,14 @@ const CheckboxLabel = styled('label')<LabelElProps>(
 
 type WrapperElProps = Pick<CheckboxProps, 'noMargin'>;
 
-const wrapperBaseStyles = ({ theme }: StyleProps) => css`
+const wrapperBaseStyles = () => css`
   position: relative;
-
-  &:last-of-type {
-    margin-bottom: ${theme.spacings.mega};
-  }
 `;
 
-const wrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
+const wrapperNoMarginStyles = ({
+  theme,
+  noMargin,
+}: StyleProps & WrapperElProps) => {
   if (!noMargin) {
     if (
       process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
@@ -89,14 +88,13 @@ const wrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
         'The Checkbox component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
-
-    return null;
+    return css`
+      &:last-of-type {
+        margin-bottom: ${theme.spacings.mega};
+      }
+    `;
   }
-  return css`
-    &:last-of-type {
-      margin-bottom: 0;
-    }
-  `;
+  return null;
 };
 
 const CheckboxWrapper = styled('div')<WrapperElProps>(

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -25,7 +25,6 @@ import {
 } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
-import { deprecate } from '../../util/logger';
 import Tooltip from '../Tooltip';
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -82,14 +81,12 @@ const wrapperBaseStyles = ({ theme }: StyleProps) => css`
 const wrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
   if (!noMargin) {
     if (
+      process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      deprecate(
-        'Checkbox',
-        'The default outer spacing in the Checkbox component is deprecated.',
-        'Use the `noMargin` prop to silence this warning.',
-        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      throw new Error(
+        'The Checkbox component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
 

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -5,10 +5,6 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   position: relative;
 }
 
-.circuit-0:last-of-type {
-  margin-bottom: 16px;
-}
-
 .circuit-1 {
   border: 0;
   clip: rect(0 0 0 0);
@@ -188,10 +184,6 @@ exports[`Checkbox should render with checked styles when passed the checked prop
   position: relative;
 }
 
-.circuit-0:last-of-type {
-  margin-bottom: 16px;
-}
-
 .circuit-1 {
   border: 0;
   clip: rect(0 0 0 0);
@@ -321,13 +313,146 @@ exports[`Checkbox should render with checked styles when passed the checked prop
 </div>
 `;
 
-exports[`Checkbox should render with default styles 1`] = `
+exports[`Checkbox should render with default spacing when there is no noMargin prop 1`] = `
 .circuit-0 {
   position: relative;
 }
 
 .circuit-0:last-of-type {
   margin-bottom: 16px;
+}
+
+.circuit-1 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-1+label::before {
+  height: 18px;
+  width: 18px;
+  box-sizing: border-box;
+  box-shadow: 0;
+  background-color: #FFF;
+  border: 1px solid #999;
+  border-radius: 3px;
+  content: '';
+  display: block;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%);
+  -moz-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
+}
+
+.circuit-1+label svg {
+  height: 18px;
+  width: 18px;
+  padding: 2px;
+  box-sizing: border-box;
+  color: #FFF;
+  display: block;
+  line-height: 0;
+  opacity: 0;
+  position: absolute;
+  top: 12px;
+  left: 0;
+  -webkit-transform: translateY(-50%) scale(0, 0);
+  -moz-transform: translateY(-50%) scale(0, 0);
+  -ms-transform: translateY(-50%) scale(0, 0);
+  transform: translateY(-50%) scale(0, 0);
+  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
+  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
+}
+
+.circuit-1:hover+label::before {
+  border-color: #666;
+}
+
+.circuit-1:focus+label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+  border-color: #3063E9;
+}
+
+.circuit-1:focus+label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible)+label::before {
+  box-shadow: none;
+  border-color: #999;
+}
+
+.circuit-1:checked:focus:not(:focus-visible)+label::before {
+  border-color: #3063E9;
+}
+
+.circuit-1:checked+label>svg {
+  -webkit-transform: translateY(-50%) scale(1, 1);
+  -moz-transform: translateY(-50%) scale(1, 1);
+  -ms-transform: translateY(-50%) scale(1, 1);
+  transform: translateY(-50%) scale(1, 1);
+  opacity: 1;
+}
+
+.circuit-1:checked+label::before {
+  border-color: #3063E9;
+  background-color: #3063E9;
+}
+
+.circuit-2 {
+  color: #1A1A1A;
+  display: inline-block;
+  padding-left: 26px;
+  position: relative;
+  cursor: pointer;
+}
+
+<div
+  class="circuit-0"
+>
+  <input
+    class="circuit-1"
+    id="checkbox_5"
+    name="name"
+    type="checkbox"
+    value=""
+  />
+  <label
+    class="circuit-2"
+    for="checkbox_5"
+  >
+    <svg
+      aria-hidden="true"
+      fill="none"
+      height="16"
+      viewBox="0 0 16 16"
+      width="16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
+        fill="currentColor"
+      />
+    </svg>
+  </label>
+</div>
+`;
+
+exports[`Checkbox should render with default styles 1`] = `
+.circuit-0 {
+  position: relative;
 }
 
 .circuit-1 {
@@ -461,10 +586,6 @@ exports[`Checkbox should render with default styles 1`] = `
 exports[`Checkbox should render with disabled styles when passed the disabled prop 1`] = `
 .circuit-0 {
   position: relative;
-}
-
-.circuit-0:last-of-type {
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -613,10 +734,6 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   position: relative;
 }
 
-.circuit-0:last-of-type {
-  margin-bottom: 16px;
-}
-
 .circuit-1 {
   border: 0;
   clip: rect(0 0 0 0);
@@ -742,139 +859,6 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   <label
     class="circuit-2"
     for="checkbox_4"
-  >
-    <svg
-      aria-hidden="true"
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
-        fill="currentColor"
-      />
-    </svg>
-  </label>
-</div>
-`;
-
-exports[`Checkbox should render with noMargin styles when passed the noMargin prop 1`] = `
-.circuit-0 {
-  position: relative;
-}
-
-.circuit-1 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-1+label::before {
-  height: 18px;
-  width: 18px;
-  box-sizing: border-box;
-  box-shadow: 0;
-  background-color: #FFF;
-  border: 1px solid #999;
-  border-radius: 3px;
-  content: '';
-  display: block;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-}
-
-.circuit-1+label svg {
-  height: 18px;
-  width: 18px;
-  padding: 2px;
-  box-sizing: border-box;
-  color: #FFF;
-  display: block;
-  line-height: 0;
-  opacity: 0;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%) scale(0, 0);
-  -moz-transform: translateY(-50%) scale(0, 0);
-  -ms-transform: translateY(-50%) scale(0, 0);
-  transform: translateY(-50%) scale(0, 0);
-  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
-  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
-}
-
-.circuit-1:hover+label::before {
-  border-color: #666;
-}
-
-.circuit-1:focus+label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-1:focus+label::before::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-1:focus:not(:focus-visible)+label::before {
-  box-shadow: none;
-  border-color: #999;
-}
-
-.circuit-1:checked:focus:not(:focus-visible)+label::before {
-  border-color: #3063E9;
-}
-
-.circuit-1:checked+label>svg {
-  -webkit-transform: translateY(-50%) scale(1, 1);
-  -moz-transform: translateY(-50%) scale(1, 1);
-  -ms-transform: translateY(-50%) scale(1, 1);
-  transform: translateY(-50%) scale(1, 1);
-  opacity: 1;
-}
-
-.circuit-1:checked+label::before {
-  border-color: #3063E9;
-  background-color: #3063E9;
-}
-
-.circuit-2 {
-  color: #1A1A1A;
-  display: inline-block;
-  padding-left: 26px;
-  position: relative;
-  cursor: pointer;
-}
-
-<div
-  class="circuit-0"
->
-  <input
-    class="circuit-1"
-    id="checkbox_5"
-    name="name"
-    type="checkbox"
-    value=""
-  />
-  <label
-    class="circuit-2"
-    for="checkbox_5"
   >
     <svg
       aria-hidden="true"

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -765,14 +765,6 @@ exports[`Checkbox should render with noMargin styles when passed the noMargin pr
   position: relative;
 }
 
-.circuit-0:last-of-type {
-  margin-bottom: 16px;
-}
-
-.circuit-0:last-of-type {
-  margin-bottom: 0;
-}
-
 .circuit-1 {
   border: 0;
   clip: rect(0 0 0 0);

--- a/packages/circuit-ui/components/Headline/Headline.spec.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.spec.tsx
@@ -24,7 +24,7 @@ describe('Headline', () => {
   const elements = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
   it.each(elements)('should render as %s element', (element) => {
     const headline = create(
-      <Headline as={element}>{`${element} headline`}</Headline>,
+      <Headline noMargin as={element}>{`${element} headline`}</Headline>,
     );
     expect(headline).toMatchSnapshot();
   });
@@ -32,17 +32,13 @@ describe('Headline', () => {
   const sizes = ['one', 'two', 'three', 'four'] as const;
   it.each(sizes)('should render with size %s', (size) => {
     const headline = create(
-      <Headline as="h2" {...{ size }}>{`${size} headline`}</Headline>,
+      <Headline noMargin as="h2" {...{ size }}>{`${size} headline`}</Headline>,
     );
     expect(headline).toMatchSnapshot();
   });
 
-  it('should render with no margin styles when passed the noMargin prop', () => {
-    const actual = create(
-      <Headline as="h2" noMargin>
-        Headline
-      </Headline>,
-    );
+  it('should render with default spacing when there is no noMargin prop', () => {
+    const actual = create(<Headline as="h2">Headline</Headline>);
     expect(actual).toMatchSnapshot();
   });
 
@@ -50,7 +46,11 @@ describe('Headline', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<Headline as="h2">Headline</Headline>);
+    const wrapper = renderToHtml(
+      <Headline noMargin as="h2">
+        Headline
+      </Headline>,
+    );
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -18,7 +18,6 @@ import { css } from '@emotion/react';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
-import { deprecate } from '../../util/logger';
 
 type Size = 'one' | 'two' | 'three' | 'four';
 
@@ -54,14 +53,12 @@ const sizeStyles = ({ theme, size = 'one' }: StyleProps & HeadlineProps) => css`
 const noMarginStyles = ({ noMargin }: HeadlineProps) => {
   if (!noMargin) {
     if (
+      process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      deprecate(
-        'Headline',
-        'The default outer spacing in the Headline component is deprecated.',
-        'Use the `noMargin` prop to silence this warning.',
-        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      throw new Error(
+        'The Headline component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
 

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -40,7 +40,6 @@ export interface HeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
 
 const baseStyles = ({ theme }: StyleProps) => css`
   font-weight: ${theme.fontWeight.bold};
-  margin-bottom: ${theme.spacings.giga};
   color: ${theme.colors.black};
   letter-spacing: -0.03em;
 `;
@@ -50,7 +49,7 @@ const sizeStyles = ({ theme, size = 'one' }: StyleProps & HeadlineProps) => css`
   line-height: ${theme.typography.headline[size].lineHeight};
 `;
 
-const noMarginStyles = ({ noMargin }: HeadlineProps) => {
+const noMarginStyles = ({ theme, noMargin }: StyleProps & HeadlineProps) => {
   if (!noMargin) {
     if (
       process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
@@ -62,12 +61,12 @@ const noMarginStyles = ({ noMargin }: HeadlineProps) => {
       );
     }
 
-    return null;
+    return css`
+      margin-bottom: ${theme.spacings.giga};
+    `;
   }
 
-  return css`
-    margin-bottom: 0;
-  `;
+  return null;
 };
 
 /**

--- a/packages/circuit-ui/components/Headline/__snapshots__/Headline.spec.tsx.snap
+++ b/packages/circuit-ui/components/Headline/__snapshots__/Headline.spec.tsx.snap
@@ -3,11 +3,11 @@
 exports[`Headline should render as h1 element 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
+  margin-bottom: 24px;
 }
 
 <h1
@@ -20,11 +20,11 @@ exports[`Headline should render as h1 element 1`] = `
 exports[`Headline should render as h2 element 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -37,11 +37,11 @@ exports[`Headline should render as h2 element 1`] = `
 exports[`Headline should render as h3 element 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
+  margin-bottom: 24px;
 }
 
 <h3
@@ -54,11 +54,11 @@ exports[`Headline should render as h3 element 1`] = `
 exports[`Headline should render as h4 element 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
+  margin-bottom: 24px;
 }
 
 <h4
@@ -71,11 +71,11 @@ exports[`Headline should render as h4 element 1`] = `
 exports[`Headline should render as h5 element 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
+  margin-bottom: 24px;
 }
 
 <h5
@@ -88,11 +88,11 @@ exports[`Headline should render as h5 element 1`] = `
 exports[`Headline should render as h6 element 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
+  margin-bottom: 24px;
 }
 
 <h6
@@ -105,12 +105,10 @@ exports[`Headline should render as h6 element 1`] = `
 exports[`Headline should render with no margin styles when passed the noMargin prop 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
-  margin-bottom: 0;
 }
 
 <h2
@@ -123,11 +121,11 @@ exports[`Headline should render with no margin styles when passed the noMargin p
 exports[`Headline should render with size four 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -140,11 +138,11 @@ exports[`Headline should render with size four 1`] = `
 exports[`Headline should render with size one 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -157,11 +155,11 @@ exports[`Headline should render with size one 1`] = `
 exports[`Headline should render with size three 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 20px;
   line-height: 24px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -174,11 +172,11 @@ exports[`Headline should render with size three 1`] = `
 exports[`Headline should render with size two 1`] = `
 .circuit-0 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 24px;
   line-height: 28px;
+  margin-bottom: 24px;
 }
 
 <h2

--- a/packages/circuit-ui/components/Headline/__snapshots__/Headline.spec.tsx.snap
+++ b/packages/circuit-ui/components/Headline/__snapshots__/Headline.spec.tsx.snap
@@ -7,7 +7,6 @@ exports[`Headline should render as h1 element 1`] = `
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
-  margin-bottom: 24px;
 }
 
 <h1
@@ -24,7 +23,6 @@ exports[`Headline should render as h2 element 1`] = `
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
-  margin-bottom: 24px;
 }
 
 <h2
@@ -41,7 +39,6 @@ exports[`Headline should render as h3 element 1`] = `
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
-  margin-bottom: 24px;
 }
 
 <h3
@@ -58,7 +55,6 @@ exports[`Headline should render as h4 element 1`] = `
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
-  margin-bottom: 24px;
 }
 
 <h4
@@ -75,7 +71,6 @@ exports[`Headline should render as h5 element 1`] = `
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
-  margin-bottom: 24px;
 }
 
 <h5
@@ -92,7 +87,6 @@ exports[`Headline should render as h6 element 1`] = `
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
-  margin-bottom: 24px;
 }
 
 <h6
@@ -102,13 +96,14 @@ exports[`Headline should render as h6 element 1`] = `
 </h6>
 `;
 
-exports[`Headline should render with no margin styles when passed the noMargin prop 1`] = `
+exports[`Headline should render with default spacing when there is no noMargin prop 1`] = `
 .circuit-0 {
   font-weight: 700;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
+  margin-bottom: 24px;
 }
 
 <h2
@@ -125,7 +120,6 @@ exports[`Headline should render with size four 1`] = `
   letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
-  margin-bottom: 24px;
 }
 
 <h2
@@ -142,7 +136,6 @@ exports[`Headline should render with size one 1`] = `
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
-  margin-bottom: 24px;
 }
 
 <h2
@@ -159,7 +152,6 @@ exports[`Headline should render with size three 1`] = `
   letter-spacing: -0.03em;
   font-size: 20px;
   line-height: 24px;
-  margin-bottom: 24px;
 }
 
 <h2
@@ -176,7 +168,6 @@ exports[`Headline should render with size two 1`] = `
   letter-spacing: -0.03em;
   font-size: 24px;
   line-height: 28px;
-  margin-bottom: 24px;
 }
 
 <h2

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -34,7 +34,6 @@ import { uniqueId } from '../../util/id';
 import Label from '../Label';
 import ValidationHint from '../ValidationHint';
 import { ReturnType } from '../../types/return-type';
-import { deprecate } from '../../util/logger';
 
 export type InputElement = HTMLInputElement & HTMLTextAreaElement;
 type CircuitInputHTMLAttributes = InputHTMLAttributes<HTMLInputElement> &
@@ -132,14 +131,12 @@ const labelNoMarginStyles = ({
 }: StyleProps & LabelElProps) => {
   if (!noMargin) {
     if (
+      process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      deprecate(
-        'Input',
-        'The default outer spacing in the Input component is deprecated.',
-        'Use the `noMargin` prop to silence this warning.',
-        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      throw new Error(
+        'The Input component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
 

--- a/packages/circuit-ui/components/List/List.spec.tsx
+++ b/packages/circuit-ui/components/List/List.spec.tsx
@@ -23,7 +23,7 @@ describe('List', () => {
    */
   it('should render with default styles', () => {
     const actual = create(
-      <List>
+      <List noMargin>
         <li>List</li>
       </List>,
     );
@@ -33,7 +33,7 @@ describe('List', () => {
   const variants: ListProps['variant'][] = ['ordered', 'unordered'];
   it.each(variants)('should render the %s variant', (variant) => {
     const actual = create(
-      <List variant={variant}>
+      <List noMargin variant={variant}>
         <li>{variant}</li>
       </List>,
     );
@@ -43,7 +43,7 @@ describe('List', () => {
   const sizes: ListProps['size'][] = ['one', 'two'];
   it.each(sizes)('should render with size %s', (size) => {
     const actual = create(
-      <List size={size}>
+      <List noMargin size={size}>
         <li>{size}</li>
       </List>,
     );
@@ -52,9 +52,9 @@ describe('List', () => {
 
   it('should render a nested list', () => {
     const actual = create(
-      <List>
+      <List noMargin>
         <li>First level</li>
-        <List>
+        <List noMargin>
           <li>Second level</li>
         </List>
       </List>,
@@ -62,9 +62,9 @@ describe('List', () => {
     expect(actual).toMatchSnapshot();
   });
 
-  it('should render with no margin styles when passed the noMargin prop', () => {
+  it('should render with default spacing when there is no noMargin prop', () => {
     const actual = create(
-      <List noMargin>
+      <List>
         <li>no margin</li>
       </List>,
     );
@@ -76,7 +76,7 @@ describe('List', () => {
    */
   it('should meet accessibility guidelines', async () => {
     const wrapper = renderToHtml(
-      <List>
+      <List noMargin>
         <li>List</li>
       </List>,
     );

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -69,17 +69,27 @@ const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
     li {
       margin-bottom: ${marginBottom};
       margin-left: ${marginLeft};
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
 
     ul,
     ol {
       margin-bottom: ${marginBottom};
       margin-left: ${marginLeft};
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
   `;
 };
 
-const marginStyles = ({ theme, noMargin }: StyleProps & ListProps) => {
+const marginStyles = ({
+  theme,
+  noMargin,
+  size = 'one',
+}: StyleProps & ListProps) => {
   if (!noMargin) {
     if (
       process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
@@ -90,19 +100,21 @@ const marginStyles = ({ theme, noMargin }: StyleProps & ListProps) => {
         'The List component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
+    const sizeMap = {
+      one: theme.spacings.byte,
+      two: theme.spacings.kilo,
+    };
     return css`
       margin-bottom: ${theme.spacings.mega};
+
+      li:last-child,
+      ul:last-child,
+      ol:last-child {
+        margin-bottom: ${sizeMap[size]};
+      }
     `;
   }
-  return css`
-    li:last-child {
-      margin-bottom: 0;
-    }
-    ul:last-child,
-    ol:last-child {
-      margin-bottom: 0;
-    }
-  `;
+  return null;
 };
 
 const BaseList = styled('ul', {

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -19,7 +19,6 @@ import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { typography } from '../../styles/style-mixins';
-import { deprecate } from '../../util/logger';
 
 type Size = 'one' | 'two';
 type Variant = 'ordered' | 'unordered';
@@ -45,7 +44,6 @@ export interface ListProps extends OlHTMLAttributes<HTMLOListElement> {
 
 const baseStyles = ({ theme }: StyleProps) => css`
   font-weight: ${theme.fontWeight.regular};
-  margin-bottom: ${theme.spacings.mega};
 `;
 
 const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
@@ -81,24 +79,22 @@ const sizeStyles = ({ theme, size = 'one' }: ListProps & StyleProps) => {
   `;
 };
 
-const marginStyles = ({ noMargin }: ListProps) => {
+const marginStyles = ({ theme, noMargin }: StyleProps & ListProps) => {
   if (!noMargin) {
     if (
+      process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      deprecate(
-        'List',
-        'The default outer spacing in the List component is deprecated.',
-        'Use the `noMargin` prop to silence this warning.',
-        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      throw new Error(
+        'The List component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
-
-    return null;
+    return css`
+      margin-bottom: ${theme.spacings.mega};
+    `;
   }
   return css`
-    margin-bottom: 0;
     li:last-child {
       margin-bottom: 0;
     }

--- a/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
+++ b/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
@@ -6,7 +6,6 @@ exports[`List should render a nested list 1`] = `
   padding-left: 12px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
 }
 
 .circuit-0 li {
@@ -18,6 +17,15 @@ exports[`List should render a nested list 1`] = `
 .circuit-0 ol {
   margin-bottom: 8px;
   margin-left: 12px;
+}
+
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
+.circuit-0 ul:last-child,
+.circuit-0 ol:last-child {
+  margin-bottom: 0;
 }
 
 <ul
@@ -42,7 +50,6 @@ exports[`List should render the ordered variant 1`] = `
   padding-left: 12px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 16px;
 }
 
 .circuit-0 li {
@@ -54,6 +61,15 @@ exports[`List should render the ordered variant 1`] = `
 .circuit-0 ol {
   margin-bottom: 8px;
   margin-left: 12px;
+}
+
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
+.circuit-0 ul:last-child,
+.circuit-0 ol:last-child {
+  margin-bottom: 0;
 }
 
 <ol
@@ -66,64 +82,6 @@ exports[`List should render the ordered variant 1`] = `
 `;
 
 exports[`List should render the unordered variant 1`] = `
-.circuit-0 {
-  font-weight: 400;
-  padding-left: 12px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 16px;
-}
-
-.circuit-0 li {
-  margin-bottom: 8px;
-  margin-left: 12px;
-}
-
-.circuit-0 ul,
-.circuit-0 ol {
-  margin-bottom: 8px;
-  margin-left: 12px;
-}
-
-<ul
-  class="circuit-0"
->
-  <li>
-    unordered
-  </li>
-</ul>
-`;
-
-exports[`List should render with default styles 1`] = `
-.circuit-0 {
-  font-weight: 400;
-  padding-left: 12px;
-  font-size: 16px;
-  line-height: 24px;
-  margin-bottom: 16px;
-}
-
-.circuit-0 li {
-  margin-bottom: 8px;
-  margin-left: 12px;
-}
-
-.circuit-0 ul,
-.circuit-0 ol {
-  margin-bottom: 8px;
-  margin-left: 12px;
-}
-
-<ul
-  class="circuit-0"
->
-  <li>
-    List
-  </li>
-</ul>
-`;
-
-exports[`List should render with no margin styles when passed the noMargin prop 1`] = `
 .circuit-0 {
   font-weight: 400;
   padding-left: 12px;
@@ -155,12 +113,12 @@ exports[`List should render with no margin styles when passed the noMargin prop 
   class="circuit-0"
 >
   <li>
-    no margin
+    unordered
   </li>
 </ul>
 `;
 
-exports[`List should render with size one 1`] = `
+exports[`List should render with default spacing when there is no noMargin prop 1`] = `
 .circuit-0 {
   font-weight: 400;
   padding-left: 12px;
@@ -184,6 +142,80 @@ exports[`List should render with size one 1`] = `
   class="circuit-0"
 >
   <li>
+    no margin
+  </li>
+</ul>
+`;
+
+exports[`List should render with default styles 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  padding-left: 12px;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.circuit-0 li {
+  margin-bottom: 8px;
+  margin-left: 12px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-bottom: 8px;
+  margin-left: 12px;
+}
+
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
+.circuit-0 ul:last-child,
+.circuit-0 ol:last-child {
+  margin-bottom: 0;
+}
+
+<ul
+  class="circuit-0"
+>
+  <li>
+    List
+  </li>
+</ul>
+`;
+
+exports[`List should render with size one 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  padding-left: 12px;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.circuit-0 li {
+  margin-bottom: 8px;
+  margin-left: 12px;
+}
+
+.circuit-0 ul,
+.circuit-0 ol {
+  margin-bottom: 8px;
+  margin-left: 12px;
+}
+
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
+.circuit-0 ul:last-child,
+.circuit-0 ol:last-child {
+  margin-bottom: 0;
+}
+
+<ul
+  class="circuit-0"
+>
+  <li>
     one
   </li>
 </ul>
@@ -195,7 +227,6 @@ exports[`List should render with size two 1`] = `
   padding-left: 12px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 16px;
 }
 
 .circuit-0 li {
@@ -207,6 +238,15 @@ exports[`List should render with size two 1`] = `
 .circuit-0 ol {
   margin-bottom: 12px;
   margin-left: 4px;
+}
+
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
+.circuit-0 ul:last-child,
+.circuit-0 ol:last-child {
+  margin-bottom: 0;
 }
 
 <ul

--- a/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
+++ b/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
@@ -3,10 +3,10 @@
 exports[`List should render a nested list 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 .circuit-0 li {
@@ -39,10 +39,10 @@ exports[`List should render a nested list 1`] = `
 exports[`List should render the ordered variant 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 .circuit-0 li {
@@ -68,10 +68,10 @@ exports[`List should render the ordered variant 1`] = `
 exports[`List should render the unordered variant 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 .circuit-0 li {
@@ -97,10 +97,10 @@ exports[`List should render the unordered variant 1`] = `
 exports[`List should render with default styles 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 .circuit-0 li {
@@ -126,11 +126,9 @@ exports[`List should render with default styles 1`] = `
 exports[`List should render with no margin styles when passed the noMargin prop 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-0 li {
@@ -165,10 +163,10 @@ exports[`List should render with no margin styles when passed the noMargin prop 
 exports[`List should render with size one 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 16px;
   line-height: 24px;
+  margin-bottom: 16px;
 }
 
 .circuit-0 li {
@@ -194,10 +192,10 @@ exports[`List should render with size one 1`] = `
 exports[`List should render with size two 1`] = `
 .circuit-0 {
   font-weight: 400;
-  margin-bottom: 16px;
   padding-left: 12px;
   font-size: 14px;
   line-height: 20px;
+  margin-bottom: 16px;
 }
 
 .circuit-0 li {

--- a/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
+++ b/packages/circuit-ui/components/List/__snapshots__/List.spec.tsx.snap
@@ -13,14 +13,14 @@ exports[`List should render a nested list 1`] = `
   margin-left: 12px;
 }
 
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
 .circuit-0 ul,
 .circuit-0 ol {
   margin-bottom: 8px;
   margin-left: 12px;
-}
-
-.circuit-0 li:last-child {
-  margin-bottom: 0;
 }
 
 .circuit-0 ul:last-child,
@@ -57,14 +57,14 @@ exports[`List should render the ordered variant 1`] = `
   margin-left: 12px;
 }
 
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
 .circuit-0 ul,
 .circuit-0 ol {
   margin-bottom: 8px;
   margin-left: 12px;
-}
-
-.circuit-0 li:last-child {
-  margin-bottom: 0;
 }
 
 .circuit-0 ul:last-child,
@@ -94,14 +94,14 @@ exports[`List should render the unordered variant 1`] = `
   margin-left: 12px;
 }
 
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
 .circuit-0 ul,
 .circuit-0 ol {
   margin-bottom: 8px;
   margin-left: 12px;
-}
-
-.circuit-0 li:last-child {
-  margin-bottom: 0;
 }
 
 .circuit-0 ul:last-child,
@@ -132,10 +132,25 @@ exports[`List should render with default spacing when there is no noMargin prop 
   margin-left: 12px;
 }
 
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
 .circuit-0 ul,
 .circuit-0 ol {
   margin-bottom: 8px;
   margin-left: 12px;
+}
+
+.circuit-0 ul:last-child,
+.circuit-0 ol:last-child {
+  margin-bottom: 0;
+}
+
+.circuit-0 li:last-child,
+.circuit-0 ul:last-child,
+.circuit-0 ol:last-child {
+  margin-bottom: 8px;
 }
 
 <ul
@@ -160,14 +175,14 @@ exports[`List should render with default styles 1`] = `
   margin-left: 12px;
 }
 
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
 .circuit-0 ul,
 .circuit-0 ol {
   margin-bottom: 8px;
   margin-left: 12px;
-}
-
-.circuit-0 li:last-child {
-  margin-bottom: 0;
 }
 
 .circuit-0 ul:last-child,
@@ -197,14 +212,14 @@ exports[`List should render with size one 1`] = `
   margin-left: 12px;
 }
 
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
 .circuit-0 ul,
 .circuit-0 ol {
   margin-bottom: 8px;
   margin-left: 12px;
-}
-
-.circuit-0 li:last-child {
-  margin-bottom: 0;
 }
 
 .circuit-0 ul:last-child,
@@ -234,14 +249,14 @@ exports[`List should render with size two 1`] = `
   margin-left: 4px;
 }
 
+.circuit-0 li:last-child {
+  margin-bottom: 0;
+}
+
 .circuit-0 ul,
 .circuit-0 ol {
   margin-bottom: 12px;
   margin-left: 4px;
-}
-
-.circuit-0 li:last-child {
-  margin-bottom: 0;
 }
 
 .circuit-0 ul:last-child,

--- a/packages/circuit-ui/components/ListItem/__snapshots__/ListItem.spec.tsx.snap
+++ b/packages/circuit-ui/components/ListItem/__snapshots__/ListItem.spec.tsx.snap
@@ -88,10 +88,8 @@ exports[`ListItem business logic should not render a ListItem with a suffix deta
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -205,10 +203,8 @@ exports[`ListItem business logic should not render a ListItem with both a suffix
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -332,10 +328,8 @@ exports[`ListItem business logic should render as a button when the onClick prop
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -459,10 +453,8 @@ exports[`ListItem business logic should render as a link when the href prop is p
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -577,10 +569,8 @@ exports[`ListItem styles should render a ListItem with a custom details line 1`]
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -602,10 +592,8 @@ exports[`ListItem styles should render a ListItem with a custom details line 1`]
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
 }
 
 <div
@@ -724,10 +712,8 @@ exports[`ListItem styles should render a ListItem with a custom label 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 <div
@@ -876,10 +862,8 @@ exports[`ListItem styles should render a ListItem with a custom prefix 1`] = `
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1002,10 +986,8 @@ exports[`ListItem styles should render a ListItem with a custom suffix 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1181,10 +1163,8 @@ exports[`ListItem styles should render a ListItem with a custom suffix details l
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1229,10 +1209,8 @@ exports[`ListItem styles should render a ListItem with a custom suffix details l
 
 .circuit-6 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
@@ -1251,10 +1229,8 @@ exports[`ListItem styles should render a ListItem with a custom suffix details l
 
 .circuit-8 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   color: #666;
 }
 
@@ -1387,10 +1363,8 @@ exports[`ListItem styles should render a ListItem with a custom suffix label 1`]
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1435,10 +1409,8 @@ exports[`ListItem styles should render a ListItem with a custom suffix label 1`]
 
 .circuit-6 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
@@ -1562,10 +1534,8 @@ exports[`ListItem styles should render a ListItem with a details line 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1587,10 +1557,8 @@ exports[`ListItem styles should render a ListItem with a details line 1`] = `
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   color: #666;
 }
 
@@ -1721,10 +1689,8 @@ exports[`ListItem styles should render a ListItem with a prefix icon 1`] = `
 
 .circuit-4 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1855,10 +1821,8 @@ exports[`ListItem styles should render a ListItem with a suffix details line 1`]
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1903,10 +1867,8 @@ exports[`ListItem styles should render a ListItem with a suffix details line 1`]
 
 .circuit-6 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
@@ -1925,10 +1887,8 @@ exports[`ListItem styles should render a ListItem with a suffix details line 1`]
 
 .circuit-8 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   color: #666;
 }
 
@@ -2061,10 +2021,8 @@ exports[`ListItem styles should render a ListItem with a suffix label 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -2109,10 +2067,8 @@ exports[`ListItem styles should render a ListItem with a suffix label 1`] = `
 
 .circuit-6 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
@@ -2236,10 +2192,8 @@ exports[`ListItem styles should render a disabled ListItem 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -2354,10 +2308,8 @@ exports[`ListItem styles should render a navigation variant ListItem 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -2549,10 +2501,8 @@ exports[`ListItem styles should render a selected ListItem 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -2666,10 +2616,8 @@ exports[`ListItem styles should render the action variant ListItem by default 1`
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;

--- a/packages/circuit-ui/components/ListItemGroup/__snapshots__/ListItemGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/ListItemGroup/__snapshots__/ListItemGroup.spec.tsx.snap
@@ -40,10 +40,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom detail
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -60,10 +58,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom detail
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
 }
 
 .circuit-6 {
@@ -187,10 +183,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom detail
 
 .circuit-11 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -332,10 +326,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom label 
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
 }
 
 .circuit-4 {
@@ -459,10 +451,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with a custom label 
 
 .circuit-9 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -595,10 +585,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with a details line 
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -615,10 +603,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with a details line 
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
 }
 
 .circuit-6 {
@@ -742,10 +728,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with a details line 
 
 .circuit-11 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -896,10 +880,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with a hidden label 
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1027,10 +1009,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with a hidden label 
 
 .circuit-9 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1163,10 +1143,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with interactive ite
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1309,10 +1287,8 @@ exports[`ListItemGroup styles should render a ListItemGroup with interactive ite
 
 .circuit-9 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1448,10 +1424,8 @@ exports[`ListItemGroup styles should render a plain variant ListItemGroup 1`] = 
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1581,10 +1555,8 @@ exports[`ListItemGroup styles should render a plain variant ListItemGroup 1`] = 
 
 .circuit-9 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1777,10 +1749,8 @@ exports[`ListItemGroup styles should render the focused item in a ListItemGroup 
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1846,10 +1816,8 @@ exports[`ListItemGroup styles should render the inset variant ListItemGroup by d
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -1977,10 +1945,8 @@ exports[`ListItemGroup styles should render the inset variant ListItemGroup by d
 
 .circuit-9 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -2192,10 +2158,8 @@ exports[`ListItemGroup styles should render the selected item in a ListItemGroup
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;
@@ -2348,10 +2312,8 @@ exports[`ListItemGroup styles should render the selected item in a plain ListIte
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   max-width: 100%;
   overflow-x: hidden;
   white-space: nowrap;

--- a/packages/circuit-ui/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
@@ -75,10 +75,8 @@ exports[`NotificationBanner styles should render a promotional banner 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-size: 14px;
   line-height: 20px;
   margin-bottom: 8px;
@@ -345,10 +343,8 @@ exports[`NotificationBanner styles should render with default styles 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-size: 14px;
   line-height: 20px;
   margin-bottom: 8px;

--- a/packages/circuit-ui/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationBanner/__snapshots__/NotificationBanner.spec.tsx.snap
@@ -55,12 +55,10 @@ exports[`NotificationBanner styles should render a promotional banner 1`] = `
 
 .circuit-2 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
-  margin-bottom: 0;
   font-size: 18px;
   line-height: 24px;
   margin-bottom: 8px;
@@ -323,12 +321,10 @@ exports[`NotificationBanner styles should render with default styles 1`] = `
 
 .circuit-2 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 32px;
   line-height: 36px;
-  margin-bottom: 0;
   font-size: 18px;
   line-height: 24px;
   margin-bottom: 8px;

--- a/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
@@ -44,12 +44,10 @@ exports[`NotificationFullscreen styles should render with default styles 1`] = `
 
 .circuit-2 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 24px;
   line-height: 28px;
-  margin-bottom: 0;
   margin-top: 24px;
   margin-bottom: 8px;
   text-align: center;

--- a/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
@@ -57,10 +57,8 @@ exports[`NotificationFullscreen styles should render with default styles 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   text-align: center;
 }
 

--- a/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
@@ -72,10 +72,8 @@ exports[`NotificationInline styles should render notification inline with alert 
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 <body>
@@ -194,10 +192,8 @@ exports[`NotificationInline styles should render notification inline with confir
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 <body>
@@ -316,10 +312,8 @@ exports[`NotificationInline styles should render notification inline with info s
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 <body>
@@ -455,10 +449,8 @@ exports[`NotificationInline styles should render notification inline with notify
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 <body>
@@ -595,10 +587,8 @@ exports[`NotificationInline styles should render notification toast with an acti
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-6 {
@@ -847,10 +837,8 @@ exports[`NotificationInline styles should render with default styles 1`] = `
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 <body>

--- a/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
@@ -202,12 +202,10 @@ exports[`NotificationModal styles should render with default styles 1`] = `
 
 .circuit-8 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 20px;
   line-height: 24px;
-  margin-bottom: 0;
   margin-top: 24px;
   margin-bottom: 8px;
 }

--- a/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
@@ -214,10 +214,8 @@ exports[`NotificationModal styles should render with default styles 1`] = `
 
 .circuit-9 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-10 {

--- a/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
@@ -88,10 +88,8 @@ exports[`NotificationToast styles should render notification toast with alert st
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-6 {
@@ -380,10 +378,8 @@ exports[`NotificationToast styles should render notification toast with confirm 
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-6 {
@@ -672,19 +668,15 @@ exports[`NotificationToast styles should render notification toast with headline
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
 .circuit-6 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-7 {
@@ -978,10 +970,8 @@ exports[`NotificationToast styles should render notification toast with info sty
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-6 {
@@ -1287,10 +1277,8 @@ exports[`NotificationToast styles should render notification toast with notify s
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-6 {
@@ -1581,10 +1569,8 @@ exports[`NotificationToast styles should render with default styles 1`] = `
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-6 {

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -29,7 +29,6 @@ import { ReturnType } from '../../types/return-type';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import Label from '../Label';
 import ValidationHint from '../ValidationHint';
-import { deprecate } from '../../util/logger';
 
 export type SelectOption = {
   value: string | number;
@@ -141,14 +140,12 @@ type LabelElProps = Pick<SelectProps, 'noMargin' | 'inline'>;
 const labelMarginStyles = ({ theme, noMargin }: StyleProps & LabelElProps) => {
   if (!noMargin) {
     if (
+      process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      deprecate(
-        'Select',
-        'The default outer spacing in the Select component is deprecated.',
-        'Use the `noMargin` prop to silence this warning.',
-        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      throw new Error(
+        'The Select component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
 

--- a/packages/circuit-ui/components/Selector/Selector.spec.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.spec.tsx
@@ -37,12 +37,16 @@ describe('Selector', () => {
    * Style tests.
    */
   it('should render a default selector', () => {
-    const actual = create(<Selector {...defaultProps}>Label</Selector>);
+    const actual = create(
+      <Selector noMargin {...defaultProps}>
+        Label
+      </Selector>,
+    );
     expect(actual).toMatchSnapshot();
   });
   it('should render a disabled selector', () => {
     const actual = create(
-      <Selector {...defaultProps} disabled>
+      <Selector noMargin {...defaultProps} disabled>
         Label
       </Selector>,
     );
@@ -50,32 +54,30 @@ describe('Selector', () => {
   });
   it('should render a checked selector', () => {
     const actual = create(
-      <Selector {...defaultProps} checked>
+      <Selector noMargin {...defaultProps} checked>
         Label
       </Selector>,
     );
     expect(actual).toMatchSnapshot();
   });
 
-  it('should render a noMargin selector', () => {
-    const actual = create(
-      <Selector {...defaultProps} noMargin>
-        Label
-      </Selector>,
-    );
+  it('should render a default spacing when there is no noMargin prop passed', () => {
+    const actual = create(<Selector {...defaultProps}>Label</Selector>);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render a radio input by default', () => {
     const { getByLabelText } = render(
-      <Selector {...defaultProps}>Label</Selector>,
+      <Selector noMargin {...defaultProps}>
+        Label
+      </Selector>,
     );
     expect(getByLabelText('Label')).toHaveAttribute('type', 'radio');
   });
 
   it('should render a checkbox input when multiple options can be selected', () => {
     const { getByLabelText } = render(
-      <Selector {...defaultProps} multiple>
+      <Selector noMargin {...defaultProps} multiple>
         Label
       </Selector>,
     );
@@ -87,7 +89,9 @@ describe('Selector', () => {
    */
   it('should be unchecked by default', () => {
     const { getByLabelText } = render(
-      <Selector {...defaultProps}>Label</Selector>,
+      <Selector noMargin {...defaultProps}>
+        Label
+      </Selector>,
     );
     const inputEl = getByLabelText('Label', {
       exact: false,
@@ -97,7 +101,9 @@ describe('Selector', () => {
 
   it('should call the change handler when clicked', () => {
     const { getByLabelText } = render(
-      <Selector {...defaultProps}>Label</Selector>,
+      <Selector noMargin {...defaultProps}>
+        Label
+      </Selector>,
     );
     const inputEl = getByLabelText('Label', {
       exact: false,
@@ -116,7 +122,9 @@ describe('Selector', () => {
      */
     it('should accept a working ref', () => {
       const tref = createRef<HTMLInputElement>();
-      const { container } = render(<Selector {...defaultProps} ref={tref} />);
+      const { container } = render(
+        <Selector noMargin {...defaultProps} ref={tref} />,
+      );
       const input = container.querySelector('input');
       expect(tref.current).toBe(input);
     });
@@ -126,7 +134,11 @@ describe('Selector', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<Selector {...defaultProps}>Label</Selector>);
+    const wrapper = renderToHtml(
+      <Selector noMargin {...defaultProps}>
+        Label
+      </Selector>,
+    );
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -24,7 +24,6 @@ import {
 } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
-import { deprecate } from '../../util/logger';
 
 export type SelectorSize = 'kilo' | 'mega' | 'flexible';
 
@@ -83,7 +82,6 @@ const baseStyles = ({ theme }: StyleProps) => css`
   border: none;
   border-radius: ${theme.borderRadius.byte};
   transition: box-shadow ${theme.transitions.default};
-  margin-bottom: ${theme.spacings.mega};
 
   &::before {
     display: block;
@@ -120,25 +118,23 @@ const baseStyles = ({ theme }: StyleProps) => css`
 const disabledStyles = ({ disabled }: LabelElProps) =>
   disabled && css(disableVisually());
 
-const noMarginStyles = ({ noMargin }: LabelElProps) => {
+const noMarginStyles = ({ theme, noMargin }: StyleProps & LabelElProps) => {
   if (!noMargin) {
     if (
+      process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      deprecate(
-        'Selector',
-        'The default outer spacing in the Selector component is deprecated.',
-        'Use the `noMargin` prop to silence this warning.',
-        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      throw new Error(
+        'The Selector component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
 
-    return null;
+    return css`
+      margin-bottom: ${theme.spacings.mega};
+    `;
   }
-  return css`
-    margin-bottom: 0;
-  `;
+  return null;
 };
 
 const sizeStyles = ({ theme, size = 'mega' }: LabelElProps & StyleProps) => {

--- a/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -53,8 +53,8 @@ HTMLCollection [
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
-  margin-bottom: 16px;
   padding: calc(12px) 24px;
+  margin-bottom: 16px;
 }
 
 .circuit-0::before {
@@ -150,8 +150,8 @@ HTMLCollection [
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
-  margin-bottom: 16px;
   padding: calc(12px) 24px;
+  margin-bottom: 16px;
 }
 
 .circuit-0::before {
@@ -248,11 +248,11 @@ HTMLCollection [
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
-  margin-bottom: 16px;
   padding: calc(12px) 24px;
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
+  margin-bottom: 16px;
 }
 
 .circuit-0::before {
@@ -349,9 +349,7 @@ HTMLCollection [
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
-  margin-bottom: 16px;
   padding: calc(12px) 24px;
-  margin-bottom: 0;
 }
 
 .circuit-0::before {

--- a/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -54,7 +54,6 @@ HTMLCollection [
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
   padding: calc(12px) 24px;
-  margin-bottom: 16px;
 }
 
 .circuit-0::before {
@@ -151,7 +150,6 @@ HTMLCollection [
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
   padding: calc(12px) 24px;
-  margin-bottom: 16px;
 }
 
 .circuit-0::before {
@@ -189,6 +187,103 @@ HTMLCollection [
 <label
     class="circuit-0"
     for="selector_1"
+  >
+    Label
+  </label>,
+]
+`;
+
+exports[`Selector should render a default spacing when there is no noMargin prop passed 1`] = `
+HTMLCollection [
+  .circuit-0 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-0:focus+label::before {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus+label::before::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible)+label::before {
+  box-shadow: none;
+}
+
+.circuit-0:checked+label {
+  background-color: #F0F6FF;
+}
+
+.circuit-0:checked+label::before {
+  border: 2px solid #3063E9;
+}
+
+<input
+    class="circuit-0"
+    id="selector_4"
+    name="name"
+    type="radio"
+    value="value"
+  />,
+  .circuit-0 {
+  display: inline-block;
+  cursor: pointer;
+  background-color: #FFF;
+  text-align: center;
+  position: relative;
+  border: none;
+  border-radius: 8px;
+  -webkit-transition: box-shadow 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out;
+  padding: calc(12px) 24px;
+  margin-bottom: 16px;
+}
+
+.circuit-0::before {
+  display: block;
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  border: 1px solid #CCC;
+  -webkit-transition: border 120ms ease-in-out;
+  transition: border 120ms ease-in-out;
+}
+
+.circuit-0:hover {
+  background-color: #F5F5F5;
+}
+
+.circuit-0:hover::before {
+  border-color: #999;
+}
+
+.circuit-0:active {
+  background-color: #E6E6E6;
+}
+
+.circuit-0:active::before {
+  border-color: #666;
+}
+
+<label
+    class="circuit-0"
+    for="selector_4"
   >
     Label
   </label>,
@@ -252,7 +347,6 @@ HTMLCollection [
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  margin-bottom: 16px;
 }
 
 .circuit-0::before {
@@ -291,102 +385,6 @@ HTMLCollection [
     class="circuit-0"
     disabled=""
     for="selector_2"
-  >
-    Label
-  </label>,
-]
-`;
-
-exports[`Selector should render a noMargin selector 1`] = `
-HTMLCollection [
-  .circuit-0 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-0:focus+label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0:focus+label::before::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-0:focus:not(:focus-visible)+label::before {
-  box-shadow: none;
-}
-
-.circuit-0:checked+label {
-  background-color: #F0F6FF;
-}
-
-.circuit-0:checked+label::before {
-  border: 2px solid #3063E9;
-}
-
-<input
-    class="circuit-0"
-    id="selector_4"
-    name="name"
-    type="radio"
-    value="value"
-  />,
-  .circuit-0 {
-  display: inline-block;
-  cursor: pointer;
-  background-color: #FFF;
-  text-align: center;
-  position: relative;
-  border: none;
-  border-radius: 8px;
-  -webkit-transition: box-shadow 120ms ease-in-out;
-  transition: box-shadow 120ms ease-in-out;
-  padding: calc(12px) 24px;
-}
-
-.circuit-0::before {
-  display: block;
-  content: '';
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border-radius: 8px;
-  border: 1px solid #CCC;
-  -webkit-transition: border 120ms ease-in-out;
-  transition: border 120ms ease-in-out;
-}
-
-.circuit-0:hover {
-  background-color: #F5F5F5;
-}
-
-.circuit-0:hover::before {
-  border-color: #999;
-}
-
-.circuit-0:active {
-  background-color: #E6E6E6;
-}
-
-.circuit-0:active::before {
-  border-color: #666;
-}
-
-<label
-    class="circuit-0"
-    for="selector_4"
   >
     Label
   </label>,

--- a/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -80,9 +80,7 @@ exports[`SelectorGroup should render with default styles 1`] = `
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
-  margin-bottom: 16px;
   padding: calc(12px) 24px;
-  margin-bottom: 0;
   width: 100%;
 }
 
@@ -260,9 +258,7 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
   border-radius: 8px;
   -webkit-transition: box-shadow 120ms ease-in-out;
   transition: box-shadow 120ms ease-in-out;
-  margin-bottom: 16px;
   padding: calc(12px) 24px;
-  margin-bottom: 0;
   width: 100%;
 }
 

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
@@ -168,10 +168,8 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
 
 .circuit-6 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
@@ -228,9 +226,7 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 12px;
   color: #000;
-  margin-bottom: 0;
 }
 
 .circuit-14 {
@@ -306,10 +302,8 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
 
 .circuit-16 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 <div>
@@ -600,10 +594,8 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
 
 .circuit-6 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 @media (max-width: 1279px) {

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
@@ -207,12 +207,10 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
 
 .circuit-9 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-11 {

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/__snapshots__/MobileNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/__snapshots__/MobileNavigation.spec.tsx.snap
@@ -314,10 +314,8 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
 
 .circuit-13 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
@@ -366,9 +364,7 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 12px;
   color: #000;
-  margin-bottom: 0;
 }
 
 .circuit-19 {
@@ -444,10 +440,8 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
 
 .circuit-21 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 <body
@@ -954,10 +948,8 @@ exports[`MobileNavigation styles should render without secondary links 1`] = `
 
 .circuit-13 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 @media (max-width: 1279px) {

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/__snapshots__/PrimaryLink.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/__snapshots__/PrimaryLink.spec.tsx.snap
@@ -105,10 +105,8 @@ exports[`PrimaryLink styles should render with active styles 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
@@ -265,10 +263,8 @@ exports[`PrimaryLink styles should render with badge styles 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 @media (max-width: 1279px) {
@@ -411,10 +407,8 @@ exports[`PrimaryLink styles should render with default styles 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 @media (max-width: 1279px) {
@@ -565,10 +559,8 @@ exports[`PrimaryLink styles should render with open styles 1`] = `
 
 .circuit-3 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
@@ -78,10 +78,8 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
 
 .circuit-4 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-8 {
@@ -164,10 +162,8 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
 
 .circuit-11 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
@@ -182,9 +178,7 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 12px;
   color: #000;
-  margin-bottom: 0;
 }
 
 <ul

--- a/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -85,12 +85,10 @@ exports[`SidePanel should match the snapshot 1`] = `
 
 .circuit-4 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
-  margin-bottom: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -413,12 +411,10 @@ exports[`SidePanel when the panel is on mobile resolution should match the snaps
 
 .circuit-4 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
-  margin-bottom: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;

--- a/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanelContext.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanelContext.spec.tsx.snap
@@ -112,12 +112,10 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
 
 .circuit-5 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
-  margin-bottom: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -454,12 +452,10 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
 
 .circuit-5 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
-  margin-bottom: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -795,12 +791,10 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
 
 .circuit-5 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
-  margin-bottom: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;

--- a/packages/circuit-ui/components/SidePanel/components/Header/__snapshots__/Header.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/components/Header/__snapshots__/Header.spec.tsx.snap
@@ -49,12 +49,10 @@ exports[`Header should have a bottom separator when sticky 1`] = `
 
 .circuit-1 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
-  margin-bottom: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -276,12 +274,10 @@ exports[`Header should match the snapshot 1`] = `
 
 .circuit-1 {
   font-weight: 700;
-  margin-bottom: 24px;
   color: #000;
   letter-spacing: -0.03em;
   font-size: 18px;
   line-height: 24px;
-  margin-bottom: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.spec.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.spec.tsx
@@ -24,13 +24,16 @@ describe('SubHeadline', () => {
   const elements = ['h2', 'h3', 'h4', 'h5', 'h6'] as const;
   it.each(elements)('should render as %s element', (element) => {
     const subheading = create(
-      <SubHeadline as={element}>{`${element} subheading`}</SubHeadline>,
+      <SubHeadline
+        noMargin
+        as={element}
+      >{`${element} subheading`}</SubHeadline>,
     );
     expect(subheading).toMatchSnapshot();
   });
 
-  it('should render with no margin styles when passed the noMargin prop', () => {
-    const actual = create(<SubHeadline as="h3" noMargin />);
+  it('should render with default spacing when there is no noMargin prop', () => {
+    const actual = create(<SubHeadline as="h3" />);
     expect(actual).toMatchSnapshot();
   });
 
@@ -38,7 +41,11 @@ describe('SubHeadline', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<SubHeadline as="h3">Subheading</SubHeadline>);
+    const wrapper = renderToHtml(
+      <SubHeadline noMargin as="h3">
+        Subheading
+      </SubHeadline>,
+    );
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -18,7 +18,6 @@ import { css } from '@emotion/react';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
-import { deprecate } from '../../util/logger';
 
 export interface SubHeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
   /**
@@ -38,29 +37,26 @@ const baseStyles = ({ theme }: StyleProps) => css`
   font-weight: ${theme.fontWeight.bold};
   font-size: ${theme.typography.subHeadline.fontSize};
   line-height: ${theme.typography.subHeadline.lineHeight};
-  margin-bottom: ${theme.spacings.kilo};
   color: ${theme.colors.black};
 `;
 
-const noMarginStyles = ({ noMargin }: SubHeadlineProps) => {
+const noMarginStyles = ({ theme, noMargin }: StyleProps & SubHeadlineProps) => {
   if (!noMargin) {
     if (
+      process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      deprecate(
-        'SubHeadline',
-        'The default outer spacing in the SubHeadline component is deprecated.',
-        'Use the `noMargin` prop to silence this warning.',
-        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      throw new Error(
+        'The SubHeadline component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
 
-    return null;
+    return css`
+      margin-bottom: ${theme.spacings.kilo};
+    `;
   }
-  return css`
-    margin-bottom: 0;
-  `;
+  return null;
 };
 
 /**

--- a/packages/circuit-ui/components/SubHeadline/__snapshots__/SubHeadline.spec.tsx.snap
+++ b/packages/circuit-ui/components/SubHeadline/__snapshots__/SubHeadline.spec.tsx.snap
@@ -6,8 +6,8 @@ exports[`SubHeadline should render as h2 element 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 12px;
   color: #000;
+  margin-bottom: 12px;
 }
 
 <h2
@@ -23,8 +23,8 @@ exports[`SubHeadline should render as h3 element 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 12px;
   color: #000;
+  margin-bottom: 12px;
 }
 
 <h3
@@ -40,8 +40,8 @@ exports[`SubHeadline should render as h4 element 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 12px;
   color: #000;
+  margin-bottom: 12px;
 }
 
 <h4
@@ -57,8 +57,8 @@ exports[`SubHeadline should render as h5 element 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 12px;
   color: #000;
+  margin-bottom: 12px;
 }
 
 <h5
@@ -74,8 +74,8 @@ exports[`SubHeadline should render as h6 element 1`] = `
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 12px;
   color: #000;
+  margin-bottom: 12px;
 }
 
 <h6
@@ -91,9 +91,7 @@ exports[`SubHeadline should render with no margin styles when passed the noMargi
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 12px;
   color: #000;
-  margin-bottom: 0;
 }
 
 <h3

--- a/packages/circuit-ui/components/SubHeadline/__snapshots__/SubHeadline.spec.tsx.snap
+++ b/packages/circuit-ui/components/SubHeadline/__snapshots__/SubHeadline.spec.tsx.snap
@@ -7,7 +7,6 @@ exports[`SubHeadline should render as h2 element 1`] = `
   font-size: 14px;
   line-height: 20px;
   color: #000;
-  margin-bottom: 12px;
 }
 
 <h2
@@ -24,7 +23,6 @@ exports[`SubHeadline should render as h3 element 1`] = `
   font-size: 14px;
   line-height: 20px;
   color: #000;
-  margin-bottom: 12px;
 }
 
 <h3
@@ -41,7 +39,6 @@ exports[`SubHeadline should render as h4 element 1`] = `
   font-size: 14px;
   line-height: 20px;
   color: #000;
-  margin-bottom: 12px;
 }
 
 <h4
@@ -58,7 +55,6 @@ exports[`SubHeadline should render as h5 element 1`] = `
   font-size: 14px;
   line-height: 20px;
   color: #000;
-  margin-bottom: 12px;
 }
 
 <h5
@@ -75,7 +71,6 @@ exports[`SubHeadline should render as h6 element 1`] = `
   font-size: 14px;
   line-height: 20px;
   color: #000;
-  margin-bottom: 12px;
 }
 
 <h6
@@ -85,13 +80,14 @@ exports[`SubHeadline should render as h6 element 1`] = `
 </h6>
 `;
 
-exports[`SubHeadline should render with no margin styles when passed the noMargin prop 1`] = `
+exports[`SubHeadline should render with default spacing when there is no noMargin prop 1`] = `
 .circuit-0 {
   text-transform: uppercase;
   font-weight: 700;
   font-size: 14px;
   line-height: 20px;
   color: #000;
+  margin-bottom: 12px;
 }
 
 <h3

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -19,7 +19,6 @@ import { css } from '@emotion/react';
 import styled, { StyleProps } from '../../styles/styled';
 import { disableVisually } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
-import { deprecate } from '../../util/logger';
 import { Body, BodyProps } from '../Body/Body';
 
 import { Switch, SwitchProps } from './components/Switch/Switch';
@@ -67,7 +66,6 @@ type WrapperElProps = Pick<ToggleProps, 'noMargin' | 'disabled'>;
 const toggleWrapperStyles = ({ theme }: StyleProps) => css`
   display: flex;
   align-items: flex-start;
-  margin-bottom: ${theme.spacings.mega};
 
   ${theme.mq.untilKilo} {
     flex-direction: row-reverse;
@@ -81,25 +79,26 @@ const toggleWrapperDisabledStyles = ({ disabled }: WrapperElProps) =>
     ${disableVisually()};
   `;
 
-const toggleWrapperNoMarginStyles = ({ noMargin }: WrapperElProps) => {
+const toggleWrapperNoMarginStyles = ({
+  theme,
+  noMargin,
+}: StyleProps & WrapperElProps) => {
   if (!noMargin) {
     if (
+      process.env.UNSAFE_DISABLE_NO_MARGIN_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      deprecate(
-        'Toggle',
-        'The default outer spacing in the Toggle component is deprecated.',
-        'Use the `noMargin` prop to silence this warning.',
-        'Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
+      throw new Error(
+        'The Toggle component requires the `noMargin` prop to be passed. Read more at https://github.com/sumup-oss/circuit-ui/issues/534.',
       );
     }
 
-    return null;
+    return css`
+      margin-bottom: ${theme.spacings.mega};
+    `;
   }
-  return css`
-    margin-bottom: 0;
-  `;
+  return null;
 };
 
 const ToggleWrapper = styled('div')<WrapperElProps>(

--- a/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -104,18 +104,14 @@ exports[`Toggle should render with default styles 1`] = `
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-6 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   color: #666;
 }
 
@@ -168,8 +164,6 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-  margin-bottom: 16px;
-  margin-bottom: 0;
 }
 
 @media (max-width: 479px) {
@@ -263,18 +257,14 @@ exports[`Toggle should render with no margin styles when passed the noMargin pro
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 .circuit-6 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   color: #666;
 }
 

--- a/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
@@ -397,10 +397,8 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
 
 .circuit-16 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 @media (max-width: 479px) {
@@ -502,19 +500,15 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
 
 .circuit-22 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
 .circuit-24 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
 }
 
 .circuit-25 {

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
@@ -111,10 +111,8 @@ exports[`ProfileMenu styles should render with a profile picture 1`] = `
 
 .circuit-6 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 
@@ -282,10 +280,8 @@ exports[`ProfileMenu styles should render without a profile picture 1`] = `
 
 .circuit-5 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 14px;
   line-height: 20px;
-  margin-bottom: 0;
   font-weight: 700;
 }
 

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/__snapshots__/UtilityLinks.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/__snapshots__/UtilityLinks.spec.tsx.snap
@@ -86,10 +86,8 @@ exports[`UtilityLinks styles should match the snapshot 1`] = `
 
 .circuit-4 {
   font-weight: 400;
-  margin-bottom: 16px;
   font-size: 16px;
   line-height: 24px;
-  margin-bottom: 0;
 }
 
 @media (max-width: 479px) {

--- a/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
@@ -245,7 +245,6 @@ Object {
     "modal": 1000,
     "navigation": 800,
     "popover": 30,
-    "sidebar": 800,
     "toast": 1100,
     "tooltip": 40,
   },

--- a/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
@@ -245,6 +245,7 @@ Object {
     "modal": 1000,
     "navigation": 800,
     "popover": 30,
+    "sidebar": 800,
     "toast": 1100,
     "tooltip": 40,
   },


### PR DESCRIPTION
## Purpose

For the Circuit UI v5 instead of removing the `noMargin` prop completely, since it requires large-scale changes in the apps, we are going to throw a dev-time error for now. This way, we're providing an escape hatch to allow developers to work on their applications.

The errors will not be thrown if the `UNSAFE_DISABLE_NO_MARGIN_ERRORS` environment variable is set to `true`.

## Approach and changes

- add a check for the `UNSAFE_DISABLE_NO_MARGIN_ERRORS` environment variable before throwing when `noMargin` is missing
- change the styles to default to no outer spacing

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
