### PR TITLE
Remove the deprecated RadioButton children prop

### DIFF
--- a/.changeset/mean-olives-watch.md
+++ b/.changeset/mean-olives-watch.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-Removed the `RadioButton`'s deprecated `children` prop. Use the `label` prop (now required) instead.
+Removed the `RadioButton`'s deprecated `children` prop. Use the `label` prop (now required) instead, in both the `RadioButton` and the `RadioButtonGroup`'s `options`.

--- a/.changeset/mean-olives-watch.md
+++ b/.changeset/mean-olives-watch.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Removed the `RadioButton`'s deprecated `children` prop. Use the `label` prop (now required) instead.

--- a/.changeset/thin-trainers-occur.md
+++ b/.changeset/thin-trainers-occur.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Made the `RadioButton`'s `label` prop required and throw an error if it isn't passed. This is an accessibility requirement.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -144,6 +144,7 @@ Read more about the new notification components in [the Notification section in 
 
 - The deprecated `zIndex.sidebar` design token was removed from `@sumup/design-tokens`. Use `sIndex.navigation` instead. There is no codemod for this change: search and replace the old value for the new one in your codebase.
 - The deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins were removed. Use the `shadow()` style mixin instead. There is no codemod for this change: migrate manually by searching for the deprecated style mixins in your codebase, and verify the changes visually.
+- The `RadioButton` component's deprecated `children` prop was removed. Use the `label` prop, now typed as required, instead. The is no codemod for this change: search your codebase for uses of the `RadioButton` or `RadioButtonGroup` component and migrate manually.
 
 ## From v4 to v4.1
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -144,7 +144,7 @@ Read more about the new notification components in [the Notification section in 
 
 - The deprecated `zIndex.sidebar` design token was removed from `@sumup/design-tokens`. Use `sIndex.navigation` instead. There is no codemod for this change: search and replace the old value for the new one in your codebase.
 - The deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins were removed. Use the `shadow()` style mixin instead. There is no codemod for this change: migrate manually by searching for the deprecated style mixins in your codebase, and verify the changes visually.
-- The `RadioButton` component's deprecated `children` prop was removed. Use the `label` prop, now typed as required, instead. The is no codemod for this change: search your codebase for uses of the `RadioButton` or `RadioButtonGroup` component and migrate manually.
+- The `RadioButton` component's deprecated `children` prop was removed. Use the `label` prop, now typed as required, instead. There is no codemod for this change: search your codebase for uses of the `RadioButton` or `RadioButtonGroup` component and migrate them manually.
 
 ## From v4 to v4.1
 

--- a/packages/circuit-ui/components/RadioButton/RadioButton.stories.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.stories.tsx
@@ -28,6 +28,7 @@ export default {
     docs: { page: docs },
   },
   argTypes: {
+    label: { control: 'text' },
     name: { control: 'text' },
     value: { control: 'text' },
     disabled: { control: 'boolean' },

--- a/packages/circuit-ui/components/RadioButton/RadioButton.stories.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.stories.tsx
@@ -63,20 +63,22 @@ Base.args = {
 };
 
 export const Invalid = (args: RadioButtonProps) => (
-  <RadioButtonWithState {...args}>Invalid</RadioButtonWithState>
+  <RadioButtonWithState {...args} />
 );
 
 Invalid.args = {
+  label: 'Invalid',
   name: 'invalid',
   value: 'true',
   invalid: true,
 };
 
 export const Disabled = (args: RadioButtonProps) => (
-  <RadioButtonWithState {...args}>Disabled</RadioButtonWithState>
+  <RadioButtonWithState {...args} />
 );
 
 Disabled.args = {
+  label: 'Disabled',
   name: 'disabled',
   value: 'true',
   disabled: true,

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -205,6 +205,15 @@ export const RadioButton = forwardRef(
     }: RadioButtonProps,
     ref: RadioButtonProps['ref'],
   ) => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !label
+    ) {
+      throw new Error(
+        'The RadioButton component is missing a `label` prop. This is an accessibility requirement.',
+      );
+    }
     const id = customId || uniqueId('radio-button_');
     const handleChange = useClickEvent(onChange, tracking, 'radio-button');
 

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -34,14 +34,9 @@ import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 export interface RadioButtonProps
   extends InputHTMLAttributes<HTMLInputElement> {
   /**
-   * @deprecated
-   * Use the label prop instead.
-   */
-  children?: ReactNode;
-  /**
    * A clear and concise description of the option's purpose.
    */
-  label?: ReactNode;
+  label: ReactNode;
   /**
    * Triggers error styles on the component.
    */
@@ -196,7 +191,6 @@ export const RadioButton = forwardRef(
   (
     {
       onChange,
-      children,
       label,
       id: customId,
       name,
@@ -238,7 +232,7 @@ export const RadioButton = forwardRef(
           className={className}
           style={style}
         >
-          {children || label}
+          {label}
         </RadioButtonLabel>
       </Fragment>
     );

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -64,7 +64,6 @@ const labelBaseStyles = ({ theme }: StyleProps) => css`
     box-sizing: border-box;
     height: 18px;
     width: 18px;
-    box-shadow: 0;
     background-color: ${theme.colors.white};
     border: 1px solid ${theme.colors.n500};
     border-radius: 100%;

--- a/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
@@ -68,7 +68,6 @@ HTMLCollection [
   box-sizing: border-box;
   height: 18px;
   width: 18px;
-  box-shadow: 0;
   background-color: #FFF;
   border: 1px solid #999;
   border-radius: 100%;
@@ -181,7 +180,6 @@ HTMLCollection [
   box-sizing: border-box;
   height: 18px;
   width: 18px;
-  box-shadow: 0;
   background-color: #FFF;
   border: 1px solid #999;
   border-radius: 100%;
@@ -298,7 +296,6 @@ HTMLCollection [
   box-sizing: border-box;
   height: 18px;
   width: 18px;
-  box-shadow: 0;
   background-color: #FFF;
   border: 1px solid #999;
   border-radius: 100%;
@@ -436,7 +433,6 @@ HTMLCollection [
   box-sizing: border-box;
   height: 18px;
   width: 18px;
-  box-shadow: 0;
   background-color: #FFF;
   border: 1px solid #999;
   border-radius: 100%;

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.spec.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.spec.tsx
@@ -30,15 +30,15 @@ describe('RadioButtonGroup', () => {
   const baseProps = {
     options: [
       {
-        children: 'Option 1',
+        label: 'Option 1',
         value: 'first',
       },
       {
-        children: 'Option 2',
+        label: 'Option 2',
         value: 'second',
       },
       {
-        children: 'Option 3',
+        label: 'Option 3',
         value: 'third',
       },
     ],

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -130,14 +130,7 @@ export const RadioButtonGroup = forwardRef(
         <Legend hideLabel={hideLabel}>{label}</Legend>
         {options &&
           options.map(
-            ({
-              children,
-              label: optionLabel,
-              value,
-              className,
-              style,
-              ...rest
-            }) => (
+            ({ label: optionLabel, value, className, style, ...rest }) => (
               <div
                 key={value && value.toString()}
                 className={className}
@@ -146,7 +139,7 @@ export const RadioButtonGroup = forwardRef(
                 <RadioButton
                   {...{ ...rest, value, name, required, onChange }}
                   checked={value === activeValue}
-                  label={optionLabel || children}
+                  label={optionLabel}
                 />
               </div>
             ),

--- a/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
@@ -66,7 +66,6 @@ exports[`RadioButtonGroup should render with default styles 1`] = `
   box-sizing: border-box;
   height: 18px;
   width: 18px;
-  box-shadow: 0;
   background-color: #FFF;
   border: 1px solid #999;
   border-radius: 100%;


### PR DESCRIPTION
## Purpose

Remove the deprecated RadioButton children prop

## Approach and changes

- Remove the prop (use `label` instead)
- Update stories still using `children`
- Make the `label` prop required in the `RadioButton` and throw an error if it isn't passed (we were doing this for the `RadioButtonGroup` but not here)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
