### PR TITLE
Accept an as prop in the Button component

### DIFF
--- a/.changeset/twelve-cougars-sniff.md
+++ b/.changeset/twelve-cougars-sniff.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added support for the `as` prop in the `Button` component. This is necessary to render buttons in a `ButtonGroup` as links with routing.

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -18,7 +18,7 @@ import { css } from '@emotion/react';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
-import { AsPropType } from '../../types/prop-types';
+import { AsPropType, EmotionAsPropType } from '../../types/prop-types';
 
 type Size = 'one' | 'two';
 type Variant = 'highlight' | 'quote' | 'confirm' | 'alert' | 'subtle';
@@ -132,7 +132,7 @@ function getHTMLElement(variant?: Variant): AsPropType {
  */
 export const Body = forwardRef((props: BodyProps, ref?: BodyProps['ref']) => {
   const as = props.as || getHTMLElement(props.variant);
-  return <StyledBody {...props} ref={ref} as={as} />;
+  return <StyledBody {...props} ref={ref} as={as as EmotionAsPropType} />;
 });
 
 Body.displayName = 'Body';

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.tsx
@@ -18,7 +18,7 @@ import { css } from '@emotion/react';
 import isPropValid from '@emotion/is-prop-valid';
 
 import styled, { StyleProps } from '../../styles/styled';
-import { AsPropType } from '../../types/prop-types';
+import { AsPropType, EmotionAsPropType } from '../../types/prop-types';
 
 type Variant = 'highlight' | 'quote' | 'confirm' | 'alert' | 'subtle';
 
@@ -100,7 +100,9 @@ function getHTMLElement(variant?: Variant): AsPropType {
 export const BodyLarge = forwardRef(
   (props: BodyLargeProps, ref?: BodyLargeProps['ref']) => {
     const as = props.as || getHTMLElement(props.variant);
-    return <StyledBodyLarge {...props} ref={ref} as={as} />;
+    return (
+      <StyledBodyLarge {...props} ref={ref} as={as as EmotionAsPropType} />
+    );
   },
 );
 

--- a/packages/circuit-ui/components/Button/Button.spec.tsx
+++ b/packages/circuit-ui/components/Button/Button.spec.tsx
@@ -106,6 +106,23 @@ describe('Button', () => {
       expect(buttonEl).toHaveAttribute('href');
     });
 
+    it('should render as a custom element when passed the as prop', () => {
+      const CustomLink = ({ children, ...props }: ButtonProps) => (
+        <a {...props} href="https://sumup.com">
+          {children}
+        </a>
+      );
+      const props = {
+        ...baseProps,
+        'data-testid': 'custom-link-button',
+        'as': CustomLink,
+      };
+      const { getByTestId } = renderButton(render, props);
+      const buttonEl = getByTestId('custom-link-button');
+      expect(buttonEl.tagName).toBe('A');
+      expect(buttonEl).toHaveAttribute('href');
+    });
+
     it('should render loading button with loading label', () => {
       const loadingLabel = 'Loading';
       const props = {
@@ -185,8 +202,8 @@ describe('Button', () => {
           Link button
         </Button>,
       );
-      const button = container.querySelector('a');
-      expect(tref.current).toBe(button);
+      const anchor = container.querySelector('a');
+      expect(tref.current).toBe(anchor);
     });
   });
 

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -35,7 +35,7 @@ import {
 } from '../../styles/style-mixins';
 import { ReturnType } from '../../types/return-type';
 import { ClickEvent } from '../../types/events';
-import { AsPropType } from '../../types/prop-types';
+import { AsPropType, EmotionAsPropType } from '../../types/prop-types';
 import { useComponents } from '../ComponentsContext';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import Spinner from '../Spinner';
@@ -94,6 +94,10 @@ export interface BaseProps {
    * impaired users.
    */
   'loadingLabel'?: string;
+  /**
+   * Render the Button using any element.
+   */
+  'as'?: AsPropType;
 }
 
 type LinkElProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'>;
@@ -349,6 +353,7 @@ export const Button = forwardRef(
       loadingLabel,
       icon: Icon,
       tracking,
+      as,
       ...props
     }: ButtonProps,
     ref?: BaseProps['ref'],
@@ -363,8 +368,8 @@ export const Button = forwardRef(
         'The Button component has `isLoading` but is missing a `loadingLabel` prop. This is an accessibility requirement.',
       );
     }
-    const components = useComponents();
-    const Link = components.Link as AsPropType;
+    const { Link } = useComponents();
+    const linkOrButton = props.href ? Link : 'button';
 
     const handleClick = useClickEvent(props.onClick, tracking, 'button');
 
@@ -378,7 +383,7 @@ export const Button = forwardRef(
           })}
         disabled={disabled || isLoading}
         ref={ref}
-        as={props.href ? Link : 'button'}
+        as={(as || linkOrButton) as EmotionAsPropType}
         onClick={handleClick}
       >
         <LoadingIcon isLoading={Boolean(isLoading)} size="byte">

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../styles/style-mixins';
 import { ReturnType } from '../../types/return-type';
 import { ClickEvent } from '../../types/events';
-import { AsPropType } from '../../types/prop-types';
+import { EmotionAsPropType } from '../../types/prop-types';
 import { isFunction, isString } from '../../util/type-check';
 import { warn } from '../../util/logger';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
@@ -341,10 +341,10 @@ export const ListItem = forwardRef(
       }
     }
 
-    const components = useComponents();
-    let as: AsPropType = 'div';
+    const { Link } = useComponents();
+    let as: EmotionAsPropType = 'div';
     if (props.href) {
-      as = components.Link as AsPropType;
+      as = Link as EmotionAsPropType;
     } else if (props.onClick) {
       as = 'button';
     }

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -36,7 +36,7 @@ import { IconProps } from '@sumup/icons';
 import { useClickTrigger } from '@sumup/collector';
 
 import { ClickEvent } from '../../types/events';
-import { AsPropType } from '../../types/prop-types';
+import { EmotionAsPropType } from '../../types/prop-types';
 import styled, { StyleProps } from '../../styles/styled';
 import { listItem, shadow, typography } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
@@ -112,14 +112,13 @@ export const PopoverItem = ({
   tracking,
   ...props
 }: PopoverItemProps): JSX.Element => {
-  const components = useComponents();
-  const Link = components.Link as AsPropType;
+  const { Link } = useComponents();
 
   const handleClick = useClickEvent(onClick, tracking, 'popover-item');
 
   return (
     <PopoverItemWrapper
-      as={props.href ? Link : 'button'}
+      as={props.href ? (Link as EmotionAsPropType) : 'button'}
       onClick={handleClick}
       role="menuitem"
       {...props}

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -26,7 +26,7 @@ import {
 } from '../../../../styles/style-mixins';
 import { useClickEvent } from '../../../../hooks/useClickEvent';
 import { ClickEvent } from '../../../../types/events';
-import { AsPropType } from '../../../../types/prop-types';
+import { EmotionAsPropType } from '../../../../types/prop-types';
 import { useComponents } from '../../../ComponentsContext';
 import Body from '../../../Body';
 import { Skeleton } from '../../../Skeleton';
@@ -186,8 +186,7 @@ export function PrimaryLink({
   secondaryGroups,
   ...props
 }: PrimaryLinkProps): JSX.Element {
-  const components = useComponents();
-  const Link = components.Link as AsPropType;
+  const { Link } = useComponents();
 
   const handleClick = useClickEvent<ClickEvent>(
     onClick,
@@ -205,7 +204,7 @@ export function PrimaryLink({
       isActive={isActive}
       isOpen={isOpen}
       aria-current={isActive ? 'page' : undefined}
-      as={props.href ? Link : 'button'}
+      as={props.href ? (Link as EmotionAsPropType) : 'button'}
     >
       <Skeleton css={cx(iconStyles, badge && iconWithBadgeStyles)}>
         <Icon role="presentation" size="24" />

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -22,7 +22,7 @@ import { TrackingElement } from '@sumup/collector';
 
 import styled, { StyleProps, NoTheme } from '../../../../styles/styled';
 import { navigationItem } from '../../../../styles/style-mixins';
-import { AsPropType } from '../../../../types/prop-types';
+import { EmotionAsPropType } from '../../../../types/prop-types';
 import { useClickEvent } from '../../../../hooks/useClickEvent';
 import { useFocusList, FocusProps } from '../../../../hooks/useFocusList';
 import SubHeadline from '../../../SubHeadline';
@@ -63,8 +63,7 @@ function SecondaryLink({
   badge,
   ...props
 }: SecondaryLinkProps) {
-  const components = useComponents();
-  const Link = components.Link as AsPropType;
+  const { Link } = useComponents();
 
   const handleClick = useClickEvent<MouseEvent | KeyboardEvent>(
     onClick,
@@ -78,7 +77,7 @@ function SecondaryLink({
         {...props}
         onClick={handleClick}
         aria-current={props.isActive ? 'page' : undefined}
-        as={props.href ? Link : 'button'}
+        as={props.href ? (Link as EmotionAsPropType) : 'button'}
       >
         <Skeleton css={labelStyles}>
           <Body

--- a/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.tsx
@@ -20,7 +20,7 @@ import isPropValid from '@emotion/is-prop-valid';
 import styled, { StyleProps } from '../../../../styles/styled';
 import { useClickEvent, TrackingProps } from '../../../../hooks/useClickEvent';
 import { ClickEvent } from '../../../../types/events';
-import { AsPropType } from '../../../../types/prop-types';
+import { EmotionAsPropType } from '../../../../types/prop-types';
 import { useComponents } from '../../../ComponentsContext';
 import { getIcon } from '../../SidebarService';
 import { NavLabel } from '../NavLabel';
@@ -129,8 +129,7 @@ export function NavItem({
   tracking,
   ...props
 }: NavItemProps): JSX.Element {
-  const components = useComponents();
-  const Link = components.Link as AsPropType;
+  const { Link } = useComponents();
 
   const handleClick = useClickEvent(onClick, tracking, 'sidebar-nav-item');
 
@@ -144,7 +143,7 @@ export function NavItem({
       `}
     >
       <NavLink
-        as={Link}
+        as={Link as EmotionAsPropType}
         onClick={!disabled ? handleClick : undefined}
         selected={selected}
         secondary={secondary}

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -20,7 +20,7 @@ import { IconProps } from '@sumup/icons';
 
 import styled, { NoTheme, StyleProps } from '../../../../styles/styled';
 import { hideVisually, navigationItem } from '../../../../styles/style-mixins';
-import { AsPropType } from '../../../../types/prop-types';
+import { EmotionAsPropType } from '../../../../types/prop-types';
 import { useClickEvent, TrackingProps } from '../../../../hooks/useClickEvent';
 import Body from '../../../Body';
 import { useComponents } from '../../../ComponentsContext';
@@ -89,8 +89,7 @@ function UtilityLink({
   tracking,
   ...props
 }: UtilityLinkProps) {
-  const components = useComponents();
-  const Link = components.Link as AsPropType;
+  const { Link } = useComponents();
 
   const handleClick = useClickEvent(onClick, tracking, 'utility-link');
 
@@ -98,7 +97,7 @@ function UtilityLink({
     <UtilityAnchor
       {...props}
       onClick={handleClick}
-      as={props.href ? Link : 'button'}
+      as={props.href ? (Link as EmotionAsPropType) : 'button'}
     >
       <Skeleton css={iconStyles}>
         <Icon role="presentation" size="24" />

--- a/packages/circuit-ui/types/prop-types.ts
+++ b/packages/circuit-ui/types/prop-types.ts
@@ -15,4 +15,9 @@
 
 import { ElementType } from 'react';
 
-export type AsPropType = ElementType<any> & string; // This comes from Emotion's types
+// This is how we should type the `as` prop in Circuit components, because the
+// prop should accept either a Component or a string (for an element)
+export type AsPropType = ElementType<any> | string;
+
+// This is the type that Emotion expects
+export type EmotionAsPropType = ElementType<any> & string;


### PR DESCRIPTION
## Purpose

The new `ButtonGroup`'s `actions` API accepts buttons as objects rather than JSX children.

While this is fine in many cases, the former API allowed for extra use cases, such as wrapping one of the button children in a Next.js `Link` (for routing purposes).

This isn't possible anymore with the `actions` API, which only accept up to two object of `ButtonProps`.

A similar result could be achieved by wrapping a tree in the `ComponentsContext` to transform "raw" anchors into links with routing, however this can also lead to TypeScript issues.

This PR introduces another, simpler solution by accepting an `as` prop in the `Button` component. If the prop is passed, it will be forwarded to the underlying styled component. Otherwise, the component will fall back to a `a` (if `href` is passed) or to a `button`.

For example:

```tsx
import Link from "next/link";
import { ButtonGroup } from "@sumup/circuit-ui";

function CustomLink({ children, ...props }) {
  return (
    <Link {...props}>
      <a>{children}</a>
    </Link>
  );
}

function Buttons() {
  return (
    <ButtonGroup
      actions={{
        primary: {
          href: '/',
          children: 'Go to the homepage',
          as: CustomLink,
        },
        secondary: {
          onClick: () => window.location.reload(),
          children: 'Reload the page',
        },
      }}
    />
  );
};
```

## Approach and changes

- Changed the shared `AsPropType` to the developer-friendly `ElementType<any> | string` instead of the Emotion-friendly `ElementType<any> & string`. Introduced an `EmotionAsPropType` for internal use, switched uses in components (for typecasting).
- Added `as` prop type support to the `Button` component, added tests

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
