### PR TITLE
Fix SidePanel snapshot timing

### DIFF
--- a/packages/circuit-ui/components/SidePanel/SidePanel.stories.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.stories.tsx
@@ -235,6 +235,8 @@ WithTopNavigation.parameters = {
   chromatic: { viewports: [320, 960, 1280] },
 };
 
+const SIDEPANEL_UPDATE_DURATION = 1000;
+
 const ComponentWithSidePanelExtended = (props: SidePanelHookProps) => {
   const [selectedItem, setSelectedItem] = useState<string>(null);
   const { setSidePanel, updateSidePanel, removeSidePanel } = useSidePanel();
@@ -273,7 +275,7 @@ const ComponentWithSidePanelExtended = (props: SidePanelHookProps) => {
                   />
                 ),
               });
-            }, 1000);
+            }, SIDEPANEL_UPDATE_DURATION);
           }
         },
         'data-testid': `list-item-${item.key}`,
@@ -295,3 +297,6 @@ export const UpdateAndRemove = (props: SidePanelHookProps): JSX.Element => (
 );
 UpdateAndRemove.args = baseArgs;
 UpdateAndRemove.play = basePlay;
+UpdateAndRemove.parameters = {
+  chromatic: { delay: SIDEPANEL_UPDATE_DURATION },
+};


### PR DESCRIPTION
## Purpose

A SidePanel component story using a timeout (to reflect a loading behavior) had flaky snapshots.

## Approach and changes

Use the built-in Chromatic `delay` param to take the snapshot only after the timeout has resolved.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
