### PR TITLE
Move the Checkbox validationHint outside of a tooltip

### DIFF
--- a/.changeset/pretty-waves-sit.md
+++ b/.changeset/pretty-waves-sit.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Rendered the `Checkbox`'s `validationHint` under the input instead of in a tooltip. This makes the behavior consistent with other form components and improves accessibility.

--- a/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
@@ -15,13 +15,7 @@
 
 import { createRef } from 'react';
 
-import {
-  create,
-  render,
-  renderToHtml,
-  axe,
-  userEvent,
-} from '../../util/test-utils';
+import { render, axe, userEvent } from '../../util/test-utils';
 
 import { Checkbox } from './Checkbox';
 
@@ -35,30 +29,29 @@ describe('Checkbox', () => {
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(<Checkbox {...defaultProps} />);
-    expect(actual).toMatchSnapshot();
+    const { container } = render(<Checkbox {...defaultProps} />);
+    expect(container).toMatchSnapshot();
   });
 
-  it('should render with checked styles when passed the checked prop', () => {
-    const actual = create(<Checkbox checked {...defaultProps} />);
-    expect(actual).toMatchSnapshot();
+  it('should render with checked styles', () => {
+    const { container } = render(<Checkbox checked {...defaultProps} />);
+    expect(container).toMatchSnapshot();
   });
 
-  it('should render with disabled styles when passed the disabled prop', () => {
-    const actual = create(<Checkbox disabled {...defaultProps} />);
-    expect(actual).toMatchSnapshot();
+  it('should render with disabled styles', () => {
+    const { container } = render(<Checkbox disabled {...defaultProps} />);
+    expect(container).toMatchSnapshot();
   });
 
-  it('should render with invalid styles when passed the invalid prop', () => {
-    const actual = create(<Checkbox invalid {...defaultProps} />);
-    expect(actual).toMatchSnapshot();
-  });
-
-  it('should render with a tooltip when passed a validation hint', () => {
-    const actual = create(
-      <Checkbox validationHint="This field is required." {...defaultProps} />,
+  it('should render with invalid styles and an error message', () => {
+    const { container } = render(
+      <Checkbox
+        invalid
+        validationHint="This field is required."
+        {...defaultProps}
+      />,
     );
-    expect(actual).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   /**
@@ -103,12 +96,12 @@ describe('Checkbox', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(
+    const { container } = render(
       <div>
         <Checkbox {...defaultProps}>Label</Checkbox>
       </div>,
     );
-    const actual = await axe(wrapper);
+    const actual = await axe(container);
     expect(actual).toHaveNoViolations();
   });
 });

--- a/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
@@ -91,3 +91,17 @@ Disabled.args = {
   value: 'true',
   disabled: true,
 };
+
+export const Multiple = (args: CheckboxProps) => (
+  <>
+    <CheckboxWithState {...args} value="apples" name="fruits">
+      Apples
+    </CheckboxWithState>
+    <CheckboxWithState {...args} value="bananas" name="fruits">
+      Bananas
+    </CheckboxWithState>
+    <CheckboxWithState {...args} value="oranges" name="fruits">
+      Oranges
+    </CheckboxWithState>
+  </>
+);

--- a/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { useState, ChangeEvent, Fragment } from 'react';
+import { useState, ChangeEvent } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { Checkbox, CheckboxProps } from './Checkbox';
@@ -91,17 +91,3 @@ Disabled.args = {
   value: 'true',
   disabled: true,
 };
-
-export const Multiple = (args: CheckboxProps) => (
-  <Fragment>
-    <CheckboxWithState {...args} value="apples" name="fruits">
-      Apples
-    </CheckboxWithState>
-    <CheckboxWithState {...args} value="bananas" name="fruits">
-      Bananas
-    </CheckboxWithState>
-    <CheckboxWithState {...args} value="oranges" name="fruits">
-      Oranges
-    </CheckboxWithState>
-  </Fragment>
-);

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -25,8 +25,7 @@ import {
 } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
-import Tooltip from '../Tooltip';
-import { FieldWrapper } from '../FieldAtoms';
+import { FieldValidationHint, FieldWrapper } from '../FieldAtoms';
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   /**
@@ -34,7 +33,7 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
    */
   invalid?: boolean;
   /**
-   * Warning or error message, displayed in a tooltip.
+   * An information or error message, displayed below the checkbox.
    */
   validationHint?: string;
   /**
@@ -167,12 +166,6 @@ const CheckboxInput = styled('input')<InputElProps>(
   inputDisabledStyles,
 );
 
-const tooltipStyles = ({ theme }: StyleProps) => css`
-  left: -${theme.spacings.kilo};
-`;
-
-const CheckboxTooltip = styled(Tooltip)(tooltipStyles);
-
 /**
  * Checkbox component for forms.
  */
@@ -214,10 +207,12 @@ export const Checkbox = forwardRef(
           {children}
           <Checkmark aria-hidden="true" />
         </CheckboxLabel>
-        {!disabled && validationHint && (
-          <CheckboxTooltip position={'top'} align={'right'}>
-            {validationHint}
-          </CheckboxTooltip>
+        {validationHint && (
+          <FieldValidationHint
+            disabled={disabled}
+            invalid={invalid}
+            validationHint={validationHint}
+          />
         )}
       </CheckboxWrapper>
     );

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Checkbox should render with a tooltip when passed a validation hint 1`] = `
+exports[`Checkbox should render with checked styles 1`] = `
 .circuit-0 {
   position: relative;
 }
@@ -102,214 +102,37 @@ exports[`Checkbox should render with a tooltip when passed a validation hint 1`]
   cursor: pointer;
 }
 
-.circuit-3 {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: #1A1A1A;
-  color: #FFF;
-  border-radius: 4px;
-  padding: 8px 12px;
-  position: absolute;
-  z-index: 40;
-  -webkit-transition: opacity 0.3s;
-  transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
-  left: 50%;
-  left: calc(50% - (16px + 4px));
-  bottom: 100%;
-  bottom: calc(100% + 12px);
-  left: -12px;
-}
-
-.circuit-3::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-3::after {
-  left: 12px;
-}
-
-.circuit-3::after {
-  top: 100%;
-  border-top-color: #1A1A1A;
-}
-
-<div
-  class="circuit-0"
->
-  <input
-    class="circuit-1"
-    id="checkbox_5"
-    name="name"
-    type="checkbox"
-    value=""
-  />
-  <label
-    class="circuit-2"
-    for="checkbox_5"
-  >
-    <svg
-      aria-hidden="true"
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
-        fill="currentColor"
-      />
-    </svg>
-  </label>
+<div>
   <div
-    class="circuit-3"
+    class="circuit-0"
   >
-    This field is required.
-  </div>
-</div>
-`;
-
-exports[`Checkbox should render with checked styles when passed the checked prop 1`] = `
-.circuit-0 {
-  position: relative;
-}
-
-.circuit-1 {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
-}
-
-.circuit-1+label::before {
-  height: 18px;
-  width: 18px;
-  box-sizing: border-box;
-  box-shadow: 0;
-  background-color: #FFF;
-  border: 1px solid #999;
-  border-radius: 3px;
-  content: '';
-  display: block;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  -webkit-transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-  transition: border 120ms ease-in-out,background-color 120ms ease-in-out;
-}
-
-.circuit-1+label svg {
-  height: 18px;
-  width: 18px;
-  padding: 2px;
-  box-sizing: border-box;
-  color: #FFF;
-  display: block;
-  line-height: 0;
-  opacity: 0;
-  position: absolute;
-  top: 12px;
-  left: 0;
-  -webkit-transform: translateY(-50%) scale(0, 0);
-  -moz-transform: translateY(-50%) scale(0, 0);
-  -ms-transform: translateY(-50%) scale(0, 0);
-  transform: translateY(-50%) scale(0, 0);
-  -webkit-transition: -webkit-transform 120ms ease-in-out,opacity 120ms ease-in-out;
-  transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
-}
-
-.circuit-1:hover+label::before {
-  border-color: #666;
-}
-
-.circuit-1:focus+label::before {
-  outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
-  border-color: #3063E9;
-}
-
-.circuit-1:focus+label::before::-moz-focus-inner {
-  border: 0;
-}
-
-.circuit-1:focus:not(:focus-visible)+label::before {
-  box-shadow: none;
-  border-color: #999;
-}
-
-.circuit-1:checked:focus:not(:focus-visible)+label::before {
-  border-color: #3063E9;
-}
-
-.circuit-1:checked+label>svg {
-  -webkit-transform: translateY(-50%) scale(1, 1);
-  -moz-transform: translateY(-50%) scale(1, 1);
-  -ms-transform: translateY(-50%) scale(1, 1);
-  transform: translateY(-50%) scale(1, 1);
-  opacity: 1;
-}
-
-.circuit-1:checked+label::before {
-  border-color: #3063E9;
-  background-color: #3063E9;
-}
-
-.circuit-2 {
-  color: #1A1A1A;
-  display: inline-block;
-  padding-left: 26px;
-  position: relative;
-  cursor: pointer;
-}
-
-<div
-  class="circuit-0"
->
-  <input
-    checked=""
-    class="circuit-1"
-    id="checkbox_2"
-    name="name"
-    type="checkbox"
-    value=""
-  />
-  <label
-    class="circuit-2"
-    for="checkbox_2"
-  >
-    <svg
-      aria-hidden="true"
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <input
+      checked=""
+      class="circuit-1"
+      id="checkbox_2"
+      name="name"
+      type="checkbox"
+      value=""
+    />
+    <label
+      class="circuit-2"
+      for="checkbox_2"
     >
-      <path
-        d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
-        fill="currentColor"
-      />
-    </svg>
-  </label>
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
+          fill="currentColor"
+        />
+      </svg>
+    </label>
+  </div>
 </div>
 `;
 
@@ -415,38 +238,40 @@ exports[`Checkbox should render with default styles 1`] = `
   cursor: pointer;
 }
 
-<div
-  class="circuit-0"
->
-  <input
-    class="circuit-1"
-    id="checkbox_1"
-    name="name"
-    type="checkbox"
-    value=""
-  />
-  <label
-    class="circuit-2"
-    for="checkbox_1"
+<div>
+  <div
+    class="circuit-0"
   >
-    <svg
-      aria-hidden="true"
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <input
+      class="circuit-1"
+      id="checkbox_1"
+      name="name"
+      type="checkbox"
+      value=""
+    />
+    <label
+      class="circuit-2"
+      for="checkbox_1"
     >
-      <path
-        d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
-        fill="currentColor"
-      />
-    </svg>
-  </label>
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
+          fill="currentColor"
+        />
+      </svg>
+    </label>
+  </div>
 </div>
 `;
 
-exports[`Checkbox should render with disabled styles when passed the disabled prop 1`] = `
+exports[`Checkbox should render with disabled styles 1`] = `
 .circuit-0 {
   opacity: 0.5;
   pointer-events: none;
@@ -559,39 +384,41 @@ exports[`Checkbox should render with disabled styles when passed the disabled pr
   cursor: pointer;
 }
 
-<div
-  class="circuit-0"
->
-  <input
-    class="circuit-1"
-    disabled=""
-    id="checkbox_3"
-    name="name"
-    type="checkbox"
-    value=""
-  />
-  <label
-    class="circuit-2"
-    for="checkbox_3"
+<div>
+  <div
+    class="circuit-0"
   >
-    <svg
-      aria-hidden="true"
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <input
+      class="circuit-1"
+      disabled=""
+      id="checkbox_3"
+      name="name"
+      type="checkbox"
+      value=""
+    />
+    <label
+      class="circuit-2"
+      for="checkbox_3"
     >
-      <path
-        d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
-        fill="currentColor"
-      />
-    </svg>
-  </label>
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
+          fill="currentColor"
+        />
+      </svg>
+    </label>
+  </div>
 </div>
 `;
 
-exports[`Checkbox should render with invalid styles when passed the invalid prop 1`] = `
+exports[`Checkbox should render with invalid styles and an error message 1`] = `
 .circuit-0 {
   position: relative;
 }
@@ -708,33 +535,78 @@ exports[`Checkbox should render with invalid styles when passed the invalid prop
   cursor: pointer;
 }
 
-<div
-  class="circuit-0"
->
-  <input
-    class="circuit-1"
-    id="checkbox_4"
-    name="name"
-    type="checkbox"
-    value=""
-  />
-  <label
-    class="circuit-2"
-    for="checkbox_4"
+.circuit-3 {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  display: block;
+  margin-top: 4px;
+  color: #666;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+  color: #D23F47;
+}
+
+.circuit-4 {
+  display: inline-block;
+  position: relative;
+  width: 16px;
+  height: 16px;
+  vertical-align: text-top;
+  margin-right: 4px;
+  color: #D23F47;
+}
+
+<div>
+  <div
+    class="circuit-0"
   >
-    <svg
-      aria-hidden="true"
-      fill="none"
-      height="16"
-      viewBox="0 0 16 16"
-      width="16"
-      xmlns="http://www.w3.org/2000/svg"
+    <input
+      class="circuit-1"
+      id="checkbox_4"
+      name="name"
+      type="checkbox"
+      value=""
+    />
+    <label
+      class="circuit-2"
+      for="checkbox_4"
     >
-      <path
-        d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
-        fill="currentColor"
-      />
-    </svg>
-  </label>
+      <svg
+        aria-hidden="true"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M5.992 14.5a.992.992 0 0 1-.707-.293l-5-5A1 1 0 0 1 1.7 7.794L5.909 12l8.308-10.125a1.001 1.001 0 1 1 1.563 1.251l-9.006 11a1 1 0 0 1-.726.375l-.056-.001z"
+          fill="currentColor"
+        />
+      </svg>
+    </label>
+    <span
+      class="circuit-3"
+    >
+      <div
+        class="circuit-4"
+      >
+        <svg
+          fill="none"
+          height="16"
+          role="presentation"
+          viewBox="0 0 16 16"
+          width="16"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3 11a1 1 0 0 1-1.41 0L8 9.41 6.41 11A1 1 0 0 1 5 9.59L6.59 8 5 6.41A1 1 0 0 1 5 5a1 1 0 0 1 1.41 0L8 6.59 9.59 5A1 1 0 0 1 11 5a1 1 0 0 1 0 1.41L9.41 8 11 9.59A1 1 0 0 1 11 11z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+      This field is required.
+    </span>
+  </div>
 </div>
 `;

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -61,7 +61,7 @@ export interface InputProps extends CircuitInputHTMLAttributes {
    */
   renderSuffix?: ({ className }: { className?: string }) => JSX.Element | null;
   /**
-   * Warning or error message, displayed below the input.
+   * An information, warning or error message, displayed below the input.
    */
   validationHint?: string;
   /**

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -60,7 +60,7 @@ export interface RadioButtonGroupProps
    */
   ref?: Ref<HTMLFieldSetElement>;
   /**
-   * Warning/error/valid message, displayed below the radio buttons.
+   * An information, warning or error message, displayed below the input.
    */
   validationHint?: string;
   /**

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -61,9 +61,9 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
    */
   invalid?: boolean;
   /**
-   * Currently selected value. Matches the "value" property of
-   * the options objects. If value is falsy, Select will render
-   * the "placeholder" prop as currently selected.
+   * Currently selected value. Matches the "value" property of the options
+   * objects. If value is falsy, Select will render the "placeholder" prop as
+   * currently selected.
    */
   value?: string | number;
   /**
@@ -82,7 +82,7 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
     className?: string;
   }) => JSX.Element;
   /**
-   * Warning or error message, displayed below the select.
+   * An information or error message, displayed below the select.
    */
   validationHint?: string;
   /**
@@ -91,16 +91,17 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
    */
   optionalLabel?: string;
   /**
-   * Visually hide the label. This should only be used in rare cases and only if the
-   * purpose of the field can be inferred from other context.
+   * Visually hide the label. This should only be used in rare cases and only
+   * if the purpose of the field can be inferred from other context.
    */
   hideLabel?: boolean;
   /**
-   * A unique identifier for the input field. If not defined, a randomly generated id is used.
+   * A unique identifier for the input field. If not defined, a randomly
+   * generated id is used.
    */
   id?: string;
   /**
-   * The ref to the HTML DOM element
+   * The ref to the HTML DOM element.
    */
   ref?: Ref<HTMLSelectElement>;
   /**


### PR DESCRIPTION
Closes #1768 

## Purpose

Improve consistency and accessibility of the description and error messages for checkboxes.

## Approach and changes

- Move the Checkbox's `validationHint` (used for either a description or an error message) out of a tooltip and under the input (using the shared internal `FieldValidationHint` component)
- Update tests and stories (replace deprecated test utils, remove unnecessary snapshot+story)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
