### PR TITLE
Tweak the design of the Toggle component

### DIFF
--- a/.changeset/silver-vans-smash.md
+++ b/.changeset/silver-vans-smash.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Tweaked the design of the Toggle component.

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -60,6 +60,10 @@ const ToggleTextWrapper = styled('label')(textWrapperStyles);
 
 const explanationStyles = css`
   color: var(--cui-fg-subtle);
+
+  .${CLASS_DISABLED} & {
+    color: var(--cui-fg-normal-disabled);
+  }
 `;
 
 const ToggleExplanation = styled(Body)<BodyProps>(explanationStyles);

--- a/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -96,7 +96,7 @@ exports[`Toggle should render with default styles 1`] = `
 .circuit-2 {
   display: block;
   background-color: var(--cui-fg-on-strong);
-  box-shadow: 0 2px 0 0 var(--cui-border-normal-pressed);
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.25);
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px, -50%, 0);
@@ -111,7 +111,6 @@ exports[`Toggle should render with default styles 1`] = `
 }
 
 [aria-checked='true'] .circuit-2 {
-  box-shadow: 0 2px 0 0 var(--cui-border-accent-pressed);
   -webkit-transform: translate3d(
           calc(40px - 16px - 4px),
           -50%,
@@ -132,16 +131,6 @@ exports[`Toggle should render with default styles 1`] = `
           -50%,
           0
         );
-}
-
-button:disabled .circuit-2,
-button[disabled] .circuit-2 {
-  box-shadow: 0 2px 0 0 var(--cui-border-normal-disabled);
-}
-
-button[aria-checked='true']:disabled .circuit-2,
-button[aria-checked='true'][disabled] .circuit-2 {
-  box-shadow: 0 2px 0 0 var(--cui-border-accent-disabled);
 }
 
 .circuit-3 {

--- a/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -112,25 +112,30 @@ exports[`Toggle should render with default styles 1`] = `
 
 [aria-checked='true'] .circuit-2 {
   -webkit-transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
   -moz-transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
   -ms-transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
   transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
+}
+
+.circuit-2:disabled .circuit-2,
+.circuit-2[disabled] .circuit-2 {
+  background-color: var(--cui-fg-on-strong-disabled);
 }
 
 .circuit-3 {
@@ -173,6 +178,10 @@ exports[`Toggle should render with default styles 1`] = `
   font-size: 0.875rem;
   line-height: 1.25rem;
   color: var(--cui-fg-subtle);
+}
+
+.cui-field-disabled .circuit-6 {
+  color: var(--cui-fg-normal-disabled);
 }
 
 <div

--- a/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
+++ b/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
@@ -49,8 +49,6 @@ const TRACK_HEIGHT = '24px';
 const KNOB_SIZE = '16px';
 const ANIMATION_TIMING = '200ms ease-in-out';
 
-const knobShadow = (color: string) => `0 2px 0 0 ${color}`;
-
 type TrackElProps = Omit<SwitchProps, 'checkedLabel' | 'uncheckedLabel'>;
 
 const trackBaseStyles = css`
@@ -115,7 +113,7 @@ type KnobElProps = Pick<SwitchProps, 'checked'>;
 const knobBaseStyles = ({ theme }: StyleProps) => css`
   display: block;
   background-color: var(--cui-fg-on-strong);
-  box-shadow: ${knobShadow('var(--cui-border-normal-pressed)')};
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.25);
   position: absolute;
   top: 50%;
   transform: translate3d(${theme.spacings.bit}, -50%, 0);
@@ -128,7 +126,6 @@ const knobBaseStyles = ({ theme }: StyleProps) => css`
 const knobOnStyles = ({ theme }: StyleProps) =>
   css`
     [aria-checked='true'] & {
-      box-shadow: ${knobShadow('var(--cui-border-accent-pressed)')};
       transform: translate3d(
         calc(${TRACK_WIDTH} - ${KNOB_SIZE} - ${theme.spacings.bit}),
         -50%,
@@ -137,23 +134,7 @@ const knobOnStyles = ({ theme }: StyleProps) =>
     }
   `;
 
-const knobDisabledStyles = () => css`
-  button:disabled &,
-  button[disabled] & {
-    box-shadow: ${knobShadow('var(--cui-border-normal-disabled)')};
-  }
-
-  button[aria-checked='true']:disabled &,
-  button[aria-checked='true'][disabled] & {
-    box-shadow: ${knobShadow('var(--cui-border-accent-disabled)')};
-  }
-`;
-
-const SwitchKnob = styled('span')<KnobElProps>(
-  knobBaseStyles,
-  knobOnStyles,
-  knobDisabledStyles,
-);
+const SwitchKnob = styled('span')<KnobElProps>(knobBaseStyles, knobOnStyles);
 
 // Important for accessibility
 const SwitchLabel = styled('span')(hideVisually);

--- a/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
+++ b/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
@@ -121,20 +121,22 @@ const knobBaseStyles = ({ theme }: StyleProps) => css`
   height: ${KNOB_SIZE};
   width: ${KNOB_SIZE};
   border-radius: ${KNOB_SIZE};
+
+  [aria-checked='true'] & {
+    transform: translate3d(
+      calc(${TRACK_WIDTH} - ${KNOB_SIZE} - ${theme.spacings.bit}),
+      -50%,
+      0
+    );
+  }
+
+  &:disabled &,
+  &[disabled] & {
+    background-color: var(--cui-fg-on-strong-disabled);
+  }
 `;
 
-const knobOnStyles = ({ theme }: StyleProps) =>
-  css`
-    [aria-checked='true'] & {
-      transform: translate3d(
-        calc(${TRACK_WIDTH} - ${KNOB_SIZE} - ${theme.spacings.bit}),
-        -50%,
-        0
-      );
-    }
-  `;
-
-const SwitchKnob = styled('span')<KnobElProps>(knobBaseStyles, knobOnStyles);
+const SwitchKnob = styled('span')<KnobElProps>(knobBaseStyles);
 
 // Important for accessibility
 const SwitchLabel = styled('span')(hideVisually);

--- a/packages/circuit-ui/components/Toggle/components/Switch/__snapshots__/Switch.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/components/Switch/__snapshots__/Switch.spec.tsx.snap
@@ -86,25 +86,30 @@ exports[`Switch should have the correct default styles 1`] = `
 
 [aria-checked='true'] .circuit-1 {
   -webkit-transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
   -moz-transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
   -ms-transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
   transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
+}
+
+.circuit-1:disabled .circuit-1,
+.circuit-1[disabled] .circuit-1 {
+  background-color: var(--cui-fg-on-strong-disabled);
 }
 
 .circuit-2 {
@@ -222,25 +227,30 @@ exports[`Switch should have the correct on styles 1`] = `
 
 [aria-checked='true'] .circuit-1 {
   -webkit-transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
   -moz-transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
   -ms-transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
   transform: translate3d(
-          calc(40px - 16px - 4px),
-          -50%,
-          0
-        );
+        calc(40px - 16px - 4px),
+        -50%,
+        0
+      );
+}
+
+.circuit-1:disabled .circuit-1,
+.circuit-1[disabled] .circuit-1 {
+  background-color: var(--cui-fg-on-strong-disabled);
 }
 
 .circuit-2 {

--- a/packages/circuit-ui/components/Toggle/components/Switch/__snapshots__/Switch.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/components/Switch/__snapshots__/Switch.spec.tsx.snap
@@ -70,7 +70,7 @@ exports[`Switch should have the correct default styles 1`] = `
 .circuit-1 {
   display: block;
   background-color: var(--cui-fg-on-strong);
-  box-shadow: 0 2px 0 0 var(--cui-border-normal-pressed);
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.25);
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px, -50%, 0);
@@ -85,7 +85,6 @@ exports[`Switch should have the correct default styles 1`] = `
 }
 
 [aria-checked='true'] .circuit-1 {
-  box-shadow: 0 2px 0 0 var(--cui-border-accent-pressed);
   -webkit-transform: translate3d(
           calc(40px - 16px - 4px),
           -50%,
@@ -106,16 +105,6 @@ exports[`Switch should have the correct default styles 1`] = `
           -50%,
           0
         );
-}
-
-button:disabled .circuit-1,
-button[disabled] .circuit-1 {
-  box-shadow: 0 2px 0 0 var(--cui-border-normal-disabled);
-}
-
-button[aria-checked='true']:disabled .circuit-1,
-button[aria-checked='true'][disabled] .circuit-1 {
-  box-shadow: 0 2px 0 0 var(--cui-border-accent-disabled);
 }
 
 .circuit-2 {
@@ -217,7 +206,7 @@ exports[`Switch should have the correct on styles 1`] = `
 .circuit-1 {
   display: block;
   background-color: var(--cui-fg-on-strong);
-  box-shadow: 0 2px 0 0 var(--cui-border-normal-pressed);
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.25);
   position: absolute;
   top: 50%;
   -webkit-transform: translate3d(4px, -50%, 0);
@@ -232,7 +221,6 @@ exports[`Switch should have the correct on styles 1`] = `
 }
 
 [aria-checked='true'] .circuit-1 {
-  box-shadow: 0 2px 0 0 var(--cui-border-accent-pressed);
   -webkit-transform: translate3d(
           calc(40px - 16px - 4px),
           -50%,
@@ -253,16 +241,6 @@ exports[`Switch should have the correct on styles 1`] = `
           -50%,
           0
         );
-}
-
-button:disabled .circuit-1,
-button[disabled] .circuit-1 {
-  box-shadow: 0 2px 0 0 var(--cui-border-normal-disabled);
-}
-
-button[aria-checked='true']:disabled .circuit-1,
-button[aria-checked='true'][disabled] .circuit-1 {
-  box-shadow: 0 2px 0 0 var(--cui-border-accent-disabled);
 }
 
 .circuit-2 {


### PR DESCRIPTION
## Purpose

The Toggle's shadow is using a "hard" style for shadows which we don't have anywhere else. This has become especially noticeable with the new color tokens.

## Approach and changes

- Replace the Toggle's hard shadow with a soft one
- Fix some of the disabled colors

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
