### PR TITLE
Rename ListItem leading and trailing element props

### DIFF
--- a/.changeset/strange-seas-beam.md
+++ b/.changeset/strange-seas-beam.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Renamed the `ListItem` component's `prefix` and `suffix` props into `leadingComponent` and `trailingComponent`. Renamed the `suffixLabel` and `suffixDetails` props into `trailingLabel` and `trailingDetails`.

--- a/.changeset/strange-seas-beam.md
+++ b/.changeset/strange-seas-beam.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-Renamed the `ListItem` component's `prefix` and `suffix` props into `leadingComponent` and `trailingComponent`. Renamed the `suffixLabel` and `suffixDetails` props into `trailingLabel` and `trailingDetails`.
+Renamed the `ListItem` component's `prefix` and `suffix` props to `leadingComponent` and `trailingComponent`. Renamed the `suffixLabel` and `suffixDetails` props to `trailingLabel` and `trailingDetails`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -171,7 +171,7 @@ Keep in mind that this escape hatch is not meant as a way to permanently bypass 
 - The deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins were removed. Use the `shadow()` style mixin instead. There is no codemod for this change: migrate manually by searching for the deprecated style mixins in your codebase, and verify the changes visually.
 - The `RadioButton` component's deprecated `children` prop was removed. Use the `label` prop, now typed as required, instead. There is no codemod for this change: search your codebase for uses of the `RadioButton` or `RadioButtonGroup` component and migrate them manually.
 - The deprecated `showValid` option was removed from the `inputOutline` style mixin.
-- The `ListItem` component's `prefix` and `suffix` props were renamed into `leadingComponent` and `trailingComponent`. The `suffixLabel` and `suffixDetails` props were renamed into `trailingLabel` and `trailingDetails`. The codemod will not transform uses of the `ListItem` as `ListItemGroup` items. (_🤖 listitem-prop-names_)
+- The `ListItem` component's `prefix` and `suffix` props were renamed to `leadingComponent` and `trailingComponent`. The `suffixLabel` and `suffixDetails` props were renamed to `trailingLabel` and `trailingDetails`. The codemod will not transform uses of the `ListItem` as `ListItemGroup` items. (_🤖 listitem-prop-names_)
 
 ## From v4 to v4.1
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -171,6 +171,7 @@ Keep in mind that this escape hatch is not meant as a way to permanently bypass 
 - The deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins were removed. Use the `shadow()` style mixin instead. There is no codemod for this change: migrate manually by searching for the deprecated style mixins in your codebase, and verify the changes visually.
 - The `RadioButton` component's deprecated `children` prop was removed. Use the `label` prop, now typed as required, instead. There is no codemod for this change: search your codebase for uses of the `RadioButton` or `RadioButtonGroup` component and migrate them manually.
 - The deprecated `showValid` option was removed from the `inputOutline` style mixin.
+- The `ListItem` component's `prefix` and `suffix` props were renamed into `leadingComponent` and `trailingComponent`. The `suffixLabel` and `suffixDetails` props were renamed into `trailingLabel` and `trailingDetails`. The codemod will not transform uses of the `ListItem` as `ListItemGroup` items. (_🤖 listitem-prop-names_)
 
 ## From v4 to v4.1
 

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/label-prop-names.input.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/label-prop-names.input.js
@@ -5,7 +5,7 @@ const RedHamburger = styled(Hamburger)`
   color: red;
 `;
 
-const Component = (
+const Component = () => (
   <Card>
     <CardHeader labelCloseButton="Close">A strange component</CardHeader>
     <Hamburger labelActive="Active" labelInActive="Inactive" />

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/label-prop-names.output.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/label-prop-names.output.js
@@ -5,7 +5,7 @@ const RedHamburger = styled(Hamburger)`
   color: red;
 `;
 
-const Component = (
+const Component = () => (
   <Card>
     <CardHeader closeButtonLabel="Close">A strange component</CardHeader>
     <Hamburger activeLabel="Active" inactiveLabel="Inactive" />

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/listitem-prop-names.input.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/listitem-prop-names.input.js
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+import { ListItem, Badge } from '@sumup/circuit-ui';
+import { SumUpCard } from '@sumup/icons';
+
+const WithCustomComponents = () => (
+  <ListItem
+    label="MasterCard •••• 4494"
+    prefix={SumUpCard}
+    suffix={<Badge variant="promo">Promo</Badge>}
+  />
+);
+
+const WithLabelAndDetails = () => (
+  <ListItem
+    label="MasterCard •••• 4494"
+    suffixLabel="12 €"
+    suffixDetails="VAT included"
+  />
+);
+
+const StyledListItem = styled(ListItem)`
+  margin-bottom: ${(p) => p.theme.spacings.giga};
+`;
+
+const StyledComponent = () => (
+  <StyledListItem
+    label="MasterCard •••• 4494"
+    prefix={SumUpCard}
+    suffix={<Badge variant="promo">Promo</Badge>}
+  />
+);

--- a/packages/circuit-ui/cli/migrate/__testfixtures__/listitem-prop-names.output.js
+++ b/packages/circuit-ui/cli/migrate/__testfixtures__/listitem-prop-names.output.js
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+import { ListItem, Badge } from '@sumup/circuit-ui';
+import { SumUpCard } from '@sumup/icons';
+
+const WithCustomComponents = () => (
+  <ListItem
+    label="MasterCard •••• 4494"
+    leadingComponent={SumUpCard}
+    trailingComponent={<Badge variant="promo">Promo</Badge>}
+  />
+);
+
+const WithLabelAndDetails = () => (
+  <ListItem
+    label="MasterCard •••• 4494"
+    trailingLabel="12 €"
+    trailingDetails="VAT included"
+  />
+);
+
+const StyledListItem = styled(ListItem)`
+  margin-bottom: ${(p) => p.theme.spacings.giga};
+`;
+
+const StyledComponent = () => (
+  <StyledListItem
+    label="MasterCard •••• 4494"
+    leadingComponent={SumUpCard}
+    trailingComponent={<Badge variant="promo">Promo</Badge>}
+  />
+);

--- a/packages/circuit-ui/cli/migrate/__tests__/migrate.spec.js
+++ b/packages/circuit-ui/cli/migrate/__tests__/migrate.spec.js
@@ -63,6 +63,7 @@ defineTest('component-names-v4-1');
 // v5
 defineTest('semantic-color-names');
 defineTest('semantic-variant-names');
+defineTest('listitem-prop-names');
 
 function defineTest(transformName, testFilePrefix, testOptions = {}) {
   const dirName = __dirname;

--- a/packages/circuit-ui/cli/migrate/listitem-prop-names.ts
+++ b/packages/circuit-ui/cli/migrate/listitem-prop-names.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2022, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform } from 'jscodeshift';
+
+import { renameJSXAttribute, findLocalNames } from './utils';
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const propsMapping = [
+    {
+      fromName: 'prefix',
+      toName: 'leadingComponent',
+    },
+    {
+      fromName: 'suffix',
+      toName: 'trailingComponent',
+    },
+    {
+      fromName: 'suffixLabel',
+      toName: 'trailingLabel',
+    },
+    {
+      fromName: 'suffixDetails',
+      toName: 'trailingDetails',
+    },
+  ];
+
+  propsMapping.forEach(({ fromName, toName }) => {
+    const components = findLocalNames(j, root, 'ListItem');
+
+    if (!components) {
+      return;
+    }
+
+    components.forEach((component) => {
+      renameJSXAttribute(j, root, component, fromName, toName);
+    });
+  });
+
+  return root.toSource();
+};
+
+export default transform;

--- a/packages/circuit-ui/components/ListItem/ListItem.docs.mdx
+++ b/packages/circuit-ui/components/ListItem/ListItem.docs.mdx
@@ -4,10 +4,11 @@ import { Status, Props, Story } from '../../../../.storybook/components';
 
 <Status.Stable />
 
-The ListItem component is used to represent data in a structured and concise manner.
-It covers various levels of complexity by being split into several designated areas that can hold textual, presentational or interactive components.
-In its simplest form the ListItem only requires a label.
-While ListItem can be used on its own, in most cases the ListItemGroup component should be used to render a list of items.
+The `ListItem` component is used to represent data in a structured and concise manner.
+
+It covers various levels of complexity by being split into several designated areas that can hold textual, presentational or interactive components. In its simplest form, the `ListItem` only requires a label.
+
+While the `ListItem` can be used on its own, in most cases the `ListItemGroup` component should be used to render a list of items.
 
 <Story id="components-listitem--base" />
 <Props />
@@ -18,34 +19,33 @@ While ListItem can be used on its own, in most cases the ListItemGroup component
 
 ## Content guidelines
 
-- **Do** use size `24` Circuit UI icon, a custom 48x48 image, or other similar sized components, such as a circular Badge, for the `prefix` if applicable.
-- **Do** use the default styles for `label`, `details`, `suffixLabel` and `suffixDetails` by passing a string instead of a custom component.
-- **Do** use size `one` Body for the `label` and `suffixLabel` when using a custom component if applicable.
-- **Do** use size `two` subtle Body for the `details` and `suffixDetails` when using a custom component if applicable.
+- **Do** use size `24` Circuit UI icon, a custom 48x48 image, or other similar sized components, such as a circular Badge, for the `leadingComponent` if applicable.
+- **Do** use the default styles for `label`, `details`, `trailingLabel` and `trailingDetails` by passing a string instead of a custom component.
+- **Do** use size `one` Body for the `label` and `trailingLabel` when using a custom component if applicable.
+- **Do** use size `two` subtle Body for the `details` and `trailingDetails` when using a custom component if applicable.
 - **Do** use `&middot;` to split the `details` line in two sections if applicable.
-- **Do not** use `suffixDetails` on their own without also providing a `suffixLabel`.
-- **Do not** use a combination of a custom `suffix` component and `suffixLabel`.
+- **Do not** use `trailingDetails` on their own without also providing a `trailingLabel`.
+- **Do not** use a `trailingLabel` together with a custom `trailingComponent`. Add a label to the `trailingComponent` directly instead.
 
 ### Variants
 
-In addition to the standard `action` variant there is also the `navigation` variant.
-It shows a chevron icon in the suffix area of the ListItem indicating to the user that clicking on the item
-will either change the page or lead to a major change in the layout, such as opening a side panel.
+In addition to the default `action` variant there is also the `navigation` variant.
+
+It renders a chevron icon in the trailing area of the `ListItem`, indicating to the user that clicking on the item will either change the page or lead to a major change in the layout, such as opening a side panel.
 
 <Story id="components-listitem--navigation-variant" />
 
 ### Elements
 
-A standard Circuit UI icon can be used as a `prefix` to provide additional visual context to the user.
+A standard Circuit UI icon can be used as a `leadingComponent` to provide additional visual context to the user.
 
-<Story id="components-listitem--with-icon" />
+<Story id="components-listitem--with-leading-icon" />
 
-The `prefix` can also be used for custom components, such as a circular Badge or a Checkbox.
+The `leadingComponent` can also be used for custom components, such as a circular `Badge`.
 
-<Story id="components-listitem--with-custom-prefix" />
+<Story id="components-listitem--with-leading-component" />
 
-When the `label` is provided as a string it is rendered as a size `one` Body and is truncated when it gets too long.
-A custom component can be used for special cases, such as a multiline label.
+When the `label` is provided as a string, it is rendered as a size `one` Body and is truncated when it gets too long. A custom component can be used for special cases, such as a multiline label.
 
 <Story id="components-listitem--with-custom-label" />
 
@@ -55,22 +55,21 @@ The `details` line can be used to provide additional textual and visual informat
 
 <Story id="components-listitem--with-custom-details" />
 
-The suffix area can hold a combination of `suffixLabel` and `suffixDetails` or a standalone custom `suffix` component. The `suffixLabel` and `suffixDetails` can be custom components as well, but they should be used only for textual information.
+The trailing area can hold a combination of `trailingLabel` and `trailingDetails` or a standalone custom `trailingComponent`. The `trailingLabel` and `trailingDetails` can be custom components as well, but they should be used only for textual information.
 
-<Story id="components-listitem--with-suffix-label" />
+<Story id="components-listitem--with-trailing-label" />
 
-<Story id="components-listitem--with-suffix-label-and-details" />
+<Story id="components-listitem--with-trailing-label-and-details" />
 
-<Story id="components-listitem--with-custom-suffix-label-and-details" />
+<Story id="components-listitem--with-trailing-label-and-details-components" />
 
-<Story id="components-listitem--with-custom-suffix" />
+<Story id="components-listitem--with-trailing-component" />
 
-The ListItem component becomes interactive when it receives the `onClick` or `href` prop.
-This applies additional styles and accessibility features.
+The ListItem component becomes interactive when it receives an `onClick` or an `href` prop. This applies additional styles and accessibility features.
 
 <Story id="components-listitem--clickable" />
 
-Make sure to use the `navigation` variant when applicable, such as in this case when the ListItem acts as a link.
+Make sure to use the `navigation` variant when applicable, such as when the `ListItem` acts as a link.
 
 <Story id="components-listitem--as-link" />
 

--- a/packages/circuit-ui/components/ListItem/ListItem.spec.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.spec.tsx
@@ -53,18 +53,18 @@ describe('ListItem', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render a ListItem with a prefix icon', () => {
+    it('should render a ListItem with a leading icon', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        prefix: SumUpCard,
+        leadingComponent: SumUpCard,
       });
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render a ListItem with a custom prefix', () => {
+    it('should render a ListItem with a custom leading component', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        prefix: (
+        leadingComponent: (
           <Badge variant="alert" circle>
             3
           </Badge>
@@ -105,52 +105,52 @@ describe('ListItem', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render a ListItem with a suffix label', () => {
+    it('should render a ListItem with a trailing label', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        suffixLabel: 'Suffix label',
+        trailingLabel: 'trailingComponent label',
       });
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render a ListItem with a custom suffix label', () => {
+    it('should render a ListItem with a custom trailing label', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        suffixLabel: (
+        trailingLabel: (
           <Body size="one" variant="highlight" noMargin>
-            Suffix label
+            trailingComponent label
           </Body>
         ),
       });
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render a ListItem with a suffix details line', () => {
+    it('should render a ListItem with trailing details', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        suffixLabel: 'Suffix label',
-        suffixDetails: 'Suffix details',
+        trailingLabel: 'trailingComponent label',
+        trailingDetails: 'trailingComponent details',
       });
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render a ListItem with a custom suffix details line', () => {
+    it('should render a ListItem with custom trailing details', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        suffixLabel: 'Suffix label',
-        suffixDetails: (
+        trailingLabel: 'trailingComponent label',
+        trailingDetails: (
           <Body size="two" variant="subtle" noMargin>
-            Suffix details
+            trailingComponent details
           </Body>
         ),
       });
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render a ListItem with a custom suffix', () => {
+    it('should render a ListItem with a custom trailing component', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        suffix: <Badge variant="promo">Promo</Badge>,
+        trailingComponent: <Badge variant="promo">Promo</Badge>,
       });
       expect(wrapper).toMatchSnapshot();
     });
@@ -173,19 +173,10 @@ describe('ListItem', () => {
   });
 
   describe('business logic', () => {
-    it('should not render a ListItem with a suffix details line without a suffix label', () => {
+    it('should not render a trailing section with details but no label', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        suffixDetails: 'Suffix details',
-      });
-      expect(wrapper).toMatchSnapshot();
-    });
-
-    it('should not render a ListItem with both a suffix label and a custom suffix', () => {
-      const wrapper = renderListItem(create, {
-        ...baseProps,
-        suffixLabel: 'Suffix label',
-        suffix: <Badge variant="promo">Promo</Badge>,
+        trailingDetails: 'trailing details',
       });
       expect(wrapper).toMatchSnapshot();
     });
@@ -236,10 +227,10 @@ describe('ListItem', () => {
       const wrapper = renderListItem(renderToHtml, {
         ...baseProps,
         variant: 'navigation',
-        prefix: SumUpCard,
+        leadingComponent: SumUpCard,
         details: 'Details',
-        suffixLabel: 'Suffix label',
-        suffixDetails: 'Suffix details',
+        trailingLabel: 'trailing label',
+        trailingDetails: 'trailing details',
         onClick: jest.fn(),
       });
       const actual = await axe(wrapper);

--- a/packages/circuit-ui/components/ListItem/ListItem.spec.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.spec.tsx
@@ -108,7 +108,7 @@ describe('ListItem', () => {
     it('should render a ListItem with a trailing label', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        trailingLabel: 'trailingComponent label',
+        trailingLabel: 'Trailing label',
       });
       expect(wrapper).toMatchSnapshot();
     });
@@ -118,7 +118,7 @@ describe('ListItem', () => {
         ...baseProps,
         trailingLabel: (
           <Body size="one" variant="highlight" noMargin>
-            trailingComponent label
+            Trailing label
           </Body>
         ),
       });
@@ -128,8 +128,8 @@ describe('ListItem', () => {
     it('should render a ListItem with trailing details', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        trailingLabel: 'trailingComponent label',
-        trailingDetails: 'trailingComponent details',
+        trailingLabel: 'Trailing label',
+        trailingDetails: 'Trailing details',
       });
       expect(wrapper).toMatchSnapshot();
     });
@@ -137,10 +137,10 @@ describe('ListItem', () => {
     it('should render a ListItem with custom trailing details', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        trailingLabel: 'trailingComponent label',
+        trailingLabel: 'Trailing label',
         trailingDetails: (
           <Body size="two" variant="subtle" noMargin>
-            trailingComponent details
+            Trailing details
           </Body>
         ),
       });
@@ -176,7 +176,7 @@ describe('ListItem', () => {
     it('should not render a trailing section with details but no label', () => {
       const wrapper = renderListItem(create, {
         ...baseProps,
-        trailingDetails: 'trailing details',
+        trailingDetails: 'Trailing details',
       });
       expect(wrapper).toMatchSnapshot();
     });
@@ -229,8 +229,8 @@ describe('ListItem', () => {
         variant: 'navigation',
         leadingComponent: SumUpCard,
         details: 'Details',
-        trailingLabel: 'trailing label',
-        trailingDetails: 'trailing details',
+        trailingLabel: 'Trailing label',
+        trailingDetails: 'Trailing details',
         onClick: jest.fn(),
       });
       const actual = await axe(wrapper);

--- a/packages/circuit-ui/components/ListItem/ListItem.stories.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.stories.tsx
@@ -43,8 +43,8 @@ export default {
   argTypes: {
     label: { control: 'text' },
     details: { control: 'text' },
-    suffixLabel: { control: 'text' },
-    suffixDetails: { control: 'text' },
+    trailingLabel: { control: 'text' },
+    trailingDetails: { control: 'text' },
   },
 };
 
@@ -56,7 +56,7 @@ const item: Item = {
   timestamp: '17:21',
 };
 
-const PrefixBadge = (
+const LeadingBadge = (
   <Badge variant="alert" circle>
     3
   </Badge>
@@ -89,23 +89,23 @@ const Details = (
   </div>
 );
 
-const failedSuffixStyles = css`
+const lineThrough = css`
   text-decoration-line: line-through;
 `;
 
-const SuffixLabel = (
-  <Body size="one" variant="subtle" noMargin css={failedSuffixStyles}>
+const TrailingLabel = (
+  <Body size="one" variant="subtle" noMargin css={lineThrough}>
     {item.amount}
   </Body>
 );
 
-const SuffixDetails = (
-  <Body size="two" variant="subtle" noMargin css={failedSuffixStyles}>
+const TrailingDetails = (
+  <Body size="two" variant="subtle" noMargin css={lineThrough}>
     {item.fee} fee
   </Body>
 );
 
-const SuffixBadge = <Badge variant="promo">Promo</Badge>;
+const TrailingBadge = <Badge variant="promo">Promo</Badge>;
 
 const baseStyles = css`
   width: 500px;
@@ -118,12 +118,12 @@ const stylesWithMargin = (theme: Theme) => css`
 
 const baseArgs: ListItemProps = {
   variant: undefined,
-  prefix: undefined,
+  leadingComponent: undefined,
   label: item.title,
   details: undefined,
-  suffixLabel: undefined,
-  suffixDetails: undefined,
-  suffix: undefined,
+  trailingLabel: undefined,
+  trailingDetails: undefined,
+  trailingComponent: undefined,
   selected: undefined,
   disabled: undefined,
   onClick: null,
@@ -143,17 +143,17 @@ NavigationVariant.args = {
   variant: 'navigation',
 } as ListItemProps;
 
-export const WithIcon = (args: ListItemProps) => (
-  <ListItem {...args} prefix={SumUpCard} css={baseStyles} />
+export const WithLeadingIcon = (args: ListItemProps) => (
+  <ListItem {...args} leadingComponent={SumUpCard} css={baseStyles} />
 );
-WithIcon.args = {
+WithLeadingIcon.args = {
   ...baseArgs,
 } as ListItemProps;
 
-export const WithCustomPrefix = (args: ListItemProps) => (
-  <ListItem {...args} prefix={PrefixBadge} css={baseStyles} />
+export const WithLeadingComponent = (args: ListItemProps) => (
+  <ListItem {...args} leadingComponent={LeadingBadge} css={baseStyles} />
 );
-WithCustomPrefix.args = {
+WithLeadingComponent.args = {
   ...baseArgs,
 } as ListItemProps;
 
@@ -161,13 +161,13 @@ export const WithCustomLabel = (args: ListItemProps) => (
   <>
     <ListItem
       {...args}
-      prefix={SumUpCard}
+      leadingComponent={SumUpCard}
       label={`Default truncated label: ${args.label as string}`}
       css={stylesWithMargin}
     />
     <ListItem
       {...args}
-      prefix={SumUpCard}
+      leadingComponent={SumUpCard}
       label={
         <Body size="one" noMargin>
           Custom multiline label: {args.label}
@@ -198,39 +198,39 @@ WithCustomDetails.args = {
   ...baseArgs,
 } as ListItemProps;
 
-export const WithSuffixLabel = (args: ListItemProps) => (
+export const WithTrailingLabel = (args: ListItemProps) => (
   <ListItem {...args} css={baseStyles} />
 );
-WithSuffixLabel.args = {
+WithTrailingLabel.args = {
   ...baseArgs,
-  suffixLabel: item.amount,
+  trailingLabel: item.amount,
 } as ListItemProps;
 
-export const WithSuffixLabelAndDetails = (args: ListItemProps) => (
+export const WithTrailingLabelAndDetails = (args: ListItemProps) => (
   <ListItem {...args} css={baseStyles} />
 );
-WithSuffixLabelAndDetails.args = {
+WithTrailingLabelAndDetails.args = {
   ...baseArgs,
-  suffixLabel: item.amount,
-  suffixDetails: `${item.fee} fee`,
+  trailingLabel: item.amount,
+  trailingDetails: `${item.fee} fee`,
 } as ListItemProps;
 
-export const WithCustomSuffixLabelAndDetails = (args: ListItemProps) => (
+export const WithTrailingLabelAndDetailsComponents = (args: ListItemProps) => (
   <ListItem
     {...args}
-    suffixLabel={SuffixLabel}
-    suffixDetails={SuffixDetails}
+    trailingLabel={TrailingLabel}
+    trailingDetails={TrailingDetails}
     css={baseStyles}
   />
 );
-WithCustomSuffixLabelAndDetails.args = {
+WithTrailingLabelAndDetailsComponents.args = {
   ...baseArgs,
 } as ListItemProps;
 
-export const WithCustomSuffix = (args: ListItemProps) => (
-  <ListItem {...args} suffix={SuffixBadge} css={baseStyles} />
+export const WithTrailingComponent = (args: ListItemProps) => (
+  <ListItem {...args} trailingComponent={TrailingBadge} css={baseStyles} />
 );
-WithCustomSuffix.args = {
+WithTrailingComponent.args = {
   ...baseArgs,
 } as ListItemProps;
 
@@ -272,12 +272,17 @@ Disabled.args = {
 } as ListItemProps;
 
 export const SampleConfiguration = (args: ListItemProps) => (
-  <ListItem {...args} prefix={SumUpCard} details={Details} css={baseStyles} />
+  <ListItem
+    {...args}
+    leadingComponent={SumUpCard}
+    details={Details}
+    css={baseStyles}
+  />
 );
 SampleConfiguration.args = {
   ...baseArgs,
   variant: 'navigation',
-  suffixLabel: item.amount,
-  suffixDetails: `${item.fee} fee`,
+  trailingLabel: item.amount,
+  trailingDetails: `${item.fee} fee`,
   onClick: action('ListItem clicked'),
 } as ListItemProps;

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -35,7 +35,7 @@ import {
 import { ReturnType } from '../../types/return-type';
 import { ClickEvent } from '../../types/events';
 import { AsPropType } from '../../types/prop-types';
-import { isFunction } from '../../util/type-check';
+import { isFunction, isString } from '../../util/type-check';
 import { warn } from '../../util/logger';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import { useComponents } from '../ComponentsContext';
@@ -400,7 +400,7 @@ export const ListItem = forwardRef(
               isNavigation={isNavigation}
             >
               <TrailingChevronContainer>
-                {typeof trailingLabel === 'string' ? (
+                {isString(trailingLabel) ? (
                   <Body size="one" variant="highlight" noMargin>
                     {trailingLabel}
                   </Body>

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -50,7 +50,8 @@ interface BaseProps {
    */
   variant?: Variant;
   /**
-   * Display a leading icon, status image, checkbox, etc. in addition to the text content.
+   * Display a leading component.
+   * Pass an icon from `@sumup/icons` or a custom component.
    */
   leadingComponent?: FC<IconProps> | ReactNode;
   /**

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -375,7 +375,7 @@ export const ListItem = forwardRef(
         )}
         <ContentContainer>
           <MainContainer>
-            {typeof label === 'string' ? (
+            {isString(label) ? (
               <Label size="one" noMargin>
                 {label}
               </Label>
@@ -384,7 +384,7 @@ export const ListItem = forwardRef(
             )}
             {details && (
               <DetailsContainer>
-                {typeof details === 'string' ? (
+                {isString(details) ? (
                   <Body size="two" variant="subtle" noMargin>
                     {details}
                   </Body>
@@ -418,7 +418,7 @@ export const ListItem = forwardRef(
               </TrailingChevronContainer>
               {trailingDetails && (
                 <TrailingDetailsContainer isNavigation={isNavigation}>
-                  {typeof trailingDetails === 'string' ? (
+                  {isString(trailingDetails) ? (
                     <Body size="two" variant="subtle" noMargin>
                       {trailingDetails}
                     </Body>

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -20,11 +20,10 @@ import {
   ButtonHTMLAttributes,
   AnchorHTMLAttributes,
   HTMLAttributes,
-  FC,
 } from 'react';
 import { css } from '@emotion/react';
 import isPropValid from '@emotion/is-prop-valid';
-import { ChevronRight, IconProps } from '@sumup/icons';
+import { ChevronRight } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
 import {
@@ -52,7 +51,7 @@ interface BaseProps {
   /**
    * Display a leading icon, status image, checkbox, etc. in addition to the text content.
    */
-  prefix?: FC<IconProps> | ReactNode;
+  leadingElement?: ReactNode;
   /**
    * Display a main label.
    */
@@ -65,16 +64,16 @@ interface BaseProps {
    * Display a trailing label.
    * If using the `navigation` variant, the chevron icon will be center aligned with this label.
    */
-  suffixLabel?: ReactNode;
+  trailingLabel?: string | ReactNode;
   /**
    * Display a trailing details label.
    */
-  suffixDetails?: ReactNode;
+  trailingDetails?: string | ReactNode;
   /**
    * Display a custom trailing component.
    * If using the `navigation` variant, the chevron icon will be center aligned with this component.
    */
-  suffix?: ReactNode;
+  trailingElement?: ReactNode;
   /**
    * Visually mark the list item as selected.
    */
@@ -315,33 +314,33 @@ export const ListItem = forwardRef(
   (
     {
       variant = 'action',
-      prefix: Prefix,
+      leadingElement: Prefix,
       label,
       details,
-      suffixLabel,
-      suffixDetails,
-      suffix,
+      trailingLabel,
+      trailingDetails,
+      trailingElement,
       tracking,
       ...props
     }: ListItemProps,
     ref?: BaseProps['ref'],
   ): ReturnType => {
-    const hasOnlySuffixDetails = suffixDetails && !suffixLabel;
-    const hasCustomAndLabelSuffix = suffix && suffixLabel;
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      if (hasOnlySuffixDetails) {
+      if (trailingDetails && !trailingLabel) {
         warn(
           'ListItem',
-          'Using `suffixDetails` without `suffixLabel` is not supported.',
+          'Using `trailingDetails` without `trailingLabel` is not supported.',
+          'Use a custom `trailingElement` if necessary.',
         );
       }
-      if (hasCustomAndLabelSuffix) {
+      if (trailingElement && trailingLabel) {
         warn(
           'ListItem',
-          'Using `suffixLabel` and `suffix` at the same time is not supported.',
+          'Using `trailingLabel` and `trailingElement` at the same time is not supported.',
+          'Add a label to the custom `trailingElement` if necessary.',
         );
       }
     }
@@ -358,10 +357,8 @@ export const ListItem = forwardRef(
 
     const isInteractive = !!props.href || !!props.onClick;
     const isNavigation = variant === 'navigation';
-    const hasSuffix = !!suffixLabel || !!suffix;
-    const hasInvalidSuffix = hasOnlySuffixDetails || hasCustomAndLabelSuffix;
-    const shouldRenderSuffixContainer =
-      !hasInvalidSuffix && (hasSuffix || isNavigation);
+    const hasSuffix = !!trailingLabel || !!trailingElement;
+    const shouldRenderSuffixContainer = hasSuffix || isNavigation;
 
     return (
       <StyledListItem
@@ -403,18 +400,18 @@ export const ListItem = forwardRef(
           </MainContainer>
           {shouldRenderSuffixContainer && (
             <SuffixContainer
-              hasLabel={!!suffixLabel}
+              hasLabel={!!trailingLabel}
               isNavigation={isNavigation}
             >
               <SuffixChevronContainer>
-                {typeof suffixLabel === 'string' ? (
+                {typeof trailingLabel === 'string' ? (
                   <Body size="one" variant="highlight" noMargin>
-                    {suffixLabel}
+                    {trailingLabel}
                   </Body>
                 ) : (
-                  suffixLabel
+                  trailingLabel
                 )}
-                {suffix}
+                {trailingElement}
                 {isNavigation && (
                   <ChevronRight
                     size="16"
@@ -423,14 +420,14 @@ export const ListItem = forwardRef(
                   />
                 )}
               </SuffixChevronContainer>
-              {suffixDetails && (
+              {trailingDetails && (
                 <SuffixDetailsContainer isNavigation={isNavigation}>
-                  {typeof suffixDetails === 'string' ? (
+                  {typeof trailingDetails === 'string' ? (
                     <Body size="two" variant="subtle" noMargin>
-                      {suffixDetails}
+                      {trailingDetails}
                     </Body>
                   ) : (
-                    suffixDetails
+                    trailingDetails
                   )}
                 </SuffixDetailsContainer>
               )}

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -20,10 +20,11 @@ import {
   ButtonHTMLAttributes,
   AnchorHTMLAttributes,
   HTMLAttributes,
+  FC,
 } from 'react';
 import { css } from '@emotion/react';
 import isPropValid from '@emotion/is-prop-valid';
-import { ChevronRight } from '@sumup/icons';
+import { ChevronRight, IconProps } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
 import {
@@ -51,7 +52,7 @@ interface BaseProps {
   /**
    * Display a leading icon, status image, checkbox, etc. in addition to the text content.
    */
-  leadingElement?: ReactNode;
+  leadingElement?: FC<IconProps> | ReactNode;
   /**
    * Display a main label.
    */
@@ -100,15 +101,9 @@ interface BaseProps {
   ref?: Ref<HTMLDivElement & HTMLAnchorElement & HTMLButtonElement>;
 }
 
-type DivElProps = Omit<HTMLAttributes<HTMLDivElement>, 'prefix' | 'onClick'>;
-type LinkElProps = Omit<
-  AnchorHTMLAttributes<HTMLAnchorElement>,
-  'prefix' | 'onClick'
->;
-type ButtonElProps = Omit<
-  ButtonHTMLAttributes<HTMLButtonElement>,
-  'prefix' | 'onClick'
->;
+type DivElProps = Omit<HTMLAttributes<HTMLDivElement>, 'onClick'>;
+type LinkElProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'>;
+type ButtonElProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'>;
 
 export type ListItemProps = BaseProps &
   DivElProps &
@@ -207,13 +202,13 @@ const StyledListItem = styled('div', {
   selectedStyles,
 );
 
-const prefixContainerStyles = ({ theme }: StyleProps) => css`
+const leadingContainerStyles = ({ theme }: StyleProps) => css`
   flex: none;
   display: flex;
   margin-right: ${theme.spacings.mega};
 `;
 
-const PrefixContainer = styled.div(prefixContainerStyles);
+const LeadingContainer = styled.div(leadingContainerStyles);
 
 const contentContainerStyles = css`
   flex: auto;
@@ -255,12 +250,12 @@ const DetailsContainer = styled.div(detailsContainerStyles);
 
 type NavigationProps = { isNavigation: boolean };
 
-type SuffixContainerProps = { hasLabel: boolean } & NavigationProps;
+type TrailingContainerProps = { hasLabel: boolean } & NavigationProps;
 
-const suffixContainerStyles = ({
+const trailingContainerStyles = ({
   theme,
   hasLabel,
-}: StyleProps & SuffixContainerProps) => css`
+}: StyleProps & TrailingContainerProps) => css`
   flex: none;
   align-self: stretch;
   display: flex;
@@ -270,28 +265,28 @@ const suffixContainerStyles = ({
   margin-left: ${theme.spacings.mega};
 `;
 
-const suffixContainerNavigationStyles = ({
+const trailingContainerNavigationStyles = ({
   theme,
   isNavigation,
-}: StyleProps & SuffixContainerProps) =>
+}: StyleProps & TrailingContainerProps) =>
   isNavigation &&
   css`
     margin-right: -${theme.spacings.bit};
   `;
 
-const SuffixContainer = styled.div(
-  suffixContainerStyles,
-  suffixContainerNavigationStyles,
+const TrailingContainer = styled.div(
+  trailingContainerStyles,
+  trailingContainerNavigationStyles,
 );
 
-const suffixChevronContainerStyles = css`
+const trailingChevronContainerStyles = css`
   display: flex;
   align-items: center;
 `;
 
-const SuffixChevronContainer = styled.div(suffixChevronContainerStyles);
+const TrailingChevronContainer = styled.div(trailingChevronContainerStyles);
 
-const suffixDetailsContainerNavigationStyles = ({
+const trailingDetailsContainerNavigationStyles = ({
   theme,
   isNavigation,
 }: StyleProps & NavigationProps) =>
@@ -301,9 +296,9 @@ const suffixDetailsContainerNavigationStyles = ({
     height: ${theme.typography.body.one.lineHeight};
   `;
 
-const SuffixDetailsContainer = styled.div(
+const TrailingDetailsContainer = styled.div(
   detailsContainerStyles,
-  suffixDetailsContainerNavigationStyles,
+  trailingDetailsContainerNavigationStyles,
 );
 
 /**
@@ -314,7 +309,7 @@ export const ListItem = forwardRef(
   (
     {
       variant = 'action',
-      leadingElement: Prefix,
+      leadingElement: LeadingElement,
       label,
       details,
       trailingLabel,
@@ -357,8 +352,8 @@ export const ListItem = forwardRef(
 
     const isInteractive = !!props.href || !!props.onClick;
     const isNavigation = variant === 'navigation';
-    const hasSuffix = !!trailingLabel || !!trailingElement;
-    const shouldRenderSuffixContainer = hasSuffix || isNavigation;
+    const hasTrailing = !!trailingLabel || !!trailingElement;
+    const shouldRenderTrailingContainer = hasTrailing || isNavigation;
 
     return (
       <StyledListItem
@@ -368,14 +363,14 @@ export const ListItem = forwardRef(
         isInteractive={isInteractive}
         onClick={handleClick}
       >
-        {Prefix && (
-          <PrefixContainer>
-            {isFunction(Prefix) ? (
-              <Prefix size="24" role="presentation" />
+        {LeadingElement && (
+          <LeadingContainer>
+            {isFunction(LeadingElement) ? (
+              <LeadingElement size="24" role="presentation" />
             ) : (
-              Prefix
+              LeadingElement
             )}
-          </PrefixContainer>
+          </LeadingContainer>
         )}
         <ContentContainer>
           <MainContainer>
@@ -398,12 +393,12 @@ export const ListItem = forwardRef(
               </DetailsContainer>
             )}
           </MainContainer>
-          {shouldRenderSuffixContainer && (
-            <SuffixContainer
+          {shouldRenderTrailingContainer && (
+            <TrailingContainer
               hasLabel={!!trailingLabel}
               isNavigation={isNavigation}
             >
-              <SuffixChevronContainer>
+              <TrailingChevronContainer>
                 {typeof trailingLabel === 'string' ? (
                   <Body size="one" variant="highlight" noMargin>
                     {trailingLabel}
@@ -416,12 +411,12 @@ export const ListItem = forwardRef(
                   <ChevronRight
                     size="16"
                     role="presentation"
-                    css={hasSuffix && spacing({ left: 'bit' })}
+                    css={hasTrailing && spacing({ left: 'bit' })}
                   />
                 )}
-              </SuffixChevronContainer>
+              </TrailingChevronContainer>
               {trailingDetails && (
-                <SuffixDetailsContainer isNavigation={isNavigation}>
+                <TrailingDetailsContainer isNavigation={isNavigation}>
                   {typeof trailingDetails === 'string' ? (
                     <Body size="two" variant="subtle" noMargin>
                       {trailingDetails}
@@ -429,9 +424,9 @@ export const ListItem = forwardRef(
                   ) : (
                     trailingDetails
                   )}
-                </SuffixDetailsContainer>
+                </TrailingDetailsContainer>
               )}
-            </SuffixContainer>
+            </TrailingContainer>
           )}
         </ContentContainer>
       </StyledListItem>

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -52,7 +52,7 @@ interface BaseProps {
   /**
    * Display a leading icon, status image, checkbox, etc. in addition to the text content.
    */
-  leadingElement?: FC<IconProps> | ReactNode;
+  leadingComponent?: FC<IconProps> | ReactNode;
   /**
    * Display a main label.
    */
@@ -74,7 +74,7 @@ interface BaseProps {
    * Display a custom trailing component.
    * If using the `navigation` variant, the chevron icon will be center aligned with this component.
    */
-  trailingElement?: ReactNode;
+  trailingComponent?: ReactNode;
   /**
    * Visually mark the list item as selected.
    */
@@ -309,12 +309,12 @@ export const ListItem = forwardRef(
   (
     {
       variant = 'action',
-      leadingElement: LeadingElement,
+      leadingComponent: LeadingComponent,
       label,
       details,
       trailingLabel,
       trailingDetails,
-      trailingElement,
+      trailingComponent,
       tracking,
       ...props
     }: ListItemProps,
@@ -328,14 +328,14 @@ export const ListItem = forwardRef(
         warn(
           'ListItem',
           'Using `trailingDetails` without `trailingLabel` is not supported.',
-          'Use a custom `trailingElement` if necessary.',
+          'Use a custom `trailingComponent` if necessary.',
         );
       }
-      if (trailingElement && trailingLabel) {
+      if (trailingComponent && trailingLabel) {
         warn(
           'ListItem',
-          'Using `trailingLabel` and `trailingElement` at the same time is not supported.',
-          'Add a label to the custom `trailingElement` if necessary.',
+          'Using `trailingLabel` and `trailingComponent` at the same time is not supported.',
+          'Add a label to the custom `trailingComponent` if necessary.',
         );
       }
     }
@@ -352,7 +352,7 @@ export const ListItem = forwardRef(
 
     const isInteractive = !!props.href || !!props.onClick;
     const isNavigation = variant === 'navigation';
-    const hasTrailing = !!trailingLabel || !!trailingElement;
+    const hasTrailing = !!trailingLabel || !!trailingComponent;
     const shouldRenderTrailingContainer = hasTrailing || isNavigation;
 
     return (
@@ -363,12 +363,12 @@ export const ListItem = forwardRef(
         isInteractive={isInteractive}
         onClick={handleClick}
       >
-        {LeadingElement && (
+        {LeadingComponent && (
           <LeadingContainer>
-            {isFunction(LeadingElement) ? (
-              <LeadingElement size="24" role="presentation" />
+            {isFunction(LeadingComponent) ? (
+              <LeadingComponent size="24" role="presentation" />
             ) : (
-              LeadingElement
+              LeadingComponent
             )}
           </LeadingContainer>
         )}
@@ -406,7 +406,7 @@ export const ListItem = forwardRef(
                 ) : (
                   trailingLabel
                 )}
-                {trailingElement}
+                {trailingComponent}
                 {isNavigation && (
                   <ChevronRight
                     size="16"

--- a/packages/circuit-ui/components/ListItem/__snapshots__/ListItem.spec.tsx.snap
+++ b/packages/circuit-ui/components/ListItem/__snapshots__/ListItem.spec.tsx.snap
@@ -1,121 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ListItem business logic should not render a ListItem with a suffix details line without a suffix label 1`] = `
-.circuit-0 {
-  background-color: #FFF;
-  color: #1A1A1A;
-  border: 2px solid #E6E6E6;
-  border-radius: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  padding: 12px 16px;
-  margin: 0;
-  width: 100%;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  position: relative;
-}
-
-.circuit-0:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-0:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-0:focus {
-  border-color: transparent;
-  z-index: 2;
-}
-
-.circuit-0:focus:not(:focus-visible) {
-  border-color: #E6E6E6;
-  z-index: auto;
-}
-
-.circuit-0:disabled,
-.circuit-0[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-1 {
-  -webkit-flex: auto;
-  -ms-flex: auto;
-  flex: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-}
-
-.circuit-2 {
-  -webkit-flex: auto;
-  -ms-flex: auto;
-  flex: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  min-width: 0;
-}
-
-.circuit-3 {
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 24px;
-  max-width: 100%;
-  overflow-x: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-<div
-  class="circuit-0"
->
-  <div
-    class="circuit-1"
-  >
-    <div
-      class="circuit-2"
-    >
-      <p
-        class="circuit-3"
-      >
-        Label
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`ListItem business logic should not render a ListItem with both a suffix label and a custom suffix 1`] = `
+exports[`ListItem business logic should not render a trailing section with details but no label 1`] = `
 .circuit-0 {
   background-color: #FFF;
   color: #1A1A1A;
@@ -735,7 +620,7 @@ exports[`ListItem styles should render a ListItem with a custom label 1`] = `
 </div>
 `;
 
-exports[`ListItem styles should render a ListItem with a custom prefix 1`] = `
+exports[`ListItem styles should render a ListItem with a custom leading component 1`] = `
 .circuit-0 {
   background-color: #FFF;
   color: #1A1A1A;
@@ -898,7 +783,7 @@ exports[`ListItem styles should render a ListItem with a custom prefix 1`] = `
 </div>
 `;
 
-exports[`ListItem styles should render a ListItem with a custom suffix 1`] = `
+exports[`ListItem styles should render a ListItem with a custom trailing component 1`] = `
 .circuit-0 {
   background-color: #FFF;
   color: #1A1A1A;
@@ -1075,207 +960,7 @@ exports[`ListItem styles should render a ListItem with a custom suffix 1`] = `
 </div>
 `;
 
-exports[`ListItem styles should render a ListItem with a custom suffix details line 1`] = `
-.circuit-0 {
-  background-color: #FFF;
-  color: #1A1A1A;
-  border: 2px solid #E6E6E6;
-  border-radius: 16px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  padding: 12px 16px;
-  margin: 0;
-  width: 100%;
-  text-align: left;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  position: relative;
-}
-
-.circuit-0:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-0:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-0:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-0:focus {
-  border-color: transparent;
-  z-index: 2;
-}
-
-.circuit-0:focus:not(:focus-visible) {
-  border-color: #E6E6E6;
-  z-index: auto;
-}
-
-.circuit-0:disabled,
-.circuit-0[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-1 {
-  -webkit-flex: auto;
-  -ms-flex: auto;
-  flex: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  min-width: 0;
-}
-
-.circuit-2 {
-  -webkit-flex: auto;
-  -ms-flex: auto;
-  flex: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  min-width: 0;
-}
-
-.circuit-3 {
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 24px;
-  max-width: 100%;
-  overflow-x: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-.circuit-4 {
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-  -webkit-align-self: stretch;
-  -ms-flex-item-align: stretch;
-  align-self: stretch;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  margin-left: 16px;
-}
-
-.circuit-5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.circuit-6 {
-  font-weight: 400;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 700;
-}
-
-.circuit-7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  max-width: 100%;
-  min-height: 24px;
-}
-
-.circuit-8 {
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 20px;
-  color: #666;
-}
-
-<div
-  class="circuit-0"
->
-  <div
-    class="circuit-1"
-  >
-    <div
-      class="circuit-2"
-    >
-      <p
-        class="circuit-3"
-      >
-        Label
-      </p>
-    </div>
-    <div
-      class="circuit-4"
-    >
-      <div
-        class="circuit-5"
-      >
-        <strong
-          class="circuit-6"
-        >
-          Suffix label
-        </strong>
-      </div>
-      <div
-        class="circuit-7"
-      >
-        <p
-          class="circuit-8"
-        >
-          Suffix details
-        </p>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`ListItem styles should render a ListItem with a custom suffix label 1`] = `
+exports[`ListItem styles should render a ListItem with a custom trailing label 1`] = `
 .circuit-0 {
   background-color: #FFF;
   color: #1A1A1A;
@@ -1438,7 +1123,7 @@ exports[`ListItem styles should render a ListItem with a custom suffix label 1`]
         <strong
           class="circuit-6"
         >
-          Suffix label
+          Trailing label
         </strong>
       </div>
     </div>
@@ -1590,7 +1275,7 @@ exports[`ListItem styles should render a ListItem with a details line 1`] = `
 </div>
 `;
 
-exports[`ListItem styles should render a ListItem with a prefix icon 1`] = `
+exports[`ListItem styles should render a ListItem with a leading icon 1`] = `
 .circuit-0 {
   background-color: #FFF;
   color: #1A1A1A;
@@ -1733,7 +1418,178 @@ exports[`ListItem styles should render a ListItem with a prefix icon 1`] = `
 </div>
 `;
 
-exports[`ListItem styles should render a ListItem with a suffix details line 1`] = `
+exports[`ListItem styles should render a ListItem with a trailing label 1`] = `
+.circuit-0 {
+  background-color: #FFF;
+  color: #1A1A1A;
+  border: 2px solid #E6E6E6;
+  border-radius: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 12px 16px;
+  margin: 0;
+  width: 100%;
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  position: relative;
+}
+
+.circuit-0:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-0:focus {
+  border-color: transparent;
+  z-index: 2;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  border-color: #E6E6E6;
+  z-index: auto;
+}
+
+.circuit-0:disabled,
+.circuit-0[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-1 {
+  -webkit-flex: auto;
+  -ms-flex: auto;
+  flex: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  min-width: 0;
+}
+
+.circuit-2 {
+  -webkit-flex: auto;
+  -ms-flex: auto;
+  flex: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.circuit-3 {
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 24px;
+  max-width: 100%;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.circuit-4 {
+  -webkit-flex: none;
+  -ms-flex: none;
+  flex: none;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  margin-left: 16px;
+}
+
+.circuit-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.circuit-6 {
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 700;
+}
+
+<div
+  class="circuit-0"
+>
+  <div
+    class="circuit-1"
+  >
+    <div
+      class="circuit-2"
+    >
+      <p
+        class="circuit-3"
+      >
+        Label
+      </p>
+    </div>
+    <div
+      class="circuit-4"
+    >
+      <div
+        class="circuit-5"
+      >
+        <strong
+          class="circuit-6"
+        >
+          Trailing label
+        </strong>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ListItem styles should render a ListItem with custom trailing details 1`] = `
 .circuit-0 {
   background-color: #FFF;
   color: #1A1A1A;
@@ -1916,7 +1772,7 @@ exports[`ListItem styles should render a ListItem with a suffix details line 1`]
         <strong
           class="circuit-6"
         >
-          Suffix label
+          Trailing label
         </strong>
       </div>
       <div
@@ -1925,7 +1781,7 @@ exports[`ListItem styles should render a ListItem with a suffix details line 1`]
         <p
           class="circuit-8"
         >
-          Suffix details
+          Trailing details
         </p>
       </div>
     </div>
@@ -1933,7 +1789,7 @@ exports[`ListItem styles should render a ListItem with a suffix details line 1`]
 </div>
 `;
 
-exports[`ListItem styles should render a ListItem with a suffix label 1`] = `
+exports[`ListItem styles should render a ListItem with trailing details 1`] = `
 .circuit-0 {
   background-color: #FFF;
   color: #1A1A1A;
@@ -2072,6 +1928,26 @@ exports[`ListItem styles should render a ListItem with a suffix label 1`] = `
   font-weight: 700;
 }
 
+.circuit-7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  max-width: 100%;
+  min-height: 24px;
+}
+
+.circuit-8 {
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  color: #666;
+}
+
 <div
   class="circuit-0"
 >
@@ -2096,8 +1972,17 @@ exports[`ListItem styles should render a ListItem with a suffix label 1`] = `
         <strong
           class="circuit-6"
         >
-          Suffix label
+          Trailing label
         </strong>
+      </div>
+      <div
+        class="circuit-7"
+      >
+        <p
+          class="circuit-8"
+        >
+          Trailing details
+        </p>
       </div>
     </div>
   </div>

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.docs.mdx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.docs.mdx
@@ -4,16 +4,15 @@ import { Status, Props, Story } from '../../../../.storybook/components';
 
 <Status.Stable />
 
-The ListItemGroup component is used to render a list of contextually similar items.
-It applies additional styling to the ListItem elements and provides accessibility features out of the box.
+The `ListItemGroup` component is used to render a list of contextually similar items. It applies additional styling to the `ListItem` elements and provides accessibility features out of the box.
 
 <Story id="components-listitem-listitemgroup--base" />
 <Props />
 
 ## Usage guidelines
 
-- **Do** use ListItemGroup to display a group of contextually similar ListItems.
-- **Do** always accompany a ListItemGroup with a label in order to ensure it is accessible.
+- **Do** use `ListItemGroup` to display a group of contextually similar ListItems.
+- **Do** always accompany a `ListItemGroup` with a label in order to ensure it is accessible.
 
 ## Content guidelines
 
@@ -23,13 +22,13 @@ It applies additional styling to the ListItem elements and provides accessibilit
 
 ### Variants
 
-The ListItemGroup component offers a `plain` variant, which can be used for full-width lists on mobile resolutions or in containers with limited horizontal space, such as the side panel.
+The `ListItemGroup` component offers a `plain` variant, which can be used for full-width lists on mobile resolutions or in containers with limited horizontal space, such as the side panel.
 
 <Story id="components-listitem-listitemgroup--plain-variant" />
 
 ### Elements
 
-The ListItemGroup should always have a `label` in order to be accessible. If necessary the label can be visually hidden through the `hideLabel` prop.
+The `ListItemGroup` should always have a `label` in order to be accessible. If necessary the label can be visually hidden through the `hideLabel` prop.
 
 <Story id="components-listitem-listitemgroup--with-hidden-label" />
 

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.stories.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.stories.tsx
@@ -104,15 +104,15 @@ const Details = ({ item }: { item: Item }) => (
   </div>
 );
 
-const failedSuffixStyles = css`
+const strikeThrough = css`
   text-decoration-line: line-through;
 `;
 
-const Suffix = ({ item }: { item: Item }) => (
+const TrailingLabel = ({ item }: { item: Item }) => (
   <Body
     size="one"
     variant={item.status === 'Failed' ? 'subtle' : 'highlight'}
-    css={item.status === 'Failed' && failedSuffixStyles}
+    css={item.status === 'Failed' && strikeThrough}
     noMargin
   >
     {item.amount}
@@ -173,10 +173,10 @@ export const SampleConfiguration = (args: ListItemGroupProps) => {
       items={items.map((item) => ({
         key: item.id,
         variant: 'navigation',
-        prefix: SumUpCard,
+        leadingComponent: SumUpCard,
         label: item.title,
         details: <Details item={item} />,
-        suffixLabel: <Suffix item={item} />,
+        trailingLabel: <TrailingLabel item={item} />,
         selected: item.id === selectedId,
         onClick: () => setSelectedId(item.id),
       }))}


### PR DESCRIPTION
## Purpose

Rename `ListItem` leading and trailing element props for consistency with Figma and mobile platforms.

## Approach and changes

- Rename:
  - `prefix` into `leadingComponent`
  - `suffix` into `trailingComponent`
  - `suffixLabel` into `trailingLabel`
  - `suffixDetails` into `trailingDetails`
- Rename internal use of this wording for consistency/clarity
- Update specs and stories
- Add a codemod for `ListItem`
- ~Add a codemod for `ListItemGroup`~ 👈 this is too complex to codemod, we'll advise a search-and-replace migration strategy

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
