### PR TITLE
Revert ImageInput breaking change

### DIFF
--- a/.changeset/odd-wolves-deny.md
+++ b/.changeset/odd-wolves-deny.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Reverted a breaking change in the ImageInput component API.

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -43,11 +43,10 @@ export interface ImageInputProps
    */
   label: string;
   /**
-   * The visual component to render as an image input.
-   * It should accept an `src` prop to render the image, and `aria-hidden` to
-   * hide it from assistive technology.
+   * The visual component to render as an image input. It should accept an src
+   * prop to render the image.
    */
-  component: (props: { 'src'?: string; 'aria-hidden': 'true' }) => JSX.Element;
+  component: (props: { src?: string; alt: string }) => JSX.Element;
   /**
    * A callback function to call when the user has selected an image.
    */
@@ -458,7 +457,7 @@ export const ImageInput = ({
           onDrop={handleDrop}
         >
           <span css={hideVisually()}>{label}</span>
-          <Component src={src || previewImage} aria-hidden="true" />
+          <Component src={src || previewImage} alt="" />
         </Label>
         {src ? (
           <ActionButton

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -1151,7 +1151,6 @@ exports[`ImageInput Styles should render with an existing image 1`] = `
         </span>
         <img
           alt=""
-          aria-hidden="true"
           class="circuit-5"
           src="/images/illustration-coffee.jpg"
         />


### PR DESCRIPTION
## Purpose

We introduced a breaking change in v6.3.0, by changing the `ImageInput` component's surface API.

## Approach and changes

Reverts the change. We'll look into it for v7 (this is a change that we're getting audited at the moment anyways).

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* ~Unit and integration tests~ (stories look good now, we should be fine)
* ~Meets minimum browser support~
* ~Meets accessibility requirements~
