### PR TITLE
Silence act warnings in the Popover component

### DIFF
--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable react/display-name */
-
 import { FC } from 'react';
 import { Delete, Add, Download, IconProps } from '@sumup/icons';
 import { Placement } from '@floating-ui/react-dom';
@@ -47,7 +45,7 @@ describe('PopoverItem', () => {
     icon: Download as FC<IconProps>,
   };
 
-  describe('styles', () => {
+  describe('Styles', () => {
     it('should render as Link when an href (and onClick) is passed', () => {
       const props = {
         ...baseProps,
@@ -67,7 +65,7 @@ describe('PopoverItem', () => {
     });
   });
 
-  describe('business logic', () => {
+  describe('Logic', () => {
     it('should call onClick when rendered as Link', async () => {
       const props = {
         ...baseProps,
@@ -105,6 +103,20 @@ describe('Popover', () => {
       typeof state === 'boolean' ? state : state(initialState);
   }
 
+  /**
+   * Flushes microtasks to prevent act() warnings.
+   *
+   * From https://floating-ui.com/docs/react-dom#testing:
+   *
+   * > The position of floating elements is computed asynchronously, so a state
+   * > update occurs during a Promise microtask.
+   * >
+   * > The state update happens after tests complete, resulting in act warnings.
+   */
+  async function flushMicrotasks() {
+    await act(async () => {});
+  }
+
   const baseProps: PopoverProps = {
     component: (triggerProps) => <button {...triggerProps}>Button</button>,
     actions: [
@@ -126,32 +138,31 @@ describe('Popover', () => {
     tracking: { label: 'test-popover' },
   };
 
-  describe('styles', () => {
+  describe('Styles', () => {
     /**
-     * FIXME: some of these tests, including style snapshots, throw act()
-     * warnings. We should look into it.
-     *
-     * NOTE: we can't test the offset behavior enabled by the `offset`
-     * prop with `jsdom`. The logic is covered in Chromatic.
+     * Note: we can't test the offset behavior enabled by the `offset` prop
+     * with `jsdom`. The logic is covered in Chromatic.
      */
-    it('should render with default styles', () => {
+    it('should render with default styles', async () => {
       const { baseElement } = renderPopover(baseProps);
       expect(baseElement).toMatchSnapshot();
+      await flushMicrotasks();
     });
 
-    it('should render with closed styles', () => {
+    it('should render with closed styles', async () => {
       const { baseElement } = renderPopover({ ...baseProps, isOpen: false });
       expect(baseElement).toMatchSnapshot();
+      await flushMicrotasks();
     });
 
-    it.each(placements)('should render popover on %s', (placement) => {
+    it.each(placements)('should render popover on %s', async (placement) => {
       const { baseElement } = renderPopover({ ...baseProps, placement });
-
       expect(baseElement).toMatchSnapshot();
+      await flushMicrotasks();
     });
   });
 
-  describe('business logic', () => {
+  describe('Logic', () => {
     it('should open the popover when clicking the trigger element', async () => {
       const isOpen = false;
       const onToggle = jest.fn(createStateSetter(isOpen));
@@ -246,7 +257,7 @@ describe('Popover', () => {
       expect(dispatch).toHaveBeenCalledTimes(1);
     });
 
-    it('should move focus to the first popover item after opening', () => {
+    it('should move focus to the first popover item after opening', async () => {
       const isOpen = false;
       const onToggle = jest.fn(createStateSetter(isOpen));
 
@@ -263,9 +274,11 @@ describe('Popover', () => {
       const popoverItems = getAllByRole('menuitem');
 
       expect(popoverItems[0]).toHaveFocus();
+
+      await flushMicrotasks();
     });
 
-    it('should move focus to the trigger element after closing', () => {
+    it('should move focus to the trigger element after closing', async () => {
       const { getByRole, rerender } = renderPopover(baseProps);
 
       act(() => {
@@ -275,15 +288,19 @@ describe('Popover', () => {
       const popoverTrigger = getByRole('button');
 
       expect(popoverTrigger).toHaveFocus();
+
+      await flushMicrotasks();
     });
   });
 
-  describe('accessibility', () => {
+  describe('Accessibility', () => {
     it('should meet accessibility guidelines', async () => {
       const { container } = renderPopover(baseProps);
 
-      const actual = await axe(container);
-      expect(actual).toHaveNoViolations();
+      await act(async () => {
+        const actual = await axe(container);
+        expect(actual).toHaveNoViolations();
+      });
     });
   });
 });

--- a/packages/circuit-ui/components/Popover/Popover.stories.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.stories.tsx
@@ -15,7 +15,7 @@
 
 import { action } from '@storybook/addon-actions';
 import { Add, Edit, Delete } from '@sumup/icons';
-import { useState } from 'react';
+import { useState, ReactNode } from 'react';
 
 import Button from '../Button';
 
@@ -27,6 +27,11 @@ export default {
   component: Popover,
   parameters: {
     docs: { page: docs },
+    chromatic: {
+      // Fixes flakiness in UI tests. The popover is positioned asynchronously
+      // so we wait before taking the screenshot.
+      delay: 300,
+    },
   },
   argTypes: {
     children: { control: 'text' },
@@ -55,7 +60,7 @@ const actions = [
 
 // This wrapper is necessary because the Popover's floating element renders
 // in a Portal, and Chromatic excludes it from screenshots by default.
-function PopoverWrapper({ children }) {
+function PopoverWrapper({ children }: { children: ReactNode }) {
   return <div style={{ width: 200, height: 250 }}>{children}</div>;
 }
 

--- a/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
+++ b/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Popover styles should render popover on bottom 1`] = `
+exports[`Popover Styles should render popover on bottom 1`] = `
 .circuit-0 {
   display: inline-block;
 }
@@ -267,7 +267,7 @@ exports[`Popover styles should render popover on bottom 1`] = `
 </body>
 `;
 
-exports[`Popover styles should render popover on left 1`] = `
+exports[`Popover Styles should render popover on left 1`] = `
 .circuit-0 {
   display: inline-block;
 }
@@ -534,7 +534,7 @@ exports[`Popover styles should render popover on left 1`] = `
 </body>
 `;
 
-exports[`Popover styles should render popover on right 1`] = `
+exports[`Popover Styles should render popover on right 1`] = `
 .circuit-0 {
   display: inline-block;
 }
@@ -801,7 +801,7 @@ exports[`Popover styles should render popover on right 1`] = `
 </body>
 `;
 
-exports[`Popover styles should render popover on top 1`] = `
+exports[`Popover Styles should render popover on top 1`] = `
 .circuit-0 {
   display: inline-block;
 }
@@ -1068,7 +1068,7 @@ exports[`Popover styles should render popover on top 1`] = `
 </body>
 `;
 
-exports[`Popover styles should render with closed styles 1`] = `
+exports[`Popover Styles should render with closed styles 1`] = `
 .circuit-0 {
   display: inline-block;
 }
@@ -1317,7 +1317,7 @@ exports[`Popover styles should render with closed styles 1`] = `
 </body>
 `;
 
-exports[`Popover styles should render with default styles 1`] = `
+exports[`Popover Styles should render with default styles 1`] = `
 .circuit-0 {
   display: inline-block;
 }

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.spec.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.spec.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { axe, render, renderToHtml } from '../../../../util/test-utils';
+import { act, axe, render } from '../../../../util/test-utils';
 import { PopoverProps } from '../../../Popover';
 
 import { ProfileMenu } from './ProfileMenu';
@@ -40,7 +40,7 @@ describe('ProfileMenu', () => {
     ] as PopoverProps['actions'],
   };
 
-  describe('styles', () => {
+  describe('Styles', () => {
     it('should render with a profile picture', () => {
       const { container } = render(
         <ProfileMenu
@@ -59,11 +59,14 @@ describe('ProfileMenu', () => {
     });
   });
 
-  describe('accessibility', () => {
+  describe('Accessibility', () => {
     it('should meet accessibility guidelines', async () => {
-      const wrapper = renderToHtml(<ProfileMenu {...baseProps} />);
-      const actual = await axe(wrapper);
-      expect(actual).toHaveNoViolations();
+      const { container } = render(<ProfileMenu {...baseProps} />);
+
+      await act(async () => {
+        const actual = await axe(container);
+        expect(actual).toHaveNoViolations();
+      });
     });
   });
 });

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProfileMenu styles should render with a profile picture 1`] = `
+exports[`ProfileMenu Styles should render with a profile picture 1`] = `
 .circuit-0 {
   display: inline-block;
 }
@@ -189,7 +189,7 @@ exports[`ProfileMenu styles should render with a profile picture 1`] = `
 </div>
 `;
 
-exports[`ProfileMenu styles should render without a profile picture 1`] = `
+exports[`ProfileMenu Styles should render without a profile picture 1`] = `
 .circuit-0 {
   display: inline-block;
 }


### PR DESCRIPTION
## Purpose

This addresses `act()` warnings in `Popover` and `ProfileMenu` (uses `Popover`).

From the [Floating UI docs](https://floating-ui.com/docs/react-dom#testing):

> The position of floating elements is computed asynchronously, so a state update occurs during a Promise microtask.
>
> The state update happens after tests complete, resulting in act warnings.

It's safe to ignore these warnings and flush the microtask queue to silence them.

## Approach and changes

Flush the microtask queue using `await act(async () => {})` as recommended in the Floating UI docs.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
