### PR TITLE
Add option to have optional automatic closing in NotificationModal's action

### DIFF
--- a/.changeset/weak-books-lie.md
+++ b/.changeset/weak-books-lie.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Add option to have optional automatic closing in NotificationModal's action

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
@@ -19,7 +19,9 @@ import { css } from '@emotion/react';
 import styled, { StyleProps } from '../../styles/styled';
 import Button, { ButtonProps } from '../Button';
 
-type Action = Omit<ButtonProps, 'variant'>;
+type Action = Omit<ButtonProps, 'variant'> & {
+  disableAutomaticClosing?: boolean;
+};
 
 export interface ButtonGroupProps
   extends Omit<HTMLAttributes<HTMLDivElement>, 'align'> {

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
@@ -223,9 +223,14 @@ export const NotificationModal: ModalComponent<NotificationModalProps> = ({
           ...props,
         };
 
-        function wrapOnClick(onClick?: ButtonProps['onClick']) {
+        function wrapOnClick(
+          onClick?: ButtonProps['onClick'],
+          disableAutomaticClosing?: boolean,
+        ) {
           return (event: ClickEvent) => {
-            handleClose?.(event);
+            if (!disableAutomaticClosing) {
+              handleClose?.(event);
+            }
             onClick?.(event);
           };
         }
@@ -256,11 +261,17 @@ export const NotificationModal: ModalComponent<NotificationModalProps> = ({
                 actions={{
                   primary: {
                     ...actions.primary,
-                    onClick: wrapOnClick(actions.primary.onClick),
+                    onClick: wrapOnClick(
+                      actions.primary.onClick,
+                      actions.primary.disableAutomaticClosing,
+                    ),
                   },
                   secondary: actions.secondary && {
                     ...actions.secondary,
-                    onClick: wrapOnClick(actions.secondary.onClick),
+                    onClick: wrapOnClick(
+                      actions.secondary.onClick,
+                      actions.secondary.disableAutomaticClosing,
+                    ),
                   },
                 }}
                 css={spacing({ top: 'giga' })}


### PR DESCRIPTION
## Purpose

Currently, the circuit-ui's `NotificationModal` component have a functionality which closes the modal when either the `secondary` button or the `primary` button are clicked. The action then goes through, all the while the modal is being closed.

But, due to the issue raised in #1628, the maintainers of the repository have decided to extend the functionality to have an option to remove the automatic closing functionality for each action. Thus, this pull request is made.

## Approach and changes

I have extended the type in the `Action` type in `ButtonGroup`.

<img width="304" alt="image" src="https://user-images.githubusercontent.com/55081132/200346790-17034599-0598-47e0-a696-b1eb79d7bc43.png">

And then, I've changed the `wrapOnClick` function to have a check on the `disableAutomaticClosing`, on which if it is not disabled, then it closes automatically. This enables having backward compatibility on previous changes.

<img width="320" alt="image" src="https://user-images.githubusercontent.com/55081132/200346839-8a8cd342-c174-4fdb-a150-78187f9fcdc4.png">

Finally, I pass the function the `disableAutomaticClosing` param to the argument of the function in the `ButtonGroup` component.

<img width="387" alt="image" src="https://user-images.githubusercontent.com/55081132/200347063-2573861e-1c49-4627-afbf-b1a972f3a425.png">



## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
