### PR TITLE
Improve migration guide section for labelStyles changes

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -157,17 +157,28 @@ function Address() {
 
 #### The `labelStyles` prop was removed
 
-The prop was from the `Input` and `TextArea` components.
+The prop was removed from the `Input` and `TextArea` components.
 
-In v5, it is predominantly used to apply styles to the component's wrapper (previously the `label` element).
+In v5, `labelStyles` is predominantly used to apply styles to a form component's wrapper, the `label` element. Wrapper styles can't be passed via the `style` or `className` prop, because these are forwarded to the underlying form element.
 
-It can be replaced by the Emotion.js `css` prop, since classes are now applied to a wrapper around all form components:
+In v6, form components are wrapped in a `div` that receives any `style` or `className` props, including via the Emotion.js `css` prop.
+
+Therefore, to migrate:
+
+- `labelStyles` should be replaced by the Emotion.js `css` prop
+- `css` (previously passed to the underlying form element) should be replaced by `inputStyles`
+
+For example:
 
 ```diff
 <Input
   label="Name"
+  /* wrapper styles */
 -  labelStyles={spacing({ bottom: "giga" })}
 +  css={spacing({ bottom: "giga" })}
+  /* input styles */
+-  css={customInputStyles}
++  inputStyles={customInputStyles}
 />
 ```
 


### PR DESCRIPTION
## Purpose

A detail was missing from the migration guide entry about the removal of the Input's `labelStyles` prop:

- `labelStyles` should be migrated to `css` (✅ this was already documented)
- `css` (previously applied to the `<input>`) should be migrated to `inputStyles` (❌ this was left out)

## Approach and changes

Improved the section by mentioning both the migration from `labelStyles` to `css` (most common) but also the migration from `css` to `inputStyles` (less common because `inputStyles` is already available in v5, but some implementations were using `css` anyways).

## Definition of done

n/a (docs)
