### PR TITLE
Fix table types

### DIFF
--- a/.changeset/eight-papayas-scream.md
+++ b/.changeset/eight-papayas-scream.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Improved `Table` component types. Deprecated the `Cell` type in favor of `HeaderCell` and `RowCell`, to reflect differences in sorting-related props. Correctly typed the `align` prop on the `Cell` instead of the `Row`.

--- a/packages/circuit-ui/components/Table/Table.spec.tsx
+++ b/packages/circuit-ui/components/Table/Table.spec.tsx
@@ -23,13 +23,13 @@ import {
 import Badge from '../Badge';
 
 import Table from './Table';
-import { Cell, Direction } from './types';
+import { HeaderCell, Direction } from './types';
 
 const sortLabel = ({ direction }: { direction?: Direction }) => {
   const order = direction === 'ascending' ? 'descending' : 'ascending';
   return `Sort in ${order} order`;
 };
-const headers: Cell[] = [
+const headers: HeaderCell[] = [
   {
     children: 'Letters',
     sortable: true,

--- a/packages/circuit-ui/components/Table/Table.stories.tsx
+++ b/packages/circuit-ui/components/Table/Table.stories.tsx
@@ -41,7 +41,7 @@ export const Base = ({ onSortBy, ...args }: TableProps): JSX.Element => (
   <Table {...args} />
 );
 
-Base.args = {
+const baseProps: TableProps = {
   headers: [
     { children: 'Name', sortable: true, sortLabel },
     { children: 'Created at', sortable: true, sortLabel },
@@ -50,17 +50,12 @@ Base.args = {
   ],
   rows: [
     {
-      'cells': [
+      cells: [
         'Lorem ipsum',
-        {
-          'children': '12/01/2017',
-          'sortByValue': 0,
-          'data-selector': 'item-1-cell-date-12/01/2017',
-        },
+        { children: '12/01/2017', sortByValue: 0 },
         '-',
         { children: 'Disabled', align: 'right' },
       ],
-      'data-selector': 'item-1',
     },
     [
       'Consectetur adipiscing',
@@ -78,6 +73,8 @@ Base.args = {
   rowHeaders: true,
   onRowClick: action('onRowClick'),
 };
+
+Base.args = baseProps;
 
 export const WithComponentRows = ({
   onSortBy,

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -23,13 +23,13 @@ import { throttle } from '../../util/helpers';
 import TableHead from './components/TableHead';
 import TableBody from './components/TableBody';
 import { defaultSortBy, getSortDirection } from './utils';
-import { Direction, Row, Cell } from './types';
+import { Direction, Row, HeaderCell } from './types';
 
 export interface TableProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * An array of header cells for the table.
    */
-  headers?: Cell[];
+  headers?: HeaderCell[];
   /**
    * An array of rows or an object with children containing an array of cells
    * for the table.

--- a/packages/circuit-ui/components/Table/components/TableHead/TableHead.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHead/TableHead.spec.tsx
@@ -20,7 +20,7 @@ import {
   axe,
   userEvent,
 } from '../../../../util/test-utils';
-import { Cell, Direction } from '../../types';
+import { HeaderCell, Direction } from '../../types';
 
 import TableHead from '.';
 
@@ -28,7 +28,7 @@ const sortLabel = ({ direction }: { direction?: Direction }) => {
   const order = direction === 'ascending' ? 'descending' : 'ascending';
   return `Sort in ${order} order`;
 };
-const fixtureHeaders: Cell[] = [
+const fixtureHeaders: HeaderCell[] = [
   { children: 'Foo', sortable: true, sortLabel },
   'Bar',
   'Baz',
@@ -61,7 +61,9 @@ describe('TableHead', () => {
     });
 
     it('should dispatch the onSortBy handler', async () => {
-      const headers: Cell[] = [{ children: 'Foo', sortable: true, sortLabel }];
+      const headers: HeaderCell[] = [
+        { children: 'Foo', sortable: true, sortLabel },
+      ];
       const onSortByMock = jest.fn();
       const { getByRole } = render(
         <TableHead onSortBy={onSortByMock} headers={headers} />,
@@ -88,7 +90,9 @@ describe('TableHead', () => {
     });
 
     it('should dispatch the onSortEnter handler', async () => {
-      const headers: Cell[] = [{ children: 'Foo', sortable: true, sortLabel }];
+      const headers: HeaderCell[] = [
+        { children: 'Foo', sortable: true, sortLabel },
+      ];
       const onSortEnterMock = jest.fn();
       const { getByRole } = render(
         <TableHead onSortEnter={onSortEnterMock} headers={headers} />,
@@ -103,7 +107,9 @@ describe('TableHead', () => {
 
   describe('onSortLeave', () => {
     it('should dispatch the onSortLeave handler', async () => {
-      const headers: Cell[] = [{ children: 'Foo', sortable: true, sortLabel }];
+      const headers: HeaderCell[] = [
+        { children: 'Foo', sortable: true, sortLabel },
+      ];
       const onSortLeaveMock = jest.fn();
       const { getByRole } = render(
         <TableHead onSortLeave={onSortLeaveMock} headers={headers} />,

--- a/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
@@ -20,7 +20,7 @@ import TableRow from '../TableRow';
 import TableHeader from '../TableHeader';
 import TableCell from '../TableCell';
 import { mapCellProps, getCellChildren, getSortParams } from '../../utils';
-import { Cell, Direction } from '../../types';
+import { Direction, HeaderCell } from '../../types';
 import styled, { StyleProps } from '../../../../styles/styled';
 
 type ScrollableOptions =
@@ -43,7 +43,7 @@ type TableHeadProps = ScrollableOptions & {
   /**
    * An array of header cells for the table.
    */
-  headers?: Cell[];
+  headers?: HeaderCell[];
   /**
    * Enables/disables sticky columns on mobile
    */

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -20,16 +20,16 @@ import isPropValid from '@emotion/is-prop-valid';
 import { focusOutline, typography } from '../../../../styles/style-mixins';
 import SortArrow from '../SortArrow';
 import styled, { StyleProps } from '../../../../styles/styled';
-import { SortParams } from '../../types';
+import { CellAlignment, SortParams } from '../../types';
 import { ClickEvent } from '../../../../types/events';
 import { AccessibilityError } from '../../../../util/errors';
 
 export interface TableHeaderProps
-  extends ThHTMLAttributes<HTMLTableHeaderCellElement> {
+  extends ThHTMLAttributes<HTMLTableCellElement> {
   /**
    * Aligns the content of the Header with text-align.
    */
-  align?: 'left' | 'right' | 'center';
+  align?: CellAlignment;
   /**
    * Adds row or col styles based on the provided Scope.
    */

--- a/packages/circuit-ui/components/Table/index.ts
+++ b/packages/circuit-ui/components/Table/index.ts
@@ -16,10 +16,24 @@
 import Table, { TableProps } from './Table';
 import {
   Direction as TableSortDirection,
-  Cell as TableCell,
+  RowCell as TableRowCell,
+  HeaderCell as TableHeaderCell,
   Row as TableRow,
 } from './types';
 
-export type { TableProps, TableSortDirection, TableCell, TableRow };
+/**
+ * @deprecated
+ * Use `TableRowCell` or `TableHeaderCell` instead.
+ */
+type TableCell = TableRowCell | TableHeaderCell;
+
+export type {
+  TableProps,
+  TableSortDirection,
+  TableCell,
+  TableRowCell,
+  TableHeaderCell,
+  TableRow,
+};
 
 export default Table;

--- a/packages/circuit-ui/components/Table/types.ts
+++ b/packages/circuit-ui/components/Table/types.ts
@@ -25,7 +25,7 @@ type SortableHeaderCell =
   | { sortable?: false; sortLabel?: never; sortByValue?: never }
   | {
       /**
-       * Makes a table column sortable. An accessible sortLabel also needs to
+       * Makes a table column sortable. An accessible `sortLabel` also needs to
        * be provided.
        */
       sortable: true;

--- a/packages/circuit-ui/components/Table/types.ts
+++ b/packages/circuit-ui/components/Table/types.ts
@@ -19,12 +19,14 @@ export type SortByValue = boolean | number | string | Date;
 
 export type Direction = 'ascending' | 'descending';
 
-type SortableCellProps =
+export type CellAlignment = 'left' | 'right' | 'center';
+
+type SortableHeaderCell =
   | { sortable?: false; sortLabel?: never; sortByValue?: never }
   | {
       /**
-       * Makes a table column sortable when passed to a header cell. An
-       * accessible sortLabel also needs to be provided.
+       * Makes a table column sortable. An accessible sortLabel also needs to
+       * be provided.
        */
       sortable: true;
       /**
@@ -34,24 +36,31 @@ type SortableCellProps =
       sortLabel:
         | string
         | (({ direction }: { direction?: Direction }) => string);
-      /**
-       * An optional value to change the order of the table rows.
-       */
-      sortByValue?: SortByValue;
     };
 
-export type CellObject = SortableCellProps & {
-  children: ReactNode;
+type SortableRowCell = {
+  /**
+   * An optional value to change the order of the table rows.
+   */
+  sortByValue?: SortByValue;
 };
 
-export type Cell = string | number | CellObject | null | undefined;
+type CellObject = {
+  children: ReactNode;
+  align?: CellAlignment;
+};
 
-export type Row =
-  | Cell[]
-  | {
-      cells: Cell[];
-      align?: string;
-    };
+export type RowCellObject = SortableRowCell & CellObject;
+
+export type HeaderCellObject = CellObject & SortableHeaderCell;
+
+type Cell = string | number | null | undefined;
+
+export type HeaderCell = Cell | HeaderCellObject;
+
+export type RowCell = Cell | RowCellObject;
+
+export type Row = RowCell[] | { cells: RowCell[] };
 
 export type SortParams =
   | {

--- a/packages/circuit-ui/components/Table/utils.spec.ts
+++ b/packages/circuit-ui/components/Table/utils.spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Cell, Direction, SortParams } from './types';
+import { RowCell, Direction, SortParams } from './types';
 import * as utils from './utils';
 
 describe('Table utils', () => {
@@ -109,10 +109,8 @@ describe('Table utils', () => {
     });
 
     it('should return the sortByValue', () => {
-      const props: Cell = {
+      const props: RowCell = {
         children: 'Foo',
-        sortable: true,
-        sortLabel: 'Sort',
         sortByValue: 'Foo',
       };
       const expected = props.sortByValue;

--- a/packages/circuit-ui/components/Table/utils.ts
+++ b/packages/circuit-ui/components/Table/utils.ts
@@ -20,29 +20,36 @@ import { isFunction } from '../../util/type-check';
 import {
   Direction,
   SortByValue,
-  CellObject,
-  Cell,
+  RowCellObject,
+  HeaderCellObject,
+  HeaderCell,
+  RowCell,
   Row,
   SortParams,
 } from './types';
 
-export const mapRowProps = (props: Row): { cells: Cell[] } =>
+export const mapRowProps = (props: Row): { cells: RowCell[] } =>
   Array.isArray(props) ? { cells: props } : props;
 
-export const getRowCells = (props: Row): Cell[] => mapRowProps(props).cells;
+export const getRowCells = (props: Row): RowCell[] => mapRowProps(props).cells;
 
-export const mapCellProps = (props: Cell): CellObject =>
-  typeof props === 'string' ||
-  typeof props === 'number' ||
-  props === null ||
-  props === undefined
+export function mapCellProps(props: RowCell): RowCellObject;
+export function mapCellProps(props: HeaderCell): HeaderCellObject;
+export function mapCellProps(
+  props: RowCell | HeaderCell,
+): RowCellObject | HeaderCellObject {
+  return typeof props === 'string' ||
+    typeof props === 'number' ||
+    props === null ||
+    props === undefined
     ? { children: props }
     : props;
+}
 
-export const getCellChildren = (props: Cell): ReactNode =>
+export const getCellChildren = (props: HeaderCell | RowCell): ReactNode =>
   mapCellProps(props).children;
 
-export const getSortByValue = (props: Cell): SortByValue | ReactNode => {
+export const getSortByValue = (props: RowCell): SortByValue | ReactNode => {
   const cell = mapCellProps(props);
 
   return cell.sortByValue !== undefined ? cell.sortByValue : cell.children;

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -171,10 +171,6 @@ export type {
   TableSortDirection,
   TableHeaderCell,
   TableRowCell,
-  /**
-   * @deprecated
-   * Use `TableRowCell` or `TableHeaderCell` instead.
-   */
   TableCell,
   TableRow,
 } from './components/Table';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -169,6 +169,12 @@ export { default as Table } from './components/Table';
 export type {
   TableProps,
   TableSortDirection,
+  TableHeaderCell,
+  TableRowCell,
+  /**
+   * @deprecated
+   * Use `TableRowCell` or `TableHeaderCell` instead.
+   */
   TableCell,
   TableRow,
 } from './components/Table';


### PR DESCRIPTION
## Purpose

We received a report that the `align` prop was incorrectly typed as a prop of a table `Row` instead of a table `CellObject`.

## Approach and changes

- fixed typings for a table cell's `align` prop
  - added a new `CellAlignment` type to share between files
  - moved the `align` prop declaration to the `CellObject` type
- fixed typings for a table's sorting-related props
  - split the `Cell` type into two: `RowCell` and `HeaderCell`. It doesn't make sense to have a single one, since they don't accept the same props for sorting: a header cell can receive `sortable` and `sortLabel` to enable sorting, while a row cell can receive an optional `sortByValue` to customize the sort order.
  - updated all specs and components that were using the `Cell` type to use either `RowCell` or `HeaderCell`
  - exported both new cell types and marked the `Cell` type export as deprecated

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
