### PR TITLE
Change the icon for `notify` variants

### DIFF
--- a/.changeset/twenty-games-own.md
+++ b/.changeset/twenty-games-own.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Changed the `notify` icon for the NotificationInline and NotificationToast components and the form field validation hint.

--- a/packages/circuit-ui/components/FieldAtoms/FieldValidationHint.tsx
+++ b/packages/circuit-ui/components/FieldAtoms/FieldValidationHint.tsx
@@ -15,7 +15,7 @@
 
 import { HTMLAttributes } from 'react';
 import { css } from '@emotion/react';
-import { Confirm, NotifyCircle, Alert } from '@sumup/icons';
+import { Confirm, Notify, Alert } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { typography } from '../../styles/style-mixins';
@@ -112,7 +112,7 @@ const getIcon = (props: FieldValidationHintProps) => {
     case props.hasWarning: {
       return (
         <IconWrapper {...props}>
-          <NotifyCircle role="presentation" size="16" />
+          <Notify role="presentation" size="16" />
         </IconWrapper>
       );
     }

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -22,7 +22,7 @@ import {
   useState,
 } from 'react';
 import { css } from '@emotion/react';
-import { Alert, Confirm, IconProps, Info, NotifyCircle } from '@sumup/icons';
+import { Alert, Confirm, IconProps, Info, Notify } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { useAnimation } from '../../hooks/useAnimation';
@@ -100,7 +100,7 @@ const iconMap: Record<Variant, FC<IconProps<'16' | '24'>>> = {
   info: Info,
   confirm: Confirm,
   alert: Alert,
-  notify: NotifyCircle,
+  notify: Notify,
 };
 
 // TODO: Align variant names with token names in the next major.

--- a/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
@@ -458,7 +458,7 @@ exports[`NotificationInline styles should render notification inline with notify
           >
             <path
               clip-rule="evenodd"
-              d="M11.994 1.006a10.994 10.994 0 1 0 .012 0zm-1 6a1 1 0 0 1 2 0v5a1 1 0 1 1-2 0zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+              d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
               fill="currentColor"
               fill-rule="evenodd"
             />

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -22,7 +22,7 @@ import {
   useState,
 } from 'react';
 import { css } from '@emotion/react';
-import { Alert, Confirm, IconProps, Info, NotifyCircle } from '@sumup/icons';
+import { Alert, Confirm, IconProps, Info, Notify } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { useAnimation } from '../../hooks/useAnimation';
@@ -76,7 +76,7 @@ const iconMap: Record<Variant, FC<IconProps<'16' | '24'>>> = {
   info: Info,
   confirm: Confirm,
   alert: Alert,
-  notify: NotifyCircle,
+  notify: Notify,
 };
 
 // TODO: Align variant names with token names in the next major.

--- a/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
@@ -1733,7 +1733,7 @@ exports[`NotificationToast styles should render with notify variant styles 1`] =
           >
             <path
               clip-rule="evenodd"
-              d="M11.994 1.006a10.994 10.994 0 1 0 .012 0zm-1 6a1 1 0 0 1 2 0v5a1 1 0 1 1-2 0zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+              d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
               fill="currentColor"
               fill-rule="evenodd"
             />


### PR DESCRIPTION
## Purpose

The new semantic color tokens changed the `notify` color from yellow to orange for better color contrast and removed the black color of the `!` inside. The design team has asked us to replace the round icon with a triangular one, essentially reverting #1386.  

## Approach and changes

- Changed the `notify` icon for the NotificationInline and NotificationToast components and the form field validation hint

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
