### PR TITLE
Upgrade to react-number-format v5

### DIFF
--- a/.changeset/young-grapes-work.md
+++ b/.changeset/young-grapes-work.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Upgraded to `react-number-format` version 5. This could be a breaking change if you were relying on internal `react-number-format` props. Refer to the `react-number-format` [migration guide](https://s-yadav.github.io/react-number-format/docs/migration/) for details. Any explicit typings will also need to be updated.

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -14,7 +14,7 @@
  */
 
 import { ChangeEvent, createRef, useState } from 'react';
-import NumberFormat from 'react-number-format';
+import { NumericFormatProps } from 'react-number-format';
 
 import {
   create,
@@ -48,7 +48,7 @@ describe('CurrencyInput', () => {
      * Should accept a working ref
      */
     it('should accept a working ref', () => {
-      const tref = createRef<NumberFormat<InputProps>>();
+      const tref = createRef<NumericFormatProps<InputProps>>();
       const { container } = render(
         <CurrencyInput
           locale="de-DE"

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -15,7 +15,7 @@
 
 import { Ref, forwardRef } from 'react';
 import { resolveCurrencyFormat } from '@sumup/intl';
-import NumberFormat from 'react-number-format';
+import { NumericFormat, NumericFormatProps } from 'react-number-format';
 
 import styled from '../../styles/styled';
 import Input from '../Input';
@@ -47,7 +47,7 @@ export interface CurrencyInputProps
   /**
    * The ref to the HTML DOM element.
    */
-  ref?: Ref<NumberFormat<InputProps>>;
+  ref?: Ref<NumericFormatProps<InputProps>>;
   /**
    * The value of the input element.
    */
@@ -118,8 +118,8 @@ export const CurrencyInput = forwardRef(
         : undefined;
 
     return (
-      <NumberFormat
-        // NumberFormat props
+      <NumericFormat
+        // react-number-format props
         thousandSeparator={groupDelimiter}
         decimalSeparator={
           maximumFractionDigits > 0 ? decimalDelimiter : DUMMY_DELIMITER

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -14,7 +14,7 @@
  */
 
 import { forwardRef, useState, useEffect } from 'react';
-import NumberFormat from 'react-number-format';
+import { PatternFormat } from 'react-number-format';
 
 import styled from '../../styles/styled';
 import { Input, InputProps } from '../Input/Input';
@@ -65,8 +65,8 @@ export const DateInput = forwardRef(
     // TODO: Fallback explainer, with enforced format
     if (!supportsDate) {
       return (
-        <NumberFormat
-          // NumberFormat props
+        <PatternFormat
+          // react-number-format props
           placeholder={placeholder}
           format="####-##-##"
           mask={['y', 'y', 'y', 'y', 'm', 'm', 'd', 'd']}

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -43,7 +43,7 @@
     "prop-types": "^15.7.2",
     "react-dates": "^21.2.0",
     "react-modal": "^3.15.1",
-    "react-number-format": "^4.9.4",
+    "react-number-format": "^5.0.1",
     "use-latest": "^1.2.1",
     "use-previous": "^1.1.0",
     "yargs": "^17.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15274,10 +15274,10 @@ react-moment-proptypes@^1.6.0:
   dependencies:
     moment ">=1.6.0"
 
-react-number-format@^4.9.4:
-  version "4.9.4"
-  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-4.9.4.tgz#013ae526000e676e491763ce14da66fb330a9bd8"
-  integrity sha512-Gq20Z3ugqPLFgeaidnx5on9cNpbQZntPN3QgNAL/WJrNNlQnNznY0LCx7g8xtssmRBw0/hw+SCqw6zAcajooiA==
+react-number-format@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.0.1.tgz#23a3a693c978c7be328fa9c00dee5135111ca32b"
+  integrity sha512-Tyv5Ygb77ZbC5vUNNAfXwE+zQKaN0LsTo7GwjudU/MckXa7beVAlFddq7QQnGobEglyq+4zsBltKvM9HMQD0GA==
   dependencies:
     prop-types "^15.7.2"
 


### PR DESCRIPTION
## Purpose

As title suggests. See the [migration guide](https://s-yadav.github.io/react-number-format/docs/migration/).

## Approach and changes

Replaces #1778 to make sure this goes into the upcoming major.

- Upgrades the dependency
- Addresses breaking changes

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~ (all green!)
* [x] Meets minimum browser support (read through [the diff](https://github.com/s-yadav/react-number-format/compare/v4.9.4...v5.0.1) and it looks fine, and [the TS target](https://github.com/s-yadav/react-number-format/blob/a0174a00a48d8e741e5385e0bc46c4481abb816f/rollup.config.js#L49-L51) matches our support policy)
* ~Meets accessibility requirements~  (⚠️ generally I'd like to get components using this library audited/test them with users. I have a bad feeling about the automatic cursor move on the `DateInput`, for example. But this is unrelated to the v5: will do separately.)
