### PR TITLE
Add support for Docusaurus

### DIFF
--- a/.changeset/wet-turtles-wonder.md
+++ b/.changeset/wet-turtles-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added support for Docusaurus to the Modal.

--- a/packages/circuit-ui/components/ModalContext/ModalContext.tsx
+++ b/packages/circuit-ui/components/ModalContext/ModalContext.tsx
@@ -35,9 +35,11 @@ import { BaseModalProps, ModalComponent } from './types';
 // with a query selector identifying the root of the app.
 // http://reactcommunity.org/react-modal/accessibility/#app-element
 if (typeof window !== 'undefined') {
-  // These are the default app elements in Next.js and CRA.
+  // These are the default app elements in Next.js, Docusaurus, and CRA.
   const appElement =
-    document.getElementById('__next') || document.getElementById('root');
+    document.getElementById('__next') ||
+    document.getElementById('__docusaurus') ||
+    document.getElementById('root');
 
   if (appElement) {
     ReactModal.setAppElement(appElement);


### PR DESCRIPTION
## Purpose

Alongside Next.js and create-react-app, [Docusaurus](https://docusaurus.io/) is another well-established and popular React framework. I believe we should add out-of-the-box support for it. 

## Approach and changes

- Add `__docusaurus` to the list of root ids in the ModalContext

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
