### PR TITLE
Export NotificationBanner from Circuit

### DIFF
--- a/.changeset/beige-swans-applaud.md
+++ b/.changeset/beige-swans-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Exported the `NotificationBanner` component from `@sumup/circuit-ui`.

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -80,6 +80,8 @@ export { default as SelectorGroup } from './components/SelectorGroup';
 export type { SelectorGroupProps } from './components/SelectorGroup';
 
 // Notifications
+export { default as NotificationBanner } from './components/NotificationBanner';
+export type { NotificationBannerProps } from './components/NotificationBanner';
 export { default as NotificationFullscreen } from './components/NotificationFullscreen';
 export type { NotificationFullscreenProps } from './components/NotificationFullscreen';
 export { useNotificationToast } from './components/NotificationToast';


### PR DESCRIPTION
Follows up on #1518 

## Purpose

We mistakenly removed the `NotificationBanner` from the Circuit UI named exports. This adds it again.

## Approach and changes

☝️ 

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
