### PR TITLE
Add currency symbol id to the CurrencyInput description

### DIFF
--- a/.changeset/sweet-cheetahs-smell.md
+++ b/.changeset/sweet-cheetahs-smell.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Added the currency symbol to the `CurrencyInput`'s accessible description.

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -21,21 +21,31 @@ import { InputProps } from '../Input';
 
 import CurrencyInput, { CurrencyInputProps } from '.';
 
+// Note: these defaults render a '€' as an input suffix
 const defaultProps = {
+  locale: 'de-DE',
   currency: 'EUR',
   label: 'Amount',
 };
 
 describe('CurrencyInput', () => {
   describe('Styles', () => {
-    it('should render with default styles', () => {
+    it('should render with default styles and format', () => {
+      const { container } = render(
+        // @ts-expect-error the locale is intentionally left out to cover the default currency format
+        <CurrencyInput label={defaultProps.label} />,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should render a currency as a suffix', () => {
       const { container } = render(<CurrencyInput {...defaultProps} />);
       expect(container).toMatchSnapshot();
     });
 
-    it('should adjust input padding and suffix width to match currency symbol width', () => {
+    it('should render a currency as a prefix', () => {
       const { container } = render(
-        <CurrencyInput {...defaultProps} currency="CHF" />,
+        <CurrencyInput {...defaultProps} locale="de-CH" currency="CHF" />,
       );
       expect(container).toMatchSnapshot();
     });
@@ -53,7 +63,7 @@ describe('CurrencyInput', () => {
 
     it('should format a en-GB amount correctly', async () => {
       const { getByRole } = render(
-        <CurrencyInput {...defaultProps} locale="en-GB" />,
+        <CurrencyInput {...defaultProps} currency="GBP" locale="en-GB" />,
       );
 
       const input = getByRole('textbox') as HTMLInputElement;
@@ -65,7 +75,7 @@ describe('CurrencyInput', () => {
 
     it('should format a de-DE amount correctly', async () => {
       const { getByRole } = render(
-        <CurrencyInput {...defaultProps} locale="de-DE" />,
+        <CurrencyInput {...defaultProps} currency="EUR" locale="de-DE" />,
       );
 
       const input = getByRole('textbox') as HTMLInputElement;
@@ -91,12 +101,12 @@ describe('CurrencyInput', () => {
       const { getByRole } = render(<ControlledCurrencyInput />);
 
       const input = getByRole('textbox') as HTMLInputElement;
-      expect(input.value).toBe('1,234.5');
+      expect(input.value).toBe('1.234,5');
 
       await userEvent.clear(input);
-      await userEvent.type(input, '1234.56');
+      await userEvent.type(input, '1234,56');
 
-      expect(input.value).toBe('1,234.56');
+      expect(input.value).toBe('1.234,56');
     });
   });
 

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -16,37 +16,29 @@
 import { ChangeEvent, createRef, useState } from 'react';
 import { NumericFormatProps } from 'react-number-format';
 
-import {
-  create,
-  render,
-  renderToHtml,
-  axe,
-  userEvent,
-} from '../../util/test-utils';
+import { render, userEvent, axe } from '../../util/test-utils';
 import { InputProps } from '../Input';
 
 import CurrencyInput, { CurrencyInputProps } from '.';
 
 describe('CurrencyInput', () => {
-  /**
-   * Style tests.
-   */
-  it('should render with default styles', () => {
-    const actual = create(<CurrencyInput currency="EUR" label="Amount" />);
-    expect(actual).toMatchSnapshot();
+  describe('Styles', () => {
+    it('should render with default styles', () => {
+      const { container } = render(
+        <CurrencyInput currency="EUR" label="Amount" />,
+      );
+      expect(container).toMatchSnapshot();
+    });
+
+    it('should adjust input padding and suffix width to match currency symbol width', () => {
+      const { container } = render(
+        <CurrencyInput placeholder="123,45" currency="CHF" label="Amount" />,
+      );
+      expect(container).toMatchSnapshot();
+    });
   });
 
-  it('should adjust input padding and suffix width to match currency symbol width', () => {
-    const actual = create(
-      <CurrencyInput placeholder="123,45" currency="CHF" label="Amount" />,
-    );
-    expect(actual).toMatchSnapshot();
-  });
-
-  describe('business logic', () => {
-    /**
-     * Should accept a working ref
-     */
+  describe('Logic', () => {
     it('should accept a working ref', () => {
       const tref = createRef<NumericFormatProps<InputProps>>();
       const { container } = render(
@@ -112,14 +104,13 @@ describe('CurrencyInput', () => {
     });
   });
 
-  /**
-   * Accessibility tests.
-   */
-  it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(
-      <CurrencyInput locale="de-DE" currency="EUR" label="Product price" />,
-    );
-    const actual = await axe(wrapper);
-    expect(actual).toHaveNoViolations();
+  describe('Accessibility', () => {
+    it('should have no violations', async () => {
+      const { container } = render(
+        <CurrencyInput locale="de-DE" currency="EUR" label="Product price" />,
+      );
+      const actual = await axe(container);
+      expect(actual).toHaveNoViolations();
+    });
   });
 });

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -41,7 +41,7 @@ describe('CurrencyInput', () => {
   describe('Logic', () => {
     it('should accept a working ref', () => {
       const tref = createRef<NumericFormatProps<InputProps>>();
-      const { container } = render(
+      const { getByRole } = render(
         <CurrencyInput
           locale="de-DE"
           currency="EUR"
@@ -49,16 +49,16 @@ describe('CurrencyInput', () => {
           label="Amount"
         />,
       );
-      const input = container.querySelector('input');
+      const input = getByRole('textbox');
       expect(tref.current).toBe(input);
     });
 
     it('should format a en-GB amount correctly', async () => {
-      const { getByLabelText } = render(
+      const { getByRole } = render(
         <CurrencyInput locale="en-GB" currency="EUR" label="Amount" />,
       );
 
-      const input = getByLabelText(/Amount/) as HTMLInputElement;
+      const input = getByRole('textbox') as HTMLInputElement;
 
       await userEvent.type(input, '1234.56');
 
@@ -66,11 +66,11 @@ describe('CurrencyInput', () => {
     });
 
     it('should format a de-DE amount correctly', async () => {
-      const { getByLabelText } = render(
+      const { getByRole } = render(
         <CurrencyInput locale="de-DE" currency="EUR" label="Amount" />,
       );
 
-      const input = getByLabelText(/Amount/) as HTMLInputElement;
+      const input = getByRole('textbox') as HTMLInputElement;
 
       await userEvent.type(input, '1234,56');
 
@@ -92,9 +92,9 @@ describe('CurrencyInput', () => {
           />
         );
       };
-      const { getByLabelText } = render(<ControlledCurrencyInput />);
+      const { getByRole } = render(<ControlledCurrencyInput />);
 
-      const input = getByLabelText(/Amount/) as HTMLInputElement;
+      const input = getByRole('textbox') as HTMLInputElement;
       expect(input.value).toBe('1.234,5');
 
       await userEvent.clear(input);

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -106,5 +106,35 @@ describe('CurrencyInput', () => {
       const actual = await axe(container);
       expect(actual).toHaveNoViolations();
     });
+
+    describe('Labeling', () => {
+      const EUR_CURRENCY_SYMBOL = '€'; // formatted by `@sumup/intl`
+      /**
+       * Note: further labeling logic is covered by the underlying `Input` component.
+       */
+      it('should have the currency symbol as part of its accessible description', () => {
+        const { getByRole } = render(<CurrencyInput {...defaultProps} />);
+        expect(getByRole('textbox')).toHaveAccessibleDescription(
+          EUR_CURRENCY_SYMBOL,
+        );
+      });
+
+      it('should accept a custom description via aria-describedby', () => {
+        const customDescription = 'Custom description';
+        const customDescriptionId = 'customDescriptionId';
+        const { getByRole } = render(
+          <>
+            <span id={customDescriptionId}>{customDescription}</span>
+            <CurrencyInput
+              {...defaultProps}
+              aria-describedby={customDescriptionId}
+            />
+          </>,
+        );
+        expect(getByRole('textbox')).toHaveAccessibleDescription(
+          `${customDescription} ${EUR_CURRENCY_SYMBOL}`,
+        );
+      });
+    });
   });
 });

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -21,18 +21,21 @@ import { InputProps } from '../Input';
 
 import CurrencyInput, { CurrencyInputProps } from '.';
 
+const defaultProps = {
+  currency: 'EUR',
+  label: 'Amount',
+};
+
 describe('CurrencyInput', () => {
   describe('Styles', () => {
     it('should render with default styles', () => {
-      const { container } = render(
-        <CurrencyInput currency="EUR" label="Amount" />,
-      );
+      const { container } = render(<CurrencyInput {...defaultProps} />);
       expect(container).toMatchSnapshot();
     });
 
     it('should adjust input padding and suffix width to match currency symbol width', () => {
       const { container } = render(
-        <CurrencyInput placeholder="123,45" currency="CHF" label="Amount" />,
+        <CurrencyInput {...defaultProps} currency="CHF" />,
       );
       expect(container).toMatchSnapshot();
     });
@@ -42,12 +45,7 @@ describe('CurrencyInput', () => {
     it('should accept a working ref', () => {
       const tref = createRef<NumericFormatProps<InputProps>>();
       const { getByRole } = render(
-        <CurrencyInput
-          locale="de-DE"
-          currency="EUR"
-          ref={tref}
-          label="Amount"
-        />,
+        <CurrencyInput {...defaultProps} ref={tref} />,
       );
       const input = getByRole('textbox');
       expect(tref.current).toBe(input);
@@ -55,7 +53,7 @@ describe('CurrencyInput', () => {
 
     it('should format a en-GB amount correctly', async () => {
       const { getByRole } = render(
-        <CurrencyInput locale="en-GB" currency="EUR" label="Amount" />,
+        <CurrencyInput {...defaultProps} locale="en-GB" />,
       );
 
       const input = getByRole('textbox') as HTMLInputElement;
@@ -67,7 +65,7 @@ describe('CurrencyInput', () => {
 
     it('should format a de-DE amount correctly', async () => {
       const { getByRole } = render(
-        <CurrencyInput locale="de-DE" currency="EUR" label="Amount" />,
+        <CurrencyInput {...defaultProps} locale="de-DE" />,
       );
 
       const input = getByRole('textbox') as HTMLInputElement;
@@ -82,10 +80,8 @@ describe('CurrencyInput', () => {
         const [value, setValue] = useState<CurrencyInputProps['value']>(1234.5);
         return (
           <CurrencyInput
-            locale="de-DE"
-            currency="EUR"
+            {...defaultProps}
             value={value}
-            label="Amount"
             onChange={(
               e: ChangeEvent<HTMLInputElement & HTMLTextAreaElement>,
             ) => setValue(e.target.value)}
@@ -95,20 +91,18 @@ describe('CurrencyInput', () => {
       const { getByRole } = render(<ControlledCurrencyInput />);
 
       const input = getByRole('textbox') as HTMLInputElement;
-      expect(input.value).toBe('1.234,5');
+      expect(input.value).toBe('1,234.5');
 
       await userEvent.clear(input);
-      await userEvent.type(input, '1234,56');
+      await userEvent.type(input, '1234.56');
 
-      expect(input.value).toBe('1.234,56');
+      expect(input.value).toBe('1,234.56');
     });
   });
 
   describe('Accessibility', () => {
     it('should have no violations', async () => {
-      const { container } = render(
-        <CurrencyInput locale="de-DE" currency="EUR" label="Product price" />,
-      );
+      const { container } = render(<CurrencyInput {...defaultProps} />);
       const actual = await axe(container);
       expect(actual).toHaveNoViolations();
     });

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -20,6 +20,7 @@ import { NumericFormat, NumericFormatProps } from 'react-number-format';
 import styled from '../../styles/styled';
 import Input from '../Input';
 import { InputProps } from '../Input/Input';
+import { uniqueId } from '../../util/id';
 
 import { formatPlaceholder } from './CurrencyInputService';
 
@@ -77,15 +78,26 @@ const CurrencyIcon = styled('span')`
 `;
 
 /**
- * CurrencyInput component for forms. Automatically looks up
- * symbols and places the symbol according to the locale. The corresponding
- * service exports a parser for formatting values automatically.
+ * CurrencyInput component for forms. Automatically looks up symbols and places
+ * the symbol according to the locale. The corresponding service exports a
+ * parser for formatting values automatically.
  */
 export const CurrencyInput = forwardRef(
   (
-    { locale, currency, placeholder, ...props }: CurrencyInputProps,
+    {
+      locale,
+      currency,
+      placeholder,
+      'aria-describedby': descriptionId,
+      ...props
+    }: CurrencyInputProps,
     ref: CurrencyInputProps['ref'],
   ) => {
+    const currencySymbolId = uniqueId('currency-symbol_');
+    const descriptionIds = `${
+      descriptionId ? `${descriptionId} ` : ''
+    }${currencySymbolId}`;
+
     const currencyFormat =
       resolveCurrencyFormat(locale, currency) || DEFAULT_FORMAT;
     const {
@@ -106,14 +118,18 @@ export const CurrencyInput = forwardRef(
     const renderPrefix =
       currencyPosition === 'prefix'
         ? (prefixProps: { className?: string }) => (
-            <CurrencyIcon {...prefixProps}>{currencySymbol}</CurrencyIcon>
+            <CurrencyIcon {...prefixProps} id={currencySymbolId}>
+              {currencySymbol}
+            </CurrencyIcon>
           )
         : undefined;
 
     const renderSuffix =
       currencyPosition === 'suffix'
         ? (suffixProps: { className?: string }) => (
-            <CurrencyIcon {...suffixProps}>{currencySymbol}</CurrencyIcon>
+            <CurrencyIcon {...suffixProps} id={currencySymbolId}>
+              {currencySymbol}
+            </CurrencyIcon>
           )
         : undefined;
 
@@ -135,6 +151,7 @@ export const CurrencyInput = forwardRef(
         textAlign="right"
         type="text"
         inputMode="decimal"
+        aria-describedby={descriptionIds}
         {...props}
       />
     );

--- a/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -120,7 +120,6 @@ exports[`CurrencyInput Styles should adjust input padding and suffix width to ma
         class="circuit-6"
         id="input_9"
         inputmode="decimal"
-        placeholder="123,45"
         type="text"
         value=""
       />

--- a/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -97,7 +97,7 @@ exports[`CurrencyInput should adjust input padding and suffix width to match cur
 >
   <label
     class="circuit-1"
-    for="input_7"
+    for="input_9"
   >
     <span
       class="circuit-2 circuit-3"
@@ -110,13 +110,14 @@ exports[`CurrencyInput should adjust input padding and suffix width to match cur
   >
     <span
       class="circuit-5"
+      id="currency-symbol_6"
     >
       CHF
     </span>
     <input
-      aria-describedby="validation-hint_8"
+      aria-describedby="currency-symbol_6 validation-hint_10"
       class="circuit-6"
-      id="input_7"
+      id="input_9"
       inputmode="decimal"
       placeholder="123,45"
       type="text"
@@ -227,7 +228,7 @@ exports[`CurrencyInput should render with default styles 1`] = `
 >
   <label
     class="circuit-1"
-    for="input_3"
+    for="input_4"
   >
     <span
       class="circuit-2 circuit-3"
@@ -240,13 +241,14 @@ exports[`CurrencyInput should render with default styles 1`] = `
   >
     <span
       class="circuit-5"
+      id="currency-symbol_1"
     >
       €
     </span>
     <input
-      aria-describedby="validation-hint_4"
+      aria-describedby="currency-symbol_1 validation-hint_5"
       class="circuit-6"
-      id="input_3"
+      id="input_4"
       inputmode="decimal"
       type="text"
       value=""

--- a/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CurrencyInput should adjust input padding and suffix width to match currency symbol width 1`] = `
+exports[`CurrencyInput Styles should adjust input padding and suffix width to match currency symbol width 1`] = `
 .circuit-1 {
   display: block;
   font-size: 0.875rem;
@@ -92,46 +92,48 @@ exports[`CurrencyInput should adjust input padding and suffix width to match cur
   box-shadow: 0 0 0 1px #3063E9;
 }
 
-<div
-  class="circuit-0"
->
-  <label
-    class="circuit-1"
-    for="input_9"
-  >
-    <span
-      class="circuit-2 circuit-3"
-    >
-      Amount
-    </span>
-  </label>
+<div>
   <div
-    class="circuit-4"
+    class="circuit-0"
   >
-    <span
-      class="circuit-5"
-      id="currency-symbol_6"
+    <label
+      class="circuit-1"
+      for="input_9"
     >
-      CHF
-    </span>
-    <input
-      aria-describedby="currency-symbol_6 validation-hint_10"
-      class="circuit-6"
-      id="input_9"
-      inputmode="decimal"
-      placeholder="123,45"
-      type="text"
-      value=""
+      <span
+        class="circuit-2 circuit-3"
+      >
+        Amount
+      </span>
+    </label>
+    <div
+      class="circuit-4"
+    >
+      <span
+        class="circuit-5"
+        id="currency-symbol_6"
+      >
+        CHF
+      </span>
+      <input
+        aria-describedby="currency-symbol_6 validation-hint_10"
+        class="circuit-6"
+        id="input_9"
+        inputmode="decimal"
+        placeholder="123,45"
+        type="text"
+        value=""
+      />
+    </div>
+    <span
+      aria-live="polite"
+      role="status"
     />
   </div>
-  <span
-    aria-live="polite"
-    role="status"
-  />
 </div>
 `;
 
-exports[`CurrencyInput should render with default styles 1`] = `
+exports[`CurrencyInput Styles should render with default styles 1`] = `
 .circuit-1 {
   display: block;
   font-size: 0.875rem;
@@ -223,40 +225,42 @@ exports[`CurrencyInput should render with default styles 1`] = `
   box-shadow: 0 0 0 1px #3063E9;
 }
 
-<div
-  class="circuit-0"
->
-  <label
-    class="circuit-1"
-    for="input_4"
-  >
-    <span
-      class="circuit-2 circuit-3"
-    >
-      Amount
-    </span>
-  </label>
+<div>
   <div
-    class="circuit-4"
+    class="circuit-0"
   >
-    <span
-      class="circuit-5"
-      id="currency-symbol_1"
+    <label
+      class="circuit-1"
+      for="input_4"
     >
-      €
-    </span>
-    <input
-      aria-describedby="currency-symbol_1 validation-hint_5"
-      class="circuit-6"
-      id="input_4"
-      inputmode="decimal"
-      type="text"
-      value=""
+      <span
+        class="circuit-2 circuit-3"
+      >
+        Amount
+      </span>
+    </label>
+    <div
+      class="circuit-4"
+    >
+      <span
+        class="circuit-5"
+        id="currency-symbol_1"
+      >
+        €
+      </span>
+      <input
+        aria-describedby="currency-symbol_1 validation-hint_5"
+        class="circuit-6"
+        id="input_4"
+        inputmode="decimal"
+        type="text"
+        value=""
+      />
+    </div>
+    <span
+      aria-live="polite"
+      role="status"
     />
   </div>
-  <span
-    aria-live="polite"
-    role="status"
-  />
 </div>
 `;

--- a/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CurrencyInput Styles should adjust input padding and suffix width to match currency symbol width 1`] = `
+exports[`CurrencyInput Styles should render a currency as a prefix 1`] = `
 .circuit-1 {
   display: block;
   font-size: 0.875rem;
@@ -98,7 +98,7 @@ exports[`CurrencyInput Styles should adjust input padding and suffix width to ma
   >
     <label
       class="circuit-1"
-      for="input_9"
+      for="input_14"
     >
       <span
         class="circuit-2 circuit-3"
@@ -111,14 +111,14 @@ exports[`CurrencyInput Styles should adjust input padding and suffix width to ma
     >
       <span
         class="circuit-5"
-        id="currency-symbol_6"
+        id="currency-symbol_11"
       >
         CHF
       </span>
       <input
-        aria-describedby="currency-symbol_6 validation-hint_10"
+        aria-describedby="currency-symbol_11 validation-hint_15"
         class="circuit-6"
-        id="input_9"
+        id="input_14"
         inputmode="decimal"
         type="text"
         value=""
@@ -132,7 +132,143 @@ exports[`CurrencyInput Styles should adjust input padding and suffix width to ma
 </div>
 `;
 
-exports[`CurrencyInput Styles should render with default styles 1`] = `
+exports[`CurrencyInput Styles should render a currency as a suffix 1`] = `
+.circuit-1 {
+  display: block;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.circuit-2 {
+  display: inline-block;
+  margin-bottom: 4px;
+}
+
+.circuit-4 {
+  position: relative;
+}
+
+.circuit-5 {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-appearance: none;
+  background-color: #FFF;
+  border: none;
+  outline: 0;
+  border-radius: 8px;
+  padding: 12px 16px;
+  -webkit-transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
+  transition: box-shadow 120ms ease-in-out,padding 120ms ease-in-out;
+  width: 100%;
+  margin: 0;
+  text-align: right;
+  padding-right: 48px;
+  box-shadow: 0 0 0 1px #999;
+}
+
+.circuit-5::-webkit-input-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-5::-moz-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-5:-ms-input-placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-5::placeholder {
+  color: #999;
+  -webkit-transition: color 120ms ease-in-out;
+  transition: color 120ms ease-in-out;
+}
+
+.circuit-5:hover {
+  box-shadow: 0 0 0 1px #666;
+}
+
+.circuit-5:focus {
+  box-shadow: 0 0 0 2px #3063E9;
+}
+
+.circuit-5:active {
+  box-shadow: 0 0 0 1px #3063E9;
+}
+
+.circuit-6 {
+  line-height: 16px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: absolute;
+  top: 0;
+  right: 0;
+  pointer-events: none;
+  color: #666;
+  padding: 12px 16px;
+  height: 48px;
+  width: 48px;
+  -webkit-transition: right 120ms ease-in-out;
+  transition: right 120ms ease-in-out;
+}
+
+<div>
+  <div
+    class="circuit-0"
+  >
+    <label
+      class="circuit-1"
+      for="input_9"
+    >
+      <span
+        class="circuit-2 circuit-3"
+      >
+        Amount
+      </span>
+    </label>
+    <div
+      class="circuit-4"
+    >
+      <input
+        aria-describedby="currency-symbol_6 validation-hint_10"
+        class="circuit-5"
+        id="input_9"
+        inputmode="decimal"
+        type="text"
+        value=""
+      />
+      <span
+        class="circuit-6"
+        id="currency-symbol_6"
+      >
+        €
+      </span>
+    </div>
+    <span
+      aria-live="polite"
+      role="status"
+    />
+  </div>
+</div>
+`;
+
+exports[`CurrencyInput Styles should render with default styles and format 1`] = `
 .circuit-1 {
   display: block;
   font-size: 0.875rem;
@@ -245,7 +381,7 @@ exports[`CurrencyInput Styles should render with default styles 1`] = `
         class="circuit-5"
         id="currency-symbol_1"
       >
-        €
+        $
       </span>
       <input
         aria-describedby="currency-symbol_1 validation-hint_5"


### PR DESCRIPTION
Enabled by #1813 

## Purpose

This ensures that the `CurrencyInput`'s currency symbol (rendered as either a suffix or prefix, depending on the currency and locale) is exposed to assistive technology as describing the input element.

For example, with this input:

<img width="324" alt="CurrencyInput with '€' currency and a 'Excluding VAT' validationHint" src="https://user-images.githubusercontent.com/35560568/198005111-5a3784e2-3eac-412d-ac23-9389be46a516.png">

Notice how the accessible description now includes the currency symbol in addition to the `validationHint` description:

| Before (`next`) | After (this branch) |
| --- | --- |
| <img width="514" alt="Description: 'Excluding VAT'" src="https://user-images.githubusercontent.com/35560568/198005324-a4f7a552-154e-4492-bf4b-e51d5d62e069.png"> | <img width="514" alt="Description: '€ Excluding VAT'" src="https://user-images.githubusercontent.com/35560568/198005405-db70a865-b833-4974-b154-7d4834c6c8ad.png"> |

## Approach and changes

- the actual change: 999e288
  - generated an id for the currency symbol element (passed the same ID to the prefix and suffix elements, they're never both rendered together)
  - combined the id with any custom `aria-describedby` value passed by the implementation (similar to #1813 but with an extra layer)
  - passed the list of ids to the `CurrencyInput` (it is combined with the `validationHint` id in the underlying `Input component`)
- tests: eb10bb6
- refreshed the specs (replaced old helpers, improved queries and structure, added defaultProps...) (rest of the commits)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
