### PR TITLE
This is an example of overriding theme values for a component

### DIFF
--- a/packages/circuit-ui/components/Button/Button.stories.tsx
+++ b/packages/circuit-ui/components/Button/Button.stories.tsx
@@ -16,6 +16,8 @@
 import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { Plus } from '@sumup/icons';
+import { ThemeProvider } from '@emotion/react';
+import { Theme } from '@sumup/design-tokens';
 
 import { Stack } from '../../../../.storybook/components';
 import ButtonGroup from '../ButtonGroup';
@@ -124,3 +126,24 @@ Loading.args = {
   children: 'Things take time',
   loadingLabel: 'Loading',
 };
+
+const customTheme = (circuitTheme: Theme) => ({
+  ...circuitTheme,
+  colors: {
+    ...circuitTheme.colors,
+    p500: 'rebeccapurple',
+  },
+  spacings: {
+    ...circuitTheme.spacings,
+    kilo: circuitTheme.spacings.giga,
+    giga: circuitTheme.spacings.exa,
+  },
+});
+
+export const ThemedButton = (args: ButtonProps) => (
+  <ThemeProvider theme={customTheme}>
+    <Button {...args} variant="primary">
+      A big purple button
+    </Button>
+  </ThemeProvider>
+);


### PR DESCRIPTION
⚠️ **This is a POC, not for review** ⚠️ 

It shows how theme values can be overridden using Emotion's `ThemeProvider`.

Prefer wrapping individual components in a `ThemeProvider` (e.g. a local shared "CustomButton" component) instead of a large part of the component tree, to avoid side-effects.

Disclaimer: note that this way of theming is brittle and might break under future Circuit UI releases. The design system team is currently working on built-in support for theming colors by abstracting raw color values behind semantic color tokens (which will make it easier to override color values and will remove unintended side-effects). Theming for other token types (spacings, font sizes, etc.) is on the roadmap but not currently planned.