### PR TITLE
Remove the patch for event.code in the SidePanel spec

### DIFF
--- a/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
@@ -21,20 +21,6 @@ jest.mock('../../util/id', () => ({
   uniqueId: () => 'the_one',
 }));
 
-/**
- * We need to patch the key event because `react-modal` uses the deprecated
- * `KeyboardEvent.keyCode`.
- * See https://github.com/testing-library/user-event/issues/969
- */
-function patchKeyEvent(e: KeyboardEvent) {
-  Object.defineProperty(e, 'keyCode', {
-    get: () => (e.code === 'Escape' ? 27 : 0),
-  });
-}
-beforeAll(() => {
-  document.addEventListener('keydown', patchKeyEvent, { capture: true });
-});
-
 describe('SidePanel', () => {
   const baseProps: SidePanelProps = {
     backButtonLabel: 'Back',


### PR DESCRIPTION
## Purpose

See https://github.com/testing-library/user-event/issues/969 and https://github.com/reactjs/react-modal/issues/952.

The issue was fixed upstream in `react-modal` by https://github.com/reactjs/react-modal/pull/953 (released in `react-modal@3.16.1`). The version was bumped 15 minutes ago in https://github.com/sumup-oss/circuit-ui/pull/1804.

This means that we can remove the workaround that we had in the `SidePanel` spec (patching the key event to ensure that `event.keyCode` exists in the test env).

## Approach and changes

Removed the workaround, as described above.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
