### PR TITLE
[CLOSED] Body component- extend with size three

### DIFF
--- a/docs/features/theme.stories.mdx
+++ b/docs/features/theme.stories.mdx
@@ -392,6 +392,7 @@ Avoid using `theme.typography` directly in your styles, rather use the specializ
 <Preview>
   <Type size="one" component={Body} name="body" />
   <Type size="two" component={Body} name="body" />
+  <Type size="three" component={Body} name="body" />
 </Preview>
 
 ## Font stack

--- a/packages/circuit-ui/components/Body/Body.docs.mdx
+++ b/packages/circuit-ui/components/Body/Body.docs.mdx
@@ -15,7 +15,7 @@ The Body component is used to present content to our users.
 
 ### Sizes
 
-The Body component comes in two sizes. Use the default `one` size in most cases. Consider using the [BodyLarge component](Typography/BodyLarge) for large typography in specific cases.
+The Body component comes in three sizes. Use the default `one` size in most cases. Consider using the [BodyLarge component](Typography/BodyLarge) for large typography in specific cases.
 
 <Story id="typography-body--sizes" />
 

--- a/packages/circuit-ui/components/Body/Body.spec.tsx
+++ b/packages/circuit-ui/components/Body/Body.spec.tsx
@@ -26,7 +26,7 @@ describe('Body', () => {
     expect(actual).toMatchSnapshot();
   });
 
-  const sizes: BodyProps['size'][] = ['one', 'two'];
+  const sizes: BodyProps['size'][] = ['one', 'two', 'three'];
   it.each(sizes)('should render with size "%s"', (size) => {
     const actual = create(<Body size={size}>{size} Body</Body>);
     expect(actual).toMatchSnapshot();

--- a/packages/circuit-ui/components/Body/Body.stories.tsx
+++ b/packages/circuit-ui/components/Body/Body.stories.tsx
@@ -34,7 +34,7 @@ export default {
 
 export const Base = (args: BodyProps) => <Body {...args}>{content}</Body>;
 
-const sizes = ['one', 'two'] as const;
+const sizes = ['one', 'two', 'three'] as const;
 
 export const Sizes = (args: BodyProps) =>
   sizes.map((s) => (

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -20,7 +20,7 @@ import isPropValid from '@emotion/is-prop-valid';
 import styled, { StyleProps } from '../../styles/styled';
 import { AsPropType, EmotionAsPropType } from '../../types/prop-types';
 
-type Size = 'one' | 'two';
+type Size = 'one' | 'two' | 'three';
 type Variant = 'highlight' | 'quote' | 'confirm' | 'alert' | 'subtle';
 
 export interface BodyProps extends HTMLAttributes<HTMLParagraphElement> {

--- a/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
+++ b/packages/circuit-ui/components/Body/__snapshots__/Body.spec.tsx.snap
@@ -111,6 +111,21 @@ exports[`Body should render with size "one" 1`] = `
 </p>
 `;
 
+exports[`Body should render with size "three" 1`] = `
+.circuit-0 {
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+<p
+  class="circuit-0"
+>
+  three
+   Body
+</p>
+`;
+
 exports[`Body should render with size "two" 1`] = `
 .circuit-0 {
   font-weight: 400;

--- a/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
@@ -183,6 +183,10 @@ exports[`Themes light should match the snapshot 1`] = `
         "fontSize": "1rem",
         "lineHeight": "1.5rem",
       },
+      "three": {
+        "fontSize": "0.75rem",
+        "lineHeight": "1rem",
+      },
       "two": {
         "fontSize": "0.875rem",
         "lineHeight": "1.25rem",

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -110,6 +110,10 @@ export const typography = {
       fontSize: '0.875rem',
       lineHeight: '1.25rem',
     },
+    three: {
+      fontSize: '0.75rem',
+      lineHeight: '1rem',
+    },
   },
   bodyLarge: {
     fontSize: '1.25rem',

--- a/packages/design-tokens/types/index.ts
+++ b/packages/design-tokens/types/index.ts
@@ -214,6 +214,7 @@ export interface Theme {
     body: {
       one: Typography;
       two: Typography;
+      three: Typography;
     };
     bodyLarge: Typography;
   };


### PR DESCRIPTION
Ticket [SA-67934](https://sumupteam.atlassian.net/browse/SA-67934)
## Purpose

`three` = `12px fontSize` & `16px lineHeight`

This PR introduces the new `three` size to the Body component. In the newest feature which is in progress by OS Engage team, we want to use `12px` font size text elements. 

During the discussion with design team, we found two solutions:
1. Introducing new `Caption` component
2. Extending existing `Body` component with size `three`

Since we would like to have such size as soon as possible we would like to choose second solution for now. We are open to implement the first option in the future.

**Update**
New component will be implemented in Dashboard shared components instead of extending `Body` component 

## Approach and changes

1. Update `Body` component with size `three`
2. Update docs & tests
3. Update `Theme` docs

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
