### PR TITLE
ImageInput accessibility improvements

### DIFF
--- a/.changeset/violet-rats-reflect.md
+++ b/.changeset/violet-rats-reflect.md
@@ -1,7 +1,5 @@
 ---
-'@sumup/circuit-ui': minor
+'@sumup/circuit-ui': patch
 ---
 
-Improved accessibility for the `ImageInput` component.
-
-- Now the error message is associated with the input field by `aria-describedby`.
+Improved the accessibility of the `ImageInput` component by associating the validation hint with the input and announcing updates to screen reader users.

--- a/.changeset/violet-rats-reflect.md
+++ b/.changeset/violet-rats-reflect.md
@@ -1,0 +1,7 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Improved accessibility for the `ImageInput` component.
+
+- Now the error message is associated with the input field by `aria-describedby`.

--- a/packages/circuit-ui/components/ImageInput/ImageInput.docs.mdx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.docs.mdx
@@ -57,9 +57,16 @@ There are some caveats with this approach:
 #### Error message associated with input field
 
 Error messages should be simple and clear to understand, also provide guidance on how to correct mistakes.
-The error messages must be associated with their respective controls (e.g. Input field), via labeling or `aria-describedby`.
-The screen readers call the error message with a live region by applying an `aria-live` property or using one of the live region roles (e.g alert).
+The error messages must be associated with respective controls (e.g. Input field), via `aria-describedby` or labeling.
+The screen readers announce the error message with a live region by applying an `aria-live` property.
 
 The `aria-describedby` is added to the Input field, and `aria-invalid="true"` when the error is triggered.
-The `aria-live="assertive"` indicate that screen readers should immediately announce the error message rather than completing other announcements first.
-This increases the possibility that users are aware of the error message before they move focus out of the input.
+The `aria-live="polite"` indicates that the error message will be announced after completing other announcements first.
+
+### Resources
+
+#### Related articles
+
+- [Testing error messages](https://www.davidmacd.com/blog/test-aria-describedby-errormessage-aria-live.html) Web Accessibility Training
+- [Using live regions to identify error messages](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA19.html)
+- [Error messages with aria-live] (https://gaurav5430.medium.com/accessibility-quick-wins-error-messages-with-aria-live-7a622cb606f9)

--- a/packages/circuit-ui/components/ImageInput/ImageInput.docs.mdx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.docs.mdx
@@ -49,24 +49,3 @@ There are some caveats with this approach:
 ### Using a div element
 
 <Story id="forms-imageinput--custom-component-div" />
-
-## Accessibility
-
-### Best practices
-
-#### Error message associated with input field
-
-Error messages should be simple and clear to understand, also provide guidance on how to correct mistakes.
-The error messages must be associated with respective controls (e.g. Input field), via `aria-describedby` or labeling.
-The screen readers announce the error message with a live region by applying an `aria-live` property.
-
-The `aria-describedby` is added to the Input field, and `aria-invalid="true"` when the error is triggered.
-The `aria-live="polite"` indicates that the error message will be announced after completing other announcements first.
-
-### Resources
-
-#### Related articles
-
-- [Testing error messages](https://www.davidmacd.com/blog/test-aria-describedby-errormessage-aria-live.html) Web Accessibility Training
-- [Using live regions to identify error messages](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA19.html)
-- [Error messages with aria-live] (https://gaurav5430.medium.com/accessibility-quick-wins-error-messages-with-aria-live-7a622cb606f9)

--- a/packages/circuit-ui/components/ImageInput/ImageInput.docs.mdx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.docs.mdx
@@ -49,3 +49,17 @@ There are some caveats with this approach:
 ### Using a div element
 
 <Story id="forms-imageinput--custom-component-div" />
+
+## Accessibility
+
+### Best practices
+
+#### Error message associated with input field
+
+Error messages should be simple and clear to understand, also provide guidance on how to correct mistakes.
+The error messages must be associated with their respective controls (e.g. Input field), via labeling or `aria-describedby`.
+The screen readers call the error message with a live region by applying an `aria-live` property or using one of the live region roles (e.g alert).
+
+The `aria-describedby` is added to the Input field, and `aria-invalid="true"` when the error is triggered.
+The `aria-live="assertive"` indicate that screen readers should immediately announce the error message rather than completing other announcements first.
+This increases the possibility that users are aware of the error message before they move focus out of the input.

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -483,7 +483,7 @@ export const ImageInput = ({
       </InputWrapper>
       <ValidationHint
         id="validation_hint"
-        aria-live="assertive"
+        aria-live="polite"
         validationHint={validationHint}
         invalid={invalid}
       />

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -434,6 +434,7 @@ export const ImageInput = ({
           onClick={handleClick}
           disabled={disabled || isLoading}
           aria-invalid={invalid}
+          aria-describedby="validation_hint"
           {...props}
         />
         <StyledLabel
@@ -480,7 +481,12 @@ export const ImageInput = ({
           <LoadingLabel>{loadingLabel}</LoadingLabel>
         </LoadingIcon>
       </InputWrapper>
-      <ValidationHint validationHint={validationHint} invalid={invalid} />
+      <ValidationHint
+        id="validation_hint"
+        aria-live="assertive"
+        validationHint={validationHint}
+        invalid={invalid}
+      />
     </Fragment>
   );
 };

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -335,6 +335,7 @@ export const ImageInput = ({
 
   const inputRef = useRef<HTMLInputElement>(null);
   const id = customId || uniqueId('image-input_');
+  const validationHintId = uniqueId('validation-hint_');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isDragging, setDragging] = useState<boolean>(false);
   const [previewImage, setPreviewImage] = useState<string>('');
@@ -434,7 +435,7 @@ export const ImageInput = ({
           onClick={handleClick}
           disabled={disabled || isLoading}
           aria-invalid={invalid}
-          aria-describedby="validation_hint"
+          aria-describedby={validationHintId}
           {...props}
         />
         <StyledLabel
@@ -482,7 +483,7 @@ export const ImageInput = ({
         </LoadingIcon>
       </InputWrapper>
       <ValidationHint
-        id="validation_hint"
+        id={validationHintId}
         aria-live="polite"
         validationHint={validationHint}
         invalid={invalid}

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -289,15 +289,15 @@ exports[`ImageInput styles should render a custom component 1`] = `
   >
     <input
       accept="image/*"
-      aria-describedby="validation_hint"
+      aria-describedby="validation-hint_10"
       aria-invalid="false"
       class="circuit-1"
-      id="image-input_5"
+      id="image-input_9"
       type="file"
     />
     <label
       class="circuit-2"
-      for="image-input_5"
+      for="image-input_9"
     >
       <span
         class="circuit-3"
@@ -664,15 +664,15 @@ exports[`ImageInput styles should render with an existing image 1`] = `
   >
     <input
       accept="image/*"
-      aria-describedby="validation_hint"
+      aria-describedby="validation-hint_4"
       aria-invalid="false"
       class="circuit-1"
-      id="image-input_2"
+      id="image-input_3"
       type="file"
     />
     <label
       class="circuit-2"
-      for="image-input_2"
+      for="image-input_3"
     >
       <span
         class="circuit-3"
@@ -1040,7 +1040,7 @@ exports[`ImageInput styles should render with default styles 1`] = `
   >
     <input
       accept="image/*"
-      aria-describedby="validation_hint"
+      aria-describedby="validation-hint_2"
       aria-invalid="false"
       class="circuit-1"
       id="image-input_1"
@@ -1441,15 +1441,15 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
   >
     <input
       accept="image/*"
-      aria-describedby="validation_hint"
+      aria-describedby="validation-hint_6"
       aria-invalid="true"
       class="circuit-1"
-      id="image-input_3"
+      id="image-input_5"
       type="file"
     />
     <label
       class="circuit-2"
-      for="image-input_3"
+      for="image-input_5"
     >
       <span
         class="circuit-3"
@@ -1512,7 +1512,7 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
   <span
     aria-live="polite"
     class="circuit-12"
-    id="validation_hint"
+    id="validation-hint_6"
   >
     <div
       class="circuit-13"
@@ -1843,15 +1843,15 @@ exports[`ImageInput styles should render with smaller button 1`] = `
   >
     <input
       accept="image/*"
-      aria-describedby="validation_hint"
+      aria-describedby="validation-hint_8"
       aria-invalid="false"
       class="circuit-1"
-      id="image-input_4"
+      id="image-input_7"
       type="file"
     />
     <label
       class="circuit-2"
-      for="image-input_4"
+      for="image-input_7"
     >
       <span
         class="circuit-3"

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -1510,7 +1510,7 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
     </span>
   </div>
   <span
-    aria-live="assertive"
+    aria-live="polite"
     class="circuit-12"
     id="validation_hint"
   >

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -289,6 +289,7 @@ exports[`ImageInput styles should render a custom component 1`] = `
   >
     <input
       accept="image/*"
+      aria-describedby="validation_hint"
       aria-invalid="false"
       class="circuit-1"
       id="image-input_5"
@@ -663,6 +664,7 @@ exports[`ImageInput styles should render with an existing image 1`] = `
   >
     <input
       accept="image/*"
+      aria-describedby="validation_hint"
       aria-invalid="false"
       class="circuit-1"
       id="image-input_2"
@@ -1038,6 +1040,7 @@ exports[`ImageInput styles should render with default styles 1`] = `
   >
     <input
       accept="image/*"
+      aria-describedby="validation_hint"
       aria-invalid="false"
       class="circuit-1"
       id="image-input_1"
@@ -1438,6 +1441,7 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
   >
     <input
       accept="image/*"
+      aria-describedby="validation_hint"
       aria-invalid="true"
       class="circuit-1"
       id="image-input_3"
@@ -1506,7 +1510,9 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
     </span>
   </div>
   <span
+    aria-live="assertive"
     class="circuit-12"
+    id="validation_hint"
   >
     <div
       class="circuit-13"
@@ -1837,6 +1843,7 @@ exports[`ImageInput styles should render with smaller button 1`] = `
   >
     <input
       accept="image/*"
+      aria-describedby="validation_hint"
       aria-invalid="false"
       class="circuit-1"
       id="image-input_4"

--- a/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
+++ b/packages/circuit-ui/components/ValidationHint/ValidationHint.tsx
@@ -148,6 +148,7 @@ export const ValidationHint = ({
 
   return (
     <Wrapper
+      {...props}
       invalid={props.invalid}
       showValid={props.showValid}
       hasWarning={props.hasWarning}


### PR DESCRIPTION

## Purpose

- The error message in the ImageInput component is not associated with input.
- This PR improves accessibility for the ImageInput component.

## Approach and changes


- Added aria-describedby to the Input field to associate it with the ValidationHint
- Make the ValidationHint a live region, by passing the aria-live='polite'

Note: Currently there is an issue with VoiceOver on Mac, aria-live content is read twice for the live regions inside iframes

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
