### PR TITLE
Allow passing custom aria-describedby values to form components

### DIFF
--- a/.changeset/dirty-camels-boil.md
+++ b/.changeset/dirty-camels-boil.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Allowed passing a custom `aria-describedby` value to form components. The custom value (an element `id`, or list of `id`s separated by a space) will be combined with the generated `id` of the `validationHint` element.

--- a/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
@@ -104,6 +104,54 @@ describe('Checkbox', () => {
 
         expect(inputEl).toHaveAccessibleDescription(description);
       });
+
+      it('should accept a custom description via aria-describedby', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const { getByRole } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <Checkbox
+              aria-describedby={customDescriptionId}
+              {...defaultProps}
+            />
+            ,
+          </>,
+        );
+        const inputEl = getByRole('checkbox');
+
+        expect(inputEl).toHaveAttribute(
+          'aria-describedby',
+          expect.stringContaining(customDescriptionId),
+        );
+        expect(inputEl).toHaveAccessibleDescription(customDescription);
+      });
+
+      it('should accept a custom description in addition to a validationHint', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const description = 'Description';
+        const { getByRole } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <Checkbox
+              validationHint={description}
+              aria-describedby={customDescriptionId}
+              {...defaultProps}
+            />
+            ,
+          </>,
+        );
+        const inputEl = getByRole('checkbox');
+
+        expect(inputEl).toHaveAttribute(
+          'aria-describedby',
+          expect.stringContaining(customDescriptionId),
+        );
+        expect(inputEl).toHaveAccessibleDescription(
+          `${customDescription} ${description}`,
+        );
+      });
     });
 
     describe('Status messages', () => {

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -175,7 +175,7 @@ export const Checkbox = forwardRef(
       onChange,
       children,
       value,
-      id: customId,
+      'id': customId,
       name,
       disabled,
       validationHint,
@@ -183,12 +183,16 @@ export const Checkbox = forwardRef(
       style,
       invalid,
       tracking,
+      'aria-describedby': descriptionId,
       ...props
     }: CheckboxProps,
     ref: CheckboxProps['ref'],
   ) => {
     const id = customId || uniqueId('checkbox_');
     const validationHintId = uniqueId('validation_hint-');
+    const descriptionIds = `${
+      descriptionId ? `${descriptionId} ` : ''
+    }${validationHintId}`;
     const handleChange = useClickEvent(onChange, tracking, 'checkbox');
 
     return (
@@ -202,7 +206,7 @@ export const Checkbox = forwardRef(
           disabled={disabled}
           invalid={invalid}
           ref={ref}
-          aria-describedby={validationHintId}
+          aria-describedby={descriptionIds}
           onChange={handleChange}
         />
         <CheckboxLabel htmlFor={id}>

--- a/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
@@ -258,6 +258,54 @@ describe('ImageInput', () => {
 
         expect(inputEl).toHaveAccessibleDescription(description);
       });
+
+      it('should accept a custom description via aria-describedby', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const { getByLabelText } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <ImageInput
+              aria-describedby={customDescriptionId}
+              {...defaultProps}
+            />
+            ,
+          </>,
+        );
+        const inputEl = getByLabelText(defaultProps.label);
+
+        expect(inputEl).toHaveAttribute(
+          'aria-describedby',
+          expect.stringContaining(customDescriptionId),
+        );
+        expect(inputEl).toHaveAccessibleDescription(customDescription);
+      });
+
+      it('should accept a custom description in addition to a validationHint', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const description = 'Description';
+        const { getByLabelText } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <ImageInput
+              validationHint={description}
+              aria-describedby={customDescriptionId}
+              {...defaultProps}
+            />
+            ,
+          </>,
+        );
+        const inputEl = getByLabelText(defaultProps.label);
+
+        expect(inputEl).toHaveAttribute(
+          'aria-describedby',
+          expect.stringContaining(customDescriptionId),
+        );
+        expect(inputEl).toHaveAccessibleDescription(
+          `${customDescription} ${description}`,
+        );
+      });
     });
 
     describe('Status messages', () => {

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -290,7 +290,7 @@ export const ImageInput = ({
   src,
   alt,
   size = 'yotta',
-  id: customId,
+  'id': customId,
   clearButtonLabel,
   onChange,
   onClear,
@@ -298,9 +298,10 @@ export const ImageInput = ({
   validationHint,
   invalid = false,
   loadingLabel,
-  component: Component,
+  'component': Component,
   className,
   style,
+  'aria-describedby': descriptionId,
   ...props
 }: ImageInputProps): JSX.Element => {
   if (
@@ -330,6 +331,9 @@ export const ImageInput = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const id = customId || uniqueId('image-input_');
   const validationHintId = uniqueId('validation-hint_');
+  const descriptionIds = `${
+    descriptionId ? `${descriptionId} ` : ''
+  }${validationHintId}`;
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isDragging, setDragging] = useState<boolean>(false);
   const [previewImage, setPreviewImage] = useState<string>('');
@@ -429,7 +433,7 @@ export const ImageInput = ({
           onClick={handleClick}
           disabled={disabled || isLoading}
           aria-invalid={invalid && 'true'}
-          aria-describedby={validationHintId}
+          aria-describedby={descriptionIds}
           {...props}
         />
         <Label

--- a/packages/circuit-ui/components/Input/Input.spec.tsx
+++ b/packages/circuit-ui/components/Input/Input.spec.tsx
@@ -166,6 +166,50 @@ describe('Input', () => {
 
         expect(inputEl).toHaveAccessibleDescription(description);
       });
+
+      it('should accept a custom description via aria-describedby', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const { getByRole } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <Input aria-describedby={customDescriptionId} {...defaultProps} />,
+          </>,
+        );
+        const inputEl = getByRole('textbox');
+
+        expect(inputEl).toHaveAttribute(
+          'aria-describedby',
+          expect.stringContaining(customDescriptionId),
+        );
+        expect(inputEl).toHaveAccessibleDescription(customDescription);
+      });
+
+      it('should accept a custom description in addition to a validationHint', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const description = 'Description';
+        const { getByRole } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <Input
+              validationHint={description}
+              aria-describedby={customDescriptionId}
+              {...defaultProps}
+            />
+            ,
+          </>,
+        );
+        const inputEl = getByRole('textbox');
+
+        expect(inputEl).toHaveAttribute(
+          'aria-describedby',
+          expect.stringContaining(customDescriptionId),
+        );
+        expect(inputEl).toHaveAccessibleDescription(
+          `${customDescription} ${description}`,
+        );
+      });
     });
 
     describe('Status messages', () => {

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -240,8 +240,8 @@ export const Input = forwardRef(
   (
     {
       value,
-      renderPrefix: RenderPrefix,
-      renderSuffix: RenderSuffix,
+      'renderPrefix': RenderPrefix,
+      'renderSuffix': RenderSuffix,
       validationHint,
       optionalLabel,
       required,
@@ -253,9 +253,10 @@ export const Input = forwardRef(
       as,
       label,
       hideLabel,
-      id: customId,
+      'id': customId,
       className,
       style,
+      'aria-describedby': descriptionId,
       ...props
     }: InputProps,
     ref: InputProps['ref'],
@@ -274,6 +275,9 @@ export const Input = forwardRef(
 
     const id = customId || uniqueId('input_');
     const validationHintId = uniqueId('validation-hint_');
+    const descriptionIds = `${
+      descriptionId ? `${descriptionId} ` : ''
+    }${validationHintId}`;
 
     const prefix = RenderPrefix && <RenderPrefix css={prefixStyles} />;
     const suffix = RenderSuffix && <RenderSuffix css={suffixStyles} />;
@@ -298,7 +302,7 @@ export const Input = forwardRef(
             id={id}
             value={value}
             ref={ref}
-            aria-describedby={validationHintId}
+            aria-describedby={descriptionIds}
             invalid={invalid}
             aria-invalid={invalid && 'true'}
             required={required}

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.spec.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.spec.tsx
@@ -112,6 +112,54 @@ describe('RadioButtonGroup', () => {
 
         expect(inputEl).toHaveAccessibleDescription(description);
       });
+
+      it('should accept a custom description via aria-describedby', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const { getByRole } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <RadioButtonGroup
+              aria-describedby={customDescriptionId}
+              {...defaultProps}
+            />
+            ,
+          </>,
+        );
+        const inputEl = getByRole('radiogroup');
+
+        expect(inputEl).toHaveAttribute(
+          'aria-describedby',
+          expect.stringContaining(customDescriptionId),
+        );
+        expect(inputEl).toHaveAccessibleDescription(customDescription);
+      });
+
+      it('should accept a custom description in addition to a validationHint', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const description = 'Description';
+        const { getByRole } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <RadioButtonGroup
+              validationHint={description}
+              aria-describedby={customDescriptionId}
+              {...defaultProps}
+            />
+            ,
+          </>,
+        );
+        const inputEl = getByRole('radiogroup');
+
+        expect(inputEl).toHaveAttribute(
+          'aria-describedby',
+          expect.stringContaining(customDescriptionId),
+        );
+        expect(inputEl).toHaveAccessibleDescription(
+          `${customDescription} ${description}`,
+        );
+      });
     });
 
     describe('Status messages', () => {

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -98,8 +98,8 @@ export const RadioButtonGroup = forwardRef(
     {
       options,
       onChange,
-      value: activeValue,
-      name: customName,
+      'value': activeValue,
+      'name': customName,
       label,
       invalid,
       validationHint,
@@ -109,6 +109,7 @@ export const RadioButtonGroup = forwardRef(
       hideLabel,
       optionalLabel,
       required,
+      'aria-describedby': descriptionId,
       ...props
     }: RadioButtonGroupProps,
     ref: RadioButtonGroupProps['ref'],
@@ -125,11 +126,15 @@ export const RadioButtonGroup = forwardRef(
     }
     const name = customName || uniqueId('radio-button-group_');
     const validationHintId = uniqueId('validation-hint_');
+    const descriptionIds = `${
+      descriptionId ? `${descriptionId} ` : ''
+    }${validationHintId}`;
+
     return (
       <FieldWrapper
         as="fieldset"
         role="radiogroup"
-        aria-describedby={validationHintId}
+        aria-describedby={descriptionIds}
         aria-orientation="vertical"
         name={name}
         // @ts-expect-error TypeScript isn't smart enough to recognize the `as` prop.

--- a/packages/circuit-ui/components/Select/Select.spec.tsx
+++ b/packages/circuit-ui/components/Select/Select.spec.tsx
@@ -176,6 +176,50 @@ describe('Select', () => {
 
         expect(inputEl).toHaveAccessibleDescription(description);
       });
+
+      it('should accept a custom description via aria-describedby', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const { getByRole } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <Select aria-describedby={customDescriptionId} {...defaultProps} />,
+          </>,
+        );
+        const inputEl = getByRole('combobox');
+
+        expect(inputEl).toHaveAttribute(
+          'aria-describedby',
+          expect.stringContaining(customDescriptionId),
+        );
+        expect(inputEl).toHaveAccessibleDescription(customDescription);
+      });
+
+      it('should accept a custom description in addition to a validationHint', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const description = 'Description';
+        const { getByRole } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <Select
+              validationHint={description}
+              aria-describedby={customDescriptionId}
+              {...defaultProps}
+            />
+            ,
+          </>,
+        );
+        const inputEl = getByRole('combobox');
+
+        expect(inputEl).toHaveAttribute(
+          'aria-describedby',
+          expect.stringContaining(customDescriptionId),
+        );
+        expect(inputEl).toHaveAccessibleDescription(
+          `${customDescription} ${description}`,
+        );
+      });
     });
 
     describe('Status messages', () => {

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -236,16 +236,17 @@ export const Select = forwardRef(
       required,
       options,
       children,
-      renderPrefix: RenderPrefix,
+      'renderPrefix': RenderPrefix,
       validationHint,
       optionalLabel,
       label,
       hideLabel,
       className,
       style,
-      id: customId,
+      'id': customId,
       onChange,
       tracking,
+      'aria-describedby': descriptionId,
       ...props
     }: SelectProps,
     ref?: SelectProps['ref'],
@@ -262,6 +263,9 @@ export const Select = forwardRef(
     }
     const id = customId || uniqueId('select_');
     const validationHintId = uniqueId('validation-hint_');
+    const descriptionIds = `${
+      descriptionId ? `${descriptionId} ` : ''
+    }${validationHintId}`;
 
     const prefix = RenderPrefix && (
       <RenderPrefix css={prefixStyles} value={value} />
@@ -286,7 +290,7 @@ export const Select = forwardRef(
             id={id}
             value={value}
             ref={ref}
-            aria-describedby={validationHintId}
+            aria-describedby={descriptionIds}
             invalid={invalid}
             aria-invalid={invalid && 'true'}
             required={required}


### PR DESCRIPTION
Follows up on #1795 

## Purpose

#1795 programatically associated input `validationHint`s with input elements using `aria-describedby`.

However, it overlooked the case where an implementation wants to pass multiple descriptions to `aria-describedby`. In the current implementation, any custom id passed to the attribute would be overridden by the generated id of the `validationHint` element.

We're already running into this use case in Circuit UI itself, specifically in the `CurrencyInput` component, where the input needs to be described both by its `validationHint` but also by the currency suffix (otherwise the currency is left out of the accessibility properties of the input.

## Approach and changes

Combine the `validationHintId` (generated internally) with any custom `aria-describedby` value (a list of ids, separated with spaces) passed to the component.

Covered extensively with the awesome `@testing-library` matchers 💙 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests 👉 extended the "Accessibility > Labeling" section of the specs
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
