### PR TITLE
Fix Storybook Icons page labels

### DIFF
--- a/.storybook/components/Icons.js
+++ b/.storybook/components/Icons.js
@@ -23,10 +23,10 @@ import {
   Headline,
   Body,
   InlineElements,
-  Label,
   SearchInput,
   Select,
   spacing,
+  typography,
 } from '@sumup/circuit-ui';
 
 function groupBy(icons, key) {
@@ -177,15 +177,15 @@ const Icons = () => {
                     <Wrapper key={id}>
                       <IconWrapper>
                         <Icon
-                          id={id}
+                          aria-labelledby={id}
                           size={icon.size}
                           css={iconStyles(color)}
                         />
                       </IconWrapper>
-                      <Label htmlFor="id">
+                      <span id={id} css={typography('two')}>
                         {icon.name}
                         {size === 'all' && <Size>{icon.size}</Size>}
-                      </Label>
+                      </span>
                     </Wrapper>
                   );
                 })}


### PR DESCRIPTION
## Purpose

The `Label` component isn't exported from Circuit UI anymore (starting in v6) but was still being used on the Storybook Icons page.

## Approach and changes

Replaced the `Label` component by a span with `typography("two")` (and not by a label element because an image is not labelable).

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
