### PR TITLE
Feature/expandable table

### DIFF
--- a/.changeset/strong-deers-heal.md
+++ b/.changeset/strong-deers-heal.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Add expandable rows in Table component

--- a/packages/circuit-ui/components/Table/Table.mdx
+++ b/packages/circuit-ui/components/Table/Table.mdx
@@ -39,6 +39,23 @@ While headers and rows can accept strings as children, they can also accept obje
 
 <Story of={Stories.WithComponentRows} />
 
+### Expandable
+
+Add child elements to your data to have expandable rows:
+ ```rows = [
+            {
+                cells: ['foo', 'bar'],
+                children: [
+                    {cells: ['cell1.1', 'cell1.2']},
+                    {cells: ['cell2.1', 'cell2.2']}
+                    ]
+                }
+            ]
+```
+
+
+<Story id="components-table--expandable" />
+
 ### Sorting
 
 When creating a sortable table with the `sortable` prop in the headers object, always provide a `sortLabel` prop for visually impaired users.

--- a/packages/circuit-ui/components/Table/Table.spec.tsx
+++ b/packages/circuit-ui/components/Table/Table.spec.tsx
@@ -25,6 +25,8 @@ import Badge from '../Badge';
 import Table from './Table';
 import { HeaderCell, Direction } from './types';
 
+jest.setTimeout(500000);
+
 const sortLabel = ({ direction }: { direction?: Direction }) => {
   const order = direction === 'ascending' ? 'descending' : 'ascending';
   return `Sort in ${order} order`;
@@ -147,9 +149,9 @@ describe('Table', () => {
         );
 
         const letterHeaderEl = getAllByRole('columnheader')[0];
-        const cellEls = getAllByRole('cell');
 
         await userEvent.click(letterHeaderEl);
+        const cellEls = getAllByRole('cell');
 
         const sortedRow = ['a', 'b', 'c'];
 
@@ -186,11 +188,11 @@ describe('Table', () => {
         );
 
         const letterHeaderEl = getAllByRole('columnheader')[0];
+
+        await userEvent.click(letterHeaderEl);
+        await userEvent.click(letterHeaderEl);
+
         const cellEls = getAllByRole('cell');
-
-        await userEvent.click(letterHeaderEl);
-        await userEvent.click(letterHeaderEl);
-
         const sortedRow = ['c', 'b', 'a'];
 
         rows.forEach((_row, index) => {
@@ -222,6 +224,7 @@ describe('Table', () => {
 
       it('should call a custom sort callback', async () => {
         const onSortByMock = jest.fn();
+        onSortByMock.mockReturnValue([]);
         const index = 0;
         const nextDirection = 'ascending';
         const { getAllByRole } = render(

--- a/packages/circuit-ui/components/Table/Table.stories.tsx
+++ b/packages/circuit-ui/components/Table/Table.stories.tsx
@@ -86,6 +86,51 @@ WithComponentRows.args = {
   ],
 };
 
+export const Expandable = ({ onSortBy, ...args }: TableProps): JSX.Element => (
+  <Table {...args} />
+);
+
+Expandable.args = {
+  headers: [
+    { children: 'Name', sortable: true, sortLabel },
+    { children: 'Date added', sortable: true, sortLabel },
+  ],
+  rows: [
+    {
+      cells: ['Fruits', { children: '12/01/2017', sortByValue: 0 }],
+      children: [
+        [
+          { children: 'Apple' },
+          {
+            children: '12/12/18',
+            sortByValue: new Date('12/12/18'),
+          },
+        ],
+        {
+          cells: ['Banana', { children: '12/01/2017', sortByValue: 0 }],
+        },
+        {
+          cells: ['Orange', { children: '12/01/2017', sortByValue: 0 }],
+        },
+      ],
+    },
+    [
+      { children: 'Broccoli' },
+      {
+        children: '12/13/18',
+        sortByValue: new Date('12/13/18'),
+      },
+    ],
+    [
+      { children: 'Chickpeas' },
+      {
+        children: '12/14/18',
+        sortByValue: new Date('12/14/18'),
+      },
+    ],
+  ],
+};
+
 export const Sortable = ({ onSortBy, ...args }: TableProps): JSX.Element => (
   <Table {...args} />
 );

--- a/packages/circuit-ui/components/Table/Table.stories.tsx
+++ b/packages/circuit-ui/components/Table/Table.stories.tsx
@@ -114,6 +114,24 @@ Expandable.args = {
         },
       ],
     },
+    {
+      cells: ['Veggies', { children: '12/01/2017', sortByValue: 0 }],
+      children: [
+        [
+          { children: 'Potato' },
+          {
+            children: '12/12/18',
+            sortByValue: new Date('12/12/18'),
+          },
+        ],
+        {
+          cells: ['Bell Pepper', { children: '12/01/2017', sortByValue: 0 }],
+        },
+        {
+          cells: ['Pumpkin', { children: '12/01/2017', sortByValue: 0 }],
+        },
+      ],
+    },
     [
       { children: 'Broccoli' },
       {

--- a/packages/circuit-ui/components/Table/__snapshots__/Table.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/__snapshots__/Table.spec.tsx.snap
@@ -32,6 +32,10 @@ tbody .circuit-4:last-child td {
   border-bottom: none;
 }
 
+.circuit-4.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-6 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -244,6 +248,53 @@ tbody .circuit-4:last-child td {
   white-space: nowrap;
 }
 
+.circuit-17 {
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+}
+
+tbody .circuit-17:last-child th,
+tbody .circuit-17:last-child td {
+  border-bottom: none;
+}
+
+.circuit-17:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-17:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-17:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-17:focus td,
+tbody .circuit-17:hover td,
+tbody .circuit-17:focus th,
+tbody .circuit-17:hover th {
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-17:active td,
+tbody .circuit-17:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
+}
+
+.circuit-17.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-19 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -302,7 +353,7 @@ tbody .circuit-4:last-child td {
         class="circuit-3"
       >
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-4 circuit-5"
         >
           <th
             aria-label="Sort in ascending order"
@@ -404,7 +455,9 @@ tbody .circuit-4:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-0"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -424,7 +477,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-1"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -444,7 +499,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-2"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -499,6 +556,10 @@ exports[`Table Style tests should render "null" or "undefined" cells 1`] = `
 tbody .circuit-4:last-child th,
 tbody .circuit-4:last-child td {
   border-bottom: none;
+}
+
+.circuit-4.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-6 {
@@ -556,6 +617,53 @@ tbody .circuit-4:last-child td {
   padding: 8px 24px;
   vertical-align: middle;
   white-space: nowrap;
+}
+
+.circuit-8 {
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+}
+
+tbody .circuit-8:last-child th,
+tbody .circuit-8:last-child td {
+  border-bottom: none;
+}
+
+.circuit-8:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-8:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-8:focus td,
+tbody .circuit-8:hover td,
+tbody .circuit-8:focus th,
+tbody .circuit-8:hover th {
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-8:active td,
+tbody .circuit-8:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
+}
+
+.circuit-8.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-10 {
@@ -616,7 +724,7 @@ tbody .circuit-4:last-child td {
         class="circuit-3"
       >
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-4 circuit-5"
         >
           <th
             class="circuit-6"
@@ -634,7 +742,9 @@ tbody .circuit-4:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-8 circuit-5"
+          id="table-row-0"
+          tabindex="0"
         >
           <th
             class="circuit-10"
@@ -647,7 +757,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-8 circuit-5"
+          id="table-row-1"
+          tabindex="0"
         >
           <th
             class="circuit-10"
@@ -696,6 +808,10 @@ exports[`Table Style tests should render a collapsed table 1`] = `
 tbody .circuit-4:last-child th,
 tbody .circuit-4:last-child td {
   border-bottom: none;
+}
+
+.circuit-4.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-6 {
@@ -910,6 +1026,53 @@ tbody .circuit-4:last-child td {
   white-space: nowrap;
 }
 
+.circuit-17 {
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+}
+
+tbody .circuit-17:last-child th,
+tbody .circuit-17:last-child td {
+  border-bottom: none;
+}
+
+.circuit-17:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-17:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-17:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-17:focus td,
+tbody .circuit-17:hover td,
+tbody .circuit-17:focus th,
+tbody .circuit-17:hover th {
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-17:active td,
+tbody .circuit-17:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
+}
+
+.circuit-17.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-19 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -968,7 +1131,7 @@ tbody .circuit-4:last-child td {
         class="circuit-3"
       >
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-4 circuit-5"
         >
           <th
             aria-label="Sort in ascending order"
@@ -1070,7 +1233,9 @@ tbody .circuit-4:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-0"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -1090,7 +1255,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-1"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -1110,7 +1277,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-2"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -1167,6 +1336,10 @@ tbody .circuit-4:last-child td {
   border-bottom: none;
 }
 
+.circuit-4.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-6 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -1394,6 +1567,53 @@ tbody .circuit-4:last-child td {
   padding: 8px 16px 8px 24px;
 }
 
+.circuit-17 {
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+}
+
+tbody .circuit-17:last-child th,
+tbody .circuit-17:last-child td {
+  border-bottom: none;
+}
+
+.circuit-17:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-17:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-17:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-17:focus td,
+tbody .circuit-17:hover td,
+tbody .circuit-17:focus th,
+tbody .circuit-17:hover th {
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-17:active td,
+tbody .circuit-17:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
+}
+
+.circuit-17.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-19 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -1459,7 +1679,7 @@ tbody .circuit-4:last-child td {
         class="circuit-3"
       >
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-4 circuit-5"
         >
           <th
             aria-label="Sort in ascending order"
@@ -1561,7 +1781,9 @@ tbody .circuit-4:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-0"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -1581,7 +1803,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-1"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -1601,7 +1825,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-2"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -1651,6 +1877,10 @@ exports[`Table Style tests should render a scrollable table 1`] = `
 tbody .circuit-4:last-child th,
 tbody .circuit-4:last-child td {
   border-bottom: none;
+}
+
+.circuit-4.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-6 {
@@ -1783,6 +2013,53 @@ tbody .circuit-4:last-child td {
   white-space: nowrap;
 }
 
+.circuit-17 {
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+}
+
+tbody .circuit-17:last-child th,
+tbody .circuit-17:last-child td {
+  border-bottom: none;
+}
+
+.circuit-17:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-17:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-17:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-17:focus td,
+tbody .circuit-17:hover td,
+tbody .circuit-17:focus th,
+tbody .circuit-17:hover th {
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-17:active td,
+tbody .circuit-17:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
+}
+
+.circuit-17.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-19 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -1808,7 +2085,7 @@ tbody .circuit-4:last-child td {
         class="circuit-3"
       >
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-4 circuit-5"
         >
           <th
             aria-label="Sort in ascending order"
@@ -1910,7 +2187,9 @@ tbody .circuit-4:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-0"
+          tabindex="0"
         >
           <td
             class="circuit-19"
@@ -1929,7 +2208,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-1"
+          tabindex="0"
         >
           <td
             class="circuit-19"
@@ -1948,7 +2229,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-2"
+          tabindex="0"
         >
           <td
             class="circuit-19"
@@ -2002,6 +2285,10 @@ exports[`Table Style tests should render with component cells 1`] = `
 tbody .circuit-4:last-child th,
 tbody .circuit-4:last-child td {
   border-bottom: none;
+}
+
+.circuit-4.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-6 {
@@ -2059,6 +2346,53 @@ tbody .circuit-4:last-child td {
   padding: 8px 24px;
   vertical-align: middle;
   white-space: nowrap;
+}
+
+.circuit-8 {
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+}
+
+tbody .circuit-8:last-child th,
+tbody .circuit-8:last-child td {
+  border-bottom: none;
+}
+
+.circuit-8:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-8:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-8:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-8:focus td,
+tbody .circuit-8:hover td,
+tbody .circuit-8:focus th,
+tbody .circuit-8:hover th {
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-8:active td,
+tbody .circuit-8:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
+}
+
+.circuit-8.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-10 {
@@ -2132,7 +2466,7 @@ tbody .circuit-4:last-child td {
         class="circuit-3"
       >
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-4 circuit-5"
         >
           <th
             class="circuit-6"
@@ -2150,7 +2484,9 @@ tbody .circuit-4:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-8 circuit-5"
+          id="table-row-0"
+          tabindex="0"
         >
           <th
             class="circuit-10"
@@ -2165,7 +2501,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-8 circuit-5"
+          id="table-row-1"
+          tabindex="0"
         >
           <th
             class="circuit-10"
@@ -2180,7 +2518,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-8 circuit-5"
+          id="table-row-2"
+          tabindex="0"
         >
           <th
             class="circuit-10"
@@ -2237,6 +2577,10 @@ tbody .circuit-4:last-child td {
   border-bottom: none;
 }
 
+.circuit-4.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-6 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -2449,6 +2793,53 @@ tbody .circuit-4:last-child td {
   white-space: nowrap;
 }
 
+.circuit-17 {
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+}
+
+tbody .circuit-17:last-child th,
+tbody .circuit-17:last-child td {
+  border-bottom: none;
+}
+
+.circuit-17:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-17:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-17:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-17:focus td,
+tbody .circuit-17:hover td,
+tbody .circuit-17:focus th,
+tbody .circuit-17:hover th {
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-17:active td,
+tbody .circuit-17:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
+}
+
+.circuit-17.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-19 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -2507,7 +2898,7 @@ tbody .circuit-4:last-child td {
         class="circuit-3"
       >
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-4 circuit-5"
         >
           <th
             aria-label="Sort in ascending order"
@@ -2609,7 +3000,9 @@ tbody .circuit-4:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-0"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -2629,7 +3022,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-1"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -2649,7 +3044,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-2"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -2706,6 +3103,10 @@ tbody .circuit-4:last-child td {
   border-bottom: none;
 }
 
+.circuit-4.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-6 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -2918,6 +3319,53 @@ tbody .circuit-4:last-child td {
   white-space: nowrap;
 }
 
+.circuit-17 {
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+}
+
+tbody .circuit-17:last-child th,
+tbody .circuit-17:last-child td {
+  border-bottom: none;
+}
+
+.circuit-17:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-17:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-17:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-17:focus td,
+tbody .circuit-17:hover td,
+tbody .circuit-17:focus th,
+tbody .circuit-17:hover th {
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-17:active td,
+tbody .circuit-17:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
+}
+
+.circuit-17.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-19 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -2976,7 +3424,7 @@ tbody .circuit-4:last-child td {
         class="circuit-3"
       >
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-4 circuit-5"
         >
           <th
             aria-label="Sort in ascending order"
@@ -3078,7 +3526,9 @@ tbody .circuit-4:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-0"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -3098,7 +3548,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-1"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -3118,7 +3570,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-2"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -3174,6 +3628,10 @@ tbody .circuit-4:last-child td {
   border-bottom: none;
 }
 
+.circuit-4.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-6 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -3386,6 +3844,53 @@ tbody .circuit-4:last-child td {
   white-space: nowrap;
 }
 
+.circuit-17 {
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+}
+
+tbody .circuit-17:last-child th,
+tbody .circuit-17:last-child td {
+  border-bottom: none;
+}
+
+.circuit-17:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-17:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-17:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-17:focus td,
+tbody .circuit-17:hover td,
+tbody .circuit-17:focus th,
+tbody .circuit-17:hover th {
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-17:active td,
+tbody .circuit-17:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
+}
+
+.circuit-17.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-19 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -3444,7 +3949,7 @@ tbody .circuit-4:last-child td {
         class="circuit-3"
       >
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-4 circuit-5"
         >
           <th
             aria-label="Sort in ascending order"
@@ -3546,7 +4051,9 @@ tbody .circuit-4:last-child td {
       </thead>
       <tbody>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-0"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -3566,7 +4073,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-1"
+          tabindex="0"
         >
           <th
             class="circuit-19"
@@ -3586,7 +4095,9 @@ tbody .circuit-4:last-child td {
           </td>
         </tr>
         <tr
-          class="circuit-4 circuit-5"
+          class=" circuit-17 circuit-5"
+          id="table-row-2"
+          tabindex="0"
         >
           <th
             class="circuit-19"

--- a/packages/circuit-ui/components/Table/components/TableBody/TableBody.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableBody/TableBody.spec.tsx
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+import { screen, waitFor } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
+
 import { create, render, renderToHtml, axe } from '../../../../util/test-utils';
 
 import TableBody from '.';
@@ -66,6 +69,31 @@ describe('TableBody', () => {
           <TableBody sortHover={sortHover} rows={fixtureRows} />,
         );
         expect(wrapper).toMatchSnapshot();
+      });
+    });
+
+    describe('expandable behaviour', () => {
+      it('should toggle row with children', async () => {
+        const testId = 'row-1-testId';
+        const rows = [
+          {
+            'cells': ['Foo', 'Bar'],
+            'children': [{ cells: ['ABC', 'DEF'] }, { cells: ['123', '456'] }],
+            'data-testid': testId,
+          },
+        ];
+        render(<TableBody rows={rows} />);
+        const expandableRow = screen.getByTestId('row-1-testId');
+        fireEvent.click(expandableRow);
+        expect(screen.getByText('ABC')).toBeInTheDocument();
+        expect(screen.getByText('123')).toBeInTheDocument();
+        fireEvent.click(expandableRow);
+        await waitFor(() => {
+          expect(screen.queryByText('ABC')).not.toBeInTheDocument();
+        });
+        await waitFor(() => {
+          expect(screen.queryByText('123')).not.toBeInTheDocument();
+        });
       });
     });
 

--- a/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
+++ b/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
@@ -87,6 +87,7 @@ const TableBody = ({
                     condensed={condensed}
                     scope="row"
                     isOpen={isOpen}
+                    onChevronToggle={() => onTableRowClick(rowIndex)}
                     isExpandable={isExpandable}
                     isHovered={sortHover === cellIndex}
                     sortParams={{ sortable: false }}

--- a/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
+++ b/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
@@ -16,6 +16,7 @@
 import { useCallback } from 'react';
 
 import {
+  generateRowIds,
   mapCellProps,
   useExpandableTableOptions,
 } from '../../utils';
@@ -73,7 +74,7 @@ const TableBody = ({
   onSortBy,
   onRowClick,
 }: TableBodyProps): JSX.Element => {
-  const { data, toggleState, expandableState, toggleRow } =
+  const { data, toggleState, childCountState, toggleRow } =
     useExpandableTableOptions(rows, sortDirection, sortedRow, onSortBy);
 
   const onTableRowClick = useCallback(
@@ -90,29 +91,31 @@ const TableBody = ({
     <tbody>
       {data.map((row, rowIndex) => {
         const { cells, isChild, key, ...props } = row;
-        const isExpandable = expandableState[key];
+        const childrenCount = childCountState[key];
         const isOpen = toggleState[key];
         return (
           <TableRow
             isChild={isChild}
             key={key}
+            id={key}
             onClick={() => onTableRowClick(rowIndex, key)}
             {...props}
           >
             {cells.map((cell, cellIndex) =>
               rowHeaders && cellIndex === 0 ? (
                 <TableHeader
-                key={`table-cell-${rowIndex}-${cellIndex}`}
-                    fixed
-                    condensed={condensed}
-                    scope="row"
-                    isOpen={isOpen}
-                    onChevronToggle={() => onTableRowClick(rowIndex, key)}
-                    isExpandable={isExpandable}
-                    isHovered={sortHover === cellIndex}
-                    sortParams={{ sortable: false }}
-                    {...mapCellProps(cell)}
-                  />
+                  key={`table-cell-${rowIndex}-${cellIndex}`}
+                  fixed
+                  condensed={condensed}
+                  scope="row"
+                  isOpen={isOpen}
+                  childIds={generateRowIds(rowIndex, childrenCount)}
+                  onChevronToggle={() => onTableRowClick(rowIndex, key)}
+                  isExpandable={childrenCount > 0}
+                  isHovered={sortHover === cellIndex}
+                  sortParams={{ sortable: false }}
+                  {...mapCellProps(cell)}
+                />
               ) : (
                 <TableCell
                   key={`${key}-table-cell-${rowIndex}-${cellIndex}`}

--- a/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
+++ b/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
@@ -13,7 +13,10 @@
  * limitations under the License.
  */
 
-import { mapRowProps, mapCellProps } from '../../utils';
+import {
+  mapCellProps,
+  useExpandableTableOptions,
+} from '../../utils';
 import { Row } from '../../types';
 import TableRow from '../TableRow';
 import TableHeader from '../TableHeader';
@@ -52,40 +55,57 @@ const TableBody = ({
   rowHeaders = false,
   sortHover,
   onRowClick,
-}: TableBodyProps): JSX.Element => (
-  <tbody>
-    {rows.map((row, rowIndex) => {
-      const { cells, ...props } = mapRowProps(row);
-      return (
-        <TableRow
-          key={`table-row-${rowIndex}`}
-          onClick={onRowClick ? () => onRowClick(rowIndex) : undefined}
-          {...props}
-        >
-          {cells.map((cell, cellIndex) =>
-            rowHeaders && cellIndex === 0 ? (
-              <TableHeader
+}: TableBodyProps): JSX.Element => {
+  const { data, toggleState, expandableState, toggleRow } =
+    useExpandableTableOptions(rows);
+
+  const onTableRowClick = (index: number) => {
+    toggleRow(index);
+    if (onRowClick) {
+      onRowClick(index);
+    }
+  };
+
+  return (
+    <tbody>
+      {data.map((row, rowIndex) => {
+        const { cells, isChild, ...props } = row;
+        const isExpandable = expandableState[rowIndex];
+        const isOpen = toggleState[rowIndex];
+        return (
+          <TableRow
+            isChild={isChild}
+            key={`table-row-${rowIndex}`}
+            onClick={() => onTableRowClick(rowIndex)}
+            {...props}
+          >
+            {cells.map((cell, cellIndex) =>
+              rowHeaders && cellIndex === 0 ? (
+                <TableHeader
                 key={`table-cell-${rowIndex}-${cellIndex}`}
-                fixed
-                condensed={condensed}
-                scope="row"
-                isHovered={sortHover === cellIndex}
-                sortParams={{ sortable: false }}
-                {...mapCellProps(cell)}
-              />
-            ) : (
-              <TableCell
-                key={`table-cell-${rowIndex}-${cellIndex}`}
-                condensed={condensed}
-                isHovered={sortHover === cellIndex}
-                {...mapCellProps(cell)}
-              />
-            ),
-          )}
-        </TableRow>
-      );
-    })}
-  </tbody>
-);
+                    fixed
+                    condensed={condensed}
+                    scope="row"
+                    isOpen={isOpen}
+                    isExpandable={isExpandable}
+                    isHovered={sortHover === cellIndex}
+                    sortParams={{ sortable: false }}
+                    {...mapCellProps(cell)}
+                  />
+              ) : (
+                <TableCell
+                  key={`table-cell-${rowIndex}-${cellIndex}`}
+                  condensed={condensed}
+                  isHovered={sortHover === cellIndex}
+                  {...mapCellProps(cell)}
+                />
+              ),
+            )}
+          </TableRow>
+        );
+      })}
+    </tbody>
+  );
+};
 
 export default TableBody;

--- a/packages/circuit-ui/components/Table/components/TableBody/__snapshots__/TableBody.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableBody/__snapshots__/TableBody.spec.tsx.snap
@@ -19,7 +19,7 @@ tbody .circuit-0:last-child td {
   -ms-transform: translate(0, 0);
   transform: translate(0, 0);
   outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
 }
 
 .circuit-0:focus::-moz-focus-inner {
@@ -34,8 +34,14 @@ tbody .circuit-0:focus td,
 tbody .circuit-0:hover td,
 tbody .circuit-0:focus th,
 tbody .circuit-0:hover th {
-  color: #3063E9;
-  background-color: #F5F5F5;
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-0:active td,
+tbody .circuit-0:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
 }
 
 .circuit-0.isChild th {
@@ -56,6 +62,7 @@ tbody .circuit-0:hover th {
 <tbody>
   <tr
     class=" circuit-0 circuit-1"
+    id="table-row-0"
     tabindex="0"
   >
     <td
@@ -91,7 +98,7 @@ tbody .circuit-0:last-child td {
   -ms-transform: translate(0, 0);
   transform: translate(0, 0);
   outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
 }
 
 .circuit-0:focus::-moz-focus-inner {
@@ -106,8 +113,14 @@ tbody .circuit-0:focus td,
 tbody .circuit-0:hover td,
 tbody .circuit-0:focus th,
 tbody .circuit-0:hover th {
-  color: #3063E9;
-  background-color: #F5F5F5;
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-0:active td,
+tbody .circuit-0:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
 }
 
 .circuit-0.isChild th {
@@ -162,6 +175,7 @@ tbody .circuit-0:hover th {
 <tbody>
   <tr
     class=" circuit-0 circuit-1"
+    id="table-row-0"
     tabindex="0"
   >
     <th
@@ -198,7 +212,7 @@ tbody .circuit-0:last-child td {
   -ms-transform: translate(0, 0);
   transform: translate(0, 0);
   outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
 }
 
 .circuit-0:focus::-moz-focus-inner {
@@ -213,8 +227,14 @@ tbody .circuit-0:focus td,
 tbody .circuit-0:hover td,
 tbody .circuit-0:focus th,
 tbody .circuit-0:hover th {
-  color: #3063E9;
-  background-color: #F5F5F5;
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-0:active td,
+tbody .circuit-0:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
 }
 
 .circuit-0.isChild th {
@@ -235,6 +255,7 @@ tbody .circuit-0:hover th {
 <tbody>
   <tr
     class=" circuit-0 circuit-1"
+    id="table-row-0"
     tabindex="0"
   >
     <td
@@ -270,7 +291,7 @@ tbody .circuit-0:last-child td {
   -ms-transform: translate(0, 0);
   transform: translate(0, 0);
   outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
 }
 
 .circuit-0:focus::-moz-focus-inner {
@@ -285,8 +306,14 @@ tbody .circuit-0:focus td,
 tbody .circuit-0:hover td,
 tbody .circuit-0:focus th,
 tbody .circuit-0:hover th {
-  color: #3063E9;
-  background-color: #F5F5F5;
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-0:active td,
+tbody .circuit-0:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
 }
 
 .circuit-0.isChild th {
@@ -319,6 +346,7 @@ tbody .circuit-0:hover th {
 <tbody>
   <tr
     class=" circuit-0 circuit-1"
+    id="table-row-0"
     tabindex="0"
   >
     <td

--- a/packages/circuit-ui/components/Table/components/TableBody/__snapshots__/TableBody.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableBody/__snapshots__/TableBody.spec.tsx.snap
@@ -3,11 +3,43 @@
 exports[`TableBody Style tests should render with default styles 1`] = `
 .circuit-0 {
   vertical-align: middle;
+  cursor: pointer;
+  position: relative;
 }
 
 tbody .circuit-0:last-child th,
 tbody .circuit-0:last-child td {
   border-bottom: none;
+}
+
+.circuit-0:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-0:focus td,
+tbody .circuit-0:hover td,
+tbody .circuit-0:focus th,
+tbody .circuit-0:hover th {
+  color: #3063E9;
+  background-color: #F5F5F5;
+}
+
+.circuit-0.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-2 {
@@ -23,7 +55,8 @@ tbody .circuit-0:last-child td {
 
 <tbody>
   <tr
-    class="circuit-0 circuit-1"
+    class=" circuit-0 circuit-1"
+    tabindex="0"
   >
     <td
       class="circuit-2"
@@ -42,11 +75,43 @@ tbody .circuit-0:last-child td {
 exports[`TableBody Style tests should render with fixed header styles 1`] = `
 .circuit-0 {
   vertical-align: middle;
+  cursor: pointer;
+  position: relative;
 }
 
 tbody .circuit-0:last-child th,
 tbody .circuit-0:last-child td {
   border-bottom: none;
+}
+
+.circuit-0:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-0:focus td,
+tbody .circuit-0:hover td,
+tbody .circuit-0:focus th,
+tbody .circuit-0:hover th {
+  color: #3063E9;
+  background-color: #F5F5F5;
+}
+
+.circuit-0.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-2 {
@@ -96,7 +161,8 @@ tbody .circuit-0:last-child td {
 
 <tbody>
   <tr
-    class="circuit-0 circuit-1"
+    class=" circuit-0 circuit-1"
+    tabindex="0"
   >
     <th
       class="circuit-2"
@@ -116,11 +182,43 @@ tbody .circuit-0:last-child td {
 exports[`TableBody logic tests sortHover should not render a cell with hovered styles if its column is not currently hovered 1`] = `
 .circuit-0 {
   vertical-align: middle;
+  cursor: pointer;
+  position: relative;
 }
 
 tbody .circuit-0:last-child th,
 tbody .circuit-0:last-child td {
   border-bottom: none;
+}
+
+.circuit-0:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-0:focus td,
+tbody .circuit-0:hover td,
+tbody .circuit-0:focus th,
+tbody .circuit-0:hover th {
+  color: #3063E9;
+  background-color: #F5F5F5;
+}
+
+.circuit-0.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-2 {
@@ -136,7 +234,8 @@ tbody .circuit-0:last-child td {
 
 <tbody>
   <tr
-    class="circuit-0 circuit-1"
+    class=" circuit-0 circuit-1"
+    tabindex="0"
   >
     <td
       class="circuit-2"
@@ -155,11 +254,43 @@ tbody .circuit-0:last-child td {
 exports[`TableBody logic tests sortHover should render a cell with hovered styles if its column is currently hovered 1`] = `
 .circuit-0 {
   vertical-align: middle;
+  cursor: pointer;
+  position: relative;
 }
 
 tbody .circuit-0:last-child th,
 tbody .circuit-0:last-child td {
   border-bottom: none;
+}
+
+.circuit-0:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-0:focus td,
+tbody .circuit-0:hover td,
+tbody .circuit-0:focus th,
+tbody .circuit-0:hover th {
+  color: #3063E9;
+  background-color: #F5F5F5;
+}
+
+.circuit-0.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-2 {
@@ -187,7 +318,8 @@ tbody .circuit-0:last-child td {
 
 <tbody>
   <tr
-    class="circuit-0 circuit-1"
+    class=" circuit-0 circuit-1"
+    tabindex="0"
   >
     <td
       class="circuit-2"

--- a/packages/circuit-ui/components/Table/components/TableHead/__snapshots__/TableHead.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableHead/__snapshots__/TableHead.spec.tsx.snap
@@ -10,6 +10,10 @@ tbody .circuit-1:last-child td {
   border-bottom: none;
 }
 
+.circuit-1.isChild th {
+  padding-left: 48px;
+}
+
 .circuit-3 {
   background-color: var(--cui-bg-normal);
   border-bottom: 1px solid var(--cui-border-divider);
@@ -144,7 +148,7 @@ tbody .circuit-1:last-child td {
   class="circuit-0"
 >
   <tr
-    class="circuit-1 circuit-2"
+    class=" circuit-1 circuit-2"
   >
     <th
       aria-label="Sort in ascending order"
@@ -215,6 +219,10 @@ exports[`TableHead Style tests should render with rowHeader styles 1`] = `
 tbody .circuit-1:last-child th,
 tbody .circuit-1:last-child td {
   border-bottom: none;
+}
+
+.circuit-1.isChild th {
+  padding-left: 48px;
 }
 
 .circuit-3 {
@@ -376,7 +384,7 @@ tbody .circuit-1:last-child td {
   class="circuit-0"
 >
   <tr
-    class="circuit-1 circuit-2"
+    class=" circuit-1 circuit-2"
   >
     <th
       aria-label="Sort in ascending order"

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.spec.tsx
@@ -56,6 +56,24 @@ describe('TableHeader', () => {
       expect(actual).toMatchSnapshot();
     });
 
+    it('should render with chevron right when row closed', () => {
+      const actual = create(
+        <TableHeader isExpandable condensed>
+          {children}
+        </TableHeader>,
+      );
+      expect(actual).toMatchSnapshot();
+    });
+
+    it('should render with chevron down when row clicked', () => {
+      const actual = create(
+        <TableHeader isExpandable isOpen condensed>
+          {children}
+        </TableHeader>,
+      );
+      expect(actual).toMatchSnapshot();
+    });
+
     describe('sortable + sorted', () => {
       it('should render with sortable + sorted ascending styles', () => {
         const actual = create(

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.spec.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { screen, fireEvent } from '@testing-library/react';
+
 import { create, renderToHtml, axe } from '../../../../util/test-utils';
 
 import TableHeader from '.';
@@ -72,6 +74,19 @@ describe('TableHeader', () => {
         </TableHeader>,
       );
       expect(actual).toMatchSnapshot();
+    });
+
+    it('should fire onToggle on Enter keydown', () => {
+      const toggleSpy = jest.fn();
+      create(
+        <TableHeader isExpandable isOpen condensed onChevronToggle={toggleSpy}>
+          {children}
+        </TableHeader>,
+      );
+
+      const cheveron = screen.getByTestId('toggle-cheveron');
+      fireEvent.keyDown(cheveron, { key: 'Enter' });
+      expect(toggleSpy).toHaveBeenCalled();
     });
 
     describe('sortable + sorted', () => {

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -74,6 +74,10 @@ export interface TableHeaderProps
    */
   isOpen?: boolean;
   /**
+   * A string of space-separated ids of the children the row can expand.
+   */
+  childIds?: string;
+  /**
    * Props related to table sorting. Defaults to not sortable.
    */
   onChevronToggle?: () => void;
@@ -237,6 +241,7 @@ const TableHeader: FC<PropsWithChildren<TableHeaderProps>> = ({
   onClick,
   isExpandable,
   isOpen,
+  childIds,
   onChevronToggle,
   ...props
 }) => {
@@ -287,10 +292,12 @@ const TableHeader: FC<PropsWithChildren<TableHeaderProps>> = ({
         <IconButton
           style={{ padding: 0 }}
           label="expand"
-          aria-label="toggle-row"
+          aria-label={`expand ${childIds?.split(' ').length ?? 0} items`}
           variant="tertiary"
         >
           <CheveronToShow
+            aria-expanded={isOpen}
+            aria-controls={childIds}
             data-testid="toggle-cheveron"
             ref={cheveronReference}
             onKeyDown={onChevronKeydown}

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -13,7 +13,14 @@
  * limitations under the License.
  */
 
-import { ThHTMLAttributes, FC, PropsWithChildren } from 'react';
+import {
+  ThHTMLAttributes,
+  FC,
+  PropsWithChildren,
+  EventHandler,
+  KeyboardEvent,
+  useRef,
+} from 'react';
 import { css } from '@emotion/react';
 import isPropValid from '@emotion/is-prop-valid';
 import { ChevronRight, ChevronDown } from '@sumup/icons';
@@ -24,6 +31,7 @@ import styled, { StyleProps } from '../../../../styles/styled';
 import { CellAlignment, SortParams } from '../../types';
 import { ClickEvent } from '../../../../types/events';
 import { AccessibilityError } from '../../../../util/errors';
+import IconButton from '../../../IconButton';
 
 export interface TableHeaderProps
   extends ThHTMLAttributes<HTMLTableCellElement> {
@@ -65,6 +73,10 @@ export interface TableHeaderProps
    * Props related to table sorting. Defaults to not sortable.
    */
   isOpen?: boolean;
+  /**
+   * Props related to table sorting. Defaults to not sortable.
+   */
+  onChevronToggle?: () => void;
 }
 
 /**
@@ -225,6 +237,7 @@ const TableHeader: FC<PropsWithChildren<TableHeaderProps>> = ({
   onClick,
   isExpandable,
   isOpen,
+  onChevronToggle,
   ...props
 }) => {
   if (
@@ -239,6 +252,14 @@ const TableHeader: FC<PropsWithChildren<TableHeaderProps>> = ({
     );
   }
   const CheveronToShow = isOpen ? ChevronDown : ChevronRight;
+  const cheveronReference = useRef<SVGSVGElement>(null);
+
+  const onChevronKeydown: EventHandler<KeyboardEvent<SVGSVGElement>> = (e) => {
+    if (e.key === 'Enter' && onChevronToggle) {
+      onChevronToggle();
+    }
+  };
+
   return (
     <StyledHeader
       condensed={condensed}
@@ -262,7 +283,21 @@ const TableHeader: FC<PropsWithChildren<TableHeaderProps>> = ({
           onClick={onClick}
         />
       )}
-      {isExpandable && <CheveronToShow css={chevronStyles} />}
+      {isExpandable && (
+        <IconButton
+          style={{ padding: 0 }}
+          label="expand"
+          aria-label="toggle-row"
+          variant="tertiary"
+        >
+          <CheveronToShow
+            data-testid="toggle-cheveron"
+            ref={cheveronReference}
+            onKeyDown={onChevronKeydown}
+            css={chevronStyles}
+          />
+        </IconButton>
+      )}
       {children}
     </StyledHeader>
   );

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -16,6 +16,7 @@
 import { ThHTMLAttributes, FC, PropsWithChildren } from 'react';
 import { css } from '@emotion/react';
 import isPropValid from '@emotion/is-prop-valid';
+import { ChevronRight, ChevronDown } from '@sumup/icons';
 
 import { focusOutline, typography } from '../../../../styles/style-mixins';
 import SortArrow from '../SortArrow';
@@ -56,6 +57,14 @@ export interface TableHeaderProps
    * Props related to table sorting. Defaults to not sortable.
    */
   sortParams?: SortParams;
+  /**
+   * Props related to table sorting. Defaults to not sortable.
+   */
+  isExpandable?: boolean;
+  /**
+   * Props related to table sorting. Defaults to not sortable.
+   */
+  isOpen?: boolean;
 }
 
 /**
@@ -185,6 +194,10 @@ const condensedColStyles = ({
       ${theme.spacings.byte} ${theme.spacings.giga};
   `;
 
+const chevronStyles = css`
+  margin: -6px 0 -6px -6px;
+`;
+
 const StyledHeader = styled('th', {
   shouldForwardProp: (prop) => isPropValid(prop),
 })<ThElProps>(
@@ -210,6 +223,8 @@ const TableHeader: FC<PropsWithChildren<TableHeaderProps>> = ({
   isHovered = false,
   sortParams = { sortable: false },
   onClick,
+  isExpandable,
+  isOpen,
   ...props
 }) => {
   if (
@@ -223,6 +238,7 @@ const TableHeader: FC<PropsWithChildren<TableHeaderProps>> = ({
       'The `sortLabel` prop is missing. Omit the `sortable` prop if you intend to disable the row sorting functionality.',
     );
   }
+  const CheveronToShow = isOpen ? ChevronDown : ChevronRight;
   return (
     <StyledHeader
       condensed={condensed}
@@ -246,6 +262,7 @@ const TableHeader: FC<PropsWithChildren<TableHeaderProps>> = ({
           onClick={onClick}
         />
       )}
+      {isExpandable && <CheveronToShow css={chevronStyles} />}
       {children}
     </StyledHeader>
   );

--- a/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
@@ -1,5 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TableHeader Style tests should render with chevron down when row clicked 1`] = `
+.circuit-0 {
+  background-color: #FFF;
+  border-bottom: 1px solid #CCC;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
+  transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: #666;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  vertical-align: middle;
+  padding: 12px 16px 12px 24px;
+  padding: 8px 16px 8px 24px;
+}
+
+.circuit-1 {
+  margin: -6px 0 -6px -6px;
+}
+
+<th
+  class="circuit-0"
+  scope="col"
+>
+  <svg
+    class="circuit-1"
+    fill="none"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12 15c-.265 0-.52-.104-.71-.29l-4-4A1.013 1.013 0 0 1 7 10a1 1 0 0 1 1-1c.266 0 .52.104.71.29L12 12.58l3.29-3.29c.19-.186.445-.29.71-.29a1 1 0 0 1 1 1c0 .265-.104.52-.29.71l-4 4c-.19.186-.445.29-.71.29z"
+      fill="currentColor"
+    />
+  </svg>
+  Foo
+</th>
+`;
+
+exports[`TableHeader Style tests should render with chevron right when row closed 1`] = `
+.circuit-0 {
+  background-color: #FFF;
+  border-bottom: 1px solid #CCC;
+  padding: 24px;
+  text-align: left;
+  -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
+  transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: #666;
+  font-weight: 700;
+  padding: 8px 24px;
+  vertical-align: middle;
+  white-space: nowrap;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  vertical-align: middle;
+  padding: 12px 16px 12px 24px;
+  padding: 8px 16px 8px 24px;
+}
+
+.circuit-1 {
+  margin: -6px 0 -6px -6px;
+}
+
+<th
+  class="circuit-0"
+  scope="col"
+>
+  <svg
+    class="circuit-1"
+    fill="none"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M15 12c0 .265-.104.52-.29.71l-4 4c-.19.186-.445.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71L12.58 12 9.29 8.71A1.013 1.013 0 0 1 9 8a1 1 0 0 1 1-1c.265 0 .52.104.71.29l4 4c.186.19.29.445.29.71z"
+      fill="currentColor"
+    />
+  </svg>
+  Foo
+</th>
+`;
+
 exports[`TableHeader Style tests should render with condensed styles 1`] = `
 .circuit-0 {
   background-color: var(--cui-bg-normal);

--- a/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
@@ -18,15 +18,15 @@ exports[`TableHeader Style tests should render with chevron down when row clicke
 }
 
 .circuit-0 {
-  background-color: #FFF;
-  border-bottom: 1px solid #CCC;
+  background-color: var(--cui-bg-normal);
+  border-bottom: 1px solid var(--cui-border-divider);
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #666;
+  color: var(--cui-fg-subtle);
   font-weight: 700;
   padding: 8px 24px;
   vertical-align: middle;
@@ -65,7 +65,7 @@ exports[`TableHeader Style tests should render with chevron down when row clicke
   padding: calc(12px - 1px) calc(24px - 1px);
   background-color: transparent;
   border-color: transparent;
-  color: #3063E9;
+  color: var(--cui-fg-accent);
   padding-left: 0;
   padding-right: 0;
   position: relative;
@@ -75,7 +75,7 @@ exports[`TableHeader Style tests should render with chevron down when row clicke
 
 .circuit-1:focus {
   outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
 }
 
 .circuit-1:focus::-moz-focus-inner {
@@ -88,13 +88,11 @@ exports[`TableHeader Style tests should render with chevron down when row clicke
 
 .circuit-1:disabled,
 .circuit-1[disabled] {
-  opacity: 0.5;
   pointer-events: none;
-  box-shadow: none;
 }
 
 .circuit-1:hover {
-  color: #234BC3;
+  color: var(--cui-fg-accent-hovered);
   background-color: transparent;
   border-color: transparent;
 }
@@ -102,7 +100,14 @@ exports[`TableHeader Style tests should render with chevron down when row clicke
 .circuit-1:active,
 .circuit-1[aria-expanded='true'],
 .circuit-1[aria-pressed='true'] {
-  color: #1A368E;
+  color: var(--cui-fg-accent-pressed);
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.circuit-1:disabled,
+.circuit-1[disabled] {
+  color: var(--cui-fg-accent-disabled);
   background-color: transparent;
   border-color: transparent;
 }
@@ -164,7 +169,7 @@ exports[`TableHeader Style tests should render with chevron down when row clicke
   scope="col"
 >
   <button
-    aria-label="toggle-row"
+    aria-label="expand 0 items"
     class="circuit-1"
     style="padding: 0px;"
     title="expand"
@@ -180,6 +185,7 @@ exports[`TableHeader Style tests should render with chevron down when row clicke
       class="circuit-4"
     >
       <svg
+        aria-expanded="true"
         class="circuit-5"
         data-testid="toggle-cheveron"
         fill="none"
@@ -223,15 +229,15 @@ exports[`TableHeader Style tests should render with chevron right when row close
 }
 
 .circuit-0 {
-  background-color: #FFF;
-  border-bottom: 1px solid #CCC;
+  background-color: var(--cui-bg-normal);
+  border-bottom: 1px solid var(--cui-border-divider);
   padding: 24px;
   text-align: left;
   -webkit-transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   transition: background-color 120ms ease-in-out,color 120ms ease-in-out;
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #666;
+  color: var(--cui-fg-subtle);
   font-weight: 700;
   padding: 8px 24px;
   vertical-align: middle;
@@ -270,7 +276,7 @@ exports[`TableHeader Style tests should render with chevron right when row close
   padding: calc(12px - 1px) calc(24px - 1px);
   background-color: transparent;
   border-color: transparent;
-  color: #3063E9;
+  color: var(--cui-fg-accent);
   padding-left: 0;
   padding-right: 0;
   position: relative;
@@ -280,7 +286,7 @@ exports[`TableHeader Style tests should render with chevron right when row close
 
 .circuit-1:focus {
   outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
 }
 
 .circuit-1:focus::-moz-focus-inner {
@@ -293,13 +299,11 @@ exports[`TableHeader Style tests should render with chevron right when row close
 
 .circuit-1:disabled,
 .circuit-1[disabled] {
-  opacity: 0.5;
   pointer-events: none;
-  box-shadow: none;
 }
 
 .circuit-1:hover {
-  color: #234BC3;
+  color: var(--cui-fg-accent-hovered);
   background-color: transparent;
   border-color: transparent;
 }
@@ -307,7 +311,14 @@ exports[`TableHeader Style tests should render with chevron right when row close
 .circuit-1:active,
 .circuit-1[aria-expanded='true'],
 .circuit-1[aria-pressed='true'] {
-  color: #1A368E;
+  color: var(--cui-fg-accent-pressed);
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.circuit-1:disabled,
+.circuit-1[disabled] {
+  color: var(--cui-fg-accent-disabled);
   background-color: transparent;
   border-color: transparent;
 }
@@ -369,7 +380,7 @@ exports[`TableHeader Style tests should render with chevron right when row close
   scope="col"
 >
   <button
-    aria-label="toggle-row"
+    aria-label="expand 0 items"
     class="circuit-1"
     style="padding: 0px;"
     title="expand"

--- a/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableHeader/__snapshots__/TableHeader.spec.tsx.snap
@@ -1,6 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TableHeader Style tests should render with chevron down when row clicked 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
 .circuit-0 {
   background-color: #FFF;
   border-bottom: 1px solid #CCC;
@@ -23,6 +39,123 @@ exports[`TableHeader Style tests should render with chevron down when row clicke
 }
 
 .circuit-1 {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  background-color: transparent;
+  border-color: transparent;
+  color: #3063E9;
+  padding-left: 0;
+  padding-right: 0;
+  position: relative;
+  overflow: hidden;
+  padding: calc(12px - 1px);
+}
+
+.circuit-1:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-1:disabled,
+.circuit-1[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-1:hover {
+  color: #234BC3;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.circuit-1:active,
+.circuit-1[aria-expanded='true'],
+.circuit-1[aria-pressed='true'] {
+  color: #1A368E;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.circuit-2 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-5 {
   margin: -6px 0 -6px -6px;
 }
 
@@ -30,24 +163,65 @@ exports[`TableHeader Style tests should render with chevron down when row clicke
   class="circuit-0"
   scope="col"
 >
-  <svg
+  <button
+    aria-label="toggle-row"
     class="circuit-1"
-    fill="none"
-    height="24"
-    viewBox="0 0 24 24"
-    width="24"
-    xmlns="http://www.w3.org/2000/svg"
+    style="padding: 0px;"
+    title="expand"
   >
-    <path
-      d="M12 15c-.265 0-.52-.104-.71-.29l-4-4A1.013 1.013 0 0 1 7 10a1 1 0 0 1 1-1c.266 0 .52.104.71.29L12 12.58l3.29-3.29c.19-.186.445-.29.71-.29a1 1 0 0 1 1 1c0 .265-.104.52-.29.71l-4 4c-.19.186-.445.29-.71.29z"
-      fill="currentColor"
-    />
-  </svg>
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      <svg
+        class="circuit-5"
+        data-testid="toggle-cheveron"
+        fill="none"
+        height="24"
+        role="presentation"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 15c-.265 0-.52-.104-.71-.29l-4-4A1.013 1.013 0 0 1 7 10a1 1 0 0 1 1-1c.266 0 .52.104.71.29L12 12.58l3.29-3.29c.19-.186.445-.29.71-.29a1 1 0 0 1 1 1c0 .265-.104.52-.29.71l-4 4c-.19.186-.445.29-.71.29z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="circuit-3"
+      >
+        expand
+      </span>
+    </span>
+  </button>
   Foo
 </th>
 `;
 
 exports[`TableHeader Style tests should render with chevron right when row closed 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
 .circuit-0 {
   background-color: #FFF;
   border-bottom: 1px solid #CCC;
@@ -70,6 +244,123 @@ exports[`TableHeader Style tests should render with chevron right when row close
 }
 
 .circuit-1 {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  padding: calc(12px - 1px) calc(24px - 1px);
+  background-color: transparent;
+  border-color: transparent;
+  color: #3063E9;
+  padding-left: 0;
+  padding-right: 0;
+  position: relative;
+  overflow: hidden;
+  padding: calc(12px - 1px);
+}
+
+.circuit-1:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-1:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-1:disabled,
+.circuit-1[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
+  box-shadow: none;
+}
+
+.circuit-1:hover {
+  color: #234BC3;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.circuit-1:active,
+.circuit-1[aria-expanded='true'],
+.circuit-1[aria-pressed='true'] {
+  color: #1A368E;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.circuit-2 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-5 {
   margin: -6px 0 -6px -6px;
 }
 
@@ -77,19 +368,44 @@ exports[`TableHeader Style tests should render with chevron right when row close
   class="circuit-0"
   scope="col"
 >
-  <svg
+  <button
+    aria-label="toggle-row"
     class="circuit-1"
-    fill="none"
-    height="24"
-    viewBox="0 0 24 24"
-    width="24"
-    xmlns="http://www.w3.org/2000/svg"
+    style="padding: 0px;"
+    title="expand"
   >
-    <path
-      d="M15 12c0 .265-.104.52-.29.71l-4 4c-.19.186-.445.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71L12.58 12 9.29 8.71A1.013 1.013 0 0 1 9 8a1 1 0 0 1 1-1c.265 0 .52.104.71.29l4 4c.186.19.29.445.29.71z"
-      fill="currentColor"
-    />
-  </svg>
+    <span
+      class="circuit-2"
+    >
+      <span
+        class="circuit-3"
+      />
+    </span>
+    <span
+      class="circuit-4"
+    >
+      <svg
+        class="circuit-5"
+        data-testid="toggle-cheveron"
+        fill="none"
+        height="24"
+        role="presentation"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M15 12c0 .265-.104.52-.29.71l-4 4c-.19.186-.445.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71L12.58 12 9.29 8.71A1.013 1.013 0 0 1 9 8a1 1 0 0 1 1-1c.265 0 .52.104.71.29l4 4c.186.19.29.445.29.71z"
+          fill="currentColor"
+        />
+      </svg>
+      <span
+        class="circuit-3"
+      >
+        expand
+      </span>
+    </span>
+  </button>
   Foo
 </th>
 `;

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.spec.tsx
@@ -38,6 +38,15 @@ describe('TableRow', () => {
       );
       expect(actual).toMatchSnapshot();
     });
+
+    it('should render with child styles', () => {
+      const actual = create(
+        <TableRow onClick={jest.fn()} isChild>
+          {children}
+        </TableRow>,
+      );
+      expect(actual).toMatchSnapshot();
+    });
   });
 
   describe('Logic tests', () => {

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
@@ -22,6 +22,7 @@ import { ClickEvent } from '../../../../types/events';
 
 type TableRowProps = {
   isChild?: boolean;
+  id?: string;
   onClick?: (event: ClickEvent<HTMLTableRowElement>) => void;
 };
 
@@ -91,10 +92,12 @@ const Tr = styled.tr(baseStyles, clickableStyles, childStyles);
  */
 const TableRow: FC<PropsWithChildren<TableRowProps>> = ({
   isChild = false,
+  id,
   onClick,
   ...props
 }) => (
   <Tr
+    id={id}
     onClick={onClick}
     className={`${isChild ? 'isChild' : ''}`}
     tabIndex={onClick ? 0 : undefined}

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
@@ -21,8 +21,18 @@ import { focusOutline } from '../../../../styles/style-mixins';
 import { ClickEvent } from '../../../../types/events';
 
 type TableRowProps = {
+  isChild?: boolean;
   onClick?: (event: ClickEvent<HTMLTableRowElement>) => void;
 };
+
+const childStyles = () =>
+  css`
+    &.isChild {
+      th {
+        padding-left: 48px;
+      }
+    }
+  `;
 
 const baseStyles = () => css`
   vertical-align: middle;
@@ -74,13 +84,21 @@ const clickableStyles = ({ onClick }: TableRowProps) =>
     }
   `;
 
-const Tr = styled.tr(baseStyles, clickableStyles);
+const Tr = styled.tr(baseStyles, clickableStyles, childStyles);
 
 /**
  * TableRow for the Table component. The Table handles rendering it.
  */
 const TableRow: FC<PropsWithChildren<TableRowProps>> = ({
+  isChild = false,
   onClick,
   ...props
-}) => <Tr onClick={onClick} tabIndex={onClick ? 0 : undefined} {...props} />;
+}) => (
+  <Tr
+    onClick={onClick}
+    className={`${isChild ? 'isChild' : ''}`}
+    tabIndex={onClick ? 0 : undefined}
+    {...props}
+  />
+);
 export default TableRow;

--- a/packages/circuit-ui/components/Table/components/TableRow/__snapshots__/TableRow.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableRow/__snapshots__/TableRow.spec.tsx.snap
@@ -19,7 +19,7 @@ tbody .circuit-0:last-child td {
   -ms-transform: translate(0, 0);
   transform: translate(0, 0);
   outline: 0;
-  box-shadow: 0 0 0 4px #AFD0FE;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
 }
 
 .circuit-0:focus::-moz-focus-inner {
@@ -34,8 +34,14 @@ tbody .circuit-0:focus td,
 tbody .circuit-0:hover td,
 tbody .circuit-0:focus th,
 tbody .circuit-0:hover th {
-  color: #3063E9;
-  background-color: #F5F5F5;
+  color: var(--cui-fg-accent-hovered);
+  background-color: var(--cui-bg-normal-hovered);
+}
+
+tbody .circuit-0:active td,
+tbody .circuit-0:active th {
+  color: var(--cui-fg-accent-pressed);
+  background-color: var(--cui-bg-normal-pressed);
 }
 
 .circuit-0.isChild th {

--- a/packages/circuit-ui/components/Table/components/TableRow/__snapshots__/TableRow.spec.tsx.snap
+++ b/packages/circuit-ui/components/Table/components/TableRow/__snapshots__/TableRow.spec.tsx.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TableRow Style tests should render with child styles 1`] = `
+.circuit-0 {
+  vertical-align: middle;
+  cursor: pointer;
+  position: relative;
+}
+
+tbody .circuit-0:last-child th,
+tbody .circuit-0:last-child td {
+  border-bottom: none;
+}
+
+.circuit-0:focus {
+  z-index: 1;
+  -webkit-transform: translate(0, 0);
+  -moz-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  transform: translate(0, 0);
+  outline: 0;
+  box-shadow: 0 0 0 4px #AFD0FE;
+}
+
+.circuit-0:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+tbody .circuit-0:focus td,
+tbody .circuit-0:hover td,
+tbody .circuit-0:focus th,
+tbody .circuit-0:hover th {
+  color: #3063E9;
+  background-color: #F5F5F5;
+}
+
+.circuit-0.isChild th {
+  padding-left: 48px;
+}
+
+<tr
+  class="isChild circuit-0 circuit-1"
+  tabindex="0"
+>
+  Foo
+</tr>
+`;
+
 exports[`TableRow Style tests should render with clickable styles 1`] = `
 .circuit-0 {
   vertical-align: middle;
@@ -44,8 +94,12 @@ tbody .circuit-0:active th {
   background-color: var(--cui-bg-normal-pressed);
 }
 
+.circuit-0.isChild th {
+  padding-left: 48px;
+}
+
 <tr
-  class="circuit-0 circuit-1"
+  class=" circuit-0 circuit-1"
   tabindex="0"
 >
   Foo
@@ -62,8 +116,12 @@ tbody .circuit-0:last-child td {
   border-bottom: none;
 }
 
+.circuit-0.isChild th {
+  padding-left: 48px;
+}
+
 <tr
-  class="circuit-0 circuit-1"
+  class=" circuit-0 circuit-1"
 >
   Foo
 </tr>

--- a/packages/circuit-ui/components/Table/types.ts
+++ b/packages/circuit-ui/components/Table/types.ts
@@ -61,7 +61,7 @@ export type HeaderCell = Cell | HeaderCellObject;
 
 export type RowCell = Cell | RowCellObject;
 
-export type Row = RowCell[] | { cells: RowCell[] };
+export type Row = RowCell[] | { cells: RowCell[]; children?: Row[] };
 
 export type SortParams =
   | {

--- a/packages/circuit-ui/components/Table/types.ts
+++ b/packages/circuit-ui/components/Table/types.ts
@@ -88,3 +88,18 @@ export type SortParams =
       sortDirection?: never;
       isSorted?: never;
     };
+
+export type OnSortBy = (
+  index: number,
+  currentRows: Row[],
+  nextDirection?: Direction,
+) => Row[];
+
+export type RowWithInfo = {
+  cells: RowCell[];
+  children?: Row[];
+  isChild: boolean;
+  key: string;
+};
+
+export type StateInfo = { [key: string]: boolean };

--- a/packages/circuit-ui/components/Table/utils.spec.ts
+++ b/packages/circuit-ui/components/Table/utils.spec.ts
@@ -19,6 +19,7 @@ import {
   applyExpandAfterSort,
   computeInitialsExpandableState,
   computeInitialsToggleState,
+  generateRowIds,
 } from './utils';
 
 describe('Table utils', () => {
@@ -37,9 +38,9 @@ describe('Table utils', () => {
         const expected = {
           cells: props,
           isChild: true,
-          key: 'table-row-child-0',
+          key: 'table-row-0-child-0',
         };
-        const actual = utils.mapRowProps(props, [props], true);
+        const actual = utils.mapRowProps(props, [props], true, 0);
 
         expect(actual).toEqual(expected);
       });
@@ -54,9 +55,13 @@ describe('Table utils', () => {
     });
 
     it('should forward the props object - child', () => {
-      const props = { cells: ['Foo'], isChild: true, key: 'table-row-child-0' };
+      const props = {
+        cells: ['Foo'],
+        isChild: true,
+        key: 'table-row-0-child-0',
+      };
       const expected = props;
-      const actual = utils.mapRowProps(props, [props], true);
+      const actual = utils.mapRowProps(props, [props], true, 0);
 
       expect(actual).toEqual(expected);
     });
@@ -361,9 +366,9 @@ describe('Table utils', () => {
         ],
       ];
       const expected = {
-        'table-row-0': true,
-        'table-row-1': false,
-        'table-row-2': false,
+        'table-row-0': 3,
+        'table-row-1': 0,
+        'table-row-2': 0,
       };
       // when
       const result = computeInitialsExpandableState(rows);
@@ -444,17 +449,17 @@ describe('Table utils', () => {
             },
           ],
           isChild: true,
-          key: 'table-row-child-0',
+          key: 'table-row-0-child-0',
         },
         {
           cells: ['Banana', { children: '12/01/2017', sortByValue: 0 }],
           isChild: true,
-          key: 'table-row-child-1',
+          key: 'table-row-0-child-1',
         },
         {
           cells: ['Orange', { children: '12/01/2017', sortByValue: 0 }],
           isChild: true,
-          key: 'table-row-child-2',
+          key: 'table-row-0-child-2',
         },
         {
           cells: [
@@ -486,6 +491,19 @@ describe('Table utils', () => {
       // then
       expect(result.length).toEqual(6);
       expect(result).toEqual(expected);
+    });
+  });
+
+  describe('generateRowIds', () => {
+    test('should return concatenated ids if correct params supplied', () => {
+      const result = generateRowIds(0, 3);
+      expect(result).toEqual(
+        'table-row-0-child-0 table-row-0-child-1 table-row-0-child-2',
+      );
+    });
+    test('should return empty string if count 0', () => {
+      const result = generateRowIds(0, 0);
+      expect(result).toEqual('');
     });
   });
 });

--- a/packages/circuit-ui/components/Table/utils.spec.ts
+++ b/packages/circuit-ui/components/Table/utils.spec.ts
@@ -21,7 +21,7 @@ describe('Table utils', () => {
     describe('isArray', () => {
       it('should map the array to cells key', () => {
         const props = ['Foo'];
-        const expected = { cells: props };
+        const expected = { cells: props, isChild: false };
         const actual = utils.mapRowProps(props);
 
         expect(actual).toEqual(expected);
@@ -29,9 +29,29 @@ describe('Table utils', () => {
     });
 
     it('should forward the props object', () => {
-      const props = { cells: ['Foo'] };
+      const props = { cells: ['Foo'], isChild: false };
       const expected = props;
       const actual = utils.mapRowProps(props);
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('mapChildRowProps()', () => {
+    describe('isArray', () => {
+      it('should map the array to cells key', () => {
+        const props = ['Foo'];
+        const expected = { cells: props, isChild: true };
+        const actual = utils.mapChildRowProps(props);
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    it('should forward the props object', () => {
+      const props = { cells: ['Foo'], isChild: true };
+      const expected = props;
+      const actual = utils.mapChildRowProps(props);
 
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
Addresses issue https://github.com/sumup-oss/circuit-ui/issues/1898

## Purpose

Add the expandable row behaviour to the table component

<img width="484" alt="Screenshot 2023-01-04 at 16 51 39" src="https://user-images.githubusercontent.com/112706079/210599563-73d66f71-903f-4a66-8404-9a80839dd2d0.png">


## Approach and changes

- allow the `Row` type to accept optional children of type `Row`:  `{ cells: RowCell[]; children?: Row[] }`
- create a hook `useExpandableTableOptions` that computes a new table data when a row with children is clicked, to either show or hide the children.
- `TableHeader` with optional new prop `isExpandable` will show a chevron, who's position will depend on the `isOpen` prop.


## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
