### PR TITLE
Fix spacing in NotificationInline with an action

### DIFF
--- a/.changeset/slimy-ears-repair.md
+++ b/.changeset/slimy-ears-repair.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed extra bottom spacing from the `NotificationInline` action.

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -140,7 +140,7 @@ const actionButtonStyles = ({ theme }: StyleProps & ButtonProps) =>
     font-weight: bold;
     text-decoration-line: underline;
     color: ${theme.colors.black};
-    padding-bottom: calc(${theme.spacings.kilo} - ${theme.borderWidth.kilo});
+    margin-top: ${theme.spacings.byte};
 
     &:hover {
       color: ${theme.colors.n800};
@@ -261,7 +261,9 @@ export function NotificationInline({
             </Body>
           )}
           <Body noMargin>{body}</Body>
-          {action && <ActionButton {...action} variant={'tertiary'} />}
+          {action && (
+            <ActionButton {...action} variant="tertiary" size="kilo" />
+          )}
         </Content>
 
         {onClose && closeButtonLabel && (

--- a/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
@@ -615,7 +615,7 @@ exports[`NotificationInline styles should render notification toast with an acti
   border-radius: 999999px;
   -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
   transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
-  padding: calc(12px - 1px) calc(24px - 1px);
+  padding: calc(4px - 1px) calc(16px - 1px);
   background-color: transparent;
   border-color: transparent;
   color: #3063E9;
@@ -626,7 +626,7 @@ exports[`NotificationInline styles should render notification toast with an acti
   font-weight: bold;
   text-decoration-line: underline;
   color: #000;
-  padding-bottom: calc(12px - 1px);
+  margin-top: 8px;
 }
 
 .circuit-6:focus {


### PR DESCRIPTION
Closes #1710.

## Approach and changes

- Reduced the bottom padding of the `NotificationInline` action

<img width="632" alt="Screenshot 2022-08-20 at 11 27 20" src="https://user-images.githubusercontent.com/11017722/185739256-77947ee4-f90b-4794-a78e-e4e347eb895a.png">

<img width="632" alt="Screenshot 2022-08-20 at 11 27 11" src="https://user-images.githubusercontent.com/11017722/185739266-77752a4f-bb4f-47fd-9afb-d669b7bba681.png">

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
