### PR TITLE
Remove unnecessary passive option from scroll event listener

### DIFF
--- a/.changeset/tough-rice-hear.md
+++ b/.changeset/tough-rice-hear.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed the unnecessary `passive` option from the Popover component's scroll event listener.

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -365,12 +365,17 @@ export const Popover = ({
   useClickOutside(floatingRef, () => handleToggle(false), isOpen);
 
   useEffect(() => {
-    // When the floating element is visible, add event listeners that invoke the function `update`
-    // to update the position of the floating element when screen is resized or scrolled
+    /**
+     * When we support `ResizeObserver` (https://caniuse.com/resizeobserver),
+     * we can look into using Floating UI's `autoUpdate` (but we can't use
+     * `whileElementInMounted` because our implementation hides the floating
+     * element using CSS instead of using conditional rendering.
+     * See https://floating-ui.com/docs/react-dom#updating
+     */
     if (isOpen) {
       update();
       window.addEventListener('resize', update);
-      window.addEventListener('scroll', update, { passive: true });
+      window.addEventListener('scroll', update);
     } else {
       window.removeEventListener('resize', update);
       window.removeEventListener('scroll', update);


### PR DESCRIPTION
## Purpose

Looking into #1678 I noticed a couple of minor problems around the event listeners in the `Popover` component that I've addressed here.

## Approach and changes

- removed the unnecessary `{ passive: true }` from the scroll listener. This is only a performance best practice for wheel and touch events and doesn't do anything for the basic scroll event.
- added a note about why we use event listeners at all at the moment, even though the Floating UI docs recommend using the built-in `autoUpdate`. Two reasons: browser support for `ResizeObserver`, and the fact that we actually hide the Popover with CSS instead of using conditional rendering.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
