### PR TITLE
Fix width of the NotificationToast on narrow viewports

### DIFF
--- a/.changeset/thick-starfishes-flash.md
+++ b/.changeset/thick-starfishes-flash.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the width of the `NotificationToast` component on narrow viewports.

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -55,12 +55,20 @@ export interface ToastProviderProps {
 
 const listWrapperStyles = ({ theme }: StyleProps) => css`
   position: fixed;
+  width: 100%;
+  padding: 0 ${theme.spacings.giga};
   bottom: ${theme.spacings.giga};
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
   display: flex;
   flex-direction: column-reverse;
   z-index: ${theme.zIndex.toast};
+
+  ${theme.mq.kilo} {
+    width: auto;
+    padding: 0;
+    left: 50%;
+    transform: translateX(-50%);
+  }
 `;
 
 const ListWrapper = styled('ul')(listWrapperStyles);


### PR DESCRIPTION
## Purpose

The NotificationToast doesn't take up the available width on narrow viewports:

| Before                                                                                                                                       | After                                                                                                                                        |
|----------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
| ![Screen Shot 2022-06-10 at 14 00 49](https://user-images.githubusercontent.com/11017722/173060527-8ad3a3c5-f939-48ac-bd7b-a6deb29e16e5.png) | ![Screen Shot 2022-06-10 at 14 00 33](https://user-images.githubusercontent.com/11017722/173060544-be63f889-4122-4c8d-8291-27c7f905f0be.png) |

## Approach and changes

- Add styles to the ToastContext to stretch its children to 100% on narrow viewports

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
