### PR TITLE
Add SelectorGroup documentation

### DIFF
--- a/packages/circuit-ui/components/Headline/Headline.docs.mdx
+++ b/packages/circuit-ui/components/Headline/Headline.docs.mdx
@@ -102,7 +102,7 @@ function Product() {
 
 ### Resources
 
-#### Testing heading acessibility
+#### Testing heading accessibility
 
 Use a tool like [Wave](https://wave.webaim.org/) to extract structure from a page (in Wave, you'll find the page structure under the _Structure_ tab). Verify that sections are appropriately titled and are nested hierarchically.
 

--- a/packages/circuit-ui/components/Selector/Selector.docs.mdx
+++ b/packages/circuit-ui/components/Selector/Selector.docs.mdx
@@ -1,25 +1,17 @@
 import { Status, Props, Story } from '../../../../.storybook/components';
-import SelectorGroup from '../SelectorGroup';
 
 # Selector
 
-<Status.Stable />
+<Status.InReview />
+<Status.Description>
+  This component is under design review. Consider using radio buttons or
+  checkboxes instead.
+</Status.Description>
 
-The selector is a component that allows users to select a single or multiple options from a range of items, keeping that selection highlighted and allowing possible changes to happen on the same screen based on it.
+The Selector component should only by used as options passed to the [SelectorGroup](Forms/Selector/SelectorGroup) component.
 
 <Story id="forms-selector--base" />
 <Props />
-
-## When to use it
-
-We should use a selector when we need the user to choose a critical option on the flows that impact the
-same screen that they are currently in. For example, choosing a payment method on the order flow.
-
-## Usage guidelines
-
-- **Do** always position the selectable options on the same horizontal line for easy comparison
-- **Do** provide the possible change on the content below the selector (for instance showing credit card input fields if users select this type of payment)
-- **Do not** use a selector for more than 3 items. Consider using a select dropdown, instead.
 
 ## Component variations
 
@@ -33,19 +25,12 @@ same screen that they are currently in. For example, choosing a payment method o
 
 ### Sizes
 
-Selector component supports 3 different sizes:
+The Selector's `size` determines its padding. There are three available sizes:
 
 - **mega**, the default size
 - **kilo**, used when there are sizing constraints
-- **flexible**, used for more complex content within selector which may define its own margins. **flexible** just adds a minimal equal margin on all sides.
+- **flexible**, used for more complex content within selector which may define its own padding. Adds minimal equal padding on all sides.
+
+**Warning**: for accessibility reasons, we recommend against using the `flexible` size and may deprecate it in the future. Refer to the [SelectorGroup component](Forms/Selector/SelectorGroup)'s documentation for details.
 
 <Story id="forms-selector--sizes" />
-
-## SelectorGroup
-
-<Story id="forms-selector-selectorgroup--base" />
-<Props of={SelectorGroup} />
-
-### Multiple
-
-<Story id="forms-selector-selectorgroup--multiple" />

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.docs.mdx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.docs.mdx
@@ -1,0 +1,108 @@
+import { light } from '@sumup/design-tokens';
+import { ThemeProvider } from '@emotion/react';
+
+import { Status, Props, Story } from '../../../../.storybook/components';
+
+import { SelectorGroup, Headline, Body, spacing } from '../../index';
+
+# SelectorGroup
+
+<Status.InReview />
+<Status.Description>
+  This component is under design review. Consider using radio buttons or
+  checkboxes instead.
+</Status.Description>
+
+The SelectorGroup component allows users to select a single or multiple options from a group.
+
+<Story id="forms-selector-selectorgroup--base" />
+<Props />
+
+## Component variations
+
+### Multiple selection
+
+Pass the `multiple` prop to use a checkbox group under the hood instead of the default radio button group.
+
+<Story id="forms-selector-selectorgroup--multiple" />
+
+---
+
+## Accessibility
+
+Selectors are semantically either radio buttons or checkboxes. When it comes to accessibility, this means that they should be treated as input elements, with considerations such as proper labeling, keyboard operability, etc.
+
+### Best practices
+
+#### Write clear and concise labels
+
+The `children` prop passed to one of the SelectorGroup's `options` constitutes the Selector's label. This label should be clear and concise, and should not contain any formatted or semantic content (such as headings or lists).
+
+<ThemeProvider theme={light}>
+  <SelectorGroup
+    options={[
+      {
+        children: 'Do this',
+        value: 'valid',
+        noMargin: true,
+      },
+      {
+        children: (
+          <>
+            <Body variant="highlight" noMargin css={spacing({ bottom: 'bit' })}>
+              Bold text
+            </Body>
+            <Body noMargin>⚠️ Avoid doing this</Body>
+          </>
+        ),
+        value: 'invalid',
+        noMargin: true,
+      },
+      {
+        children: (
+          <>
+            <Headline
+              as="h4"
+              size="four"
+              noMargin
+              css={spacing({ bottom: 'bit' })}
+            >
+              Headline
+            </Headline>
+            <Body noMargin>
+              🚫 Don't do this. If you need to add details, write a paragraph
+              above the SelectorGroup.
+            </Body>
+          </>
+        ),
+        value: 'invalid',
+        noMargin: true,
+      },
+    ]}
+    label="Example"
+    css={spacing({ bottom: 'giga' })}
+  />
+</ThemeProvider>
+
+This is because the label in this case is also the input's accessible name, exposed to assistive technology as plain text.
+
+For example, screen reader user arrowing through the options in the example above would hear:
+
+- "Do this, radio button, 1 of 3"
+- "Bold text avoid doing this, radio button, 2 of 3"
+- "Headline don't do this if you need to add details write a paragraph above the SelectorGroup, radio button, 3 of 3"
+
+Using non-phrasing content in a label element is also invalid HTML.
+
+### Resources
+
+#### Testing label accessibility
+
+Use a tool like [Wave](https://wave.webaim.org/) to turn off styles (in Wave, you can use the "Styles" toggle). _Note: this feature doesn't work on this page since Storybook renders the docs are rendered in an iframe._
+
+This will expose the component's underlying checkboxes or radio buttons. Verify that the labels are appropriate.
+
+#### Related WCAG success criteria
+
+- 2.4.6: [Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html)
+- 4.1.1: [Parsing](https://www.w3.org/WAI/WCAG21/Understanding/parsing)

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
@@ -16,10 +16,14 @@
 import { useState, ChangeEvent } from 'react';
 
 import { SelectorGroup, SelectorGroupProps } from './SelectorGroup';
+import docs from './SelectorGroup.docs.mdx';
 
 export default {
   title: 'Forms/Selector/SelectorGroup',
   component: SelectorGroup,
+  parameters: {
+    docs: { page: docs },
+  },
 };
 
 const baseArgs = {


### PR DESCRIPTION
## Purpose

Add missing `SelectorGroup` documentation, focusing on an accessibility pit of failure (when the component is used with non-phrasing content as a label).

## Approach and changes

- Added docs
  - 👉 [preview](https://oss-circuit-jhgxxhsuz.sumup-vercel.app/?path=/docs/forms-selector-selectorgroup--base)
  - Note: I wrote JSX directly in Storybook docs to show a live good/bad usage comparison. I had to wrap my JSX in a ThemeProvider. If we start doing this more in the future, I'll look into wrapping all docs pages in the provider, just like stories.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
