### PR TITLE
Add documentation for typing the theme with emotion

### DIFF
--- a/docs/introduction/getting-started.stories.mdx
+++ b/docs/introduction/getting-started.stories.mdx
@@ -56,6 +56,27 @@ export default function App() {
 }
 ```
 
+#### Typing the theme
+
+If you're using TypeScript, you might run into conflicts when using the `theme` prop in styled components or the CSS prop.
+
+Type the theme by extending the `@emotion/react` module declaration, for example in a new `types/emotion.d.ts` file (make sure the file is included in `typeRoots` in your `tsconfig.json`):
+
+```ts
+// types/emotion.d.ts
+import { Theme as CircuitTheme } from '@sumup/design-tokens';
+import {} from '@emotion/react/types/css-prop'; // See https://github.com/emotion-js/emotion/pull/1941
+
+declare module '@emotion/react' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface Theme extends CircuitTheme {}
+}
+```
+
+This will also enable intellisense for the theme object.
+
+For more information, refer to [Emotion's TypeScript documentation](https://emotion.sh/docs/typescript#define-a-theme).
+
 ### Configuring the viewport
 
 Finally, make sure that the viewport meta tag includes `viewport-fit=cover`, and that your app has the right padding to render inside [CSS safe areas](<https://developer.mozilla.org/en-US/docs/Web/CSS/env()>):

--- a/docs/introduction/getting-started.stories.mdx
+++ b/docs/introduction/getting-started.stories.mdx
@@ -58,7 +58,11 @@ export default function App() {
 
 #### Typing the theme
 
-If you're using TypeScript, you might run into conflicts when using the `theme` prop in styled components or the CSS prop.
+If you're using TypeScript, you might run into type conflicts when using the `theme` prop:
+
+```
+Type 'Theme' is not assignable to type 'ThemeArgs'.ts(2322)
+```
 
 Type the theme by extending the `@emotion/react` module declaration, for example in a new `types/emotion.d.ts` file (make sure the file is included in `typeRoots` in your `tsconfig.json`):
 
@@ -73,7 +77,7 @@ declare module '@emotion/react' {
 }
 ```
 
-This will also enable intellisense for the theme object.
+This will also enable Intellisense for the theme object.
 
 For more information, refer to [Emotion's TypeScript documentation](https://emotion.sh/docs/typescript#define-a-theme).
 


### PR DESCRIPTION
## Purpose

An application using TypeScript will have to declare the Circuit UI theme when migrating to Circuit UI. This documents how to extend the `@emotion/react` module declaration with the Circuit UI theme type.

## Approach and changes

Added docs, see the deploy preview (deploying).

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
