### PR TITLE
Fix a z-index issue with the SidePanel header

### DIFF
--- a/.changeset/late-deers-explain.md
+++ b/.changeset/late-deers-explain.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed a z-index issue with the SidePanel header.

--- a/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -74,7 +74,7 @@ exports[`SidePanel should match the snapshot 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFF;
-  z-index: 1;
+  z-index: 600;
 }
 
 @media (min-width: 768px) {
@@ -400,7 +400,7 @@ exports[`SidePanel when the panel is on mobile resolution should match the snaps
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFF;
-  z-index: 1;
+  z-index: 600;
 }
 
 @media (min-width: 768px) {

--- a/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanelContext.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanelContext.spec.tsx.snap
@@ -101,7 +101,7 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFF;
-  z-index: 1;
+  z-index: 600;
 }
 
 @media (min-width: 768px) {
@@ -441,7 +441,7 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFF;
-  z-index: 1;
+  z-index: 600;
 }
 
 @media (min-width: 768px) {
@@ -780,7 +780,7 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFF;
-  z-index: 1;
+  z-index: 600;
 }
 
 @media (min-width: 768px) {

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.tsx
@@ -38,7 +38,7 @@ const headerContainerStyles = ({ theme }: StyleProps) => css`
   display: flex;
   align-items: center;
   background-color: ${theme.colors.white};
-  z-index: ${theme.zIndex.absolute};
+  z-index: ${theme.zIndex.header};
 
   ${theme.mq.mega} {
     box-shadow: inset ${theme.borderWidth.kilo} 0px 0px ${theme.colors.n300};

--- a/packages/circuit-ui/components/SidePanel/components/Header/__snapshots__/Header.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/components/Header/__snapshots__/Header.spec.tsx.snap
@@ -31,7 +31,7 @@ exports[`Header should have a bottom separator when sticky 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFF;
-  z-index: 1;
+  z-index: 600;
   box-shadow: inset 0px -1px 0px #CCC;
 }
 
@@ -263,7 +263,7 @@ exports[`Header should match the snapshot 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFF;
-  z-index: 1;
+  z-index: 600;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Approach and changes

- Bumped the z-index of the SidePanel's header from absolute (1) to header (600).

**Before:**
<img width="401" alt="Screenshot 2022-10-03 at 11 37 47" src="https://user-images.githubusercontent.com/9676303/193544706-b8d4bf5a-6cf8-41ad-8807-7d4f212d3858.png">

**After:**
<img width="401" alt="Screenshot 2022-10-03 at 11 37 57" src="https://user-images.githubusercontent.com/9676303/193544753-28c1baa0-3564-4d74-b539-40ca682fe9b1.png">

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
