### PR TITLE
Add a delay to Popover Chromatic screenshots

### DIFF
--- a/packages/circuit-ui/components/Popover/Popover.stories.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.stories.tsx
@@ -33,6 +33,7 @@ export default {
   argTypes: {
     children: { control: 'text' },
   },
+  chromatic: { delay: 300 },
 };
 
 const actions = [


### PR DESCRIPTION
🚧 

## Purpose

The Popover component screenshots on Chromatic only show the reference element, not the floating element. This makes it an unreliable UI test.

## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
