### PR TITLE
Add alignment support for ButtonGroup actions api

### DIFF
--- a/.changeset/small-pugs-train.md
+++ b/.changeset/small-pugs-train.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added alignment support for the ButtonGroup actions API, defaults to `center`.

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -20,6 +20,10 @@ import { ButtonGroup, ButtonGroupProps } from './ButtonGroup';
 export default {
   title: 'Components/Button/ButtonGroup',
   component: ButtonGroup,
+  parameters: {
+    // we don't want to center this story to be able to see the effects of the `align` prop
+    layout: 'padded',
+  },
 };
 
 export const Base = (args: ButtonGroupProps): JSX.Element => (

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
@@ -109,8 +109,11 @@ const actionWrapperStyles = ({ theme }: StyleProps) => css`
 
   ${theme.mq.kilo} {
     flex-direction: row;
-    justify-content: center;
   }
+`;
+
+const actionAlignmentStyles = ({ align = 'center' }: ButtonGroupProps) => css`
+  justify-content: ${alignmentMap[align]};
 `;
 
 const secondaryButtonStyles = ({ theme }: StyleProps) => css`
@@ -137,7 +140,10 @@ const Wrapper = styled('div')<ButtonGroupProps>(
   inlineMobileStyles,
 );
 
-const ActionsWrapper = styled('div')<ButtonGroupProps>(actionWrapperStyles);
+const ActionsWrapper = styled('div')<ButtonGroupProps>(
+  actionWrapperStyles,
+  actionAlignmentStyles,
+);
 
 /**
  * Groups its Button children into a list and adds margins between.
@@ -149,7 +155,7 @@ export const ButtonGroup = forwardRef(
   ) => {
     if (actions) {
       return (
-        <ActionsWrapper {...props}>
+        <ActionsWrapper {...props} ref={ref}>
           {actions.secondary && (
             <SecondaryButton {...actions.secondary} variant="secondary" />
           )}

--- a/packages/circuit-ui/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -873,6 +873,10 @@ exports[`ButtonGroup should render with the actions prop 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
 }
 
 @media (min-width: 480px) {
@@ -880,10 +884,6 @@ exports[`ButtonGroup should render with the actions prop 1`] = `
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
-    -webkit-box-pack: center;
-    -ms-flex-pack: center;
-    -webkit-justify-content: center;
-    justify-content: center;
   }
 }
 

--- a/packages/circuit-ui/components/Card/Card.stories.tsx
+++ b/packages/circuit-ui/components/Card/Card.stories.tsx
@@ -22,7 +22,6 @@ import { Stack } from '../../../../.storybook/components';
 import Headline from '../Headline';
 import Body from '../Body';
 import ButtonGroup from '../ButtonGroup';
-import Button from '../Button';
 
 import docs from './Card.docs.mdx';
 
@@ -108,20 +107,34 @@ export const WithFooter = () => (
     <Card css={cardStyles}>
       <Content />
       <CardFooter>
-        <ButtonGroup>
-          <Button>Cancel</Button>
-          <Button variant="primary">Confirm</Button>
-        </ButtonGroup>
+        <ButtonGroup
+          align="right"
+          actions={{
+            primary: {
+              children: 'Confirm',
+            },
+            secondary: {
+              children: 'Cancel',
+            },
+          }}
+        />
       </CardFooter>
     </Card>
 
     <Card css={cardStyles}>
       <Content />
       <CardFooter align="left">
-        <ButtonGroup align="left">
-          <Button>Cancel</Button>
-          <Button variant="primary">Confirm</Button>
-        </ButtonGroup>
+        <ButtonGroup
+          align="left"
+          actions={{
+            primary: {
+              children: 'Confirm',
+            },
+            secondary: {
+              children: 'Cancel',
+            },
+          }}
+        />
       </CardFooter>
     </Card>
   </Fragment>

--- a/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationFullscreen/__snapshots__/NotificationFullscreen.spec.tsx.snap
@@ -77,6 +77,10 @@ exports[`NotificationFullscreen styles should render with default styles 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   margin-top: 24px;
 }
 
@@ -85,10 +89,6 @@ exports[`NotificationFullscreen styles should render with default styles 1`] = `
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
-    -webkit-box-pack: center;
-    -ms-flex-pack: center;
-    -webkit-justify-content: center;
-    justify-content: center;
   }
 }
 

--- a/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
@@ -233,6 +233,10 @@ exports[`NotificationModal styles should render with default styles 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   margin-top: 24px;
 }
 
@@ -241,10 +245,6 @@ exports[`NotificationModal styles should render with default styles 1`] = `
     -webkit-flex-direction: row;
     -ms-flex-direction: row;
     flex-direction: row;
-    -webkit-box-pack: center;
-    -ms-flex-pack: center;
-    -webkit-justify-content: center;
-    justify-content: center;
   }
 }
 

--- a/packages/circuit-ui/components/Step/examples/MultiStepForm.tsx
+++ b/packages/circuit-ui/components/Step/examples/MultiStepForm.tsx
@@ -71,12 +71,19 @@ const FormTwo = ({ onNextClick, onBackClick }: FormProps) => (
       css={spacing({ bottom: 'mega' })}
       noMargin
     />
-    <ButtonGroup align="left">
-      <Button variant="primary" onClick={() => onNextClick()}>
-        Submit
-      </Button>
-      <Button onClick={() => onBackClick()}>Back</Button>
-    </ButtonGroup>
+    <ButtonGroup
+      align="left"
+      actions={{
+        primary: {
+          children: 'Submit',
+          onClick: () => onNextClick(),
+        },
+        secondary: {
+          children: 'Back',
+          onClick: () => onBackClick(),
+        },
+      }}
+    />
   </section>
 );
 

--- a/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
+++ b/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
@@ -28,7 +28,6 @@ import {
 
 import Image from '../../Image';
 import Button from '../../Button';
-import ButtonGroup from '../../ButtonGroup';
 import Step, { StepProps } from '../Step';
 import { StyleProps } from '../../../styles/styled';
 import { Actions } from '../types';
@@ -113,7 +112,13 @@ export default function YesOrNoSlider({
               swipe={swipe}
             />
           </Swipeable>
-          <ButtonGroup align={'center'}>
+          <div
+            css={(theme) => css`
+              display: flex;
+              justify-content: center;
+              gap: ${theme.spacings.mega};
+            `}
+          >
             <Button
               variant={swipe?.dir === LEFT_DIRECTION ? 'primary' : 'secondary'}
               {...getPreviousControlProps()}
@@ -126,7 +131,7 @@ export default function YesOrNoSlider({
             >
               Yes
             </Button>
-          </ButtonGroup>
+          </div>
         </SliderWrapper>
       )}
     </Step>


### PR DESCRIPTION

## Purpose

In https://github.com/sumup-oss/circuit-ui/pull/1167 we improved the ButtonGroup api to use the action config object with updated styles for mobile and deprecated the children prop.
However, changing the alignment was not supported in the new api.

## Approach and changes

- Added `actionAlignmentStyles` to enable alignment changes for the actions API in ButtonGroup, defaults to `center`.
- Updated ButtonGroup usage in circuit ui to use new actions API.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
