### PR TITLE
Improve type for icon prop

### DIFF
--- a/.changeset/serious-hats-kick.md
+++ b/.changeset/serious-hats-kick.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Narrowed the type for icon props to only allow supported sizes. TypeScript will now warn if you pass an icon of the wrong size to a component.
+Automatically set the `size` prop on the Button's `icon` prop based on the Button's `size` prop.

--- a/.changeset/serious-hats-kick.md
+++ b/.changeset/serious-hats-kick.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Narrowed the type for icon props to only allow supported sizes. TypeScript will now warn if you pass an icon of the wrong size to a component.

--- a/.changeset/tender-mangos-wave.md
+++ b/.changeset/tender-mangos-wave.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Properly hide icons inside a Button.

--- a/.changeset/yellow-lies-yell.md
+++ b/.changeset/yellow-lies-yell.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': major
+---
+
+Changed the `IconProps` default size type to `any`.

--- a/packages/circuit-ui/components/Button/Button.stories.tsx
+++ b/packages/circuit-ui/components/Button/Button.stories.tsx
@@ -80,12 +80,7 @@ export const Sizes = (args: ButtonProps) => (
 );
 
 export const WithIcon = (args: ButtonProps) => (
-  <Button
-    {...args}
-    icon={(props) => (
-      <Plus size={args.size === 'kilo' ? '16' : '24'} {...props} />
-    )}
-  >
+  <Button {...args} icon={Plus}>
     Add
   </Button>
 );

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -458,7 +458,7 @@ export const Button = forwardRef(
             <Icon
               css={iconStyles}
               size={props.size === 'kilo' ? '16' : '24'}
-              role="presentation"
+              aria-hidden="true"
             />
           )}
           {children}

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -20,10 +20,10 @@ import {
   AnchorHTMLAttributes,
   ReactNode,
   FC,
-  SVGProps,
 } from 'react';
 import { css } from '@emotion/react';
 import { Theme } from '@sumup/design-tokens';
+import { IconProps } from '@sumup/icons';
 
 import isPropValid from '../../styles/is-prop-valid.js';
 import styled, { StyleProps } from '../../styles/styled.js';
@@ -65,7 +65,7 @@ export interface BaseProps {
   /**
    * Display an icon in addition to the text to help to identify the action.
    */
-  'icon'?: FC<SVGProps<SVGSVGElement>>;
+  'icon'?: FC<IconProps<'16' | '24'>>;
   /**
    * The HTML button type
    */
@@ -455,7 +455,13 @@ export const Button = forwardRef(
           <LoadingLabel>{loadingLabel}</LoadingLabel>
         </LoadingIcon>
         <Content isLoading={Boolean(isLoading)}>
-          {Icon && <Icon css={iconStyles} role="presentation" />}
+          {Icon && (
+            <Icon
+              css={iconStyles}
+              size={props.size === 'kilo' ? '16' : '24'}
+              role="presentation"
+            />
+          )}
           {children}
         </Content>
       </StyledButton>

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -19,11 +19,10 @@ import {
   ButtonHTMLAttributes,
   AnchorHTMLAttributes,
   ReactNode,
-  FC,
 } from 'react';
 import { css } from '@emotion/react';
 import { Theme } from '@sumup/design-tokens';
-import { IconProps } from '@sumup/icons';
+import type { IconComponentType } from '@sumup/icons';
 
 import isPropValid from '../../styles/is-prop-valid.js';
 import styled, { StyleProps } from '../../styles/styled.js';
@@ -65,7 +64,7 @@ export interface BaseProps {
   /**
    * Display an icon in addition to the text to help to identify the action.
    */
-  'icon'?: FC<IconProps<'16' | '24'>>;
+  'icon'?: IconComponentType;
   /**
    * The HTML button type
    */

--- a/packages/circuit-ui/components/Button/__snapshots__/Button.spec.tsx.snap
+++ b/packages/circuit-ui/components/Button/__snapshots__/Button.spec.tsx.snap
@@ -340,10 +340,10 @@ exports[`Button > styles > should render a button with icon 1`] = `
     class="circuit-3"
   >
     <svg
+      aria-hidden="true"
       class="circuit-4"
       fill="none"
       height="24"
-      role="presentation"
       viewBox="0 0 24 24"
       width="24"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.tsx.snap
+++ b/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.tsx.snap
@@ -575,9 +575,9 @@ exports[`Carousel > styles > should render with children as a function 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -612,9 +612,9 @@ exports[`Carousel > styles > should render with children as a function 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -647,9 +647,9 @@ exports[`Carousel > styles > should render with children as a function 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1249,9 +1249,9 @@ exports[`Carousel > styles > should render with children as a node 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1286,9 +1286,9 @@ exports[`Carousel > styles > should render with children as a node 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1321,9 +1321,9 @@ exports[`Carousel > styles > should render with children as a node 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1922,9 +1922,9 @@ exports[`Carousel > styles > should render with default paused styles 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1959,9 +1959,9 @@ exports[`Carousel > styles > should render with default paused styles 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1994,9 +1994,9 @@ exports[`Carousel > styles > should render with default paused styles 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -2566,9 +2566,9 @@ exports[`Carousel > styles > should render with default styles 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -2603,9 +2603,9 @@ exports[`Carousel > styles > should render with default styles 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -2638,9 +2638,9 @@ exports[`Carousel > styles > should render with default styles 1`] = `
             class="circuit-26"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/Carousel/components/Buttons/__snapshots__/Buttons.spec.tsx.snap
+++ b/packages/circuit-ui/components/Carousel/components/Buttons/__snapshots__/Buttons.spec.tsx.snap
@@ -176,9 +176,9 @@ exports[`Buttons > styles > should render with default styles 1`] = `
         class="circuit-4"
       >
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
-          role="presentation"
           viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
@@ -212,9 +212,9 @@ exports[`Buttons > styles > should render with default styles 1`] = `
         class="circuit-4"
       >
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
-          role="presentation"
           viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
@@ -248,9 +248,9 @@ exports[`Buttons > styles > should render with default styles 1`] = `
         class="circuit-4"
       >
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
-          role="presentation"
           viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
@@ -282,9 +282,9 @@ exports[`Buttons > styles > should render with default styles 1`] = `
         class="circuit-4"
       >
         <svg
+          aria-hidden="true"
           fill="none"
           height="16"
-          role="presentation"
           viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
@@ -154,9 +154,9 @@ exports[`CloseButton > should render with default styles 1`] = `
     class="circuit-3"
   >
     <svg
+      aria-hidden="true"
       fill="none"
       height="16"
-      role="presentation"
       viewBox="0 0 16 16"
       width="16"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/Hamburger/__snapshots__/Hamburger.spec.tsx.snap
+++ b/packages/circuit-ui/components/Hamburger/__snapshots__/Hamburger.spec.tsx.snap
@@ -241,8 +241,8 @@ exports[`Hamburger > should render with active styles when passed the isActive p
     class="circuit-3"
   >
     <span
+      aria-hidden="true"
       class="circuit-4"
-      role="presentation"
     >
       <span
         class="circuit-5"
@@ -471,8 +471,8 @@ exports[`Hamburger > should render with default styles 1`] = `
     class="circuit-3"
   >
     <span
+      aria-hidden="true"
       class="circuit-4"
-      role="presentation"
     >
       <span
         class="circuit-5"
@@ -701,8 +701,8 @@ exports[`Hamburger > should render with giga styles 1`] = `
     class="circuit-3"
   >
     <span
+      aria-hidden="true"
       class="circuit-4"
-      role="presentation"
     >
       <span
         class="circuit-5"
@@ -931,8 +931,8 @@ exports[`Hamburger > should render with kilo styles 1`] = `
     class="circuit-3"
   >
     <span
+      aria-hidden="true"
       class="circuit-4"
-      role="presentation"
     >
       <span
         class="circuit-5"

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -27,7 +27,7 @@ export interface IconButtonProps extends Omit<ButtonProps, 'icon' | 'stretch'> {
   /**
    * A single icon element.
    */
-  children: ReactElement<IconProps<'16' | '24'>>;
+  children: ReactElement<IconProps>;
   /**
    * Short label to describe the function of the button. Displayed as title
    * on hover, and accessible to screen readers.

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -16,7 +16,7 @@
 import { Children, cloneElement, ReactElement, forwardRef, Ref } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
 import { Theme } from '@sumup/design-tokens';
-import { IconProps } from '@sumup/icons';
+import type { IconProps } from '@sumup/icons';
 
 import { hideVisually } from '../../styles/style-mixins.js';
 import styled from '../../styles/styled.js';
@@ -63,8 +63,8 @@ export const IconButton = forwardRef(
     const child = Children.only(children);
     const iconSize = size === 'kilo' ? '16' : '24';
     const icon = cloneElement(child, {
-      role: 'presentation',
-      size: child.props.size || iconSize,
+      'aria-hidden': 'true',
+      'size': (child.props.size as string) || iconSize,
     });
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -27,7 +27,7 @@ export interface IconButtonProps extends Omit<ButtonProps, 'icon' | 'stretch'> {
   /**
    * A single icon element.
    */
-  children: ReactElement<IconProps>;
+  children: ReactElement<IconProps<'16' | '24'>>;
   /**
    * Short label to describe the function of the button. Displayed as title
    * on hover, and accessible to screen readers.

--- a/packages/circuit-ui/components/IconButton/__snapshots__/IconButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/IconButton/__snapshots__/IconButton.spec.tsx.snap
@@ -152,9 +152,9 @@ exports[`IconButton > should render with the default styles 1`] = `
     class="circuit-3"
   >
     <svg
+      aria-hidden="true"
       fill="none"
       height="24"
-      role="presentation"
       viewBox="0 0 24 24"
       width="24"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -344,9 +344,9 @@ exports[`ImageInput > Styles > should render with a custom component 1`] = `
           class="circuit-8"
         >
           <svg
+            aria-hidden="true"
             fill="none"
             height="16"
-            role="presentation"
             viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
@@ -779,9 +779,9 @@ exports[`ImageInput > Styles > should render with a giga button 1`] = `
           class="circuit-9"
         >
           <svg
+            aria-hidden="true"
             fill="none"
             height="16"
-            role="presentation"
             viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
@@ -1172,9 +1172,9 @@ exports[`ImageInput > Styles > should render with an existing image 1`] = `
           class="circuit-9"
         >
           <svg
+            aria-hidden="true"
             fill="none"
             height="16"
-            role="presentation"
             viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
@@ -1601,9 +1601,9 @@ exports[`ImageInput > Styles > should render with default styles 1`] = `
           class="circuit-9"
         >
           <svg
+            aria-hidden="true"
             fill="none"
             height="16"
-            role="presentation"
             viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
@@ -2064,9 +2064,9 @@ exports[`ImageInput > Styles > should render with invalid styles and an error me
           class="circuit-9"
         >
           <svg
+            aria-hidden="true"
             fill="none"
             height="16"
-            role="presentation"
             viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -48,7 +48,7 @@ interface BaseProps {
    * Display a leading component.
    * Pass an icon from `@sumup/icons` or a custom component.
    */
-  leadingComponent?: FC<IconProps> | ReactNode;
+  leadingComponent?: FC<IconProps<'24'>> | ReactNode;
   /**
    * Display a main label.
    */

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -20,10 +20,9 @@ import {
   ButtonHTMLAttributes,
   AnchorHTMLAttributes,
   HTMLAttributes,
-  FC,
 } from 'react';
 import { css } from '@emotion/react';
-import { ChevronRight, IconProps } from '@sumup/icons';
+import { ChevronRight, IconComponentType } from '@sumup/icons';
 
 import isPropValid from '../../styles/is-prop-valid.js';
 import styled, { StyleProps } from '../../styles/styled.js';
@@ -48,7 +47,7 @@ interface BaseProps {
    * Display a leading component.
    * Pass an icon from `@sumup/icons` or a custom component.
    */
-  leadingComponent?: FC<IconProps<'24'>> | ReactNode;
+  leadingComponent?: IconComponentType | ReactNode;
   /**
    * Display a main label.
    */

--- a/packages/circuit-ui/components/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/packages/circuit-ui/components/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -296,9 +296,9 @@ exports[`Modal > should match the snapshot 1`] = `
               class="circuit-6"
             >
               <svg
+                aria-hidden="true"
                 fill="none"
                 height="16"
-                role="presentation"
                 viewBox="0 0 16 16"
                 width="16"
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/Notification/constants.ts
+++ b/packages/circuit-ui/components/Notification/constants.ts
@@ -13,14 +13,13 @@
  * limitations under the License.
  */
 
-import { FC } from 'react';
-import { Alert, Confirm, IconProps, Info, Notify } from '@sumup/icons';
+import { Alert, Confirm, IconComponentType, Info, Notify } from '@sumup/icons';
 
 export type NotificationVariant = 'info' | 'success' | 'warning' | 'danger';
 
 export const NOTIFICATION_ICONS: Record<
   NotificationVariant,
-  FC<IconProps<'16' | '24'>>
+  IconComponentType<'16' | '24'>
 > = {
   info: Info,
   success: Confirm,

--- a/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
@@ -501,9 +501,9 @@ exports[`NotificationModal > styles > should render with an SVG 1`] = `
             class="circuit-5"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1089,9 +1089,9 @@ exports[`NotificationModal > styles > should render with default styles 1`] = `
             class="circuit-5"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1662,9 +1662,9 @@ exports[`NotificationModal > styles > should render without an image 1`] = `
             class="circuit-5"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
@@ -294,9 +294,9 @@ exports[`NotificationToast > styles > should render with a headline 1`] = `
             class="circuit-10"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -603,9 +603,9 @@ exports[`NotificationToast > styles > should render with danger variant styles 1
             class="circuit-9"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -912,9 +912,9 @@ exports[`NotificationToast > styles > should render with default styles 1`] = `
             class="circuit-9"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1221,9 +1221,9 @@ exports[`NotificationToast > styles > should render with info variant styles 1`]
             class="circuit-9"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1530,9 +1530,9 @@ exports[`NotificationToast > styles > should render with success variant styles 
             class="circuit-9"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"
@@ -1841,9 +1841,9 @@ exports[`NotificationToast > styles > should render with warning variant styles 
             class="circuit-9"
           >
             <svg
+              aria-hidden="true"
               fill="none"
               height="16"
-              role="presentation"
               viewBox="0 0 16 16"
               width="16"
               xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
+++ b/packages/circuit-ui/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
@@ -429,9 +429,9 @@ li:last-child .circuit-11 {
       class="circuit-4"
     >
       <svg
+        aria-hidden="true"
         fill="none"
         height="16"
-        role="presentation"
         viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -573,9 +573,9 @@ li:last-child .circuit-11 {
       class="circuit-4"
     >
       <svg
+        aria-hidden="true"
         fill="none"
         height="16"
-        role="presentation"
         viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -977,9 +977,9 @@ select:not(:active)~.circuit-12 {
       class="circuit-4"
     >
       <svg
+        aria-hidden="true"
         fill="none"
         height="16"
-        role="presentation"
         viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -1122,9 +1122,9 @@ select:not(:active)~.circuit-12 {
       class="circuit-4"
     >
       <svg
+        aria-hidden="true"
         fill="none"
         height="16"
-        role="presentation"
         viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -16,7 +16,6 @@
 import { css, useTheme } from '@emotion/react';
 import { Theme } from '@sumup/design-tokens';
 import {
-  FC,
   Fragment,
   Ref,
   useEffect,
@@ -32,7 +31,7 @@ import {
   offset as offsetMiddleware,
   Placement,
 } from '@floating-ui/react-dom';
-import { IconProps } from '@sumup/icons';
+import type { IconComponentType } from '@sumup/icons';
 
 import isPropValid from '../../styles/is-prop-valid.js';
 import { ClickEvent } from '../../types/events.js';
@@ -63,7 +62,7 @@ export interface BaseProps {
   /**
    * Display an icon in addition to the label. Designed for 24px icons from `@sumup/icons`.
    */
-  icon?: FC<IconProps<'24'>>;
+  icon?: IconComponentType;
   /**
    * Destructive variant, changes the color of label and icon from blue to red to signal to the user that the action
    * is irreversible or otherwise dangerous. Interactive states are the same for destructive variant.

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -63,7 +63,7 @@ export interface BaseProps {
   /**
    * Display an icon in addition to the label. Designed for 24px icons from `@sumup/icons`.
    */
-  icon?: FC<IconProps>;
+  icon?: FC<IconProps<'24'>>;
   /**
    * Destructive variant, changes the color of label and icon from blue to red to signal to the user that the action
    * is irreversible or otherwise dangerous. Interactive states are the same for destructive variant.

--- a/packages/circuit-ui/components/Select/Select.stories.tsx
+++ b/packages/circuit-ui/components/Select/Select.stories.tsx
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { useState, FC } from 'react';
-import { FlagDe, FlagUs, FlagFr, IconProps } from '@sumup/icons';
+import { useState } from 'react';
+import { FlagDe, FlagUs, FlagFr, IconComponentType } from '@sumup/icons';
 
 import { Select, SelectProps } from './Select.js';
 
@@ -43,7 +43,7 @@ const baseArgs = {
   ],
 };
 
-const flagIconMap: { [key: string]: FC<IconProps<'16'>> } = {
+const flagIconMap: { [key: string]: IconComponentType<'16'> } = {
   DE: FlagDe,
   US: FlagUs,
   FR: FlagFr,

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/__snapshots__/MobileNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/__snapshots__/MobileNavigation.spec.tsx.snap
@@ -513,9 +513,9 @@ exports[`MobileNavigation > styles > should render with secondary links 1`] = `
                 class="circuit-7"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="16"
-                  role="presentation"
                   viewBox="0 0 16 16"
                   width="16"
                   xmlns="http://www.w3.org/2000/svg"
@@ -1041,9 +1041,9 @@ exports[`MobileNavigation > styles > should render without secondary links 1`] =
                 class="circuit-7"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="16"
-                  role="presentation"
                   viewBox="0 0 16 16"
                   width="16"
                   xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -24,7 +24,7 @@ export interface PrimaryLinkProps
    * Display an icon in addition to the text to help to identify the link.
    * On narrow viewports, only the icon is displayed.
    */
-  icon: FC<IconProps>;
+  icon: FC<IconProps<'24'>>;
   /**
    * Short label to describe the target of the link.
    */

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { FC, MouseEvent, KeyboardEvent, AnchorHTMLAttributes } from 'react';
-import { IconProps } from '@sumup/icons';
+import type { MouseEvent, KeyboardEvent, AnchorHTMLAttributes } from 'react';
+import type { IconComponentType } from '@sumup/icons';
 
 import { BadgeProps } from '../Badge/index.js';
 
@@ -24,7 +24,7 @@ export interface PrimaryLinkProps
    * Display an icon in addition to the text to help to identify the link.
    * On narrow viewports, only the icon is displayed.
    */
-  icon: FC<IconProps<'24'>>;
+  icon: IconComponentType;
   /**
    * Short label to describe the target of the link.
    */

--- a/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -291,9 +291,9 @@ exports[`SidePanel > should match the snapshot 1`] = `
                 class="circuit-8"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
-                  role="presentation"
                   viewBox="0 0 24 24"
                   width="24"
                   xmlns="http://www.w3.org/2000/svg"
@@ -624,9 +624,9 @@ exports[`SidePanel > when the panel is on mobile resolution > should match the s
                 class="circuit-8"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
-                  role="presentation"
                   viewBox="0 0 24 24"
                   width="24"
                   xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanelContext.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanelContext.spec.tsx.snap
@@ -326,9 +326,9 @@ exports[`SidePanelContext > SidePanelProvider > render > should render the side 
                 class="circuit-9"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
-                  role="presentation"
                   viewBox="0 0 24 24"
                   width="24"
                   xmlns="http://www.w3.org/2000/svg"
@@ -676,9 +676,9 @@ exports[`SidePanelContext > SidePanelProvider > render > should render the side 
                 class="circuit-9"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
-                  role="presentation"
                   viewBox="0 0 24 24"
                   width="24"
                   xmlns="http://www.w3.org/2000/svg"
@@ -1025,9 +1025,9 @@ exports[`SidePanelContext > SidePanelProvider > render > should render the side 
                 class="circuit-9"
               >
                 <svg
+                  aria-hidden="true"
                   fill="none"
                   height="24"
-                  role="presentation"
                   viewBox="0 0 24 24"
                   width="24"
                   xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/SidePanel/components/Header/__snapshots__/Header.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/components/Header/__snapshots__/Header.spec.tsx.snap
@@ -215,9 +215,9 @@ exports[`Header > should have a bottom separator when sticky 1`] = `
           class="circuit-5"
         >
           <svg
+            aria-hidden="true"
             fill="none"
             height="24"
-            role="presentation"
             viewBox="0 0 24 24"
             width="24"
             xmlns="http://www.w3.org/2000/svg"
@@ -447,9 +447,9 @@ exports[`Header > should match the snapshot 1`] = `
           class="circuit-5"
         >
           <svg
+            aria-hidden="true"
             fill="none"
             height="24"
-            role="presentation"
             viewBox="0 0 24 24"
             width="24"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/Sidebar/__snapshots__/Sidebar.spec.tsx.snap
+++ b/packages/circuit-ui/components/Sidebar/__snapshots__/Sidebar.spec.tsx.snap
@@ -245,9 +245,9 @@ exports[`Sidebar > should render and match snapshot when open 1`] = `
       class="circuit-5"
     >
       <svg
+        aria-hidden="true"
         fill="none"
         height="16"
-        role="presentation"
         viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
@@ -497,9 +497,9 @@ exports[`Sidebar > should render and match the snapshot when closed 1`] = `
       class="circuit-5"
     >
       <svg
+        aria-hidden="true"
         fill="none"
         height="16"
-        role="presentation"
         viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
@@ -168,9 +168,9 @@ exports[`CloseButton > styles > should render and match snapshot when not visibl
     class="circuit-3"
   >
     <svg
+      aria-hidden="true"
       fill="none"
       height="16"
-      role="presentation"
       viewBox="0 0 16 16"
       width="16"
       xmlns="http://www.w3.org/2000/svg"
@@ -361,9 +361,9 @@ exports[`CloseButton > styles > should render and match snapshot when visible 1`
     class="circuit-3"
   >
     <svg
+      aria-hidden="true"
       fill="none"
       height="16"
-      role="presentation"
       viewBox="0 0 16 16"
       width="16"
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/packages/circuit-ui/components/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -307,9 +307,9 @@ exports[`Tag > when is selected > should change the close icon color 1`] = `
       class="circuit-5"
     >
       <svg
+        aria-hidden="true"
         fill="none"
         height="16"
-        role="presentation"
         viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"

--- a/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
@@ -571,8 +571,8 @@ exports[`TopNavigation > styles > should match the snapshot 1`] = `
             class="circuit-6"
           >
             <span
+              aria-hidden="true"
               class="circuit-7"
-              role="presentation"
             >
               <span
                 class="circuit-8"

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -61,7 +61,7 @@ export interface UtilityLinkProps
    * Display an icon in addition to the text to help to identify the link.
    * On narrow viewports, only the icon is displayed.
    */
-  icon: FC<IconProps>;
+  icon: FC<IconProps<'24'>>;
   /**
    * Short label to describe the target of the link.
    */

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-import { MouseEvent, KeyboardEvent, FC, AnchorHTMLAttributes } from 'react';
+import type { MouseEvent, KeyboardEvent, AnchorHTMLAttributes } from 'react';
 import { css } from '@emotion/react';
-import { Theme } from '@sumup/design-tokens';
-import { IconProps } from '@sumup/icons';
+import type { Theme } from '@sumup/design-tokens';
+import type { IconComponentType } from '@sumup/icons';
 
 import styled, { NoTheme, StyleProps } from '../../../../styles/styled.js';
 import {
@@ -61,7 +61,7 @@ export interface UtilityLinkProps
    * Display an icon in addition to the text to help to identify the link.
    * On narrow viewports, only the icon is displayed.
    */
-  icon: FC<IconProps<'24'>>;
+  icon: IconComponentType;
   /**
    * Short label to describe the target of the link.
    */

--- a/packages/icons/scripts/web.ts
+++ b/packages/icons/scripts/web.ts
@@ -110,18 +110,20 @@ function buildDeclarationFile(components: Component[]): string {
   const declarationStatements = components.map((component) => {
     const sizes = component.icons.map(({ size }) => `'${size}'`).sort();
     const SizesType = sizes.join(' | ');
-    return `declare const ${component.name}: FC<IconProps<${SizesType}>>;`;
+    return `declare const ${component.name}: IconComponentType<${SizesType}>;`;
   });
   const exportNames = components.map((file) => file.name);
   return dedent`
-    import type { FC, SVGProps } from 'react';
+    import type { FunctionComponent, SVGProps } from 'react';
 
-    export interface IconProps<Sizes = '16' | '24' | '32'> extends SVGProps<SVGSVGElement> {
+    export interface IconProps<Sizes extends string = any> extends SVGProps<SVGSVGElement> {
       /**
-       * Choose between the one of the available sizes. Defaults to '24', if supported, or to the smallest available size.
+       * Choose between one of the available sizes. Defaults to '24', if supported, or to the smallest available size.
        */
       size?: Sizes;
     }
+
+    export type IconComponentType<Sizes extends string = any> = FunctionComponent<IconProps<Sizes>>;
 
     ${declarationStatements.join('\n')}
 


### PR DESCRIPTION
## Purpose

While working on the new https://developer.sumup.com, I found a couple of inconsistencies in Circuit UI. I tried to narrow the type of the `icon` prop in all components that accept it by specifying the accepted sizes. However, TypeScript throws a fit whenever the `size` prop doesn't match exactly. 

Instead, I changed the default size to `any` to work around this TypeScript limitation and added a new `IconComponentType` export to the `@sumup/icons` package.

## Approach and changes

- Changed the `IconProps` default size type to `any`
- Automatically set the `size` prop on the Button's `icon` prop based on the Button's `size` prop
- Properly hide icons inside a Button

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
