### PR TITLE
Update browser support policy

### DIFF
--- a/docs/contributing/browser-support-for-contributors.stories.mdx
+++ b/docs/contributing/browser-support-for-contributors.stories.mdx
@@ -10,14 +10,13 @@ As a Circuit UI contributor, it is important to keep [`Browser Support`](Introdu
 
 Circuit UI is built with [TypeScript](https://www.typescriptlang.org/) (and not [Babel](https://babeljs.io/)). TypeScript has limited options when it comes to transpiling code: [the compiler can only target JavaScript versions](https://www.typescriptlang.org/tsconfig#target), which generally don't match which features are actually supported by a given set of browsers.
 
-Circuit UI's [current browser support policy](Introduction/Browser-Support/page) supports `es2015` (a.k.a. `es6`) ([almost](https://caniuse.com/es6)) entirely. The target browsers also support most of the features introduced between `es2015` and `es2017`, such as destructuring, `Array.includes()`, `Object.entries()`, `Object.values()`, and the spread operator and rest parameters (`...`) ([except for objects](https://caniuse.com/mdn-javascript_operators_spread_spread_in_object_literals)). Therefore, TypeScript is configured to compile Circuit UI for `es2017` [`tsconfig.json`](https://github.com/sumup-oss/circuit-ui/blob/main/packages/circuit-ui/tsconfig.json).
-
-However, one `es2016`/`es2017` feature, [async functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function), is only partially supported by Circuit UI's target browsers: **Safari <11 doesn't support async arrow functions**.
+Circuit UI's [current browser support policy](Introduction/Browser-Support/page) supports [`es2017`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) (a.k.a. `es8`) entirely. Therefore, TypeScript is configured to compile Circuit UI for `es2017` (see [`tsconfig.json`](https://github.com/sumup-oss/circuit-ui/blob/main/packages/circuit-ui/tsconfig.json)).
 
 ## What features to avoid
 
-Because of the reasons above, all JavaScript features up to `es2017` can be safely used in Circuit UI, except for the following:
+All JavaScript features up to `es2017` can be safely used in Circuit UI. Do not use `es2018` features such as:
 
-- [async functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) (use Promises instead)
+- [The spread syntax in object literals](https://caniuse.com/mdn-javascript_operators_spread_spread_in_object_literals) (not supported by Safari iOS 11.0 and Safari macOS 11.1)
+- [`Promise.finally()`](https://caniuse.com/promise-finally) (not supported by Safari iOS 11.0 and Safari macOS 11.1)
 
-Newer JavaScript syntax, such as [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining), can be used and will be transpiled by the TypeScript compiler.
+Newer JavaScript _syntax_, such as [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining), can be used and will be transpiled by TypeScript.

--- a/docs/introduction/browser-support.stories.mdx
+++ b/docs/introduction/browser-support.stories.mdx
@@ -11,19 +11,19 @@ import { Meta, Intro } from '../../.storybook/components';
 
 ## Browser support policy
 
-Circuit UI supports all browsers that support [CSS Grid Layout](https://www.w3.org/TR/css-grid-1/):
+Circuit UI supports all browsers that support [dynamic module imports](https://caniuse.com/es6-module-dynamic-import):
 
 | Browser          | Version |
 | ---------------- | ------- |
-| Chrome           | 57+     |
-| Firefox          | 54+     |
-| Edge             | 16+     |
-| Safari iOS       | 10.3+   |
-| Safari macOS     | 10.1+   |
-| Opera            | 44+     |
-| Samsung Internet | 6.2+    |
+| Chrome           | 63+     |
+| Firefox          | 67+     |
+| Edge             | 79+     |
+| Safari iOS       | 11.0+   |
+| Safari macOS     | 11.1+   |
+| Opera            | 50+     |
+| Samsung Internet | 8.2+    |
 
-Starting in v5, Circuit UI does not need to be transpiled when bundling your application (unless you need to support legacy browsers: see below).
+Circuit UI does not need to be transpiled when bundling your application (unless you need to support legacy browsers: see below).
 
 _Did you notice a browser support bug in a Circuit UI component? [Open an issue!](https://github.com/sumup-oss/circuit-ui/issues/new?labels=&template=report-a-bug.md)_
 
@@ -31,7 +31,7 @@ _Did you notice a browser support bug in a Circuit UI component? [Open an issue!
 
 If your app needs to support older browsers such as Internet Explorer, you will need to transpile Circuit UI when bundling your application. This can be achieved in different ways depending on the framework/bundler that you use. For example, if using Next.js, you can use the [`next-transpile-module`](https://github.com/martpie/next-transpile-modules) plugin.
 
-You may also need to include polyfills in your bundled application. Some of the modern JavaScript and CSS features that Circuit UI uses are:
+You may also need to include polyfills in your bundled application. Some of the newer JavaScript and CSS features that Circuit UI uses are:
 
 - [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 - [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat)


### PR DESCRIPTION
Closes #1680

## Purpose

Update browser support documentation to align with company policy. Refer to the issue (#1680) for details.

## Approach and changes

- update docs
- no change in TS target: a significant part of es2018 is still not supported by our policy, so it doesn't make sense to bump the TS target to es2018. We now support all of es2017, so it's a sensible target to keep. Docs were updated accordingly
- targeting `next` because although there are no breaking changes right now, future components or features may not be supported by the existing support policy, No need for a changeset, this will be mentioned in the migration guide

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
