### PR TITLE
Remove ButtonGroup children

### DIFF
--- a/.changeset/tough-cycles-fail.md
+++ b/.changeset/tough-cycles-fail.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-Removed the deprecated `children` prop from the `ButtonGroup` component.
+Removed the deprecated `children` prop from the `ButtonGroup` component, use the `actions` prop instead.

--- a/.changeset/tough-cycles-fail.md
+++ b/.changeset/tough-cycles-fail.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Removed the deprecated `children` prop from the `ButtonGroup` component.

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.spec.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.spec.tsx
@@ -14,7 +14,6 @@
  */
 
 import { create, renderToHtml, axe } from '../../util/test-utils';
-import Button from '../Button';
 
 import { ButtonGroup, ButtonGroupProps } from './ButtonGroup';
 
@@ -22,30 +21,19 @@ describe('ButtonGroup', () => {
   /**
    * Style tests.
    */
-  it('should render with default styles', () => {
-    const actual = create(
-      <ButtonGroup>
-        <Button variant="secondary">Cancel</Button>
-        <Button variant="primary">Confirm</Button>
-      </ButtonGroup>,
-    );
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should render with the actions prop', () => {
-    const props: ButtonGroupProps = {
-      actions: {
-        primary: {
-          children: 'Look again',
-          onClick: jest.fn(),
-        },
-        secondary: {
-          children: 'Go elsewhere',
-          href: 'https://sumup.com',
-        },
+  const props: ButtonGroupProps = {
+    actions: {
+      primary: {
+        children: 'Look again',
+        onClick: jest.fn(),
       },
-    };
-
+      secondary: {
+        children: 'Go elsewhere',
+        href: 'https://sumup.com',
+      },
+    },
+  };
+  it('should render with default styles', () => {
     const actual = create(<ButtonGroup {...props} />);
 
     expect(actual).toMatchSnapshot();
@@ -53,24 +41,16 @@ describe('ButtonGroup', () => {
 
   describe('Center aligment', () => {
     it('should render with center alignment styles', () => {
-      const actual = create(
-        <ButtonGroup align={'center'}>
-          <Button variant="secondary">Cancel</Button>
-          <Button variant="primary">Confirm</Button>
-        </ButtonGroup>,
-      );
+      const actual = create(<ButtonGroup align={'center'} {...props} />);
+
       expect(actual).toMatchSnapshot();
     });
   });
 
   describe('Left aligment', () => {
     it('should render with left alignment styles', () => {
-      const actual = create(
-        <ButtonGroup align={'left'}>
-          <Button variant="secondary">Cancel</Button>
-          <Button variant="primary">Confirm</Button>
-        </ButtonGroup>,
-      );
+      const actual = create(<ButtonGroup align={'left'} {...props} />);
+
       expect(actual).toMatchSnapshot();
     });
   });
@@ -79,12 +59,7 @@ describe('ButtonGroup', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(
-      <ButtonGroup>
-        <Button variant="secondary">Cancel</Button>
-        <Button variant="primary">Confirm</Button>
-      </ButtonGroup>,
-    );
+    const wrapper = renderToHtml(<ButtonGroup align={'center'} {...props} />);
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -27,6 +27,7 @@ export const Base = (args: ButtonGroupProps): JSX.Element => (
 );
 
 Base.args = {
+  align: 'center',
   actions: {
     primary: {
       children: 'Look again',

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -27,7 +27,6 @@ export const Base = (args: ButtonGroupProps): JSX.Element => (
 );
 
 Base.args = {
-  align: 'center',
   actions: {
     primary: {
       children: 'Look again',

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ReactElement, Ref, forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { css } from '@emotion/react';
 
 import styled, { StyleProps } from '../../styles/styled';
@@ -23,83 +23,17 @@ type Action = Omit<ButtonProps, 'variant'>;
 
 export interface ButtonGroupProps {
   /**
-   * @deprecated Use the `actions` prop instead.
-   */
-  children?:
-    | (ReactElement<ButtonProps> | null | undefined)[]
-    | ReactElement<ButtonProps>;
-  /**
    * Direction to align the content. Either left/right
    */
   align?: 'left' | 'center' | 'right';
   /**
-   * Whether to display buttons inline on mobile.
-   */
-  inlineMobile?: boolean;
-  /**
-   * The ref to the HTML DOM element.
-   */
-  ref?: Ref<HTMLDivElement>;
-  /**
    * Action Buttons
    */
-  actions?: {
+  actions: {
     primary: Action;
     secondary?: Action;
   };
 }
-
-const getInlineStyles = ({ theme }: StyleProps) => css`
-  flex-wrap: wrap;
-  > button,
-  > a {
-    width: auto;
-
-    &:not(:last-child) {
-      margin-right: ${theme.spacings.mega};
-      margin-bottom: 0;
-    }
-  }
-`;
-
-const baseStyles = ({ theme }: StyleProps) => css`
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  width: 100%;
-
-  > button,
-  > a {
-    width: 100%;
-
-    &:not(:last-child) {
-      margin-bottom: ${theme.spacings.mega};
-    }
-  }
-
-  ${theme.mq.kilo} {
-    ${getInlineStyles({ theme })};
-  }
-`;
-
-const alignmentMap = {
-  left: 'flex-start',
-  center: 'center',
-  right: 'flex-end',
-} as const;
-
-const alignmentStyles = ({ align = 'right' }: ButtonGroupProps) => css`
-  justify-content: ${alignmentMap[align]};
-`;
-
-const inlineMobileStyles = ({
-  theme,
-  inlineMobile = false,
-}: StyleProps & ButtonGroupProps) =>
-  inlineMobile &&
-  css`
-    ${getInlineStyles({ theme })}
-  `;
 
 const actionWrapperStyles = ({ theme }: StyleProps) => css`
   display: flex;
@@ -131,43 +65,26 @@ const tertiaryButtonStyles = ({ theme }: StyleProps) => css`
 
 const TertiaryButton = styled(Button)<ButtonProps>(tertiaryButtonStyles);
 
-const Wrapper = styled('div')<ButtonGroupProps>(
-  baseStyles,
-  alignmentStyles,
-  inlineMobileStyles,
-);
-
-const ActionsWrapper = styled('div')<ButtonGroupProps>(actionWrapperStyles);
+const ActionsWrapper =
+  styled('div')<Omit<ButtonGroupProps, 'actions'>>(actionWrapperStyles);
 
 /**
  * Groups its Button children into a list and adds margins between.
  */
 export const ButtonGroup = forwardRef(
-  (
-    { children, actions, ...props }: ButtonGroupProps,
-    ref: ButtonGroupProps['ref'],
-  ) => {
-    if (actions) {
-      return (
-        <ActionsWrapper {...props}>
-          {actions.secondary && (
-            <SecondaryButton {...actions.secondary} variant="secondary" />
-          )}
+  ({ actions, ...props }: ButtonGroupProps) => (
+    <ActionsWrapper {...props}>
+      {actions.secondary && (
+        <SecondaryButton {...actions.secondary} variant="secondary" />
+      )}
 
-          <Button {...actions.primary} variant="primary" />
+      <Button {...actions.primary} variant="primary" />
 
-          {actions.secondary && (
-            <TertiaryButton {...actions.secondary} variant="tertiary" />
-          )}
-        </ActionsWrapper>
-      );
-    }
-    return (
-      <Wrapper {...props} ref={ref}>
-        {children}
-      </Wrapper>
-    );
-  },
+      {actions.secondary && (
+        <TertiaryButton {...actions.secondary} variant="tertiary" />
+      )}
+    </ActionsWrapper>
+  ),
 );
 
 ButtonGroup.displayName = 'ButtonGroup';

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
@@ -35,6 +35,18 @@ export interface ButtonGroupProps {
   };
 }
 
+const alignmentMap = {
+  left: 'flex-start',
+  center: 'center',
+  right: 'flex-end',
+} as const;
+
+type ActionsWrapperProps = Omit<ButtonGroupProps, 'actions'>;
+
+const alignmentStyles = ({ align = 'right' }: ActionsWrapperProps) => css`
+  justify-content: ${alignmentMap[align]};
+`;
+
 const actionWrapperStyles = ({ theme }: StyleProps) => css`
   display: flex;
   flex-direction: column;
@@ -43,7 +55,6 @@ const actionWrapperStyles = ({ theme }: StyleProps) => css`
 
   ${theme.mq.kilo} {
     flex-direction: row;
-    justify-content: center;
   }
 `;
 
@@ -65,8 +76,10 @@ const tertiaryButtonStyles = ({ theme }: StyleProps) => css`
 
 const TertiaryButton = styled(Button)<ButtonProps>(tertiaryButtonStyles);
 
-const ActionsWrapper =
-  styled('div')<Omit<ButtonGroupProps, 'actions'>>(actionWrapperStyles);
+const ActionsWrapper = styled('div')<ActionsWrapperProps>(
+  actionWrapperStyles,
+  alignmentStyles,
+);
 
 /**
  * Groups its Button children into a list and adds margins between.

--- a/packages/circuit-ui/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -22,14 +22,13 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   width: 100%;
   -webkit-box-pack: center;
   -ms-flex-pack: center;
@@ -37,33 +36,11 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
   justify-content: center;
 }
 
-.circuit-0>button,
-.circuit-0>a {
-  width: 100%;
-}
-
-.circuit-0>button:not(:last-child),
-.circuit-0>a:not(:last-child) {
-  margin-bottom: 16px;
-}
-
 @media (min-width: 480px) {
   .circuit-0 {
-    -webkit-box-flex-wrap: wrap;
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
-  }
-
-  .circuit-0>button,
-  .circuit-0>a {
-    width: auto;
-  }
-
-  .circuit-0>button:not(:last-child),
-  .circuit-0>a:not(:last-child) {
-    margin-right: 16px;
-    margin-bottom: 0;
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
   }
 }
 
@@ -97,6 +74,7 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
   padding: calc(12px - 1px) calc(24px - 1px);
   position: relative;
   overflow: hidden;
+  margin-right: 16px;
 }
 
 .circuit-1:focus {
@@ -129,6 +107,12 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
 .circuit-1[aria-pressed='true'] {
   background-color: #E6E6E6;
   border-color: #333;
+}
+
+@media (max-width: 479px) {
+  .circuit-1 {
+    display: none;
+  }
 }
 
 .circuit-2 {
@@ -243,11 +227,83 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
   border-color: #1A368E;
 }
 
+.circuit-9 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  background-color: transparent;
+  border-color: transparent;
+  color: #3063E9;
+  padding-left: 0;
+  padding-right: 0;
+  position: relative;
+  overflow: hidden;
+  margin-top: 16px;
+}
+
+.circuit-9:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-9:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-9:disabled,
+.circuit-9[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-9:hover {
+  color: #234BC3;
+}
+
+.circuit-9:active,
+.circuit-9[aria-expanded='true'],
+.circuit-9[aria-pressed='true'] {
+  color: #1A368E;
+}
+
+@media (min-width: 480px) {
+  .circuit-9 {
+    display: none;
+  }
+}
+
 <div
   class="circuit-0"
 >
-  <button
+  <a
     class="circuit-1"
+    href="https://sumup.com"
   >
     <span
       class="circuit-2"
@@ -259,9 +315,9 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
     <span
       class="circuit-4"
     >
-      Cancel
+      Go elsewhere
     </span>
-  </button>
+  </a>
   <button
     class="circuit-5"
   >
@@ -275,575 +331,30 @@ exports[`ButtonGroup Center aligment should render with center alignment styles 
     <span
       class="circuit-4"
     >
-      Confirm
+      Look again
     </span>
   </button>
+  <a
+    class="circuit-9"
+    href="https://sumup.com"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Go elsewhere
+    </span>
+  </a>
 </div>
 `;
 
 exports[`ButtonGroup Left aligment should render with left alignment styles 1`] = `
-@keyframes animation-0 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  width: 100%;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-}
-
-.circuit-0>button,
-.circuit-0>a {
-  width: 100%;
-}
-
-.circuit-0>button:not(:last-child),
-.circuit-0>a:not(:last-child) {
-  margin-bottom: 16px;
-}
-
-@media (min-width: 480px) {
-  .circuit-0 {
-    -webkit-box-flex-wrap: wrap;
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
-  }
-
-  .circuit-0>button,
-  .circuit-0>a {
-    width: auto;
-  }
-
-  .circuit-0>button:not(:last-child),
-  .circuit-0>a:not(:last-child) {
-    margin-right: 16px;
-    margin-bottom: 0;
-  }
-}
-
-.circuit-1 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #FFF;
-  border-color: #999;
-  color: #000;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-}
-
-.circuit-1:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-1:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-1:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-1:disabled,
-.circuit-1[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-1:hover {
-  background-color: #F5F5F5;
-  border-color: #666;
-}
-
-.circuit-1:active,
-.circuit-1[aria-expanded='true'],
-.circuit-1[aria-pressed='true'] {
-  background-color: #E6E6E6;
-  border-color: #333;
-}
-
-.circuit-2 {
-  display: block;
-  border-radius: 100%;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  -webkit-animation: animation-0 1s infinite linear;
-  animation: animation-0 1s infinite linear;
-  transform-origin: 50% 50%;
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-3 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  opacity: 1;
-  visibility: inherit;
-  -webkit-transform: scale3d(1, 1, 1);
-  -moz-transform: scale3d(1, 1, 1);
-  -ms-transform: scale3d(1, 1, 1);
-  transform: scale3d(1, 1, 1);
-  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-5 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #3063E9;
-  border-color: #3063E9;
-  color: #FFF;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-}
-
-.circuit-5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-5:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-5:disabled,
-.circuit-5[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-5:hover {
-  background-color: #234BC3;
-  border-color: #234BC3;
-}
-
-.circuit-5:active,
-.circuit-5[aria-expanded='true'],
-.circuit-5[aria-pressed='true'] {
-  background-color: #1A368E;
-  border-color: #1A368E;
-}
-
-<div
-  class="circuit-0"
->
-  <button
-    class="circuit-1"
-  >
-    <span
-      class="circuit-2"
-    >
-      <span
-        class="circuit-3"
-      />
-    </span>
-    <span
-      class="circuit-4"
-    >
-      Cancel
-    </span>
-  </button>
-  <button
-    class="circuit-5"
-  >
-    <span
-      class="circuit-2"
-    >
-      <span
-        class="circuit-3"
-      />
-    </span>
-    <span
-      class="circuit-4"
-    >
-      Confirm
-    </span>
-  </button>
-</div>
-`;
-
-exports[`ButtonGroup should render with default styles 1`] = `
-@keyframes animation-0 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  width: 100%;
-  -webkit-box-pack: end;
-  -ms-flex-pack: end;
-  -webkit-justify-content: flex-end;
-  justify-content: flex-end;
-}
-
-.circuit-0>button,
-.circuit-0>a {
-  width: 100%;
-}
-
-.circuit-0>button:not(:last-child),
-.circuit-0>a:not(:last-child) {
-  margin-bottom: 16px;
-}
-
-@media (min-width: 480px) {
-  .circuit-0 {
-    -webkit-box-flex-wrap: wrap;
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
-  }
-
-  .circuit-0>button,
-  .circuit-0>a {
-    width: auto;
-  }
-
-  .circuit-0>button:not(:last-child),
-  .circuit-0>a:not(:last-child) {
-    margin-right: 16px;
-    margin-bottom: 0;
-  }
-}
-
-.circuit-1 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #FFF;
-  border-color: #999;
-  color: #000;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-}
-
-.circuit-1:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-1:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-1:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-1:disabled,
-.circuit-1[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-1:hover {
-  background-color: #F5F5F5;
-  border-color: #666;
-}
-
-.circuit-1:active,
-.circuit-1[aria-expanded='true'],
-.circuit-1[aria-pressed='true'] {
-  background-color: #E6E6E6;
-  border-color: #333;
-}
-
-.circuit-2 {
-  display: block;
-  border-radius: 100%;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  -webkit-animation: animation-0 1s infinite linear;
-  animation: animation-0 1s infinite linear;
-  transform-origin: 50% 50%;
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-3 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  opacity: 1;
-  visibility: inherit;
-  -webkit-transform: scale3d(1, 1, 1);
-  -moz-transform: scale3d(1, 1, 1);
-  -ms-transform: scale3d(1, 1, 1);
-  transform: scale3d(1, 1, 1);
-  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-5 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #3063E9;
-  border-color: #3063E9;
-  color: #FFF;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-}
-
-.circuit-5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-5:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-5:disabled,
-.circuit-5[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-5:hover {
-  background-color: #234BC3;
-  border-color: #234BC3;
-}
-
-.circuit-5:active,
-.circuit-5[aria-expanded='true'],
-.circuit-5[aria-pressed='true'] {
-  background-color: #1A368E;
-  border-color: #1A368E;
-}
-
-<div
-  class="circuit-0"
->
-  <button
-    class="circuit-1"
-  >
-    <span
-      class="circuit-2"
-    >
-      <span
-        class="circuit-3"
-      />
-    </span>
-    <span
-      class="circuit-4"
-    >
-      Cancel
-    </span>
-  </button>
-  <button
-    class="circuit-5"
-  >
-    <span
-      class="circuit-2"
-    >
-      <span
-        class="circuit-3"
-      />
-    </span>
-    <span
-      class="circuit-4"
-    >
-      Confirm
-    </span>
-  </button>
-</div>
-`;
-
-exports[`ButtonGroup should render with the actions prop 1`] = `
 @keyframes animation-0 {
   0% {
     -webkit-transform: rotate(0deg);
@@ -873,6 +384,10 @@ exports[`ButtonGroup should render with the actions prop 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
 }
 
 @media (min-width: 480px) {
@@ -880,10 +395,360 @@ exports[`ButtonGroup should render with the actions prop 1`] = `
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
-    -webkit-box-pack: center;
-    -ms-flex-pack: center;
-    -webkit-justify-content: center;
-    justify-content: center;
+  }
+}
+
+.circuit-1 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  margin-right: 16px;
+}
+
+.circuit-1:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-1:disabled,
+.circuit-1[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-1:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-1:active,
+.circuit-1[aria-expanded='true'],
+.circuit-1[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+@media (max-width: 479px) {
+  .circuit-1 {
+    display: none;
+  }
+}
+
+.circuit-2 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-5 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #3063E9;
+  border-color: #3063E9;
+  color: #FFF;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+}
+
+.circuit-5:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-5:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-5:disabled,
+.circuit-5[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-5:hover {
+  background-color: #234BC3;
+  border-color: #234BC3;
+}
+
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
+  background-color: #1A368E;
+  border-color: #1A368E;
+}
+
+.circuit-9 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  background-color: transparent;
+  border-color: transparent;
+  color: #3063E9;
+  padding-left: 0;
+  padding-right: 0;
+  position: relative;
+  overflow: hidden;
+  margin-top: 16px;
+}
+
+.circuit-9:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-9:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-9:disabled,
+.circuit-9[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-9:hover {
+  color: #234BC3;
+}
+
+.circuit-9:active,
+.circuit-9[aria-expanded='true'],
+.circuit-9[aria-pressed='true'] {
+  color: #1A368E;
+}
+
+@media (min-width: 480px) {
+  .circuit-9 {
+    display: none;
+  }
+}
+
+<div
+  class="circuit-0"
+>
+  <a
+    class="circuit-1"
+    href="https://sumup.com"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Go elsewhere
+    </span>
+  </a>
+  <button
+    class="circuit-5"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Look again
+    </span>
+  </button>
+  <a
+    class="circuit-9"
+    href="https://sumup.com"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Go elsewhere
+    </span>
+  </a>
+</div>
+`;
+
+exports[`ButtonGroup should render with default styles 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+}
+
+@media (min-width: 480px) {
+  .circuit-0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
   }
 }
 

--- a/packages/circuit-ui/components/Card/Card.stories.tsx
+++ b/packages/circuit-ui/components/Card/Card.stories.tsx
@@ -108,20 +108,33 @@ export const WithFooter = () => (
     <Card css={cardStyles}>
       <Content />
       <CardFooter>
-        <ButtonGroup>
-          <Button>Cancel</Button>
-          <Button variant="primary">Confirm</Button>
-        </ButtonGroup>
+        <ButtonGroup
+          actions={{
+            primary: {
+              children: 'Cancel',
+            },
+            secondary: {
+              children: 'Confirm',
+            },
+          }}
+        />
       </CardFooter>
     </Card>
 
     <Card css={cardStyles}>
       <Content />
       <CardFooter align="left">
-        <ButtonGroup align="left">
-          <Button>Cancel</Button>
-          <Button variant="primary">Confirm</Button>
-        </ButtonGroup>
+        <ButtonGroup
+          align="left"
+          actions={{
+            primary: {
+              children: 'Cancel',
+            },
+            secondary: {
+              children: 'Confirm',
+            },
+          }}
+        />
       </CardFooter>
     </Card>
   </Fragment>

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
@@ -95,7 +95,9 @@ export const NotificationFullscreen = ({
           {body}
         </Body>
       )}
-      <ButtonGroup actions={actions} css={spacing({ top: 'giga' })} />
+      {actions && (
+        <ButtonGroup actions={actions} css={spacing({ top: 'giga' })} />
+      )}
     </div>
   );
 };

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
@@ -96,7 +96,11 @@ export const NotificationFullscreen = ({
         </Body>
       )}
       {actions && (
-        <ButtonGroup actions={actions} css={spacing({ top: 'giga' })} />
+        <ButtonGroup
+          align={'center'}
+          actions={actions}
+          css={spacing({ top: 'giga' })}
+        />
       )}
     </div>
   );

--- a/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
@@ -73,6 +73,10 @@ exports[`NotificationFullscreen styles should render with default styles 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   margin-top: 24px;
 }
 
@@ -81,10 +85,6 @@ exports[`NotificationFullscreen styles should render with default styles 1`] = `
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
-    -webkit-box-pack: center;
-    -ms-flex-pack: center;
-    -webkit-justify-content: center;
-    justify-content: center;
   }
 }
 

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
@@ -210,6 +210,7 @@ export const NotificationModal: ModalComponent<NotificationModalProps> = ({
             {body && <Body noMargin>{body}</Body>}
             {actions && (
               <ButtonGroup
+                align={'center'}
                 actions={{
                   primary: {
                     ...actions.primary,

--- a/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
@@ -229,6 +229,10 @@ exports[`NotificationModal styles should render with default styles 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   margin-top: 24px;
 }
 
@@ -237,10 +241,6 @@ exports[`NotificationModal styles should render with default styles 1`] = `
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
-    -webkit-box-pack: center;
-    -ms-flex-pack: center;
-    -webkit-justify-content: center;
-    justify-content: center;
   }
 }
 

--- a/packages/circuit-ui/components/Step/examples/MultiStepForm.tsx
+++ b/packages/circuit-ui/components/Step/examples/MultiStepForm.tsx
@@ -71,12 +71,19 @@ const FormTwo = ({ onNextClick, onBackClick }: FormProps) => (
       css={spacing({ bottom: 'mega' })}
       noMargin
     />
-    <ButtonGroup align="left">
-      <Button variant="primary" onClick={() => onNextClick()}>
-        Submit
-      </Button>
-      <Button onClick={() => onBackClick()}>Back</Button>
-    </ButtonGroup>
+
+    <ButtonGroup
+      actions={{
+        primary: {
+          children: 'Submit',
+          onClick: () => onNextClick(),
+        },
+        secondary: {
+          children: 'Back',
+          onClick: () => onBackClick(),
+        },
+      }}
+    />
   </section>
 );
 

--- a/packages/circuit-ui/components/Step/examples/MultiStepForm.tsx
+++ b/packages/circuit-ui/components/Step/examples/MultiStepForm.tsx
@@ -73,6 +73,7 @@ const FormTwo = ({ onNextClick, onBackClick }: FormProps) => (
     />
 
     <ButtonGroup
+      align="left"
       actions={{
         primary: {
           children: 'Submit',

--- a/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
+++ b/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
@@ -27,7 +27,6 @@ import {
 } from 'react-swipeable';
 
 import Image from '../../Image';
-import Button from '../../Button';
 import ButtonGroup from '../../ButtonGroup';
 import Step, { StepProps } from '../Step';
 import { StyleProps } from '../../../styles/styled';
@@ -113,20 +112,20 @@ export default function YesOrNoSlider({
               swipe={swipe}
             />
           </Swipeable>
-          <ButtonGroup align={'center'}>
-            <Button
-              variant={swipe?.dir === LEFT_DIRECTION ? 'primary' : 'secondary'}
-              {...getPreviousControlProps()}
-            >
-              No
-            </Button>
-            <Button
-              variant={swipe?.dir === RIGHT_DIRECTION ? 'primary' : 'secondary'}
-              {...getNextControlProps()}
-            >
-              Yes
-            </Button>
-          </ButtonGroup>
+
+          <ButtonGroup
+            align={'center'}
+            actions={{
+              primary: {
+                children: 'No',
+                ...getPreviousControlProps(),
+              },
+              secondary: {
+                children: 'Yes',
+                ...getNextControlProps(),
+              },
+            }}
+          />
         </SliderWrapper>
       )}
     </Step>


### PR DESCRIPTION


## Purpose

In #1167 we improved the ButtonGroup api to use the action config object with updated styles for mobile and deprecated the children prop.
In v5 we are removing the deprecated children prop from the ButtonGroup component.

## Approach and changes

- Removed the deprecated children prop from ButtonGroup component and the styles.
- Updated the ButtonGroup component usage in circuit ui to use the action prop instead of children.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
