### PR TITLE
Revert "chore(deps-dev): bump @types/react from 18.0.21 to 18.0.25 (#…

### DIFF
--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -67,7 +67,7 @@
     "@types/cross-spawn": "^6.0.2",
     "@types/jest-axe": "^3.5.5",
     "@types/jscodeshift": "^0.11.5",
-    "@types/react": "^18.0.25",
+    "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
     "@types/react-modal": "^3.13.1",
     "component-playground": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4886,10 +4886,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.25":
-  version "18.0.25"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.25.tgz#8b1dcd7e56fe7315535a4af25435e0bb55c8ae44"
-  integrity sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==
+"@types/react@*", "@types/react@^18.0.21":
+  version "18.0.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.21.tgz#b8209e9626bb00a34c76f55482697edd2b43cc67"
+  integrity sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
This reverts commit 0650528b872c8c1b9bf488a16d67189d4bab399b.

## Purpose

This version bump caused compatibility issues with web apps using Circuit on React 17.

It looks like the underlying HTML element types for components (such as `HTMLAttributes<HTMLParagraphElement>` for `Body`) is incompatible between React 17 and 18 types:

<img width="816" alt="Screenshot 2022-11-08 at 14 05 32" src="https://user-images.githubusercontent.com/35560568/200572379-3003e11f-be7d-47cf-ac51-eddaed259ceb.png">

The error messages point to two recent changes in the React 18 types:

- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62879
- https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63076

## Approach and changes

Before downgrading I tried:

- to upgrade the React types to v18 in the web app, but this caused too many other clashes with the internal React 17 version (and upgrading React there is not an option yet)
- to redeclare/override the Circuit UI types, without success

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
