### PR TITLE
Remove a11y env variable

### DIFF
--- a/.changeset/dirty-keys-arrive.md
+++ b/.changeset/dirty-keys-arrive.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Removed the `UNSAFE_DISABLE_ACCESSIBILITY_ERRORS` environment variable.

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -58,15 +58,7 @@ function createWebpackConfig(config) {
     }
     return rule;
   });
-  // Expose environment variables to Storybook
-  config.plugins = [
-    ...config.plugins,
-    new webpack.DefinePlugin({
-      'process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS': JSON.stringify(
-        process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS,
-      ),
-    }),
-  ];
+
   // Emotion 11
   config.resolve.alias = {
     ...config.resolve.alias,

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -354,7 +354,6 @@ export const Button = forwardRef(
     ref?: BaseProps['ref'],
   ): ReturnType => {
     if (
-      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       isLoading !== undefined &&

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -170,7 +170,6 @@ export const Hamburger = ({
   ...props
 }: HamburgerProps): JSX.Element => {
   if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     (!activeLabel || !inactiveLabel)

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -68,7 +68,6 @@ export const IconButton = forwardRef(
       size: child.props.size || iconSize,
     });
     if (
-      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -309,7 +309,6 @@ export const ImageInput = ({
   ...props
 }: ImageInputProps): JSX.Element => {
   if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     (!label || !clearButtonLabel || !loadingLabel)

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -325,7 +325,6 @@ export const Input = forwardRef(
     ref: InputProps['ref'],
   ): ReturnType => {
     if (
-      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       props.type !== 'hidden' &&

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -148,7 +148,6 @@ export const Modal: ModalComponent<ModalProps> = ({
   ...props
 }) => {
   if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     !preventClose &&

--- a/packages/circuit-ui/components/ModalContext/ModalContext.tsx
+++ b/packages/circuit-ui/components/ModalContext/ModalContext.tsx
@@ -42,7 +42,6 @@ if (typeof window !== 'undefined') {
   if (appElement) {
     ReactModal.setAppElement(appElement);
   } else if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'
   ) {

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -103,7 +103,6 @@ export const Pagination = ({
   ...props
 }: PaginationProps): ReactNode => {
   if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     (!label || !previousLabel || !nextLabel)

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -232,7 +232,6 @@ export function ProgressBar({
   ...props
 }: ProgressBarProps): JSX.Element {
   if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     !label

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -115,7 +115,6 @@ export const RadioButtonGroup = forwardRef(
     ref: RadioButtonGroupProps['ref'],
   ) => {
     if (
-      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -59,7 +59,6 @@ export const SearchInput = forwardRef(
     ref: SearchInputProps['ref'],
   ) => {
     if (
-      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       onClear &&

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -316,7 +316,6 @@ export const Select = forwardRef(
     ref?: SelectProps['ref'],
   ): ReturnType => {
     if (
-      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -140,7 +140,6 @@ export const SelectorGroup = forwardRef(
     ref: SelectorGroupProps['ref'],
   ) => {
     if (
-      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
@@ -44,7 +44,6 @@ export function SideNavigation({
   UNSAFE_components,
 }: SideNavigationProps): JSX.Element {
   if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     (!closeButtonLabel || !primaryNavigationLabel || !secondaryNavigationLabel)

--- a/packages/circuit-ui/components/SidePanel/SidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.tsx
@@ -126,7 +126,6 @@ export const SidePanel = ({
   ...props
 }: SidePanelProps): JSX.Element => {
   if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'
   ) {

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
@@ -55,7 +55,6 @@ if (typeof window !== 'undefined') {
   if (appElement) {
     ReactModal.setAppElement(appElement);
   } else if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'
   ) {

--- a/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
@@ -126,7 +126,6 @@ export function Aggregator({
   ...props
 }: AggregatorProps): JSX.Element {
   if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     !label

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -191,7 +191,6 @@ const TableHeader: FC<TableHeaderProps> = ({
   ...props
 }) => {
   if (
-    process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     sortParams.sortable &&

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -204,7 +204,6 @@ export const Tag = forwardRef(
     ref: BaseProps['ref'],
   ) => {
     if (
-      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       onRemove &&

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -117,7 +117,6 @@ export const Toggle = forwardRef(
     ref: ToggleProps['ref'],
   ) => {
     if (
-      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       !label

--- a/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
+++ b/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
@@ -128,7 +128,6 @@ export const Switch = forwardRef(
     ref: SwitchProps['ref'],
   ) => {
     if (
-      process.env.UNSAFE_DISABLE_ACCESSIBILITY_ERRORS !== 'true' &&
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       (!checkedLabel || !uncheckedLabel)


### PR DESCRIPTION

## Purpose

In the #1083 we introduced an escape hatch to allow developers to work on their applications while labels are still not provided, for example while they're being written and localized.
We added the UNSAFE_DISABLE_ACCESSIBILITY_ERRORS environment variable.
In the Circuit UI v5 we are gonna remove the accessibility environment variable.

## Approach and changes

Remove the UNSAFE_DISABLE_ACCESSIBILITY_ERRORS environment from main.js and usage in the Circuit UI.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
