### PR TITLE
Omit noMargin from AnchorProps

### DIFF
--- a/.changeset/twelve-books-dream.md
+++ b/.changeset/twelve-books-dream.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Omitted the `noMargin` prop from the Anchor component's props.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -31,7 +31,7 @@ import { Body, BodyProps } from '../Body/Body';
 import { useComponents } from '../ComponentsContext';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 
-export interface BaseProps extends BodyProps {
+export interface BaseProps extends Omit<BodyProps, 'noMargin'> {
   children: ReactNode;
   /**
    * Function that's called when the button is clicked.


### PR DESCRIPTION
## Purpose

Omit the unused `noMargin` from the Anchor component's props.

## Approach and changes

The `noMargin` prop should never have been accepted in the `Anchor` component, because while the component extends the `Body` props, it is set as default on anchors.

This started being an issue when we made the `noMargin` prop required (for migration purposes) on the `Body` component, in #1528.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
