### PR TITLE
Proposal: Add CopyInput component

### DIFF
--- a/packages/circuit-ui/components/CopyInput/CopyInput.docs.mdx
+++ b/packages/circuit-ui/components/CopyInput/CopyInput.docs.mdx
@@ -1,0 +1,10 @@
+import { Status, Props, Story } from '../../../../.storybook/components';
+
+# CopyInput
+
+<Status.Stable />
+
+An readonly input field that enables the user to easily copy its value.
+
+<Story id="forms-input-copyinput--base" />
+<Props />

--- a/packages/circuit-ui/components/CopyInput/CopyInput.spec.tsx
+++ b/packages/circuit-ui/components/CopyInput/CopyInput.spec.tsx
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRef } from 'react';
+
+import {
+  create,
+  render,
+  renderToHtml,
+  axe,
+  userEvent,
+  fireEvent,
+  waitFor,
+} from '../../util/test-utils';
+import { InputElement } from '../Input';
+
+import CopyInput from '.';
+
+describe('CopyInput', () => {
+  const baseProps = {
+    label: 'API token',
+    copyButtonLabel: 'Copy',
+    value: 'copy-me',
+    // eslint-disable-next-line no-console
+    onError: console.error,
+  };
+
+  beforeAll(() => {
+    // @ts-expect-error Can be overridden in JS DOM
+    navigator.clipboard = { writeText: jest.fn() };
+  });
+
+  it('should render with default styles', () => {
+    const actual = create(<CopyInput {...baseProps} />);
+    expect(actual).toMatchSnapshot();
+  });
+
+  // Unfortunately, this test doesn't work. I suspect that the `document.getSelection()` API isn't properly supported in JS DOM.
+  it.skip('should highlight the value on focus', () => {
+    const { getByRole } = render(<CopyInput {...baseProps} />);
+
+    userEvent.click(getByRole('textbox'));
+
+    expect(document.getSelection()?.toString()).toBe(baseProps.value);
+  });
+
+  describe('when pressing the copy button', () => {
+    it('should copy the value to the clipboard', () => {
+      const { getByRole } = render(<CopyInput {...baseProps} />);
+
+      fireEvent.click(getByRole('button', { name: baseProps.copyButtonLabel }));
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        baseProps.value,
+      );
+    });
+
+    it('should copy the value to the clipboard if the Clipboard API is not supported', () => {
+      // @ts-expect-error Can be overridden in JS DOM
+      navigator.clipboard = undefined;
+      document.execCommand = jest.fn();
+
+      const { getByRole } = render(<CopyInput {...baseProps} />);
+
+      fireEvent.click(getByRole('button', { name: baseProps.copyButtonLabel }));
+
+      expect(document.execCommand).toHaveBeenCalledWith('copy');
+    });
+
+    it('should call the onSuccess callback', () => {
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+
+      const { getByRole } = render(
+        <CopyInput {...baseProps} onSuccess={onSuccess} onError={onError} />,
+      );
+
+      fireEvent.click(getByRole('button', { name: baseProps.copyButtonLabel }));
+
+      expect(onSuccess).toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('should call the onError callback when copying fails', async () => {
+      // @ts-expect-error Can be overridden in JS DOM
+      navigator.clipboard = {
+        writeText: jest.fn().mockRejectedValueOnce('Error'),
+      };
+
+      const onSuccess = jest.fn();
+      const onError = jest.fn();
+
+      const { getByRole } = render(
+        <CopyInput {...baseProps} onSuccess={onSuccess} onError={onError} />,
+      );
+
+      fireEvent.click(getByRole('button', { name: baseProps.copyButtonLabel }));
+
+      await waitFor(() => {
+        expect(onError).toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when copying the value', () => {
+    it('should call the onSuccess callback', () => {
+      const onSuccess = jest.fn();
+
+      const { getByRole } = render(
+        <CopyInput {...baseProps} onSuccess={onSuccess} />,
+      );
+
+      fireEvent.click(getByRole('textbox'));
+      fireEvent.copy(getByRole('textbox'));
+
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+
+  it('should accept a working ref', () => {
+    const tref = createRef<InputElement>();
+    const { container } = render(<CopyInput {...baseProps} ref={tref} />);
+    const input = container.querySelector('input');
+    expect(tref.current).toBe(input);
+  });
+
+  it('should meet accessibility guidelines', async () => {
+    const wrapper = renderToHtml(<CopyInput {...baseProps} />);
+    const actual = await axe(wrapper);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/packages/circuit-ui/components/CopyInput/CopyInput.stories.tsx
+++ b/packages/circuit-ui/components/CopyInput/CopyInput.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+
+import { CopyInput, CopyInputProps } from './CopyInput';
+import docs from './CopyInput.docs.mdx';
+
+export default {
+  title: 'Forms/Input/CopyInput',
+  component: CopyInput,
+  parameters: {
+    docs: { page: docs },
+  },
+};
+
+const baseArgs = {
+  label: 'API token',
+  value: 'sumup_74452f05-3a0a-4c57-9d16',
+  copyButtonLabel: 'Copy',
+};
+
+export const Base = (args: CopyInputProps): JSX.Element => {
+  const [validationProps, setValidationProps] = useState({});
+
+  const onSuccess = () => {
+    setValidationProps({
+      validationHint: 'Copied successfully',
+      showValid: true,
+    });
+  };
+  const onError = () => {
+    setValidationProps({
+      validationHint: 'Failed to copy',
+      hasWarning: true,
+    });
+  };
+
+  return (
+    <CopyInput
+      {...args}
+      {...validationProps}
+      onSuccess={onSuccess}
+      onError={onError}
+    />
+  );
+};
+
+Base.args = baseArgs;

--- a/packages/circuit-ui/components/CopyInput/CopyInput.tsx
+++ b/packages/circuit-ui/components/CopyInput/CopyInput.tsx
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FocusEvent, forwardRef, useEffect, useRef } from 'react';
+import { css } from '@emotion/react';
+
+import styled, { StyleProps } from '../../styles/styled';
+import Input, { InputElement, InputProps } from '../Input';
+import Button from '../Button';
+import { applyMultipleRefs } from '../../util/refs';
+
+export type CopyInputProps = Omit<
+  InputProps,
+  // This is explicitly set inside the component.
+  | 'noMargin'
+  // The `value` prop is required, so the placeholder would never be shown.
+  | 'placeholder'
+  // The field is readonly and the `value` prop is prefilled.
+  | 'optionalLabel'
+  // The field is readonly so the user wouldn't be able to fix it.
+  | 'invalid'
+  // This would lead to a confusing user experience.
+  | 'disabled'
+  // The `renderSuffix` prop is set inside the component and should not be overridden.
+  | 'renderSuffix'
+  | 'onError'
+> & {
+  /**
+   * The input value that should be copied to the user's clipboard.
+   */
+  value: string;
+  /**
+   * A textual label for the copy button at the end of the input.
+   */
+  copyButtonLabel: string;
+  /**
+   * Function that is called after the user successfully copies the value.
+   */
+  onSuccess?: () => void;
+  /**
+   * Function that is called if copying the value fails after pressing the copy button.
+   * This can be caused by the browser not supporting or restricting access to the necessary APIs.
+   */
+  onError?: (error: Error) => void;
+};
+
+const copyButtonStyles = ({ theme }: StyleProps) => css`
+  border: none;
+  width: auto !important;
+  pointer-events: all !important;
+  cursor: pointer !important;
+  border-radius: ${theme.borderRadius.byte};
+
+  &:hover {
+    background-color: ${theme.colors.white};
+    color: ${theme.colors.n900};
+  }
+`;
+
+const CopyButton = styled(Button)(copyButtonStyles);
+
+/**
+ * CopyInput component to enable users to easily copy a value.
+ */
+export const CopyInput = forwardRef<InputElement, CopyInputProps>(
+  ({ value, copyButtonLabel, onSuccess, onError, ...props }, ref) => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !copyButtonLabel
+    ) {
+      throw new Error(
+        'The CopyInput component is missing a `copyButtonLabel` prop. This is an accessibility requirement.',
+      );
+    }
+
+    const localRef = useRef<InputElement>(null);
+
+    useEffect(() => {
+      if (!localRef.current || !onSuccess) {
+        return undefined;
+      }
+
+      const input = localRef.current;
+
+      input.addEventListener('copy', onSuccess);
+
+      return () => {
+        input.removeEventListener('copy', onSuccess);
+      };
+    }, [onSuccess]);
+
+    const handleCopy = async () => {
+      try {
+        if (localRef.current) {
+          localRef.current.select();
+        }
+
+        const supportsClipboardAPI = Boolean(
+          typeof navigator !== 'undefined' &&
+            /* eslint-disable compat/compat */
+            navigator.clipboard &&
+            // eslint-disable-next-line @typescript-eslint/unbound-method
+            navigator.clipboard.writeText,
+          /* eslint-enable compat/compat */
+        );
+
+        if (supportsClipboardAPI) {
+          await navigator.clipboard.writeText(value);
+        } else {
+          document.execCommand('copy');
+        }
+
+        if (onSuccess) {
+          onSuccess();
+        }
+      } catch (error) {
+        if (onError) {
+          onError(error as Error);
+        }
+      }
+    };
+
+    const handleFocus = (event: FocusEvent<InputElement>) => {
+      event.currentTarget.select();
+    };
+
+    return (
+      <Input
+        value={value}
+        type="text"
+        readOnly
+        renderSuffix={(renderProps) => (
+          <CopyButton onClick={handleCopy} {...renderProps}>
+            {copyButtonLabel}
+          </CopyButton>
+        )}
+        {...props}
+        onFocus={handleFocus}
+        noMargin
+        ref={applyMultipleRefs(localRef, ref)}
+      />
+    );
+  },
+);
+
+CopyInput.displayName = 'CopyInput';

--- a/packages/circuit-ui/components/CopyInput/__snapshots__/CopyInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/CopyInput/__snapshots__/CopyInput.spec.tsx.snap
@@ -1,0 +1,258 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CopyInput should render with default styles 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  font-size: 14px;
+  line-height: 20px;
+  display: block;
+}
+
+.circuit-1 {
+  display: inline-block;
+  margin-bottom: 4px;
+}
+
+.circuit-2 {
+  position: relative;
+}
+
+.circuit-3 {
+  font-size: 16px;
+  line-height: 24px;
+  -webkit-appearance: none;
+  background-color: #FFF;
+  border: none;
+  outline: 0;
+  border-radius: 8px;
+  padding: 12px 16px;
+  -webkit-transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
+  width: 100%;
+  margin: 0;
+  background-color: #F5F5F5;
+  padding-right: 48px;
+  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-3::-webkit-input-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-3::-moz-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-3:-ms-input-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-3::placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-3:hover {
+  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-3:focus {
+  box-shadow: 0 0 0 2px #3063E9;
+}
+
+.circuit-3:active {
+  box-shadow: 0 0 0 1px #3063E9;
+}
+
+.circuit-4 {
+  font-size: 16px;
+  line-height: 24px;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: #FFF;
+  border-color: #999;
+  color: #000;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  border: none;
+  width: auto!important;
+  pointer-events: all!important;
+  cursor: pointer!important;
+  border-radius: 8px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  pointer-events: none;
+  color: #666;
+  padding: 12px 16px;
+  height: 48px;
+  width: 48px;
+  -webkit-transition: right 120ms ease-in-out;
+  transition: right 120ms ease-in-out;
+}
+
+.circuit-4:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-4:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-4:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-4:disabled,
+.circuit-4[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-4:hover {
+  background-color: #F5F5F5;
+  border-color: #666;
+}
+
+.circuit-4:active,
+.circuit-4[aria-expanded='true'],
+.circuit-4[aria-pressed='true'] {
+  background-color: #E6E6E6;
+  border-color: #333;
+}
+
+.circuit-4:hover {
+  background-color: #FFF;
+  color: #1A1A1A;
+}
+
+.circuit-5 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-6 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<label
+  class="circuit-0"
+  for="input_1"
+>
+  <span
+    class="circuit-1"
+  >
+    API token
+  </span>
+  <div
+    class="circuit-2"
+  >
+    <input
+      class="circuit-3"
+      id="input_1"
+      readonly=""
+      type="text"
+      value="copy-me"
+    />
+    <button
+      class="circuit-4"
+    >
+      <span
+        class="circuit-5"
+      >
+        <span
+          class="circuit-6"
+        />
+      </span>
+      <span
+        class="circuit-7"
+      >
+        Copy
+      </span>
+    </button>
+  </div>
+</label>
+`;

--- a/packages/circuit-ui/components/CopyInput/index.ts
+++ b/packages/circuit-ui/components/CopyInput/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CopyInput } from './CopyInput';
+
+export type { CopyInputProps } from './CopyInput';
+
+export default CopyInput;

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -24,7 +24,7 @@ import {
   act,
   userEvent,
 } from '../../util/test-utils';
-import { InputProps } from '../Input';
+import { InputElement, InputProps } from '../Input';
 
 import CurrencyInput, { CurrencyInputProps } from '.';
 
@@ -108,9 +108,9 @@ describe('CurrencyInput', () => {
             value={value}
             label="Amount"
             noMargin
-            onChange={(
-              e: ChangeEvent<HTMLInputElement & HTMLTextAreaElement>,
-            ) => setValue(e.target.value)}
+            onChange={(e: ChangeEvent<InputElement>) =>
+              setValue(e.target.value)
+            }
           />
         );
       };

--- a/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
@@ -16,14 +16,15 @@
 import { createRef } from 'react';
 
 import { render, renderToHtml, axe } from '../../util/test-utils';
+import { InputElement } from '../Input';
 
 import DateInput from '.';
 
 describe('DateInput', () => {
-  const baseProps = { label: 'Date' };
+  const baseProps = { label: 'Date', noMargin: true } as const;
 
   it('should accept a working ref', () => {
-    const tref = createRef<HTMLInputElement & HTMLTextAreaElement>();
+    const tref = createRef<InputElement>();
     const { container } = render(<DateInput {...baseProps} ref={tref} />);
     const input = container.querySelector('input');
     expect(tref.current).toBe(input);

--- a/packages/circuit-ui/components/SearchInput/SearchInput.spec.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.spec.tsx
@@ -16,22 +16,23 @@
 import { createRef } from 'react';
 
 import { create, render, renderToHtml, axe } from '../../util/test-utils';
+import { InputElement } from '../Input';
 
 import SearchInput from '.';
 
 describe('SearchInput', () => {
-  const baseProps = { label: 'Search' };
+  const baseProps = { label: 'Search', noMargin: true } as const;
 
   /**
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(<SearchInput {...baseProps} noMargin />);
+    const actual = create(<SearchInput {...baseProps} />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should grey out icon when disabled', () => {
-    const actual = create(<SearchInput {...baseProps} disabled noMargin />);
+    const actual = create(<SearchInput {...baseProps} disabled />);
     expect(actual).toMatchSnapshot();
   });
 
@@ -45,7 +46,6 @@ describe('SearchInput', () => {
         value="Search value"
         clearLabel={clearLabel}
         onClear={mockCallback}
-        noMargin
         /**
          * We set onChange to silence a warning about adding a `value` without
          * `onChange` or `readOnly`.
@@ -62,10 +62,8 @@ describe('SearchInput', () => {
      * Should accept a working ref
      */
     it('should accept a working ref', () => {
-      const tref = createRef<HTMLInputElement & HTMLTextAreaElement>();
-      const { container } = render(
-        <SearchInput {...baseProps} ref={tref} noMargin />,
-      );
+      const tref = createRef<InputElement>();
+      const { container } = render(<SearchInput {...baseProps} ref={tref} />);
       const input = container.querySelector('input');
       expect(tref.current).toBe(input);
     });
@@ -75,7 +73,7 @@ describe('SearchInput', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<SearchInput {...baseProps} noMargin />);
+    const wrapper = renderToHtml(<SearchInput {...baseProps} />);
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/SearchInput/SearchInput.stories.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.stories.tsx
@@ -15,6 +15,8 @@
 
 import { useState, ChangeEvent } from 'react';
 
+import { InputElement } from '../Input';
+
 import { SearchInput, SearchInputProps } from './SearchInput';
 import docs from './SearchInput.docs.mdx';
 
@@ -53,7 +55,7 @@ export const Clearable = (args: SearchInputProps): JSX.Element => {
 
   const handleChange = ({
     target: { value: inputValue },
-  }: ChangeEvent<HTMLInputElement>) => {
+  }: ChangeEvent<InputElement>) => {
     setValue(inputValue);
   };
 

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -18,12 +18,21 @@ import { css } from '@emotion/react';
 import { Search, Close } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
-import Input from '../Input';
-import { InputProps } from '../Input/Input';
+import Input, { InputProps } from '../Input';
 import IconButton from '../IconButton';
 
 type ClearProps =
-  | { onClear?: never; clearLabel?: never }
+  | {
+      /**
+       * Callback function when the user clears the field.
+       */
+      onClear?: never;
+      /**
+       * Visually hidden text label on the clear button for screen readers.
+       * Crucial for accessibility.
+       */
+      clearLabel?: never;
+    }
   | {
       /**
        * Callback function when the user clears the field.

--- a/packages/circuit-ui/components/TextArea/TextArea.spec.tsx
+++ b/packages/circuit-ui/components/TextArea/TextArea.spec.tsx
@@ -16,6 +16,7 @@
 import { createRef } from 'react';
 
 import { create, render, renderToHtml, axe } from '../../util/test-utils';
+import { InputElement } from '../Input';
 
 import TextArea from '.';
 
@@ -28,7 +29,7 @@ describe('TextArea', () => {
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(<TextArea label="Textarea" />);
+    const actual = create(<TextArea label="Textarea" noMargin />);
     expect(actual).toMatchSnapshot();
   });
 
@@ -37,6 +38,7 @@ describe('TextArea', () => {
       <TextArea
         label="Textarea"
         renderPrefix={({ className }) => <DummyElement {...{ className }} />}
+        noMargin
       />,
     );
     expect(actual).toMatchSnapshot();
@@ -47,6 +49,7 @@ describe('TextArea', () => {
       <TextArea
         label="Textarea"
         renderSuffix={({ className }) => <DummyElement {...{ className }} />}
+        noMargin
       />,
     );
     expect(actual).toMatchSnapshot();
@@ -54,69 +57,68 @@ describe('TextArea', () => {
 
   it('should render with a Tooltip when passed the validationHint prop', () => {
     const actual = create(
-      <TextArea label="Textarea" validationHint="Validation hint" />,
+      <TextArea label="Textarea" validationHint="Validation hint" noMargin />,
     );
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with warning styles when passed the hasWarning prop', () => {
-    const actual = create(<TextArea label="Textarea" hasWarning />);
+    const actual = create(<TextArea label="Textarea" hasWarning noMargin />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with invalid styles when passed the invalid prop', () => {
-    const actual = create(<TextArea label="Textarea" invalid />);
+    const actual = create(<TextArea label="Textarea" invalid noMargin />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with valid styles when passed the showValid prop', () => {
-    const actual = create(<TextArea label="Textarea" showValid />);
+    const actual = create(<TextArea label="Textarea" showValid noMargin />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with readonly styles when passed the readonly prop', () => {
-    const actual = create(<TextArea label="Textarea" readOnly />);
+    const actual = create(<TextArea label="Textarea" readOnly noMargin />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with disabled styled when passed the disabled prop', () => {
-    const actual = create(<TextArea label="Textarea" disabled />);
+    const actual = create(<TextArea label="Textarea" disabled noMargin />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should prioritize disabled over error styles', () => {
-    const actual = create(<TextArea label="Textarea" invalid disabled />);
+    const actual = create(
+      <TextArea label="Textarea" invalid disabled noMargin />,
+    );
     expect(actual).toMatchSnapshot();
   });
 
   it('should prioritize disabled over warning styles', () => {
-    const actual = create(<TextArea label="Textarea" hasWarning disabled />);
+    const actual = create(
+      <TextArea label="Textarea" hasWarning disabled noMargin />,
+    );
     expect(actual).toMatchSnapshot();
   });
 
   it('should render with inline styles when passed the inline prop', () => {
-    const actual = create(<TextArea label="Textarea" inline />);
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should render with no margin styles when passed the noMargin prop', () => {
-    const actual = create(<TextArea label="Textarea" noMargin />);
+    const actual = create(<TextArea label="Textarea" inline noMargin />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render rows props when passed', () => {
-    const actual = create(<TextArea label="Textarea" rows={3} />);
+    const actual = create(<TextArea label="Textarea" rows={3} noMargin />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render without rows props when passed if rows is auto', () => {
-    const actual = create(<TextArea label="Textarea" rows="auto" />);
+    const actual = create(<TextArea label="Textarea" rows="auto" noMargin />);
     expect(actual).toMatchSnapshot();
   });
 
   it('should render minRows props as rows when passed if rows is auto', () => {
     const actual = create(
-      <TextArea label="Textarea" minRows={3} rows="auto" />,
+      <TextArea label="Textarea" minRows={3} rows="auto" noMargin />,
     );
     expect(actual).toMatchSnapshot();
   });
@@ -126,8 +128,10 @@ describe('TextArea', () => {
      * Should accept a working ref
      */
     it('should accept a working ref', () => {
-      const tref = createRef<HTMLInputElement & HTMLTextAreaElement>();
-      const { container } = render(<TextArea label="Textarea" ref={tref} />);
+      const tref = createRef<InputElement>();
+      const { container } = render(
+        <TextArea label="Textarea" ref={tref} noMargin />,
+      );
       const textarea = container.querySelector('textarea');
       expect(tref.current).toBe(textarea);
     });
@@ -137,7 +141,9 @@ describe('TextArea', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<TextArea label="Textarea" id="textarea" />);
+    const wrapper = renderToHtml(
+      <TextArea label="Textarea" id="textarea" noMargin />,
+    );
     const actual = await axe(wrapper);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
+++ b/packages/circuit-ui/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
@@ -8,7 +8,6 @@ exports[`TextArea should prioritize disabled over error styles 1`] = `
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -94,7 +93,6 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -176,7 +174,6 @@ exports[`TextArea should render minRows props as rows when passed if rows is aut
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -244,7 +241,7 @@ exports[`TextArea should render minRows props as rows when passed if rows is aut
 
 <label
   class="circuit-0"
-  for="input_32"
+  for="input_30"
 >
   <span
     class="circuit-1"
@@ -256,7 +253,7 @@ exports[`TextArea should render minRows props as rows when passed if rows is aut
   >
     <textarea
       class="circuit-3"
-      id="input_32"
+      id="input_30"
       rows="3"
       style="resize: none; overflow-y: hidden; height: auto;"
     />
@@ -269,7 +266,6 @@ exports[`TextArea should render rows props when passed 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -337,7 +333,7 @@ exports[`TextArea should render rows props when passed 1`] = `
 
 <label
   class="circuit-0"
-  for="input_28"
+  for="input_26"
 >
   <span
     class="circuit-1"
@@ -349,7 +345,7 @@ exports[`TextArea should render rows props when passed 1`] = `
   >
     <textarea
       class="circuit-3"
-      id="input_28"
+      id="input_26"
       rows="3"
     />
   </div>
@@ -361,7 +357,6 @@ exports[`TextArea should render with a Tooltip when passed the validationHint pr
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -467,7 +462,6 @@ exports[`TextArea should render with a prefix when passed the prefix prop 1`] = 
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -572,7 +566,6 @@ exports[`TextArea should render with a suffix when passed the suffix prop 1`] = 
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -681,7 +674,6 @@ exports[`TextArea should render with default styles 1`] = `
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -775,7 +767,6 @@ exports[`TextArea should render with disabled styled when passed the disabled pr
   opacity: 0.5;
   pointer-events: none;
   box-shadow: none;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -859,7 +850,6 @@ exports[`TextArea should render with inline styles when passed the inline prop 1
   display: block;
   display: inline-block;
   margin-right: 16px;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -950,7 +940,6 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -1057,102 +1046,11 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
 </label>
 `;
 
-exports[`TextArea should render with no margin styles when passed the noMargin prop 1`] = `
-.circuit-0 {
-  font-size: 14px;
-  line-height: 20px;
-  display: block;
-}
-
-.circuit-1 {
-  display: inline-block;
-  margin-bottom: 4px;
-}
-
-.circuit-2 {
-  position: relative;
-}
-
-.circuit-3 {
-  font-size: 16px;
-  line-height: 24px;
-  -webkit-appearance: none;
-  background-color: #FFF;
-  border: none;
-  outline: 0;
-  border-radius: 8px;
-  padding: 12px 16px;
-  -webkit-transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
-  transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
-  width: 100%;
-  margin: 0;
-  box-shadow: 0 0 0 1px #999;
-  overflow: auto;
-  resize: vertical;
-}
-
-.circuit-3::-webkit-input-placeholder {
-  color: #999;
-  -webkit-transition: color 120ms ease-in-out;
-  transition: color 120ms ease-in-out;
-}
-
-.circuit-3::-moz-placeholder {
-  color: #999;
-  -webkit-transition: color 120ms ease-in-out;
-  transition: color 120ms ease-in-out;
-}
-
-.circuit-3:-ms-input-placeholder {
-  color: #999;
-  -webkit-transition: color 120ms ease-in-out;
-  transition: color 120ms ease-in-out;
-}
-
-.circuit-3::placeholder {
-  color: #999;
-  -webkit-transition: color 120ms ease-in-out;
-  transition: color 120ms ease-in-out;
-}
-
-.circuit-3:hover {
-  box-shadow: 0 0 0 1px #666;
-}
-
-.circuit-3:focus {
-  box-shadow: 0 0 0 2px #3063E9;
-}
-
-.circuit-3:active {
-  box-shadow: 0 0 0 1px #3063E9;
-}
-
-<label
-  class="circuit-0"
-  for="input_26"
->
-  <span
-    class="circuit-1"
-  >
-    Textarea
-  </span>
-  <div
-    class="circuit-2"
-  >
-    <textarea
-      class="circuit-3"
-      id="input_26"
-    />
-  </div>
-</label>
-`;
-
 exports[`TextArea should render with readonly styles when passed the readonly prop 1`] = `
 .circuit-0 {
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -1245,7 +1143,6 @@ exports[`TextArea should render with valid styles when passed the showValid prop
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -1336,7 +1233,6 @@ exports[`TextArea should render with warning styles when passed the hasWarning p
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -1443,7 +1339,6 @@ exports[`TextArea should render without rows props when passed if rows is auto 1
   font-size: 14px;
   line-height: 20px;
   display: block;
-  margin-bottom: 16px;
 }
 
 .circuit-1 {
@@ -1511,7 +1406,7 @@ exports[`TextArea should render without rows props when passed if rows is auto 1
 
 <label
   class="circuit-0"
-  for="input_30"
+  for="input_28"
 >
   <span
     class="circuit-1"
@@ -1523,7 +1418,7 @@ exports[`TextArea should render without rows props when passed if rows is auto 1
   >
     <textarea
       class="circuit-3"
-      id="input_30"
+      id="input_28"
       style="resize: none; overflow-y: hidden; height: auto;"
     />
   </div>

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -52,6 +52,8 @@ export { default as RadioButtonGroup } from './components/RadioButtonGroup';
 export type { RadioButtonGroupProps } from './components/RadioButtonGroup';
 export { default as SearchInput } from './components/SearchInput';
 export type { SearchInputProps } from './components/SearchInput';
+export { default as CopyInput } from './components/CopyInput';
+export type { CopyInputProps } from './components/CopyInput';
 export { default as DateInput } from './components/DateInput';
 export type { DateInputProps } from './components/DateInput';
 export { default as Select } from './components/Select';


### PR DESCRIPTION
## Purpose

When working on the new [developers website](https://developer.sumup.com), we wanted users to be able to easily copy their API key. We took the common approach of using a read-only text field with a button to copy its value next to it. 

[![Screenshot of the component](https://user-images.githubusercontent.com/11017722/172331319-7064ee5b-1210-4ac1-a648-c366f5287a6f.png)](https://oss-circuit-ui-git-feature-copy-input.sumup-vercel.app/?path=/docs/forms-input-copyinput--base)

Copying a piece of information seems to be a common enough use case that I believe it's worth adding such a component to the design system. 

This PR is intended as a proposal. The design and implementation are very much up for debate and I welcome feedback, particularly on the following topics:

- **Button label**: This could be displayed with either an icon or a textual label. I opted for the label since we don't have a "copy" icon in our icon library yet. It also seems more intuitive for users since there is no universally recognized icon for "copy". However, a textual label might not fit in narrow viewports when translated to a language with long words (such as "Kopieren" in German).
- **Button design**: A read-only input is distinguished by its light grey background color – the same color that a hovered secondary button receives. This makes the button seem to disappear when hovered. I decided to override the styles to work around it, but I'm not happy with this hack.
- **Feedback on success**: We should provide feedback after a user has successfully copied the value. What should this look like? I've designed the component API to leave this decision to the developers, but perhaps this is something we want to build into the design system for consistency. I could imagine using the validation hint (my preference, that's how I implemented it in Storybook) or using a NotificationToast.

## Approach and changes

- The first commit cleans up some things around input components, such as consistently using the new `InputElement` type and adding the `noMargin` prop to specs that were missing it.
- The second commit implements the CopyInput based on the Input component.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [ ] Meets accessibility requirements
