### PR TITLE
Fix TS errors in test and story files

### DIFF
--- a/packages/circuit-ui/components/ListItem/ListItem.stories.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.stories.tsx
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import { css } from '@emotion/react';
 import { action } from '@storybook/addon-actions';
 import { SumUpCard, Confirm } from '@sumup/icons';

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.stories.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.stories.tsx
@@ -14,7 +14,6 @@
  */
 
 import { action } from '@storybook/addon-actions';
-import React from 'react';
 
 import {
   NotificationFullscreen,

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { ModalProvider } from '../ModalContext';

--- a/packages/circuit-ui/components/ToastContext/createUseToast.spec.tsx
+++ b/packages/circuit-ui/components/ToastContext/createUseToast.spec.tsx
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-/* eslint-disable react/display-name */
-import React from 'react';
+import { ReactElement } from 'react';
 
 import { renderHook, act } from '../../util/test-utils';
 
@@ -35,7 +34,7 @@ describe('createUseToast', () => {
   const setToast = jest.fn();
   const removeToast = jest.fn();
 
-  const wrapper = ({ children }) => (
+  const wrapper = ({ children }: { children: ReactElement }) => (
     <ToastContext.Provider value={{ setToast, removeToast }}>
       {children}
     </ToastContext.Provider>

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -27,8 +27,10 @@
   "scripts": {
     "start": "tsc --watch",
     "clean": "rm -rf ./dist",
-    "build": "tsc && tsc --project tsconfig.cjs.json && yarn build:executable",
+    "build:es": "tsc --project tsconfig.es.json",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
     "build:executable": "chmod +x ./dist/cjs/cli/index.js",
+    "build": "yarn build:es && yarn build:cjs && yarn build:executable",
     "lint": "foundry run eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "yarn lint --fix",
     "test": "jest --watch"

--- a/packages/circuit-ui/tsconfig.cjs.json
+++ b/packages/circuit-ui/tsconfig.cjs.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.es.json",
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "./dist/cjs"

--- a/packages/circuit-ui/tsconfig.es.json
+++ b/packages/circuit-ui/tsconfig.es.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist/es"
+  },
+  "exclude": [
+    "**/*/__tests__/*",
+    "**/*/__testfixtures__/*",
+    "**/*.spec.*",
+    "**/*.stories.*"
+  ]
+}

--- a/packages/circuit-ui/tsconfig.json
+++ b/packages/circuit-ui/tsconfig.json
@@ -10,21 +10,13 @@
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
     "moduleResolution": "node",
+    "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "outDir": "./dist/es",
     "resolveJsonModule": true,
     "strict": true,
-    "target": "es2017",
-    "plugins": [
-      {
-        "name": "typescript-styled-plugin",
-        "lint": {
-          "validProperties": ["label"]
-        }
-      }
-    ]
+    "target": "es2017"
   },
   "include": [
     "cli/**/*",
@@ -35,13 +27,6 @@
     "util/**/*",
     "index.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "**/*/__tests__/*",
-    "**/*/__testfixtures__/*",
-    "**/*.spec.*",
-    "**/*.stories.*"
-  ],
+  "exclude": ["node_modules", "dist"],
   "typeRoots": ["./types"]
 }

--- a/packages/circuit-ui/types/events.ts
+++ b/packages/circuit-ui/types/events.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import React from 'react';
-
 export type ClickEvent<T = Element> =
   | React.MouseEvent<T>
   | React.KeyboardEvent<T>;

--- a/packages/circuit-ui/util/errors.ts
+++ b/packages/circuit-ui/util/errors.ts
@@ -15,8 +15,6 @@
 
 /* eslint-disable max-classes-per-file */
 
-import React from 'react';
-
 export class CircuitError extends Error {
   constructor(componentName: string, message: string) {
     super(`[${componentName}] ${message}`);

--- a/packages/circuit-ui/util/errors.ts
+++ b/packages/circuit-ui/util/errors.ts
@@ -14,6 +14,7 @@
  */
 
 /* eslint-disable max-classes-per-file */
+import React from 'react';
 
 export class CircuitError extends Error {
   constructor(componentName: string, message: string) {

--- a/packages/circuit-ui/util/key-codes.ts
+++ b/packages/circuit-ui/util/key-codes.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import React from 'react';
-
 export const isEnter = (event: KeyboardEvent | React.KeyboardEvent): boolean =>
   event.key === 'Enter';
 

--- a/packages/icons/scripts/web.ts
+++ b/packages/icons/scripts/web.ts
@@ -75,6 +75,9 @@ function buildComponentFile(component: Component): string {
     component.name
   }' icon. Please use one of the available sizes: '${sizes.join("', '")}'.`;
 
+  /**
+   * TODO look into whether we still need the React import here
+   */
   return dedent`
     import React from 'react';
     ${iconImports.join('\n')}
@@ -83,7 +86,9 @@ function buildComponentFile(component: Component): string {
       ${sizeMap.join('\n')}
     }
 
-    export const ${component.name} = ({ size = '${defaultSize}', ...props }) => {
+    export const ${
+      component.name
+    } = ({ size = '${defaultSize}', ...props }) => {
       const Icon = sizeMap[size] || sizeMap['${defaultSize}'];
 
       if (
@@ -107,9 +112,7 @@ function buildIndexFile(components: Component[]): string {
 
 function buildDeclarationFile(components: Component[]): string {
   const declarationStatements = components.map((component) => {
-    const sizes = component.icons
-      .map(({ size }) => `'${size}'`)
-      .sort();
+    const sizes = component.icons.map(({ size }) => `'${size}'`).sort();
     const SizesType = sizes.join(' | ');
     return `declare const ${component.name}: FC<IconProps<${SizesType}>>;`;
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,15 +16,7 @@
     "outDir": "./dist/es",
     "resolveJsonModule": true,
     "strict": true,
-    "target": "es2017",
-    "plugins": [
-      {
-        "name": "typescript-styled-plugin",
-        "lint": {
-          "validProperties": ["label"]
-        }
-      }
-    ]
+    "target": "es2017"
   },
   "include": ["**/*"],
   "exclude": [


### PR DESCRIPTION
## Purpose

TS started showing errors locally:

<img width="969" alt="Screenshot of a test file using JSX opened in VSCode, there is an error" src="https://user-images.githubusercontent.com/35560568/189640708-b541858d-a482-49db-9e5b-e414faaec56b.png">

The error warns against using React without importing it in the module:

```
'React' refers to a UMD global, but the current file is a module. Consider adding an import instead. ts(2686)`
```

However, React actually _is_ imported via the [React 17+ JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html), and [TS 4.1+ supports the syntax](https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#jsx-factories) via the `jsx` and `jsxImportSource` config options ([source](https://github.com/sumup-oss/circuit-ui/blob/b6a1e96447ed61e705d71fb7b3d4fd586b7f60a8/packages/circuit-ui/tsconfig.json#L10-L11)).

The issue is that since [we're excluding test and story files](https://github.com/sumup-oss/circuit-ui/blob/b6a1e96447ed61e705d71fb7b3d4fd586b7f60a8/packages/circuit-ui/tsconfig.json#L41-L44) in our tsconfig, TS flags the use of JSX and recommends adding a React import.

We still need to exclude test and story files from the build, but should include them in type-checking.

## Approach and changes

This required shuffling around some tsconfig rules.

- The base `tsconfig.json` will be used locally for type checking (including test and story files). It's also a base for the other configs
- `tsconfig.es.json` extends the former and emits builds to the `dist/es` directory. It ignores test and story files from the build
- `tsconfig.cjs.json` extends the former and emits builds to the `dist/cjs` directory

We can build both ES and CJS modules by running `tsc --project tsconfig.es.json && tsc --project tsconfig.cjs.json`.

It works ✨ 

<img width="969" alt="Screenshot of a test file using JSX opened in VSCode, there are no errors" src="https://user-images.githubusercontent.com/35560568/189642511-7b301542-b071-4f61-adbe-dfd652e4bab5.png">

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
