### PR TITLE
Fix height of the DateInput component

### DIFF
--- a/.changeset/stale-lemons-join.md
+++ b/.changeset/stale-lemons-join.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the height of the `DateInput` component.

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -14,9 +14,9 @@
  */
 
 import { forwardRef, useState, useEffect } from 'react';
+import { css } from '@emotion/react';
 import { PatternFormat } from 'react-number-format';
 
-import styled from '../../styles/styled';
 import { Input, InputProps } from '../Input/Input';
 
 export interface DateInputProps
@@ -34,7 +34,7 @@ export interface DateInputProps
   defaultValue?: string | number;
 }
 
-const BaseInput = styled(Input)`
+const dateInputStyles = css`
   height: 48px;
   min-width: 8ch;
 `;
@@ -81,9 +81,10 @@ export const DateInput = forwardRef(
     }
 
     return (
-      <BaseInput
+      <Input
         {...props}
         ref={ref}
+        inputStyles={dateInputStyles}
         type="date"
         pattern="\d{4}-\d{2}-\d{2}"
         placeholder={placeholder}


### PR DESCRIPTION
## Purpose

In #1664, we changed how custom styles are applied to the `input` element inside the `Input` component: use the `inputStyles` prop instead of the `css` prop. This introduced a bug in the `DateInput` component, which wraps the `Input` component in `styled`. The custom styles were passed to the `label` element instead of the `input` component, thus forcing a wrong height for the component.

## Approach and changes

- Apply the custom styles using the `inputStyles` prop instead (this matches the approach taken in the `TextArea` component)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
