### PR TITLE
Add support for initials to the Avatar component

### DIFF
--- a/.changeset/nervous-mice-check.md
+++ b/.changeset/nervous-mice-check.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added the option of using initials as a placeholder for the `identity` variant of the `Avatar` component.

--- a/packages/circuit-ui/components/Avatar/Avatar.spec.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.spec.tsx
@@ -62,6 +62,15 @@ describe('Avatar', () => {
       });
       expect(container).toMatchSnapshot();
     });
+
+    it('should render the identity variant with initials', () => {
+      const { container } = renderAvatar({
+        variant: 'identity',
+        alt: '',
+        initials: 'JD',
+      });
+      expect(container).toMatchSnapshot();
+    });
   });
 
   describe('accessibility', () => {

--- a/packages/circuit-ui/components/Avatar/Avatar.stories.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.stories.tsx
@@ -27,6 +27,7 @@ export default {
 };
 
 export const Base = (args: AvatarProps): JSX.Element => <Avatar {...args} />;
+
 Base.args = {
   src: '/images/illustration-coffee.jpg',
   variant: 'object',
@@ -53,6 +54,7 @@ export const IdentityVariant = (): JSX.Element => (
       alt="A portrait of a grey cat"
     />
     <Avatar variant="identity" alt="" />
+    <Avatar variant="identity" alt="John Dorian" initials="JD" />
   </Stack>
 );
 
@@ -85,6 +87,10 @@ export const Sizes = (): JSX.Element => (
         size="giga"
         alt="A portrait of a grey cat"
       />
+    </Stack>
+    <Stack>
+      <Avatar variant="identity" alt="John Dorian" initials="JD" size="yotta" />
+      <Avatar variant="identity" alt="John Dorian" initials="JD" size="giga" />
     </Stack>
   </Stack>
 );

--- a/packages/circuit-ui/components/Avatar/Avatar.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.tsx
@@ -111,6 +111,8 @@ const initialStyles = ({ theme, size }: StyledProps & StyleProps) => css`
   justify-content: center;
   color: ${theme.colors.white};
   font-size: calc(${avatarSizes[size]} / 2);
+  font-weight: ${theme.fontWeight.bold};
+  user-select: none;
 `;
 
 const Initials = styled('div', {

--- a/packages/circuit-ui/components/Avatar/__snapshots__/Avatar.spec.tsx.snap
+++ b/packages/circuit-ui/components/Avatar/__snapshots__/Avatar.spec.tsx.snap
@@ -84,6 +84,11 @@ exports[`Avatar styles should render the identity variant with initials 1`] = `
   justify-content: center;
   color: #FFF;
   font-size: calc(96px / 2);
+  font-weight: 700;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 <div>

--- a/packages/circuit-ui/components/Avatar/__snapshots__/Avatar.spec.tsx.snap
+++ b/packages/circuit-ui/components/Avatar/__snapshots__/Avatar.spec.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`Avatar styles should render the giga size 1`] = `
 .circuit-0 {
-  display: block;
   width: 48px;
   height: 48px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 8px;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 8px;
 }
 
 <div>
@@ -23,14 +23,14 @@ exports[`Avatar styles should render the giga size 1`] = `
 
 exports[`Avatar styles should render the identity variant placeholder 1`] = `
 .circuit-0 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 100%;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 100%;
 }
 
 <div>
@@ -44,14 +44,14 @@ exports[`Avatar styles should render the identity variant placeholder 1`] = `
 
 exports[`Avatar styles should render the identity variant with an image 1`] = `
 .circuit-0 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 100%;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 100%;
 }
 
 <div>
@@ -63,16 +63,50 @@ exports[`Avatar styles should render the identity variant with an image 1`] = `
 </div>
 `;
 
-exports[`Avatar styles should render the object variant placeholder 1`] = `
+exports[`Avatar styles should render the identity variant with initials 1`] = `
 .circuit-0 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 100%;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  color: #FFF;
+  font-size: calc(96px / 2);
+}
+
+<div>
+  <div
+    aria-label=""
+    class="circuit-0"
+    role="img"
+  >
+    JD
+  </div>
+</div>
+`;
+
+exports[`Avatar styles should render the object variant placeholder 1`] = `
+.circuit-0 {
+  width: 96px;
+  height: 96px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  background-color: #CCC;
+  border-radius: 12px;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 12px;
 }
 
 <div>
@@ -86,14 +120,14 @@ exports[`Avatar styles should render the object variant placeholder 1`] = `
 
 exports[`Avatar styles should render the object variant with an image 1`] = `
 .circuit-0 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 12px;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 12px;
 }
 
 <div>
@@ -107,14 +141,14 @@ exports[`Avatar styles should render the object variant with an image 1`] = `
 
 exports[`Avatar styles should render the yotta size 1`] = `
 .circuit-0 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 12px;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 12px;
 }
 
 <div>
@@ -128,14 +162,14 @@ exports[`Avatar styles should render the yotta size 1`] = `
 
 exports[`Avatar styles should render with default styles 1`] = `
 .circuit-0 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 12px;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 12px;
 }
 
 <div>

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -509,14 +509,14 @@ exports[`ImageInput styles should render with an existing image 1`] = `
 }
 
 .circuit-4 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 12px;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 12px;
 }
 
 .circuit-5 {
@@ -884,14 +884,14 @@ exports[`ImageInput styles should render with default styles 1`] = `
 }
 
 .circuit-4 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 12px;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 12px;
 }
 
 .circuit-5 {
@@ -1264,14 +1264,14 @@ exports[`ImageInput styles should render with invalid styles 1`] = `
 }
 
 .circuit-4 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 12px;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 12px;
 }
 
 .circuit-5 {
@@ -1681,14 +1681,14 @@ exports[`ImageInput styles should render with smaller button 1`] = `
 }
 
 .circuit-4 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 12px;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 12px;
 }
 
 .circuit-5 {

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
@@ -60,14 +60,14 @@ exports[`ProfileMenu styles should render with a profile picture 1`] = `
 }
 
 .circuit-3 {
-  display: block;
   width: 96px;
   height: 96px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
   background-color: #CCC;
+  border-radius: 100%;
+  display: block;
   object-fit: cover;
   object-position: center;
-  border-radius: 100%;
   width: 24px;
   height: 24px;
 }


### PR DESCRIPTION
## Purpose

When displaying a list of Avatars with placeholders, it's difficult to differentiate them. Using initials as placeholders can help users to differentiate them. Initials tend to be an abbreviation of a person's first and last name (e.g. JD = Jane Doe). That's why the initials are restricted to the `identity` variant. 

Determining the appropriate initials can be challenging. If we store a person's full name, it's impossible to split it into first and last names without making flawed assumptions (the concept of a first and last name itself is culture-specific). If we store a person's first and last name separately, we cannot rely on both being present (not everyone has a first & last name). That's why the Avatar simply accepts an `initials` prop and leaves the responsibility of determining the appropriate initials to each application.

<img width="1046" alt="Screenshot 2022-10-07 at 10 32 13" src="https://user-images.githubusercontent.com/11017722/194509454-6d776c4d-0111-45d9-82ce-cbc2e8928e13.png">

## Approach and changes

- Added the `initials` prop to the Avatar component to be used as a placeholder. The initials are a 1-2 letter representation of a person's identity, usually their abbreviated name. Can only be used with the `identity` variant.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
