### PR TITLE
Hide decorative Select chevrons from assistive technology

### DIFF
--- a/.changeset/tame-rules-shout.md
+++ b/.changeset/tame-rules-shout.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Hid the decorative chevron icons in the `Select` component from assistive technology.

--- a/packages/circuit-ui/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
+++ b/packages/circuit-ui/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
@@ -1009,6 +1009,7 @@ select:not(:active)~.circuit-13 {
         </option>
       </select>
       <svg
+        aria-hidden="true"
         class="circuit-12"
         fill="none"
         height="16"
@@ -1022,6 +1023,7 @@ select:not(:active)~.circuit-13 {
         />
       </svg>
       <svg
+        aria-hidden="true"
         class="circuit-13"
         fill="none"
         height="16"

--- a/packages/circuit-ui/components/Pagination/components/PageSelect/__snapshots__/PageSelect.spec.tsx.snap
+++ b/packages/circuit-ui/components/Pagination/components/PageSelect/__snapshots__/PageSelect.spec.tsx.snap
@@ -186,6 +186,7 @@ select:not(:active)~.circuit-7 {
         </option>
       </select>
       <svg
+        aria-hidden="true"
         class="circuit-6"
         fill="none"
         height="16"
@@ -199,6 +200,7 @@ select:not(:active)~.circuit-7 {
         />
       </svg>
       <svg
+        aria-hidden="true"
         class="circuit-7"
         fill="none"
         height="16"

--- a/packages/circuit-ui/components/Select/Select.spec.tsx
+++ b/packages/circuit-ui/components/Select/Select.spec.tsx
@@ -206,5 +206,18 @@ describe('Select', () => {
         expect(liveRegionEl).toBeEmptyDOMElement();
       });
     });
+
+    it('should hide chevron icons from assistive technology', () => {
+      const { container } = render(<Select {...defaultProps} />);
+      /**
+       * We use querySelector because an element with `aria-hidden` is removed
+       * from the accessibility tree and cannot be queries with `getByRole()`.
+       */
+      const chevrons = container.querySelectorAll('svg');
+
+      chevrons.forEach((chevron) => {
+        expect(chevron).toHaveAttribute('aria-hidden', 'true');
+      });
+    });
   });
 });

--- a/packages/circuit-ui/components/Select/Select.stories.tsx
+++ b/packages/circuit-ui/components/Select/Select.stories.tsx
@@ -83,7 +83,7 @@ export const WithPrefix = (args: SelectProps) => {
       }}
       renderPrefix={(props) => {
         const Icon = props.value && flagIconMap[props.value];
-        return Icon ? <Icon {...props} /> : null;
+        return Icon ? <Icon {...props} aria-hidden="true" /> : null;
       }}
     />
   );

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -314,8 +314,8 @@ export const Select = forwardRef(
                   </option>
                 )))}
           </SelectElement>
-          <IconActive size="16" />
-          <IconInactive size="16" />
+          <IconActive size="16" aria-hidden="true" />
+          <IconInactive size="16" aria-hidden="true" />
         </SelectWrapper>
         <FieldValidationHint
           id={validationHintId}

--- a/packages/circuit-ui/components/Select/__snapshots__/Select.spec.tsx.snap
+++ b/packages/circuit-ui/components/Select/__snapshots__/Select.spec.tsx.snap
@@ -141,6 +141,7 @@ select:not(:active)~.circuit-7 {
         </option>
       </select>
       <svg
+        aria-hidden="true"
         class="circuit-6"
         fill="none"
         height="16"
@@ -154,6 +155,7 @@ select:not(:active)~.circuit-7 {
         />
       </svg>
       <svg
+        aria-hidden="true"
         class="circuit-7"
         fill="none"
         height="16"
@@ -335,6 +337,7 @@ select:not(:active)~.circuit-8 {
         </option>
       </select>
       <svg
+        aria-hidden="true"
         class="circuit-7"
         fill="none"
         height="16"
@@ -348,6 +351,7 @@ select:not(:active)~.circuit-8 {
         />
       </svg>
       <svg
+        aria-hidden="true"
         class="circuit-8"
         fill="none"
         height="16"
@@ -524,6 +528,7 @@ select:not(:active)~.circuit-7 {
         </option>
       </select>
       <svg
+        aria-hidden="true"
         class="circuit-6"
         fill="none"
         height="16"
@@ -537,6 +542,7 @@ select:not(:active)~.circuit-7 {
         />
       </svg>
       <svg
+        aria-hidden="true"
         class="circuit-7"
         fill="none"
         height="16"
@@ -718,6 +724,7 @@ select:not(:active)~.circuit-7 {
         </option>
       </select>
       <svg
+        aria-hidden="true"
         class="circuit-6"
         fill="none"
         height="16"
@@ -731,6 +738,7 @@ select:not(:active)~.circuit-7 {
         />
       </svg>
       <svg
+        aria-hidden="true"
         class="circuit-7"
         fill="none"
         height="16"
@@ -897,6 +905,7 @@ select:not(:active)~.circuit-7 {
         </option>
       </select>
       <svg
+        aria-hidden="true"
         class="circuit-6"
         fill="none"
         height="16"
@@ -910,6 +919,7 @@ select:not(:active)~.circuit-7 {
         />
       </svg>
       <svg
+        aria-hidden="true"
         class="circuit-7"
         fill="none"
         height="16"
@@ -1071,6 +1081,7 @@ select:not(:active)~.circuit-7 {
         </option>
       </select>
       <svg
+        aria-hidden="true"
         class="circuit-6"
         fill="none"
         height="16"
@@ -1084,6 +1095,7 @@ select:not(:active)~.circuit-7 {
         />
       </svg>
       <svg
+        aria-hidden="true"
         class="circuit-7"
         fill="none"
         height="16"
@@ -1252,6 +1264,7 @@ select:not(:active)~.circuit-7 {
         </option>
       </select>
       <svg
+        aria-hidden="true"
         class="circuit-6"
         fill="none"
         height="16"
@@ -1265,6 +1278,7 @@ select:not(:active)~.circuit-7 {
         />
       </svg>
       <svg
+        aria-hidden="true"
         class="circuit-7"
         fill="none"
         height="16"


### PR DESCRIPTION
## Purpose

The Select component renders chevrons to show that the combobox can expand and collapse.

However, these icons are not necessary for operation by assistive technologies, since the element is announced properly.

In fact, the icons may be announced as "image" (depending on the SR/browser combination and on verbosity settings) and confuse assistive technology users.

## Approach and changes

- Passed the `aria-hidden` attribute to the chevron icons to effectively hide them from assistive technologies
- Passed the attribute to the prefix icons in the "With Prefix" story, since the prefix in this case is also decorative. This doesn't affect the library itself but shows a good example

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
