### PR TITLE
Export additional types

### DIFF
--- a/.changeset/metal-days-cry.md
+++ b/.changeset/metal-days-cry.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added the `ClickEvent`, `PopoverItemProps`, and `TableSortByValue` types to the public exports.

--- a/packages/circuit-ui/components/Card/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Card/components/Header/Header.tsx
@@ -23,6 +23,7 @@ import {
   CloseButtonProps,
 } from '../../../CloseButton/CloseButton';
 import { TrackingProps } from '../../../../hooks/useClickEvent';
+import { isArray } from '../../../../util/type-check';
 
 type CloseProps =
   | {
@@ -61,7 +62,7 @@ const baseStyles = ({ theme }: StyleProps) => css`
 `;
 
 const noHeadlineStyles = ({ children }: ContainerElProps) =>
-  Array.isArray(children) &&
+  isArray(children) &&
   !children[0] &&
   css`
     justify-content: flex-end;

--- a/packages/circuit-ui/components/Popover/index.tsx
+++ b/packages/circuit-ui/components/Popover/index.tsx
@@ -13,23 +13,8 @@
  * limitations under the License.
  */
 
-/**
- * Copyright 2021, SumUp Ltd.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import { Popover } from './Popover';
 
-export type { PopoverProps } from './Popover';
+export type { PopoverProps, PopoverItemProps } from './Popover';
 
 export default Popover;

--- a/packages/circuit-ui/components/Sidebar/SidebarService.tsx
+++ b/packages/circuit-ui/components/Sidebar/SidebarService.tsx
@@ -29,7 +29,7 @@ export type Child = {
 
 export function hasSelectedChild(children: Child[] | Child): boolean {
   if (children) {
-    const childArray = (isArray(children) ? children : [children]) as Child[];
+    const childArray = isArray(children) ? children : [children];
     const selectedChildren = childArray.filter((item) => item.props.selected);
     return !isEmpty(selectedChildren);
   }
@@ -41,7 +41,7 @@ export function getSelectedChildIndex(children?: Child[] | Child): number {
     return -1;
   }
 
-  const childArray = (isArray(children) ? children : [children]) as Child[];
+  const childArray = isArray(children) ? children : [children];
 
   return childArray.findIndex((child: Child) => Boolean(child.props.selected));
 }
@@ -54,7 +54,7 @@ export function getSecondaryChildren(
     return undefined;
   }
 
-  const childArray = (isArray(children) ? children : [children]) as Child[];
+  const childArray = isArray(children) ? children : [children];
 
   return childArray.map((child: Child) => ({
     ...child,

--- a/packages/circuit-ui/components/Table/index.ts
+++ b/packages/circuit-ui/components/Table/index.ts
@@ -14,8 +14,9 @@
  */
 
 import Table, { TableProps } from './Table';
-import {
+import type {
   Direction as TableSortDirection,
+  SortByValue as TableSortByValue,
   RowCell as TableRowCell,
   HeaderCell as TableHeaderCell,
   Row as TableRow,
@@ -30,6 +31,7 @@ type TableCell = TableRowCell | TableHeaderCell;
 export type {
   TableProps,
   TableSortDirection,
+  TableSortByValue,
   TableCell,
   TableRowCell,
   TableHeaderCell,

--- a/packages/circuit-ui/components/Table/types.ts
+++ b/packages/circuit-ui/components/Table/types.ts
@@ -46,8 +46,9 @@ type SortableRowCell = {
 };
 
 type CellObject = {
-  children: ReactNode;
-  align?: CellAlignment;
+  'children': ReactNode;
+  'align'?: CellAlignment;
+  'data-testid'?: string;
 };
 
 export type RowCellObject = SortableRowCell & CellObject;

--- a/packages/circuit-ui/components/Table/utils.ts
+++ b/packages/circuit-ui/components/Table/utils.ts
@@ -15,7 +15,7 @@
 
 import { ReactNode } from 'react';
 
-import { isFunction } from '../../util/type-check';
+import { isArray, isFunction } from '../../util/type-check';
 
 import {
   Direction,
@@ -29,7 +29,7 @@ import {
 } from './types';
 
 export const mapRowProps = (props: Row): { cells: RowCell[] } =>
-  Array.isArray(props) ? { cells: props } : props;
+  isArray(props) ? { cells: props } : props;
 
 export const getRowCells = (props: Row): RowCell[] => mapRowProps(props).cells;
 

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -141,7 +141,7 @@ export type { ProgressBarProps } from './components/ProgressBar';
 export { default as Tag } from './components/Tag';
 export type { TagProps } from './components/Tag';
 export { default as Popover } from './components/Popover';
-export type { PopoverProps } from './components/Popover';
+export type { PopoverProps, PopoverItemProps } from './components/Popover';
 export { default as Tooltip } from './components/Tooltip';
 export type { TooltipProps } from './components/Tooltip';
 export { default as BaseStyles } from './components/BaseStyles';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -170,6 +170,7 @@ export { default as Table } from './components/Table';
 export type {
   TableProps,
   TableSortDirection,
+  TableSortByValue,
   TableHeaderCell,
   TableRowCell,
   TableCell,

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -78,6 +78,7 @@ export { default as Selector } from './components/Selector';
 export type { SelectorProps } from './components/Selector';
 export { default as SelectorGroup } from './components/SelectorGroup';
 export type { SelectorGroupProps } from './components/SelectorGroup';
+export type { ClickEvent } from './types/events';
 
 // Notifications
 export { default as NotificationBanner } from './components/NotificationBanner';

--- a/packages/circuit-ui/util/type-check.ts
+++ b/packages/circuit-ui/util/type-check.ts
@@ -26,16 +26,13 @@ export function isNumber(value?: unknown): value is number {
   return typeof value === 'number';
 }
 
-export function isArray(value?: unknown): value is [] {
-  return (
-    Boolean(value) &&
-    typeof value === 'object' &&
-    value !== null &&
-    value.constructor === Array
-  );
+export function isArray<T>(value?: unknown): value is T[] {
+  return Array.isArray(value);
 }
 
-export function isObject(value: unknown): value is Record<string, unknown> {
+export function isObject<T extends Record<string, unknown>>(
+  value: unknown,
+): value is T {
   return value === Object(value) && !isArray(value) && !isFunction(value);
 }
 


### PR DESCRIPTION
## Purpose

I found a number of imports from internal Circuit UI files (e.g. `import { ClickEvent } from '@sumup/circuit-ui/dist/es/types/events';`). These imports are most commonly for the `ClickEvent`, `PopoverItemProps`, and table-related types.

## Approach and changes

- Export the `ClickEvent`, `PopoverItemProps`, and `TableSortByValue` types

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
