### PR TITLE
increased left padding on TableCell and TableHeader for condensedStyl…

### DIFF
--- a/.changeset/red-wolves-greet.md
+++ b/.changeset/red-wolves-greet.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-In the base table with sortable columns, the direction symbol was too close to the header text in condensed mode. This change increases left padding on TableCell and TableHeader for condensedStyle.
+Fixed a spacing issue in the `Table` component when sorting a column in `condensed` mode.

--- a/.changeset/red-wolves-greet.md
+++ b/.changeset/red-wolves-greet.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+In the base table with sortable columns, the direction symbol was too close to the header text in condensed mode. This change increases left padding on TableCell and TableHeader for condensedStyle.

--- a/packages/circuit-ui/components/Table/__snapshots__/Table.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/__snapshots__/Table.spec.tsx.snap
@@ -1385,7 +1385,7 @@ tbody .circuit-4:last-child td {
   line-height: 20px;
   vertical-align: middle;
   padding: 12px 16px 12px 24px;
-  padding: 12px 16px 12px 24px;
+  padding: 8px 16px 8px 24px;
 }
 
 @media (max-width: 767px) {
@@ -1506,7 +1506,7 @@ tbody .circuit-4:last-child td {
   padding: 12px 16px 12px 24px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px 12px 24px;
+  padding: 8px 16px 8px 24px;
 }
 
 @media (max-width: 767px) {
@@ -1542,7 +1542,7 @@ tbody .circuit-4:last-child td {
   line-height: 20px;
   vertical-align: middle;
   padding: 12px 16px 12px 24px;
-  padding: 12px 16px 12px 24px;
+  padding: 8px 16px 8px 24px;
 }
 
 .circuit-12:focus-within::after {
@@ -1593,7 +1593,7 @@ tbody .circuit-4:last-child td {
   line-height: 20px;
   vertical-align: middle;
   padding: 12px 16px 12px 24px;
-  padding: 12px 16px 12px 24px;
+  padding: 8px 16px 8px 24px;
 }
 
 .circuit-20 {

--- a/packages/circuit-ui/components/Table/__snapshots__/Table.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/__snapshots__/Table.spec.tsx.snap
@@ -1384,8 +1384,8 @@ tbody .circuit-4:last-child td {
   font-size: 14px;
   line-height: 20px;
   vertical-align: middle;
-  padding: 12px 16px;
-  padding: 8px 16px;
+  padding: 12px 16px 12px 24px;
+  padding: 12px 16px 12px 24px;
 }
 
 @media (max-width: 767px) {
@@ -1494,7 +1494,7 @@ tbody .circuit-4:last-child td {
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
   overflow-wrap: break-word;
-  padding: 12px 16px;
+  padding: 12px 16px 12px 24px;
   font-size: 14px;
   line-height: 20px;
   display: none;
@@ -1503,10 +1503,10 @@ tbody .circuit-4:last-child td {
   font-weight: 700;
   padding: 8px 24px;
   white-space: nowrap;
-  padding: 12px 16px;
+  padding: 12px 16px 12px 24px;
   font-size: 14px;
   line-height: 20px;
-  padding: 8px 16px;
+  padding: 12px 16px 12px 24px;
 }
 
 @media (max-width: 767px) {
@@ -1541,8 +1541,8 @@ tbody .circuit-4:last-child td {
   font-size: 14px;
   line-height: 20px;
   vertical-align: middle;
-  padding: 12px 16px;
-  padding: 8px 16px;
+  padding: 12px 16px 12px 24px;
+  padding: 12px 16px 12px 24px;
 }
 
 .circuit-12:focus-within::after {
@@ -1592,8 +1592,8 @@ tbody .circuit-4:last-child td {
   font-size: 14px;
   line-height: 20px;
   vertical-align: middle;
-  padding: 12px 16px;
-  padding: 8px 16px;
+  padding: 12px 16px 12px 24px;
+  padding: 12px 16px 12px 24px;
 }
 
 .circuit-20 {
@@ -1606,7 +1606,7 @@ tbody .circuit-4:last-child td {
   font-size: 14px;
   line-height: 20px;
   vertical-align: middle;
-  padding: 12px 16px;
+  padding: 12px 16px 12px 24px;
 }
 
 @media (max-width: 767px) {
@@ -1628,11 +1628,11 @@ tbody .circuit-4:last-child td {
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
   overflow-wrap: break-word;
-  padding: 12px 16px;
+  padding: 12px 16px 12px 24px;
   font-size: 14px;
   line-height: 20px;
   display: none;
-  padding: 12px 16px;
+  padding: 12px 16px 12px 24px;
   font-size: 14px;
   line-height: 20px;
 }
@@ -1655,7 +1655,7 @@ tbody .circuit-4:last-child td {
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
   overflow-wrap: break-word;
-  padding: 12px 16px;
+  padding: 12px 16px 12px 24px;
   font-size: 14px;
   line-height: 20px;
 }

--- a/packages/circuit-ui/components/Table/components/TableCell/TableCell.ts
+++ b/packages/circuit-ui/components/Table/components/TableCell/TableCell.ts
@@ -88,7 +88,8 @@ const hoverStyles = ({
 const condensedStyles = ({ condensed, theme }: TableCellProps & StyleProps) =>
   condensed &&
   css`
-    padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+    padding: ${theme.spacings.kilo} ${theme.spacings.mega}
+      ${theme.spacings.kilo} ${theme.spacings.giga};
     ${typography('two')(theme)};
   `;
 
@@ -101,12 +102,14 @@ const condensedPresentationStyles = ({
   condensed &&
   role === PRESENTATION &&
   css`
-    padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+    padding: ${theme.spacings.kilo} ${theme.spacings.mega}
+      ${theme.spacings.kilo} ${theme.spacings.giga};
     ${typography('two')(theme)};
 
     ${header &&
     css`
-      padding: ${theme.spacings.byte} ${theme.spacings.mega};
+      padding: ${theme.spacings.kilo} ${theme.spacings.mega}
+        ${theme.spacings.kilo} ${theme.spacings.giga};
     `}
   `;
 

--- a/packages/circuit-ui/components/Table/components/TableCell/TableCell.ts
+++ b/packages/circuit-ui/components/Table/components/TableCell/TableCell.ts
@@ -108,8 +108,8 @@ const condensedPresentationStyles = ({
 
     ${header &&
     css`
-      padding: ${theme.spacings.kilo} ${theme.spacings.mega}
-        ${theme.spacings.kilo} ${theme.spacings.giga};
+      padding: ${theme.spacings.byte} ${theme.spacings.mega}
+        ${theme.spacings.byte} ${theme.spacings.giga};
     `}
   `;
 

--- a/packages/circuit-ui/components/Table/components/TableCell/__snapshots__/TableCell.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableCell/__snapshots__/TableCell.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`TableCell Style tests should render with condensed styles 1`] = `
   transition: background-color 120ms ease-in-out;
   vertical-align: middle;
   overflow-wrap: break-word;
-  padding: 12px 16px;
+  padding: 12px 16px 12px 24px;
   font-size: 14px;
   line-height: 20px;
 }

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -162,8 +162,8 @@ const condensedColStyles = ({
   condensed &&
   scope === 'col' &&
   css`
-    padding: ${theme.spacings.kilo} ${theme.spacings.mega}
-      ${theme.spacings.kilo} ${theme.spacings.giga};
+    padding: ${theme.spacings.byte} ${theme.spacings.mega}
+      ${theme.spacings.byte} ${theme.spacings.giga};
   `;
 
 const StyledHeader = styled('th', {

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -150,7 +150,8 @@ const condensedStyles = ({ condensed, theme }: StyleProps & ThElProps) =>
   css`
     ${typography('two')(theme)};
     vertical-align: middle;
-    padding: ${theme.spacings.kilo} ${theme.spacings.mega};
+    padding: ${theme.spacings.kilo} ${theme.spacings.mega}
+      ${theme.spacings.kilo} ${theme.spacings.giga};
   `;
 
 const condensedColStyles = ({
@@ -161,7 +162,8 @@ const condensedColStyles = ({
   condensed &&
   scope === 'col' &&
   css`
-    padding: ${theme.spacings.byte} ${theme.spacings.mega};
+    padding: ${theme.spacings.kilo} ${theme.spacings.mega}
+      ${theme.spacings.kilo} ${theme.spacings.giga};
   `;
 
 const StyledHeader = styled('th', {

--- a/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
@@ -18,8 +18,8 @@ exports[`TableHeader Style tests should render with condensed styles 1`] = `
   font-size: 14px;
   line-height: 20px;
   vertical-align: middle;
-  padding: 12px 16px;
-  padding: 8px 16px;
+  padding: 12px 16px 12px 24px;
+  padding: 12px 16px 12px 24px;
 }
 
 <th

--- a/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`TableHeader Style tests should render with condensed styles 1`] = `
   line-height: 20px;
   vertical-align: middle;
   padding: 12px 16px 12px 24px;
-  padding: 12px 16px 12px 24px;
+  padding: 8px 16px 8px 24px;
 }
 
 <th


### PR DESCRIPTION
Addresses #1618.

## Purpose

In the base table with sortable columns, the table header is too close to the sort-direction symbol. More left-padding needs to be added to the table headers and corresponding table cells.

## Approach and changes

- Increased left-padding on `TableHeader` and `TableCell` components (to `theme.spacings.giga`) for `condensedStyles` and `condensedPresentationStyles`
- Updated test snapshots 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements

## Visualisation of changes
Before
![image](https://user-images.githubusercontent.com/65017872/177819663-c7cb9747-cf00-404f-bbf8-756982023d30.png)
After
![image](https://user-images.githubusercontent.com/65017872/177819748-07f34e0d-5c4f-4b96-bd6c-0216277354ec.png)

