### PR TITLE
Fix Pagination component return type

### DIFF
--- a/.changeset/swift-mails-cross.md
+++ b/.changeset/swift-mails-cross.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Changed `Pagination` type from `ReactNode` to `ReactElement | null` to prevent a clash with React 18 types.

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 import { css } from '@emotion/react';
 import { Theme } from '@sumup/design-tokens';
 import { ChevronLeft, ChevronRight } from '@sumup/icons';
@@ -102,7 +102,7 @@ export const Pagination = ({
   totalLabel,
   tracking = {},
   ...props
-}: PaginationProps): ReactNode => {
+}: PaginationProps): ReactElement | null => {
   if (
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'


### PR DESCRIPTION
## Purpose

Currently, the `Pagination` component is typed as a `ReactNode`.

This can be a problem for apps using React 18, because `ReactNode` can be `undefined`, and `undefined` isn't a valid JSX component.

![image](https://user-images.githubusercontent.com/35560568/176613413-ea06d211-0a20-4522-ae9c-b775ac5a73e5.png)

## Approach and changes

Switch the return type to `ReactElement | null`.

This is more accurate, since the `Pagination` component never returns e.g. `undefined`, a string, or an array of `ReactElement`s (all included in the definition of `ReactNode`).

It can either be `null` (when there are less than two pages) or a `ReactElement` otherwise.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
