### PR TITLE
Fix links to package documentation pages

### DIFF
--- a/docs/features/icons.stories.mdx
+++ b/docs/features/icons.stories.mdx
@@ -6,7 +6,7 @@ import { Intro, Meta, Icons } from '../../.storybook/components';
 
 <Intro as="div">
 
-The icons used throughout Circuit UI come from SumUp's icon library, [`@sumup/icons`](Packages/icons), which is a required peer dependency of `@sumup/circuit-ui`. Refer to its [documentation](Packages/icons) for usage instructions.
+The icons used throughout Circuit UI come from SumUp's icon library, [`@sumup/icons`](Packages/icons/page), which is a required peer dependency of `@sumup/circuit-ui`. Refer to its [documentation](Packages/icons/page) for usage instructions.
 
 </Intro>
 

--- a/docs/features/theme.stories.mdx
+++ b/docs/features/theme.stories.mdx
@@ -18,7 +18,7 @@ import { Headline, SubHeadline, Body } from '../../packages/circuit-ui';
 
 <Intro as="div">
 
-The theme used throughout Circuit UI comes from SumUp's design token library, [`@sumup/design-tokens`](Packages/design-tokens), which is a required peer dependency of `@sumup/circuit-ui`. Refer to its [documentation](Packages/design-tokens) for usage instructions.
+The theme used throughout Circuit UI comes from SumUp's design token library, [`@sumup/design-tokens`](Packages/design-tokens/page), which is a required peer dependency of `@sumup/circuit-ui`. Refer to its [documentation](Packages/design-tokens/page) for usage instructions.
 
 </Intro>
 


### PR DESCRIPTION
## Purpose

Links to the documentation pages of Circuit UI's peer dependencies are broken. The custom Storybook Link component defaults to `base` for the story name, however, the package docs end with `page`. 

## Approach and changes

- Hard-code the `page` story name

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
