### PR TITLE
Add new Copy icon

### DIFF
--- a/.changeset/long-items-tap.md
+++ b/.changeset/long-items-tap.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': minor
+---
+
+Add new Copy icon.

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -66,6 +66,11 @@
       "size": "16"
     },
     {
+      "name": "copy",
+      "category": "Action",
+      "size": "24"
+    },
+    {
       "name": "crop",
       "category": "Action",
       "size": "24"

--- a/packages/icons/web/v2/copy_24.svg
+++ b/packages/icons/web/v2/copy_24.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M14 5v1h2V5a3 3 0 0 0-3-3H5a3 3 0 0 0-3 3v8a3 3 0 0 0 3 3h1v-2H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h8a1 1 0 0 1 1 1Zm8 14a3 3 0 0 1-3 3h-8a3 3 0 0 1-3-3v-8a3 3 0 0 1 3-3h8a3 3 0 0 1 3 3v8Z" fill="currentColor"/>
+</svg>


### PR DESCRIPTION
Closes #1784 

## Approach and changes

Add new Copy icon to the icons library.

![Screenshot 2022-10-06 at 16 30 10](https://user-images.githubusercontent.com/98822962/194341015-c155ae7d-54b3-417d-8b6c-352f27f74d34.png)


## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
