### PR TITLE
Migrate the Popover component to Floating UI

### DIFF
--- a/.changeset/hot-schools-attack.md
+++ b/.changeset/hot-schools-attack.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-Migrate the Popover component from Popper to Floating UI. Popper modifiers are longer supported, use offset prop for flexible placement of floating element instead.
+Migrated the Popover component from Popper to Floating UI. Popper `modifiers` are longer supported, use `offsetProp` prop for flexible placement of floating element instead.

--- a/.changeset/hot-schools-attack.md
+++ b/.changeset/hot-schools-attack.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-Migrated the Popover component from [Popper](https://popper.js.org/) to [Floating UI](https://floating-ui.com/). Popper's `modifiers` are longer supported, use the `offset` prop for flexible placement of the floating element instead. The `placement` prop no longer accepts `auto*` values. 
+Migrated the Popover component from [Popper](https://popper.js.org/) to [Floating UI](https://floating-ui.com/). Popper's `modifiers` are no longer supported, use the `offset` prop for flexible placement of the floating element instead. The `placement` prop no longer accepts `auto*` values. 

--- a/.changeset/hot-schools-attack.md
+++ b/.changeset/hot-schools-attack.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-Migrated the Popover component from Popper to Floating UI. Popper `modifiers` are longer supported, use `offsetProp` prop for flexible placement of floating element instead. `placement` prop can no longer have `auto*` values. Fixed `ProfileMenu` to use the updated `Popover` API. 
+Migrated the Popover component from [Popper](https://popper.js.org/) to [Floating UI](https://floating-ui.com/). Popper's `modifiers` are longer supported, use the `offset` prop for flexible placement of the floating element instead. The `placement` prop no longer accepts `auto*` values. 

--- a/.changeset/hot-schools-attack.md
+++ b/.changeset/hot-schools-attack.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Migrate the Popover component from popper to floating-ui. Popper modifiers are longer supported, while offsetProp is exposed to allow for flexible placement of floating element.

--- a/.changeset/hot-schools-attack.md
+++ b/.changeset/hot-schools-attack.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-Migrated the Popover component from Popper to Floating UI. Popper `modifiers` are longer supported, use `offsetProp` prop for flexible placement of floating element instead. Fixed `ProfileMenu` to use the updated `Popover` API.
+Migrated the Popover component from Popper to Floating UI. Popper `modifiers` are longer supported, use `offsetProp` prop for flexible placement of floating element instead. `placement` prop can no longer have `auto*` values. Fixed `ProfileMenu` to use the updated `Popover` API. 

--- a/.changeset/hot-schools-attack.md
+++ b/.changeset/hot-schools-attack.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-Migrate the Popover component from popper to floating-ui. Popper modifiers are longer supported, while offsetProp is exposed to allow for flexible placement of floating element.
+Migrate the Popover component from Popper to Floating UI. Popper modifiers are longer supported, use offset prop for flexible placement of floating element instead.

--- a/.changeset/hot-schools-attack.md
+++ b/.changeset/hot-schools-attack.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': major
 ---
 
-Migrated the Popover component from Popper to Floating UI. Popper `modifiers` are longer supported, use `offsetProp` prop for flexible placement of floating element instead.
+Migrated the Popover component from Popper to Floating UI. Popper `modifiers` are longer supported, use `offsetProp` prop for flexible placement of floating element instead. Fixed `ProfileMenu` to use the updated `Popover` API.

--- a/packages/circuit-ui/components/Popover/Popover.docs.mdx
+++ b/packages/circuit-ui/components/Popover/Popover.docs.mdx
@@ -8,15 +8,17 @@ Popover menus are a common pattern to display a list of subsequent action option
 <Story id="components-popover--base" />
 <Props of={Popover} />
 
-- Triggers of Popover can be primary, secondary, tertiary buttons, an overflow icon, or components with embedded buttons such as the [ImageInput component](Forms/ImageInput).
-- Each Popover action item is represented by an appropriate HTML element (button or a).
-- If needed the dividing line can be used to separate Popover action items.
+- The reference element, which triggers Popover, can be primary, secondary, tertiary buttons, an overflow icon, or components with embedded buttons such as the [ImageInput](Forms/ImageInput) component.
+- Each Popover action item is represented by an appropriate HTML element (e.g., a button element or an anchor element).
+- If needed, the dividing line can be used to separate Popover action items.
 - The leading icon is optional.
-- The Popover is powered by React Popper [https://popper.js.org/docs/v2/] which means you can easily change the Popover placement by simply passing the placement prop.
+- The Popover is powered by [Floating UI](https://floating-ui.com/docs/react-dom). You can easily change the position of the Popover relative to the reference element by passing in the `placement` prop. If you want to offset the Popover in the x and y directions, use the `offset` prop.
+
+Popover can be offset via the `offset` prop.
+
+<Story id="components-popover--offset" />
 
 ## Usage guidelines
 
 - **Do** use clear, concise and actionable labels for Popover items
 - **Do** always think about the priority of the action option to be taken and put the option order in logical order
-
-<Story id="components-popover--with-icon" />

--- a/packages/circuit-ui/components/Popover/Popover.docs.mdx
+++ b/packages/circuit-ui/components/Popover/Popover.docs.mdx
@@ -14,8 +14,6 @@ Popover menus are a common pattern to display a list of subsequent action option
 - The leading icon is optional.
 - The Popover is powered by [Floating UI](https://floating-ui.com/docs/react-dom). You can easily change the position of the Popover relative to the reference element by passing in the `placement` prop. If you want to offset the Popover in the x and y directions, use the `offset` prop.
 
-Popover can be offset via the `offset` prop.
-
 <Story id="components-popover--offset" />
 
 ## Usage guidelines

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -130,6 +130,8 @@ describe('Popover', () => {
     /**
      * FIXME: some of these tests, including style snapshots, throw act()
      * warnings. We should look into it.
+     *
+     * NOTE: the offset behavior enabled by the `offset` prop is tested with Chromatic via storybook
      */
     it('should render with default styles', () => {
       const { baseElement } = renderPopover(baseProps);

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -131,7 +131,8 @@ describe('Popover', () => {
      * FIXME: some of these tests, including style snapshots, throw act()
      * warnings. We should look into it.
      *
-     * NOTE: the offset behavior enabled by the `offset` prop is tested with Chromatic via storybook
+     * NOTE: we can't test the offset behavior enabled by the `offset`
+     * prop with `jsdom`. The logic is covered in Chromatic.
      */
     it('should render with default styles', () => {
       const { baseElement } = renderPopover(baseProps);

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -17,7 +17,7 @@
 
 import { FC } from 'react';
 import { Delete, Add, Download, IconProps } from '@sumup/icons';
-import { Placement } from '@popperjs/core';
+import { Placement } from '@floating-ui/react-dom';
 import * as Collector from '@sumup/collector';
 
 import { act, axe, RenderFn, render, userEvent } from '../../util/test-utils';
@@ -32,7 +32,7 @@ import {
 
 jest.mock('@sumup/collector');
 
-const placements: Placement[] = ['auto', 'top', 'bottom', 'left', 'right'];
+const placements: Placement[] = ['top', 'bottom', 'left', 'right'];
 
 describe('PopoverItem', () => {
   function renderPopoverItem<T>(

--- a/packages/circuit-ui/components/Popover/Popover.stories.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.stories.tsx
@@ -75,3 +75,25 @@ export const Base = (args: PopoverProps): JSX.Element => {
 Base.args = {
   actions,
 };
+
+export const Offset = (args: PopoverProps): JSX.Element => {
+  const [isOpen, setOpen] = useState(true);
+
+  return (
+    <Popover
+      {...args}
+      isOpen={isOpen}
+      onToggle={setOpen}
+      component={(props) => (
+        <Button size="kilo" variant="secondary" {...props}>
+          Open popover
+        </Button>
+      )}
+    />
+  );
+};
+
+Offset.args = {
+  actions,
+  offset: 20,
+};

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -243,7 +243,7 @@ export interface PopoverProps {
    */
   fallbackPlacements?: Placement[];
   /**
-   * The element that toggles the Popover when clicked.
+   * The element that toggles the Popover when clicked. Also referred to as the reference element.
    */
   component: (props: {
     'onClick': (event: ClickEvent) => void;
@@ -258,8 +258,8 @@ export interface PopoverProps {
    */
   tracking?: TrackingProps;
   /**
-   * Displace the floating element from its core placement along specified axes
-   * More on offset: https://floating-ui.com/docs/offset
+   * Displace the floating element from its core placement along specified axes.
+   * @see https://floating-ui.com/docs/offset
    */
   offset?: number | { mainAxis?: number; crossAxis?: number };
 }

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -356,9 +356,8 @@ export const Popover = ({
   useClickOutside(popperRef, () => handleToggle(false), isOpen);
 
   useEffect(() => {
-    // Add an event listener that invokes the function `update` to update
-    // the position of the floating element when screen is resized
-
+    // When the floating element is visible, add event listeners that invoke the function `update`
+    // to update the position of the floating element when screen is resized or scrolled
     if (isOpen) {
       update();
       window.addEventListener('resize', update);

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -200,11 +200,11 @@ const overlayOpenStyles = ({ theme, isOpen }: StyleProps & OpenProps) =>
 
 const Overlay = styled.div<OpenProps>(overlayStyles, overlayOpenStyles);
 
-const popperStyles = ({ isOpen }: OpenProps) => css`
+const floatingStyles = ({ isOpen }: OpenProps) => css`
   pointer-events: ${isOpen ? 'all' : 'none'};
 `;
 
-const Popper = styled.div<OpenProps>(popperStyles);
+const FloatingElement = styled.div<OpenProps>(floatingStyles);
 
 type Divider = { type: 'divider' };
 type Action = PopoverItemProps | Divider;
@@ -292,7 +292,7 @@ export const Popover = ({
 
   // This is a performance optimization to prevent event listeners from being
   // re-attached on every render.
-  const popperRef = useLatest(refs.floating.current);
+  const floatingRef = useLatest(refs.floating.current);
 
   const focusProps = useFocusList();
   const prevOpen = usePrevious(isOpen);
@@ -353,7 +353,7 @@ export const Popover = ({
   };
 
   useEscapeKey(() => handleToggle(false), isOpen);
-  useClickOutside(popperRef, () => handleToggle(false), isOpen);
+  useClickOutside(floatingRef, () => handleToggle(false), isOpen);
 
   useEffect(() => {
     // When the floating element is visible, add event listeners that invoke the function `update`
@@ -412,7 +412,7 @@ export const Popover = ({
           isOpen={isOpen}
           style={{ zIndex: zIndex || theme.zIndex.popover }}
         />
-        <Popper
+        <FloatingElement
           {...props}
           ref={floating}
           isOpen={isOpen}
@@ -449,7 +449,7 @@ export const Popover = ({
               ),
             )}
           </PopoverMenu>
-        </Popper>
+        </FloatingElement>
       </Portal>
     </Fragment>
   );

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -393,7 +393,7 @@ export const Popover = ({
 
     triggerKey.current = null;
 
-    // Clearn up the event listener when the component is unmounted
+    // Clean up the event listener when the component is unmounted
     return () => {
       window.removeEventListener('resize', update);
       window.removeEventListener('scroll', update);

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -28,7 +28,7 @@ import {
 } from 'react';
 import useLatest from 'use-latest';
 import usePrevious from 'use-previous';
-import { useFloating, flip, Placement } from '@floating-ui/react-dom';
+import { useFloating, flip, offset, Placement } from '@floating-ui/react-dom';
 import isPropValid from '@emotion/is-prop-valid';
 import { IconProps } from '@sumup/icons';
 import { useClickTrigger } from '@sumup/collector';
@@ -252,6 +252,11 @@ export interface PopoverProps {
    * Additional data that is dispatched with the tracking event.
    */
   tracking?: TrackingProps;
+  /**
+   * Displace the floating element from its core placement along specified axes
+   * More on offset: https://floating-ui.com/docs/offset
+   */
+  offsetProp?: number | { mainAxis?: number; crossAxis?: number };
 }
 
 type TriggerKey = 'ArrowUp' | 'ArrowDown';
@@ -264,6 +269,7 @@ export const Popover = ({
   fallbackPlacements = ['top', 'right', 'left'],
   component: Component,
   tracking,
+  offsetProp,
   ...props
 }: PopoverProps): JSX.Element | null => {
   const theme = useTheme();
@@ -279,7 +285,9 @@ export const Popover = ({
     useFloating<HTMLElement>({
       placement,
       strategy: 'fixed',
-      middleware: [flip({ fallbackPlacements })],
+      middleware: offsetProp
+        ? [offset(offsetProp), flip({ fallbackPlacements })]
+        : [flip({ fallbackPlacements })],
     });
 
   // This is a performance optimization to prevent event listeners from being

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -28,7 +28,12 @@ import {
 } from 'react';
 import useLatest from 'use-latest';
 import usePrevious from 'use-previous';
-import { useFloating, flip, offset, Placement } from '@floating-ui/react-dom';
+import {
+  useFloating,
+  flip,
+  offset as offsetMiddleware,
+  Placement,
+} from '@floating-ui/react-dom';
 import isPropValid from '@emotion/is-prop-valid';
 import { IconProps } from '@sumup/icons';
 import { useClickTrigger } from '@sumup/collector';
@@ -256,7 +261,7 @@ export interface PopoverProps {
    * Displace the floating element from its core placement along specified axes
    * More on offset: https://floating-ui.com/docs/offset
    */
-  offsetProp?: number | { mainAxis?: number; crossAxis?: number };
+  offset?: number | { mainAxis?: number; crossAxis?: number };
 }
 
 type TriggerKey = 'ArrowUp' | 'ArrowDown';
@@ -269,7 +274,7 @@ export const Popover = ({
   fallbackPlacements = ['top', 'right', 'left'],
   component: Component,
   tracking,
-  offsetProp,
+  offset,
   ...props
 }: PopoverProps): JSX.Element | null => {
   const theme = useTheme();
@@ -285,8 +290,8 @@ export const Popover = ({
     useFloating<HTMLElement>({
       placement,
       strategy: 'fixed',
-      middleware: offsetProp
-        ? [offset(offsetProp), flip({ fallbackPlacements })]
+      middleware: offset
+        ? [offsetMiddleware(offset), flip({ fallbackPlacements })]
         : [flip({ fallbackPlacements })],
     });
 

--- a/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
+++ b/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
@@ -196,10 +196,10 @@ exports[`Popover styles should render popover on bottom 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_14"
+        aria-controls="popover_16"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_13"
+        id="trigger_15"
       >
         Button
       </button>
@@ -214,14 +214,14 @@ exports[`Popover styles should render popover on bottom 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_13"
+      aria-labelledby="trigger_15"
       class="circuit-3"
-      id="popover_14"
+      id="popover_16"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="15"
+        data-focus-list="17"
         role="menuitem"
       >
         <svg
@@ -244,7 +244,7 @@ exports[`Popover styles should render popover on bottom 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="15"
+        data-focus-list="17"
         role="menuitem"
       >
         <svg
@@ -463,10 +463,10 @@ exports[`Popover styles should render popover on left 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_18"
+        aria-controls="popover_21"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_17"
+        id="trigger_20"
       >
         Button
       </button>
@@ -481,14 +481,14 @@ exports[`Popover styles should render popover on left 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_17"
+      aria-labelledby="trigger_20"
       class="circuit-3"
-      id="popover_18"
+      id="popover_21"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="19"
+        data-focus-list="22"
         role="menuitem"
       >
         <svg
@@ -511,7 +511,7 @@ exports[`Popover styles should render popover on left 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="19"
+        data-focus-list="22"
         role="menuitem"
       >
         <svg
@@ -730,10 +730,10 @@ exports[`Popover styles should render popover on right 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_22"
+        aria-controls="popover_26"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_21"
+        id="trigger_25"
       >
         Button
       </button>
@@ -748,14 +748,14 @@ exports[`Popover styles should render popover on right 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_21"
+      aria-labelledby="trigger_25"
       class="circuit-3"
-      id="popover_22"
+      id="popover_26"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="23"
+        data-focus-list="27"
         role="menuitem"
       >
         <svg
@@ -778,7 +778,7 @@ exports[`Popover styles should render popover on right 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="23"
+        data-focus-list="27"
         role="menuitem"
       >
         <svg
@@ -997,10 +997,10 @@ exports[`Popover styles should render popover on top 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_10"
+        aria-controls="popover_11"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_9"
+        id="trigger_10"
       >
         Button
       </button>
@@ -1015,14 +1015,14 @@ exports[`Popover styles should render popover on top 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_9"
+      aria-labelledby="trigger_10"
       class="circuit-3"
-      id="popover_10"
+      id="popover_11"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="11"
+        data-focus-list="12"
         role="menuitem"
       >
         <svg
@@ -1045,7 +1045,7 @@ exports[`Popover styles should render popover on top 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="11"
+        data-focus-list="12"
         role="menuitem"
       >
         <svg
@@ -1246,10 +1246,10 @@ exports[`Popover styles should render with closed styles 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_6"
+        aria-controls="popover_7"
         aria-expanded="false"
         aria-haspopup="true"
-        id="trigger_5"
+        id="trigger_6"
       >
         Button
       </button>
@@ -1264,14 +1264,14 @@ exports[`Popover styles should render with closed styles 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_5"
+      aria-labelledby="trigger_6"
       class="circuit-3"
-      id="popover_6"
+      id="popover_7"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="7"
+        data-focus-list="8"
         role="menuitem"
       >
         <svg
@@ -1294,7 +1294,7 @@ exports[`Popover styles should render with closed styles 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="7"
+        data-focus-list="8"
         role="menuitem"
       >
         <svg

--- a/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
+++ b/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Popover styles should render popover on auto 1`] = `
+exports[`Popover styles should render popover on bottom 1`] = `
 .circuit-0 {
   display: inline-block;
 }
@@ -211,7 +211,7 @@ exports[`Popover styles should render popover on auto 1`] = `
   />
   <div
     class="circuit-2"
-    style="position: fixed; left: 0px; top: 0px;"
+    style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
       aria-labelledby="trigger_13"
@@ -245,273 +245,6 @@ exports[`Popover styles should render popover on auto 1`] = `
       <button
         class="circuit-7"
         data-focus-list="15"
-        role="menuitem"
-      >
-        <svg
-          class="circuit-5"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M17 3H7a1 1 0 0 1 0-2h10a1 1 0 1 1 0 2zm5 3a1 1 0 0 1-1 1h-1v13a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3V7H3a1 1 0 0 1 0-2h18a1 1 0 0 1 1 1zm-11 4a1 1 0 0 0-2 0v8a1 1 0 1 0 2 0v-8zm4 0a1 1 0 0 0-2 0v8a1 1 0 0 0 2 0v-8z"
-            fill="currentColor"
-          />
-        </svg>
-        Remove
-      </button>
-    </div>
-  </div>
-</body>
-`;
-
-exports[`Popover styles should render popover on bottom 1`] = `
-.circuit-0 {
-  display: inline-block;
-}
-
-@media (max-width: 479px) {
-  .circuit-1 {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background-color: rgba(0, 0, 0, 0.4);
-    visibility: hidden;
-    opacity: 0;
-    -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-    transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
-  }
-}
-
-@media (max-width: 479px) {
-  .circuit-1 {
-    visibility: inherit;
-    opacity: 1;
-  }
-}
-
-.circuit-2 {
-  pointer-events: all;
-}
-
-.circuit-3 {
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
-  padding: 8px 0px;
-  border: 1px solid #E6E6E6;
-  box-sizing: border-box;
-  border-radius: 8px;
-  background-color: #FFF;
-  visibility: hidden;
-  opacity: 0;
-  opacity: 1;
-  visibility: inherit;
-}
-
-@media (max-width: 479px) {
-  .circuit-3 {
-    opacity: 1;
-    -webkit-transform: translateY(100%);
-    -moz-transform: translateY(100%);
-    -ms-transform: translateY(100%);
-    transform: translateY(100%);
-    -webkit-transition: -webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
-    transition: transform 120ms ease-in-out,visibility 120ms ease-in-out;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-}
-
-@media (max-width: 479px) {
-  .circuit-3 {
-    -webkit-transform: translateY(0);
-    -moz-transform: translateY(0);
-    -ms-transform: translateY(0);
-    transform: translateY(0);
-  }
-}
-
-.circuit-4 {
-  background-color: #FFF;
-  padding: 12px 32px 12px 16px;
-  border: 0;
-  color: #1A1A1A;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 100%;
-  font-size: 16px;
-  line-height: 24px;
-}
-
-.circuit-4:hover {
-  background-color: #F5F5F5;
-  cursor: pointer;
-}
-
-.circuit-4:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 4px #AFD0FE;
-}
-
-.circuit-4:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-4:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-4:active {
-  background-color: #E6E6E6;
-}
-
-.circuit-4:disabled,
-.circuit-4[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-.circuit-5 {
-  margin-right: 12px;
-}
-
-.circuit-6 {
-  display: block;
-  width: 100%;
-  border: 0;
-  border-top: 1px solid #CCC;
-  margin-top: 16px;
-  margin-bottom: 16px;
-  margin: 8px 16px;
-  width: calc(100% - 16px*2);
-}
-
-.circuit-7 {
-  background-color: #FFF;
-  padding: 12px 32px 12px 16px;
-  border: 0;
-  color: #D23F47;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  width: 100%;
-  font-size: 16px;
-  line-height: 24px;
-}
-
-.circuit-7:hover {
-  background-color: #F5F5F5;
-  cursor: pointer;
-}
-
-.circuit-7:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 4px #AFD0FE;
-}
-
-.circuit-7:focus::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-7:focus:not(:focus-visible) {
-  box-shadow: none;
-}
-
-.circuit-7:active {
-  background-color: #E6E6E6;
-}
-
-.circuit-7:disabled,
-.circuit-7[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
-  box-shadow: none;
-}
-
-<body>
-  <div>
-    <div
-      class="circuit-0"
-    >
-      <button
-        aria-controls="popover_26"
-        aria-expanded="true"
-        aria-haspopup="true"
-        id="trigger_25"
-      >
-        Button
-      </button>
-    </div>
-  </div>
-  <div
-    class="circuit-1"
-    style="z-index: 30;"
-  />
-  <div
-    class="circuit-2"
-    style="position: fixed; left: 0px; top: 0px;"
-  >
-    <div
-      aria-labelledby="trigger_25"
-      class="circuit-3"
-      id="popover_26"
-      role="menu"
-    >
-      <button
-        class="circuit-4"
-        data-focus-list="27"
-        role="menuitem"
-      >
-        <svg
-          class="circuit-5"
-          fill="none"
-          height="24"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 1a10.994 10.994 0 1 0 .012 0H12zm5 12h-4v4a1 1 0 0 1-2 0v-4H7a1 1 0 0 1 0-2h4V7a1 1 0 1 1 2 0v4h4a1 1 0 0 1 0 2z"
-            fill="currentColor"
-          />
-        </svg>
-        Add
-      </button>
-      <hr
-        class="circuit-6"
-      />
-      <button
-        class="circuit-7"
-        data-focus-list="27"
         role="menuitem"
       >
         <svg
@@ -730,10 +463,10 @@ exports[`Popover styles should render popover on left 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_32"
+        aria-controls="popover_18"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_31"
+        id="trigger_17"
       >
         Button
       </button>
@@ -745,17 +478,17 @@ exports[`Popover styles should render popover on left 1`] = `
   />
   <div
     class="circuit-2"
-    style="position: fixed; left: 0px; top: 0px;"
+    style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_31"
+      aria-labelledby="trigger_17"
       class="circuit-3"
-      id="popover_32"
+      id="popover_18"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="33"
+        data-focus-list="19"
         role="menuitem"
       >
         <svg
@@ -778,7 +511,7 @@ exports[`Popover styles should render popover on left 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="33"
+        data-focus-list="19"
         role="menuitem"
       >
         <svg
@@ -997,10 +730,10 @@ exports[`Popover styles should render popover on right 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_38"
+        aria-controls="popover_22"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_37"
+        id="trigger_21"
       >
         Button
       </button>
@@ -1012,17 +745,17 @@ exports[`Popover styles should render popover on right 1`] = `
   />
   <div
     class="circuit-2"
-    style="position: fixed; left: 0px; top: 0px;"
+    style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_37"
+      aria-labelledby="trigger_21"
       class="circuit-3"
-      id="popover_38"
+      id="popover_22"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="39"
+        data-focus-list="23"
         role="menuitem"
       >
         <svg
@@ -1045,7 +778,7 @@ exports[`Popover styles should render popover on right 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="39"
+        data-focus-list="23"
         role="menuitem"
       >
         <svg
@@ -1264,10 +997,10 @@ exports[`Popover styles should render popover on top 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_20"
+        aria-controls="popover_10"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_19"
+        id="trigger_9"
       >
         Button
       </button>
@@ -1279,17 +1012,17 @@ exports[`Popover styles should render popover on top 1`] = `
   />
   <div
     class="circuit-2"
-    style="position: fixed; left: 0px; top: 0px;"
+    style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_19"
+      aria-labelledby="trigger_9"
       class="circuit-3"
-      id="popover_20"
+      id="popover_10"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="21"
+        data-focus-list="11"
         role="menuitem"
       >
         <svg
@@ -1312,7 +1045,7 @@ exports[`Popover styles should render popover on top 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="21"
+        data-focus-list="11"
         role="menuitem"
       >
         <svg
@@ -1513,10 +1246,10 @@ exports[`Popover styles should render with closed styles 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_8"
+        aria-controls="popover_6"
         aria-expanded="false"
         aria-haspopup="true"
-        id="trigger_7"
+        id="trigger_5"
       >
         Button
       </button>
@@ -1528,17 +1261,17 @@ exports[`Popover styles should render with closed styles 1`] = `
   />
   <div
     class="circuit-2"
-    style="position: fixed; left: 0px; top: 0px;"
+    style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_7"
+      aria-labelledby="trigger_5"
       class="circuit-3"
-      id="popover_8"
+      id="popover_6"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="9"
+        data-focus-list="7"
         role="menuitem"
       >
         <svg
@@ -1561,7 +1294,7 @@ exports[`Popover styles should render with closed styles 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="9"
+        data-focus-list="7"
         role="menuitem"
       >
         <svg
@@ -1795,7 +1528,7 @@ exports[`Popover styles should render with default styles 1`] = `
   />
   <div
     class="circuit-2"
-    style="position: fixed; left: 0px; top: 0px;"
+    style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
       aria-labelledby="trigger_1"

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -166,7 +166,7 @@ export function ProfileMenu({
   tracking,
 }: ProfileMenuProps): JSX.Element {
   const [isOpen, setOpen] = useState(false);
-  const offsetModifier = { name: 'offset', options: { offset: [-16, 8] } };
+  const offsetProp = { mainAxis: 8, crossAxis: -16 };
 
   return (
     <TrackingElement
@@ -187,7 +187,7 @@ export function ProfileMenu({
         )}
         actions={actions}
         placement="bottom-end"
-        modifiers={[offsetModifier]}
+        offsetProp={offsetProp}
         tracking={
           tracking ? { ...tracking, component: 'profile_menu' } : undefined
         }

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -166,7 +166,7 @@ export function ProfileMenu({
   tracking,
 }: ProfileMenuProps): JSX.Element {
   const [isOpen, setOpen] = useState(false);
-  const offsetProp = { mainAxis: 8, crossAxis: -16 };
+  const offset = { mainAxis: 8, crossAxis: -16 };
 
   return (
     <TrackingElement
@@ -187,7 +187,7 @@ export function ProfileMenu({
         )}
         actions={actions}
         placement="bottom-end"
-        offsetProp={offsetProp}
+        offset={offset}
         tracking={
           tracking ? { ...tracking, component: 'profile_menu' } : undefined
         }

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
@@ -309,12 +309,12 @@ exports[`ProfileMenu styles should render without a profile picture 1`] = `
     class="circuit-0"
   >
     <button
-      aria-controls="popover_8"
+      aria-controls="popover_5"
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Open profile menu"
       class="circuit-1"
-      id="trigger_7"
+      id="trigger_4"
       title="Open profile menu"
       type="button"
     >

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -34,6 +34,7 @@
     "test": "jest --watch"
   },
   "dependencies": {
+    "@floating-ui/react-dom": "^0.7.2",
     "@popperjs/core": "^2.11.5",
     "cross-spawn": "^7.0.3",
     "jscodeshift": "^0.13.1",

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "@floating-ui/react-dom": "^0.7.2",
-    "@popperjs/core": "^2.11.5",
     "cross-spawn": "^7.0.3",
     "jscodeshift": "^0.13.1",
     "moment": "^2.29.4",
@@ -43,7 +42,6 @@
     "react-dates": "^21.2.0",
     "react-modal": "^3.15.1",
     "react-number-format": "^4.9.3",
-    "react-popper": "^2.3.0",
     "use-latest": "^1.2.1",
     "use-previous": "^1.1.0",
     "yargs": "^17.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3224,11 +3224,6 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.11.5":
-  version "2.11.5"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
-  integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
-
 "@rushstack/eslint-patch@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.3.tgz#6801033be7ff87a6b7cadaf5b337c9f366a3c4b0"
@@ -15110,11 +15105,6 @@ react-element-to-jsx-string@^14.3.4:
     is-plain-object "5.0.0"
     react-is "17.0.2"
 
-react-fast-compare@^3.0.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
-  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
-
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"
@@ -15183,14 +15173,6 @@ react-outside-click-handler@^1.2.4:
     document.contains "^1.0.1"
     object.values "^1.1.0"
     prop-types "^15.7.2"
-
-react-popper@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.3.0.tgz#17891c620e1320dce318bad9fede46a5f71c70ba"
-  integrity sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==
-  dependencies:
-    react-fast-compare "^3.0.1"
-    warning "^4.0.2"
 
 react-portal@^4.2.0:
   version "4.2.1"
@@ -18019,7 +18001,7 @@ walker@^1.0.7, walker@^1.0.8, walker@~1.0.5:
   dependencies:
     makeerror "1.0.12"
 
-warning@^4.0.2, warning@^4.0.3:
+warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1715,6 +1715,26 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@floating-ui/core@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-0.7.3.tgz#d274116678ffae87f6b60e90f88cc4083eefab86"
+  integrity sha512-buc8BXHmG9l82+OQXOFU3Kr2XQx9ys01U/Q9HMIrZ300iLc8HLMgh7dcCqgYzAzf4BkoQvDcXf5Y+CuEZ5JBYg==
+
+"@floating-ui/dom@^0.5.3":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-0.5.4.tgz#4eae73f78bcd4bd553ae2ade30e6f1f9c73fe3f1"
+  integrity sha512-419BMceRLq0RrmTSDxn8hf9R3VCJv2K9PUfugh5JyEFmdjzDo+e8U5EdR8nzKq8Yj1htzLm3b6eQEEam3/rrtg==
+  dependencies:
+    "@floating-ui/core" "^0.7.3"
+
+"@floating-ui/react-dom@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-0.7.2.tgz#0bf4ceccb777a140fc535c87eb5d6241c8e89864"
+  integrity sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==
+  dependencies:
+    "@floating-ui/dom" "^0.5.3"
+    use-isomorphic-layout-effect "^1.1.1"
+
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
Addresses #1338

## Purpose

Migrating the Popover component from [popper](https://popper.js.org/) to [floating-ui](https://floating-ui.com/).

## Approach and changes

- Replace [popper's API](https://popper.js.org/react-popper/v2/) with[ floating-ui's API](https://floating-ui.com/docs/react-dom).
- In mobile views, anchor the floating element to occupy full width at the bottom of the viewport by passing the `mobileStyles` directly to the `style` attribute of the floating element.
- Opt out of using the floating-ui's [`autoUpdate`](https://floating-ui.com/docs/autoupdate) feature for 2 reasons: (1) By default, it uses `ResizeObserver` API  which is not available in [older browsers](https://caniuse.com/mdn-api_resizeobserver).  (2) `autoUpdate` can be configured to not use `ResizeObserver`, however, its usage is advised against for floating element that relies on visibility instead of conditional rendering.
- Use `update` function that is returned from `useFloating` hook to update the position of floating element manually on scrolling or on resizing of the parent element. This is achieved by adding browser-native event listeners for `scroll` and `resize` events to invoke the `update` function. The event listeners are removed when the floating element is hidden to boost performance.
- Stop exposing popper [`modifiers`](https://popper.js.org/docs/v2/modifiers/) to keep the `Popover` component's API surface small. Only expose `offset` prop to provide an option for displacing floating element from its core placement along specified axes.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
