### PR TITLE
Remove the deprecated ButtonGroup children

### DIFF
--- a/.changeset/honest-pugs-return.md
+++ b/.changeset/honest-pugs-return.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Removed the deprecated `children` prop from the `ButtonGroup` component. Use the `actions` prop instead.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -201,6 +201,7 @@ The API hasn't changed: uses of the `LoadingButton` can be replaced by the `Butt
 - The deprecated `zIndex.sidebar` design token was removed from `@sumup/design-tokens`. Use `sIndex.navigation` instead. There is no codemod for this change: search and replace the old value for the new one in your codebase.
 - The deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins were removed. Use the `shadow()` style mixin instead. There is no codemod for this change: migrate manually by searching for the deprecated style mixins in your codebase, and verify the changes visually.
 - The `RadioButton` component's deprecated `children` prop was removed. Use the `label` prop, now typed as required, instead. There is no codemod for this change: search your codebase for uses of the `RadioButton` or `RadioButtonGroup` component and migrate them manually.
+- The `ButtonGroup` component's deprecated `children` prop was removed. Use `actions` instead. If the new `ButtonGroup` component API doesn't fit your use case, consider aligning your use case with the design system, or write a custom wrapper for your buttons.
 - The deprecated `showValid` option was removed from the `inputOutline` style mixin.
 
 ## From v3.x to v4

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -201,7 +201,7 @@ The API hasn't changed: uses of the `LoadingButton` can be replaced by the `Butt
 - The deprecated `zIndex.sidebar` design token was removed from `@sumup/design-tokens`. Use `sIndex.navigation` instead. There is no codemod for this change: search and replace the old value for the new one in your codebase.
 - The deprecated `shadowSingle`, `shadowDouble` and `shadowTriple` style mixins were removed. Use the `shadow()` style mixin instead. There is no codemod for this change: migrate manually by searching for the deprecated style mixins in your codebase, and verify the changes visually.
 - The `RadioButton` component's deprecated `children` prop was removed. Use the `label` prop, now typed as required, instead. There is no codemod for this change: search your codebase for uses of the `RadioButton` or `RadioButtonGroup` component and migrate them manually.
-- The `ButtonGroup` component's deprecated `children` prop was removed. Use `actions` instead. If the new `ButtonGroup` component API doesn't fit your use case, consider aligning your use case with the design system, or write a custom wrapper for your buttons.
+- The `ButtonGroup` component's deprecated `children` prop was removed. Use the `actions` prop instead. If the new `ButtonGroup` component API doesn't fit your use case, consider aligning your use case with the design system, or writing a custom layout wrapper for your buttons.
 - The deprecated `showValid` option was removed from the `inputOutline` style mixin.
 
 ## From v3.x to v4

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.docs.mdx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.docs.mdx
@@ -12,7 +12,7 @@ The ButtonGroup component groups and formats two buttons. It adds spacing betwee
 
 ## Component variations
 
-By default, buttons passed to the ButtonGroup will be centered. Use the `align` prop to align the buttons to the left or to the right on large screens. This has no effect on small screens.
+By default, buttons passed to the ButtonGroup will be centered. Use the `align` prop to align the buttons to the left or to the right on wide viewports. This has no effect on narrow viewports.
 
 <Story id="components-button-buttongroup--alignment" />
 

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.docs.mdx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.docs.mdx
@@ -1,0 +1,21 @@
+import { Status, Props, Story } from '../../../../.storybook/components';
+
+# ButtonGroup
+
+<Status.Stable />
+
+The ButtonGroup component groups and formats two buttons. It adds spacing between buttons and handles responsiveness.
+
+<Story id="components-button-buttongroup--base" />
+
+<Props />
+
+## Component variations
+
+By default, buttons passed to the ButtonGroup will be centered. Use the `align` prop to align the buttons to the left or to the right on large screens. This has no effect on small screens.
+
+<Story id="components-button-buttongroup--alignment" />
+
+## Accessibility
+
+All accessibility considerations for the [`Button` component](Components/Button) also apply to the `ButtonGroup`.

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.spec.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.spec.tsx
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
-import { create, renderToHtml, axe } from '../../util/test-utils';
+import { createRef } from 'react';
+
+import { create, render, renderToHtml, axe } from '../../util/test-utils';
 
 import { ButtonGroup, ButtonGroupProps } from './ButtonGroup';
 
@@ -46,6 +48,16 @@ describe('ButtonGroup', () => {
       expect(actual).toMatchSnapshot();
     },
   );
+
+  /**
+   * Logic tests
+   */
+  it('should accept a working ref', () => {
+    const tref = createRef<HTMLDivElement>();
+    const { container } = render(<ButtonGroup {...defaultProps} ref={tref} />);
+    const div = container.querySelector('div');
+    expect(tref.current).toBe(div);
+  });
 
   /**
    * Accessibility tests.

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.spec.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.spec.tsx
@@ -14,77 +14,44 @@
  */
 
 import { create, renderToHtml, axe } from '../../util/test-utils';
-import Button from '../Button';
 
 import { ButtonGroup, ButtonGroupProps } from './ButtonGroup';
 
 describe('ButtonGroup', () => {
+  const defaultProps: ButtonGroupProps = {
+    actions: {
+      primary: {
+        children: 'Continue',
+      },
+      secondary: {
+        children: 'Cancel',
+      },
+    },
+  };
+
   /**
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(
-      <ButtonGroup>
-        <Button variant="secondary">Cancel</Button>
-        <Button variant="primary">Confirm</Button>
-      </ButtonGroup>,
-    );
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should render with the actions prop', () => {
-    const props: ButtonGroupProps = {
-      actions: {
-        primary: {
-          children: 'Look again',
-          onClick: jest.fn(),
-        },
-        secondary: {
-          children: 'Go elsewhere',
-          href: 'https://sumup.com',
-        },
-      },
-    };
-
-    const actual = create(<ButtonGroup {...props} />);
+    const actual = create(<ButtonGroup {...defaultProps} />);
 
     expect(actual).toMatchSnapshot();
   });
 
-  describe('Center aligment', () => {
-    it('should render with center alignment styles', () => {
-      const actual = create(
-        <ButtonGroup align={'center'}>
-          <Button variant="secondary">Cancel</Button>
-          <Button variant="primary">Confirm</Button>
-        </ButtonGroup>,
-      );
-      expect(actual).toMatchSnapshot();
-    });
-  });
+  it.each(['center', 'left', 'right'] as const)(
+    'should render aligned to the %s',
+    (align) => {
+      const actual = create(<ButtonGroup {...defaultProps} align={align} />);
 
-  describe('Left aligment', () => {
-    it('should render with left alignment styles', () => {
-      const actual = create(
-        <ButtonGroup align={'left'}>
-          <Button variant="secondary">Cancel</Button>
-          <Button variant="primary">Confirm</Button>
-        </ButtonGroup>,
-      );
       expect(actual).toMatchSnapshot();
-    });
-  });
+    },
+  );
 
   /**
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(
-      <ButtonGroup>
-        <Button variant="secondary">Cancel</Button>
-        <Button variant="primary">Confirm</Button>
-      </ButtonGroup>,
-    );
+    const wrapper = renderToHtml(<ButtonGroup {...defaultProps} />);
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -13,8 +13,11 @@
  * limitations under the License.
  */
 
+import { css } from '@emotion/react';
 import { action } from '@storybook/addon-actions';
+import { Theme } from '@sumup/design-tokens';
 
+import docs from './ButtonGroup.docs.mdx';
 import { ButtonGroup, ButtonGroupProps } from './ButtonGroup';
 
 export default {
@@ -23,6 +26,7 @@ export default {
   parameters: {
     // we don't want to center this story to be able to see the effects of the `align` prop
     layout: 'padded',
+    docs: { page: docs },
   },
 };
 
@@ -42,3 +46,19 @@ Base.args = {
     },
   },
 };
+
+export const Alignment = (args: ButtonGroupProps): JSX.Element => (
+  <div
+    css={(theme: Theme) => css`
+      display: flex;
+      flex-direction: column;
+      gap: ${theme.spacings.giga};
+    `}
+  >
+    <ButtonGroup {...args} align="center" />
+    <ButtonGroup {...args} align="left" />
+    <ButtonGroup {...args} align="right" />
+  </div>
+);
+
+Alignment.args = Base.args;

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ReactElement, Ref, forwardRef } from 'react';
+import { Ref, forwardRef, HTMLAttributes } from 'react';
 import { css } from '@emotion/react';
 
 import styled, { StyleProps } from '../../styles/styled';
@@ -21,66 +21,24 @@ import Button, { ButtonProps } from '../Button';
 
 type Action = Omit<ButtonProps, 'variant'>;
 
-export interface ButtonGroupProps {
+export interface ButtonGroupProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'align'> {
   /**
-   * @deprecated Use the `actions` prop instead.
+   * The buttons to group. Expects a primary and optionally a secondary button.
    */
-  children?:
-    | (ReactElement<ButtonProps> | null | undefined)[]
-    | ReactElement<ButtonProps>;
+  actions: {
+    primary: Action;
+    secondary?: Action;
+  };
   /**
-   * Direction to align the content. Either left/right
+   * Direction to align the buttons. Defaults to `center`.
    */
   align?: 'left' | 'center' | 'right';
-  /**
-   * Whether to display buttons inline on mobile.
-   */
-  inlineMobile?: boolean;
   /**
    * The ref to the HTML DOM element.
    */
   ref?: Ref<HTMLDivElement>;
-  /**
-   * Action Buttons
-   */
-  actions?: {
-    primary: Action;
-    secondary?: Action;
-  };
 }
-
-const getInlineStyles = ({ theme }: StyleProps) => css`
-  flex-wrap: wrap;
-  > button,
-  > a {
-    width: auto;
-
-    &:not(:last-child) {
-      margin-right: ${theme.spacings.mega};
-      margin-bottom: 0;
-    }
-  }
-`;
-
-const baseStyles = ({ theme }: StyleProps) => css`
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  width: 100%;
-
-  > button,
-  > a {
-    width: 100%;
-
-    &:not(:last-child) {
-      margin-bottom: ${theme.spacings.mega};
-    }
-  }
-
-  ${theme.mq.kilo} {
-    ${getInlineStyles({ theme })};
-  }
-`;
 
 const alignmentMap = {
   left: 'flex-start',
@@ -88,20 +46,9 @@ const alignmentMap = {
   right: 'flex-end',
 } as const;
 
-const alignmentStyles = ({ align = 'right' }: ButtonGroupProps) => css`
-  justify-content: ${alignmentMap[align]};
-`;
+type WrapperProps = Omit<ButtonGroupProps, 'actions'>;
 
-const inlineMobileStyles = ({
-  theme,
-  inlineMobile = false,
-}: StyleProps & ButtonGroupProps) =>
-  inlineMobile &&
-  css`
-    ${getInlineStyles({ theme })}
-  `;
-
-const actionWrapperStyles = ({ theme }: StyleProps) => css`
+const wrapperStyles = ({ theme }: StyleProps) => css`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -112,9 +59,11 @@ const actionWrapperStyles = ({ theme }: StyleProps) => css`
   }
 `;
 
-const actionAlignmentStyles = ({ align = 'center' }: ButtonGroupProps) => css`
+const alignmentStyles = ({ align = 'center' }: WrapperProps) => css`
   justify-content: ${alignmentMap[align]};
 `;
+
+const Wrapper = styled('div')<WrapperProps>(wrapperStyles, alignmentStyles);
 
 const secondaryButtonStyles = ({ theme }: StyleProps) => css`
   margin-right: ${theme.spacings.mega};
@@ -134,46 +83,21 @@ const tertiaryButtonStyles = ({ theme }: StyleProps) => css`
 
 const TertiaryButton = styled(Button)<ButtonProps>(tertiaryButtonStyles);
 
-const Wrapper = styled('div')<ButtonGroupProps>(
-  baseStyles,
-  alignmentStyles,
-  inlineMobileStyles,
-);
-
-const ActionsWrapper = styled('div')<ButtonGroupProps>(
-  actionWrapperStyles,
-  actionAlignmentStyles,
-);
-
 /**
- * Groups its Button children into a list and adds margins between.
+ * The ButtonGroup component groups and formats two buttons.
  */
 export const ButtonGroup = forwardRef(
-  (
-    { children, actions, ...props }: ButtonGroupProps,
-    ref: ButtonGroupProps['ref'],
-  ) => {
-    if (actions) {
-      return (
-        <ActionsWrapper {...props} ref={ref}>
-          {actions.secondary && (
-            <SecondaryButton {...actions.secondary} variant="secondary" />
-          )}
-
-          <Button {...actions.primary} variant="primary" />
-
-          {actions.secondary && (
-            <TertiaryButton {...actions.secondary} variant="tertiary" />
-          )}
-        </ActionsWrapper>
-      );
-    }
-    return (
-      <Wrapper {...props} ref={ref}>
-        {children}
-      </Wrapper>
-    );
-  },
+  ({ actions, ...props }: ButtonGroupProps, ref: ButtonGroupProps['ref']) => (
+    <Wrapper {...props} ref={ref}>
+      {actions.secondary && (
+        <SecondaryButton {...actions.secondary} variant="secondary" />
+      )}
+      <Button {...actions.primary} variant="primary" />
+      {actions.secondary && (
+        <TertiaryButton {...actions.secondary} variant="tertiary" />
+      )}
+    </Wrapper>
+  ),
 );
 
 ButtonGroup.displayName = 'ButtonGroup';

--- a/packages/circuit-ui/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/ButtonGroup/__snapshots__/ButtonGroup.spec.tsx.snap
@@ -1,849 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ButtonGroup Center aligment should render with center alignment styles 1`] = `
-@keyframes animation-0 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  width: 100%;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-}
-
-.circuit-0>button,
-.circuit-0>a {
-  width: 100%;
-}
-
-.circuit-0>button:not(:last-child),
-.circuit-0>a:not(:last-child) {
-  margin-bottom: 16px;
-}
-
-@media (min-width: 480px) {
-  .circuit-0 {
-    -webkit-box-flex-wrap: wrap;
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
-  }
-
-  .circuit-0>button,
-  .circuit-0>a {
-    width: auto;
-  }
-
-  .circuit-0>button:not(:last-child),
-  .circuit-0>a:not(:last-child) {
-    margin-right: 16px;
-    margin-bottom: 0;
-  }
-}
-
-.circuit-1 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #FFF;
-  border-color: #999;
-  color: #000;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-}
-
-.circuit-1:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-1:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-1:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-1:disabled,
-.circuit-1[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-1:hover {
-  background-color: #F5F5F5;
-  border-color: #666;
-}
-
-.circuit-1:active,
-.circuit-1[aria-expanded='true'],
-.circuit-1[aria-pressed='true'] {
-  background-color: #E6E6E6;
-  border-color: #333;
-}
-
-.circuit-2 {
-  display: block;
-  border-radius: 100%;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  -webkit-animation: animation-0 1s infinite linear;
-  animation: animation-0 1s infinite linear;
-  transform-origin: 50% 50%;
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-3 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  opacity: 1;
-  visibility: inherit;
-  -webkit-transform: scale3d(1, 1, 1);
-  -moz-transform: scale3d(1, 1, 1);
-  -ms-transform: scale3d(1, 1, 1);
-  transform: scale3d(1, 1, 1);
-  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-5 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #3063E9;
-  border-color: #3063E9;
-  color: #FFF;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-}
-
-.circuit-5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-5:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-5:disabled,
-.circuit-5[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-5:hover {
-  background-color: #234BC3;
-  border-color: #234BC3;
-}
-
-.circuit-5:active,
-.circuit-5[aria-expanded='true'],
-.circuit-5[aria-pressed='true'] {
-  background-color: #1A368E;
-  border-color: #1A368E;
-}
-
-<div
-  class="circuit-0"
->
-  <button
-    class="circuit-1"
-  >
-    <span
-      class="circuit-2"
-    >
-      <span
-        class="circuit-3"
-      />
-    </span>
-    <span
-      class="circuit-4"
-    >
-      Cancel
-    </span>
-  </button>
-  <button
-    class="circuit-5"
-  >
-    <span
-      class="circuit-2"
-    >
-      <span
-        class="circuit-3"
-      />
-    </span>
-    <span
-      class="circuit-4"
-    >
-      Confirm
-    </span>
-  </button>
-</div>
-`;
-
-exports[`ButtonGroup Left aligment should render with left alignment styles 1`] = `
-@keyframes animation-0 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  width: 100%;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-}
-
-.circuit-0>button,
-.circuit-0>a {
-  width: 100%;
-}
-
-.circuit-0>button:not(:last-child),
-.circuit-0>a:not(:last-child) {
-  margin-bottom: 16px;
-}
-
-@media (min-width: 480px) {
-  .circuit-0 {
-    -webkit-box-flex-wrap: wrap;
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
-  }
-
-  .circuit-0>button,
-  .circuit-0>a {
-    width: auto;
-  }
-
-  .circuit-0>button:not(:last-child),
-  .circuit-0>a:not(:last-child) {
-    margin-right: 16px;
-    margin-bottom: 0;
-  }
-}
-
-.circuit-1 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #FFF;
-  border-color: #999;
-  color: #000;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-}
-
-.circuit-1:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-1:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-1:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-1:disabled,
-.circuit-1[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-1:hover {
-  background-color: #F5F5F5;
-  border-color: #666;
-}
-
-.circuit-1:active,
-.circuit-1[aria-expanded='true'],
-.circuit-1[aria-pressed='true'] {
-  background-color: #E6E6E6;
-  border-color: #333;
-}
-
-.circuit-2 {
-  display: block;
-  border-radius: 100%;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  -webkit-animation: animation-0 1s infinite linear;
-  animation: animation-0 1s infinite linear;
-  transform-origin: 50% 50%;
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-3 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  opacity: 1;
-  visibility: inherit;
-  -webkit-transform: scale3d(1, 1, 1);
-  -moz-transform: scale3d(1, 1, 1);
-  -ms-transform: scale3d(1, 1, 1);
-  transform: scale3d(1, 1, 1);
-  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-5 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #3063E9;
-  border-color: #3063E9;
-  color: #FFF;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-}
-
-.circuit-5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-5:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-5:disabled,
-.circuit-5[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-5:hover {
-  background-color: #234BC3;
-  border-color: #234BC3;
-}
-
-.circuit-5:active,
-.circuit-5[aria-expanded='true'],
-.circuit-5[aria-pressed='true'] {
-  background-color: #1A368E;
-  border-color: #1A368E;
-}
-
-<div
-  class="circuit-0"
->
-  <button
-    class="circuit-1"
-  >
-    <span
-      class="circuit-2"
-    >
-      <span
-        class="circuit-3"
-      />
-    </span>
-    <span
-      class="circuit-4"
-    >
-      Cancel
-    </span>
-  </button>
-  <button
-    class="circuit-5"
-  >
-    <span
-      class="circuit-2"
-    >
-      <span
-        class="circuit-3"
-      />
-    </span>
-    <span
-      class="circuit-4"
-    >
-      Confirm
-    </span>
-  </button>
-</div>
-`;
-
-exports[`ButtonGroup should render with default styles 1`] = `
-@keyframes animation-0 {
-  0% {
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(360deg);
-    -moz-transform: rotate(360deg);
-    -ms-transform: rotate(360deg);
-    transform: rotate(360deg);
-  }
-}
-
-.circuit-0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  width: 100%;
-  -webkit-box-pack: end;
-  -ms-flex-pack: end;
-  -webkit-justify-content: flex-end;
-  justify-content: flex-end;
-}
-
-.circuit-0>button,
-.circuit-0>a {
-  width: 100%;
-}
-
-.circuit-0>button:not(:last-child),
-.circuit-0>a:not(:last-child) {
-  margin-bottom: 16px;
-}
-
-@media (min-width: 480px) {
-  .circuit-0 {
-    -webkit-box-flex-wrap: wrap;
-    -webkit-flex-wrap: wrap;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
-  }
-
-  .circuit-0>button,
-  .circuit-0>a {
-    width: auto;
-  }
-
-  .circuit-0>button:not(:last-child),
-  .circuit-0>a:not(:last-child) {
-    margin-right: 16px;
-    margin-bottom: 0;
-  }
-}
-
-.circuit-1 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #FFF;
-  border-color: #999;
-  color: #000;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-}
-
-.circuit-1:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-1:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-1:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-1:disabled,
-.circuit-1[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-1:hover {
-  background-color: #F5F5F5;
-  border-color: #666;
-}
-
-.circuit-1:active,
-.circuit-1[aria-expanded='true'],
-.circuit-1[aria-pressed='true'] {
-  background-color: #E6E6E6;
-  border-color: #333;
-}
-
-.circuit-2 {
-  display: block;
-  border-radius: 100%;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  -webkit-animation: animation-0 1s infinite linear;
-  animation: animation-0 1s infinite linear;
-  transform-origin: 50% 50%;
-  width: 24px;
-  height: 24px;
-  position: absolute;
-  opacity: 0;
-  visibility: hidden;
-  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-3 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  opacity: 1;
-  visibility: inherit;
-  -webkit-transform: scale3d(1, 1, 1);
-  -moz-transform: scale3d(1, 1, 1);
-  -ms-transform: scale3d(1, 1, 1);
-  transform: scale3d(1, 1, 1);
-  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
-}
-
-.circuit-5 {
-  font-size: 16px;
-  line-height: 24px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  width: auto;
-  height: auto;
-  margin: 0;
-  cursor: pointer;
-  text-align: center;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  font-weight: 700;
-  border-width: 1px;
-  border-style: solid;
-  border-radius: 999999px;
-  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  background-color: #3063E9;
-  border-color: #3063E9;
-  color: #FFF;
-  padding: calc(12px - 1px) calc(24px - 1px);
-  position: relative;
-  overflow: hidden;
-}
-
-.circuit-5:focus {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-}
-
-.circuit-5:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-5:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-5:disabled,
-.circuit-5[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-5:hover {
-  background-color: #234BC3;
-  border-color: #234BC3;
-}
-
-.circuit-5:active,
-.circuit-5[aria-expanded='true'],
-.circuit-5[aria-pressed='true'] {
-  background-color: #1A368E;
-  border-color: #1A368E;
-}
-
-<div
-  class="circuit-0"
->
-  <button
-    class="circuit-1"
-  >
-    <span
-      class="circuit-2"
-    >
-      <span
-        class="circuit-3"
-      />
-    </span>
-    <span
-      class="circuit-4"
-    >
-      Cancel
-    </span>
-  </button>
-  <button
-    class="circuit-5"
-  >
-    <span
-      class="circuit-2"
-    >
-      <span
-        class="circuit-3"
-      />
-    </span>
-    <span
-      class="circuit-4"
-    >
-      Confirm
-    </span>
-  </button>
-</div>
-`;
-
-exports[`ButtonGroup should render with the actions prop 1`] = `
+exports[`ButtonGroup should render aligned to the center 1`] = `
 @keyframes animation-0 {
   0% {
     -webkit-transform: rotate(0deg);
@@ -1144,9 +301,8 @@ exports[`ButtonGroup should render with the actions prop 1`] = `
 <div
   class="circuit-0"
 >
-  <a
+  <button
     class="circuit-1"
-    href="https://sumup.com"
   >
     <span
       class="circuit-2"
@@ -1158,9 +314,9 @@ exports[`ButtonGroup should render with the actions prop 1`] = `
     <span
       class="circuit-4"
     >
-      Go elsewhere
+      Cancel
     </span>
-  </a>
+  </button>
   <button
     class="circuit-5"
   >
@@ -1174,12 +330,11 @@ exports[`ButtonGroup should render with the actions prop 1`] = `
     <span
       class="circuit-4"
     >
-      Look again
+      Continue
     </span>
   </button>
-  <a
+  <button
     class="circuit-9"
-    href="https://sumup.com"
   >
     <span
       class="circuit-2"
@@ -1191,8 +346,1064 @@ exports[`ButtonGroup should render with the actions prop 1`] = `
     <span
       class="circuit-4"
     >
-      Go elsewhere
+      Cancel
     </span>
-  </a>
+  </button>
+</div>
+`;
+
+exports[`ButtonGroup should render aligned to the left 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+}
+
+@media (min-width: 480px) {
+  .circuit-0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+.circuit-1 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  margin-right: 16px;
+}
+
+.circuit-1:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-1:disabled,
+.circuit-1[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-1:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-1:active,
+.circuit-1[aria-expanded='true'],
+.circuit-1[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+@media (max-width: 479px) {
+  .circuit-1 {
+    display: none;
+  }
+}
+
+.circuit-2 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-5 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #3063E9;
+  border-color: #3063E9;
+  color: #FFF;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+}
+
+.circuit-5:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-5:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-5:disabled,
+.circuit-5[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-5:hover {
+  background-color: #234BC3;
+  border-color: #234BC3;
+}
+
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
+  background-color: #1A368E;
+  border-color: #1A368E;
+}
+
+.circuit-9 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  background-color: transparent;
+  border-color: transparent;
+  color: #3063E9;
+  padding-left: 0;
+  padding-right: 0;
+  position: relative;
+  overflow: hidden;
+  margin-top: 16px;
+}
+
+.circuit-9:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-9:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-9:disabled,
+.circuit-9[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-9:hover {
+  color: #234BC3;
+}
+
+.circuit-9:active,
+.circuit-9[aria-expanded='true'],
+.circuit-9[aria-pressed='true'] {
+  color: #1A368E;
+}
+
+@media (min-width: 480px) {
+  .circuit-9 {
+    display: none;
+  }
+}
+
+<div
+  class="circuit-0"
+>
+  <button
+    class="circuit-1"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Cancel
+    </span>
+  </button>
+  <button
+    class="circuit-5"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Continue
+    </span>
+  </button>
+  <button
+    class="circuit-9"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Cancel
+    </span>
+  </button>
+</div>
+`;
+
+exports[`ButtonGroup should render aligned to the right 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+}
+
+@media (min-width: 480px) {
+  .circuit-0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+.circuit-1 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  margin-right: 16px;
+}
+
+.circuit-1:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-1:disabled,
+.circuit-1[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-1:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-1:active,
+.circuit-1[aria-expanded='true'],
+.circuit-1[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+@media (max-width: 479px) {
+  .circuit-1 {
+    display: none;
+  }
+}
+
+.circuit-2 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-5 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #3063E9;
+  border-color: #3063E9;
+  color: #FFF;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+}
+
+.circuit-5:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-5:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-5:disabled,
+.circuit-5[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-5:hover {
+  background-color: #234BC3;
+  border-color: #234BC3;
+}
+
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
+  background-color: #1A368E;
+  border-color: #1A368E;
+}
+
+.circuit-9 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  background-color: transparent;
+  border-color: transparent;
+  color: #3063E9;
+  padding-left: 0;
+  padding-right: 0;
+  position: relative;
+  overflow: hidden;
+  margin-top: 16px;
+}
+
+.circuit-9:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-9:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-9:disabled,
+.circuit-9[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-9:hover {
+  color: #234BC3;
+}
+
+.circuit-9:active,
+.circuit-9[aria-expanded='true'],
+.circuit-9[aria-pressed='true'] {
+  color: #1A368E;
+}
+
+@media (min-width: 480px) {
+  .circuit-9 {
+    display: none;
+  }
+}
+
+<div
+  class="circuit-0"
+>
+  <button
+    class="circuit-1"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Cancel
+    </span>
+  </button>
+  <button
+    class="circuit-5"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Continue
+    </span>
+  </button>
+  <button
+    class="circuit-9"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Cancel
+    </span>
+  </button>
+</div>
+`;
+
+exports[`ButtonGroup should render with default styles 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  width: 100%;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+@media (min-width: 480px) {
+  .circuit-0 {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+}
+
+.circuit-1 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  margin-right: 16px;
+}
+
+.circuit-1:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-1:disabled,
+.circuit-1[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-1:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-1:active,
+.circuit-1[aria-expanded='true'],
+.circuit-1[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+@media (max-width: 479px) {
+  .circuit-1 {
+    display: none;
+  }
+}
+
+.circuit-2 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-5 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #3063E9;
+  border-color: #3063E9;
+  color: #FFF;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+}
+
+.circuit-5:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-5:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-5:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-5:disabled,
+.circuit-5[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-5:hover {
+  background-color: #234BC3;
+  border-color: #234BC3;
+}
+
+.circuit-5:active,
+.circuit-5[aria-expanded='true'],
+.circuit-5[aria-pressed='true'] {
+  background-color: #1A368E;
+  border-color: #1A368E;
+}
+
+.circuit-9 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  background-color: transparent;
+  border-color: transparent;
+  color: #3063E9;
+  padding-left: 0;
+  padding-right: 0;
+  position: relative;
+  overflow: hidden;
+  margin-top: 16px;
+}
+
+.circuit-9:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-9:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-9:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-9:disabled,
+.circuit-9[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-9:hover {
+  color: #234BC3;
+}
+
+.circuit-9:active,
+.circuit-9[aria-expanded='true'],
+.circuit-9[aria-pressed='true'] {
+  color: #1A368E;
+}
+
+@media (min-width: 480px) {
+  .circuit-9 {
+    display: none;
+  }
+}
+
+<div
+  class="circuit-0"
+>
+  <button
+    class="circuit-1"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Cancel
+    </span>
+  </button>
+  <button
+    class="circuit-5"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Continue
+    </span>
+  </button>
+  <button
+    class="circuit-9"
+  >
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      Cancel
+    </span>
+  </button>
 </div>
 `;

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
@@ -45,7 +45,7 @@ export interface NotificationFullscreenProps
    */
   body?: string | ReactNode;
   /**
-   * An optional action prop to allow users to follow up on the content.
+   * Optional action buttons to allow users to follow up on the content.
    */
   actions?: ButtonGroupProps['actions'];
 }
@@ -95,7 +95,9 @@ export const NotificationFullscreen = ({
           {body}
         </Body>
       )}
-      <ButtonGroup actions={actions} css={spacing({ top: 'giga' })} />
+      {actions && (
+        <ButtonGroup actions={actions} css={spacing({ top: 'giga' })} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Purpose

Removes the deprecated `ButtonGroup` component's `children` prop. Use `actions` instead.

## Approach and changes

- remove the prop, clean up the component's implementation
- add missing stories, tests, docs

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
