### PR TITLE
Refresh Anchor spec

### DIFF
--- a/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
@@ -23,6 +23,7 @@ import {
   axe,
   RenderFn,
   userEvent,
+  screen,
 } from '../../util/test-utils';
 import { ClickEvent } from '../../types/events';
 
@@ -84,15 +85,14 @@ describe('Anchor', () => {
     it('should call the onClick handler when rendered as a link', async () => {
       const props = {
         ...baseProps,
-        'href': 'https://sumup.com',
-        'onClick': jest.fn((event: ClickEvent) => {
+        href: 'https://sumup.com',
+        onClick: jest.fn((event: ClickEvent) => {
           event.preventDefault();
         }),
-        'data-testid': 'anchor',
       };
-      const { getByTestId } = renderAnchor(render, props);
+      renderAnchor(render, props);
 
-      await userEvent.click(getByTestId('anchor'));
+      await userEvent.click(screen.getByRole('link'));
 
       expect(props.onClick).toHaveBeenCalledTimes(1);
     });

--- a/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
@@ -16,106 +16,83 @@
 import { createRef } from 'react';
 import { css } from '@emotion/react';
 
-import {
-  create,
-  render,
-  renderToHtml,
-  axe,
-  RenderFn,
-  userEvent,
-  screen,
-} from '../../util/test-utils';
+import { render, axe, userEvent, screen } from '../../util/test-utils';
 import { ClickEvent } from '../../types/events';
 
-import { Anchor, AnchorProps } from './Anchor';
+import { Anchor } from './Anchor';
 
 describe('Anchor', () => {
-  function renderAnchor<T>(renderFn: RenderFn<T>, props: AnchorProps) {
-    return renderFn(<Anchor {...props} />);
-  }
-
   const baseProps = { children: 'Anchor' };
 
   describe('styles', () => {
     it('should render with default styles', () => {
-      const actual = renderAnchor(create, {
-        ...baseProps,
-        href: 'https://sumup.com',
-      });
-      expect(actual).toMatchSnapshot();
+      const { container } = render(
+        <Anchor {...baseProps} href="https://sumup.com" />,
+      );
+      expect(container).toMatchSnapshot();
     });
 
     it('should render with custom styles', () => {
-      const actual = renderAnchor(create, {
-        ...baseProps,
-        href: 'https://sumup.com',
-        css: css`
-          color: rebeccapurple;
-        `,
-      });
-      expect(actual).toMatchSnapshot();
+      const { container } = render(
+        <Anchor
+          {...baseProps}
+          href="https://sumup.com"
+          css={css`
+            color: rebeccapurple;
+          `}
+        />,
+      );
+      expect(container).toMatchSnapshot();
     });
   });
 
   describe('business logic', () => {
     it('should render as a `span` when neither href nor onClick is passed', () => {
-      const { container } = renderAnchor(render, baseProps);
+      const { container } = render(<Anchor {...baseProps} />);
       const actual = container.querySelector('span');
       expect(actual).toBeVisible();
     });
 
     it('should render as an `a` when an href (and onClick) is passed', () => {
-      const props = {
-        ...baseProps,
-        href: 'https://sumup.com',
-        onClick: jest.fn(),
-      };
-      const { container } = renderAnchor(render, props);
+      const { container } = render(
+        <Anchor {...baseProps} href="https://sumup.com" onClick={jest.fn} />,
+      );
       const actual = container.querySelector('a');
       expect(actual).toBeVisible();
     });
 
     it('should render as a `button` when an onClick is passed', () => {
-      const props = { ...baseProps, onClick: jest.fn() };
-      const { container } = renderAnchor(render, props);
+      const { container } = render(<Anchor {...baseProps} onClick={jest.fn} />);
       const actual = container.querySelector('button');
       expect(actual).toBeVisible();
     });
 
     it('should call the onClick handler when rendered as a link', async () => {
-      const props = {
-        ...baseProps,
-        href: 'https://sumup.com',
-        onClick: jest.fn((event: ClickEvent) => {
-          event.preventDefault();
-        }),
-      };
-      renderAnchor(render, props);
+      const onClick = jest.fn((event: ClickEvent) => {
+        event.preventDefault(); // navigation is not implemented in jsdom
+      });
+      render(
+        <Anchor {...baseProps} href="https://sumup.com" onClick={onClick} />,
+      );
 
       await userEvent.click(screen.getByRole('link'));
 
-      expect(props.onClick).toHaveBeenCalledTimes(1);
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
 
     it('should call the onClick handler when rendered as a button', async () => {
-      const props = {
-        ...baseProps,
-        'onClick': jest.fn(),
-        'data-testid': 'anchor',
-      };
-      const { getByTestId } = renderAnchor(render, props);
+      const onClick = jest.fn();
+      render(<Anchor {...baseProps} onClick={onClick} />);
 
-      await userEvent.click(getByTestId('anchor'));
+      await userEvent.click(screen.getByRole('button'));
 
-      expect(props.onClick).toHaveBeenCalledTimes(1);
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
 
     it('should accept a working ref for a button', () => {
       const tref = createRef<any>();
       const { container } = render(
-        <Anchor onClick={jest.fn()} ref={tref}>
-          button
-        </Anchor>,
+        <Anchor {...baseProps} onClick={jest.fn} ref={tref} />,
       );
       const button = container.querySelector('button');
       expect(tref.current).toBe(button);
@@ -124,9 +101,7 @@ describe('Anchor', () => {
     it('should accept a working ref for a link', () => {
       const tref = createRef<any>();
       const { container } = render(
-        <Anchor href="https://sumup.com" ref={tref}>
-          link
-        </Anchor>,
+        <Anchor {...baseProps} href="https://sumup.com" ref={tref} />,
       );
       const anchor = container.querySelector('a');
       expect(tref.current).toBe(anchor);
@@ -134,7 +109,7 @@ describe('Anchor', () => {
 
     it('should accept a working ref for a span', () => {
       const tref = createRef<any>();
-      const { container } = render(<Anchor ref={tref}>span</Anchor>);
+      const { container } = render(<Anchor {...baseProps} ref={tref} />);
       const span = container.querySelector('span');
       expect(tref.current).toBe(span);
     });
@@ -142,13 +117,10 @@ describe('Anchor', () => {
 
   describe('accessibility', () => {
     it('should meet accessibility guidelines', async () => {
-      const props = {
-        ...baseProps,
-        href: 'https://sumup.com',
-        onClick: jest.fn(),
-      };
-      const wrapper = renderAnchor(renderToHtml, props);
-      const actual = await axe(wrapper);
+      const { container } = render(
+        <Anchor {...baseProps} href="https://sumup.com" onClick={jest.fn} />,
+      );
+      const actual = await axe(container);
       expect(actual).toHaveNoViolations();
     });
   });

--- a/packages/circuit-ui/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
+++ b/packages/circuit-ui/components/Anchor/__snapshots__/Anchor.spec.tsx.snap
@@ -54,12 +54,14 @@ exports[`Anchor styles should render with custom styles 1`] = `
   box-shadow: none;
 }
 
-<a
-  class="circuit-0"
-  href="https://sumup.com"
->
-  Anchor
-</a>
+<div>
+  <a
+    class="circuit-0"
+    href="https://sumup.com"
+  >
+    Anchor
+  </a>
+</div>
 `;
 
 exports[`Anchor styles should render with default styles 1`] = `
@@ -115,10 +117,12 @@ exports[`Anchor styles should render with default styles 1`] = `
   box-shadow: none;
 }
 
-<a
-  class="circuit-0"
-  href="https://sumup.com"
->
-  Anchor
-</a>
+<div>
+  <a
+    class="circuit-0"
+    href="https://sumup.com"
+  >
+    Anchor
+  </a>
+</div>
 `;

--- a/packages/circuit-ui/util/test-utils.tsx
+++ b/packages/circuit-ui/util/test-utils.tsx
@@ -49,13 +49,16 @@ const WithProviders: FunctionComponent<PropsWithChildren<unknown>> = ({
 const render: RenderFn<RenderResult> = (component, options: RenderOptions) =>
   renderTest(component, { wrapper: WithProviders, ...options });
 /**
- * FIXME: `renderToHtml` should be removed and replaced in a11y tests by
- * const { container } = render(<Component />);
+ * @deprecated renderToHtml is deprecated. Use `axe(screen)` in accessibility
+ * tests instead.
  */
 const renderToHtml: RenderFn<HTMLElement> = (component) => {
   const { container } = render(component);
   return container;
 };
+/**
+ * @deprecated create is deprecated. Use render instead.
+ */
 const create = (
   ...args: Parameters<RenderFn<RenderResult>>
 ): ChildNode | HTMLCollection | null => {

--- a/packages/circuit-ui/util/test-utils.tsx
+++ b/packages/circuit-ui/util/test-utils.tsx
@@ -49,15 +49,15 @@ const WithProviders: FunctionComponent<PropsWithChildren<unknown>> = ({
 const render: RenderFn<RenderResult> = (component, options: RenderOptions) =>
   renderTest(component, { wrapper: WithProviders, ...options });
 /**
- * @deprecated renderToHtml is deprecated. Use `axe(screen)` in accessibility
- * tests instead.
+ * @deprecated `renderToHtml` is deprecated. Instead, run axe on the container
+ * from `const { container } = render(<Component />)`.
  */
 const renderToHtml: RenderFn<HTMLElement> = (component) => {
   const { container } = render(component);
   return container;
 };
 /**
- * @deprecated create is deprecated. Use render instead.
+ * @deprecated `create` is deprecated. Use `render` instead.
  */
 const create = (
   ...args: Parameters<RenderFn<RenderResult>>


### PR DESCRIPTION
## Purpose

Refresh the Anchor spec to better follow latest `@testing-library` best practices.

## Approach and changes

- use `screen.<query>` instead of destructuring queries from the render method's return
- deprecate `renderToHtml` and `create` in favor of `render`. Discussion below 👇 
- remove render helper method. Discussion below 👇 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
