### PR TITLE
Fix spacing in imageless NotificationModal

### DIFF
--- a/.changeset/empty-bats-tan.md
+++ b/.changeset/empty-bats-tan.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Fixed spacing in imageless `NotificationModal`s.
+Fixed the spacing in imageless `NotificationModal`s.

--- a/.changeset/empty-bats-tan.md
+++ b/.changeset/empty-bats-tan.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed spacing in imageless `NotificationModal`s.

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
@@ -74,7 +74,7 @@ const imageStyles = ({ theme }: StyleProps) => css`
   max-width: 232px;
   height: 120px;
   object-fit: contain;
-  margin: 0 auto ${theme.spacings.mega};
+  margin: 0 auto ${theme.spacings.giga};
 `;
 
 const ModalImage = styled(Image)(imageStyles);
@@ -194,7 +194,7 @@ export const NotificationModal: ModalComponent<NotificationModalProps> = ({
             <Headline
               as="h2"
               size="three"
-              css={spacing({ top: 'giga', bottom: 'byte' })}
+              css={spacing({ bottom: 'byte' })}
               noMargin
             >
               {headline}

--- a/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationModal/__snapshots__/NotificationModal.spec.tsx.snap
@@ -197,7 +197,7 @@ exports[`NotificationModal styles should render with default styles 1`] = `
   max-width: 232px;
   height: 120px;
   object-fit: contain;
-  margin: 0 auto 16px;
+  margin: 0 auto 24px;
 }
 
 .circuit-8 {
@@ -206,7 +206,6 @@ exports[`NotificationModal styles should render with default styles 1`] = `
   letter-spacing: -0.03em;
   font-size: 20px;
   line-height: 24px;
-  margin-top: 24px;
   margin-bottom: 8px;
 }
 


### PR DESCRIPTION
Fixes #1689.

## Approach and changes

- Move margin from headline to image, as suggested by @Marczerwinski 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
