### PR TITLE
Raise minimum React version

### DIFF
--- a/.changeset/chilled-walls-learn.md
+++ b/.changeset/chilled-walls-learn.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Raised the minimum version of the `react` and `react-dom` peer dependencies to >=18.

--- a/.changeset/popular-eels-fetch.md
+++ b/.changeset/popular-eels-fetch.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Deprecated the `uniqueId` util. Use the official [`useId` hook](https://beta.reactjs.org/reference/react/useId) instead.

--- a/.storybook/themes.ts
+++ b/.storybook/themes.ts
@@ -1,6 +1,6 @@
 import { create } from '@storybook/theming';
 import { light as theme } from '@sumup/design-tokens';
-import { Link } from './components';
+import Link from './components/Link';
 
 const brand = {
   brandTitle: 'Circuit UI',

--- a/package-lock.json
+++ b/package-lock.json
@@ -30141,8 +30141,8 @@
         "@sumup/design-tokens": ">=5.0.0",
         "@sumup/icons": ">=2.9.0",
         "@sumup/intl": "1.x",
-        "react": ">=16.8.0 <19.0.0",
-        "react-dom": ">=16.8.0 <19.0.0"
+        "react": ">=18.0.0 <19.0.0",
+        "react-dom": ">=18.0.0 <19.0.0"
       }
     },
     "packages/circuit-ui/node_modules/fork-ts-checker-webpack-plugin": {

--- a/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.js.snap
+++ b/packages/circuit-ui/components/Carousel/__snapshots__/Carousel.spec.js.snap
@@ -556,14 +556,14 @@ exports[`Carousel styles should render with children as a function 1`] = `
         class="circuit-42 circuit-43"
       >
         <span
-          aria-labelledby="progress-bar_6"
+          aria-labelledby=":r2:"
           class="circuit-44"
           loop=""
           role="progressbar"
         />
         <span
           class="circuit-45"
-          id="progress-bar_6"
+          id=":r2:"
         >
           1 / 3
         </span>
@@ -1242,14 +1242,14 @@ exports[`Carousel styles should render with children as a node 1`] = `
         class="circuit-42 circuit-43"
       >
         <span
-          aria-labelledby="progress-bar_8"
+          aria-labelledby=":r3:"
           class="circuit-44"
           loop=""
           role="progressbar"
         />
         <span
           class="circuit-45"
-          id="progress-bar_8"
+          id=":r3:"
         >
           1 / 3
         </span>
@@ -1927,14 +1927,14 @@ exports[`Carousel styles should render with default paused styles 1`] = `
         class="circuit-42 circuit-43"
       >
         <span
-          aria-labelledby="progress-bar_4"
+          aria-labelledby=":r1:"
           class="circuit-44"
           loop=""
           role="progressbar"
         />
         <span
           class="circuit-45"
-          id="progress-bar_4"
+          id=":r1:"
         >
           1 / 3
         </span>
@@ -2583,14 +2583,14 @@ exports[`Carousel styles should render with default styles 1`] = `
         class="circuit-42 circuit-43"
       >
         <span
-          aria-labelledby="progress-bar_2"
+          aria-labelledby=":r0:"
           class="circuit-44"
           loop=""
           role="progressbar"
         />
         <span
           class="circuit-45"
-          id="progress-bar_2"
+          id=":r0:"
         >
           1 / 3
         </span>

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -13,13 +13,12 @@
  * limitations under the License.
  */
 
-import { InputHTMLAttributes, Ref, forwardRef } from 'react';
+import { InputHTMLAttributes, Ref, forwardRef, useId } from 'react';
 import { css } from '@emotion/react';
 import { Checkmark } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { hideVisually, focusOutline } from '../../styles/style-mixins';
-import { uniqueId } from '../../util/id';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import { FieldValidationHint, FieldWrapper } from '../FieldAtoms';
 import { deprecate } from '../../util/logger';
@@ -219,8 +218,9 @@ export const Checkbox = forwardRef(
       throw new AccessibilityError('Checkbox', 'The `label` prop is missing.');
     }
 
-    const id = customId || uniqueId('checkbox_');
-    const validationHintId = uniqueId('validation_hint-');
+    const id = useId();
+    const checkboxId = customId || id;
+    const validationHintId = useId();
     const descriptionIds = `${
       descriptionId ? `${descriptionId} ` : ''
     }${validationHintId}`;
@@ -230,7 +230,7 @@ export const Checkbox = forwardRef(
       <CheckboxWrapper className={className} style={style} disabled={disabled}>
         <CheckboxInput
           {...props}
-          id={id}
+          id={checkboxId}
           name={name}
           value={value}
           type="checkbox"
@@ -240,7 +240,7 @@ export const Checkbox = forwardRef(
           aria-describedby={descriptionIds}
           onChange={handleChange}
         />
-        <CheckboxLabel htmlFor={id}>
+        <CheckboxLabel htmlFor={checkboxId}>
           {label || children}
           <Checkmark aria-hidden="true" />
         </CheckboxLabel>

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -123,16 +123,16 @@ exports[`Checkbox Styles should render with checked styles 1`] = `
     class="circuit-0"
   >
     <input
-      aria-describedby="validation_hint-4"
+      aria-describedby=":r3:"
       checked=""
       class="circuit-1"
-      id="checkbox_3"
+      id=":r2:"
       type="checkbox"
       value=""
     />
     <label
       class="circuit-2"
-      for="checkbox_3"
+      for=":r2:"
     >
       Label
       <svg
@@ -280,15 +280,15 @@ exports[`Checkbox Styles should render with default styles 1`] = `
     class="circuit-0"
   >
     <input
-      aria-describedby="validation_hint-2"
+      aria-describedby=":r1:"
       class="circuit-1"
-      id="checkbox_1"
+      id=":r0:"
       type="checkbox"
       value=""
     />
     <label
       class="circuit-2"
-      for="checkbox_1"
+      for=":r0:"
     >
       Label
       <svg
@@ -436,16 +436,16 @@ exports[`Checkbox Styles should render with disabled styles 1`] = `
     class="cui-field-disabled circuit-0"
   >
     <input
-      aria-describedby="validation_hint-6"
+      aria-describedby=":r5:"
       class="circuit-1"
       disabled=""
-      id="checkbox_5"
+      id=":r4:"
       type="checkbox"
       value=""
     />
     <label
       class="circuit-2"
-      for="checkbox_5"
+      for=":r4:"
     >
       Label
       <svg
@@ -636,15 +636,15 @@ exports[`Checkbox Styles should render with invalid styles and an error message 
     class="circuit-0"
   >
     <input
-      aria-describedby="validation_hint-8"
+      aria-describedby=":r7:"
       class="circuit-1"
-      id="checkbox_7"
+      id=":r6:"
       type="checkbox"
       value=""
     />
     <label
       class="circuit-2"
-      for="checkbox_7"
+      for=":r6:"
     >
       Label
       <svg
@@ -667,7 +667,7 @@ exports[`Checkbox Styles should render with invalid styles and an error message 
     >
       <span
         class="circuit-3"
-        id="validation_hint-8"
+        id=":r7:"
       >
         <div
           class="circuit-4"

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -13,14 +13,13 @@
  * limitations under the License.
  */
 
-import { Ref, forwardRef } from 'react';
+import { Ref, forwardRef, useId } from 'react';
 import { resolveCurrencyFormat } from '@sumup/intl';
 import { NumericFormat, NumericFormatProps } from 'react-number-format';
 
 import styled from '../../styles/styled';
 import Input from '../Input';
 import { InputProps } from '../Input/Input';
-import { uniqueId } from '../../util/id';
 
 import { formatPlaceholder } from './CurrencyInputService';
 
@@ -93,7 +92,7 @@ export const CurrencyInput = forwardRef(
     }: CurrencyInputProps,
     ref: CurrencyInputProps['ref'],
   ) => {
-    const currencySymbolId = uniqueId('currency-symbol_');
+    const currencySymbolId = useId();
     const descriptionIds = `${
       descriptionId ? `${descriptionId} ` : ''
     }${currencySymbolId}`;

--- a/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/CurrencyInput/__snapshots__/CurrencyInput.spec.tsx.snap
@@ -111,7 +111,7 @@ exports[`CurrencyInput Styles should render a currency as a prefix 1`] = `
   >
     <label
       class="circuit-1"
-      for="input_14"
+      for=":r7:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -124,14 +124,14 @@ exports[`CurrencyInput Styles should render a currency as a prefix 1`] = `
     >
       <span
         class="circuit-5"
-        id="currency-symbol_11"
+        id=":r6:"
       >
         CHF
       </span>
       <input
-        aria-describedby="currency-symbol_11 validation-hint_15"
+        aria-describedby=":r6: :r8:"
         class="circuit-6"
-        id="input_14"
+        id=":r7:"
         inputmode="decimal"
         type="text"
         value=""
@@ -260,7 +260,7 @@ exports[`CurrencyInput Styles should render a currency as a suffix 1`] = `
   >
     <label
       class="circuit-1"
-      for="input_9"
+      for=":r4:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -272,16 +272,16 @@ exports[`CurrencyInput Styles should render a currency as a suffix 1`] = `
       class="circuit-4"
     >
       <input
-        aria-describedby="currency-symbol_6 validation-hint_10"
+        aria-describedby=":r3: :r5:"
         class="circuit-5"
-        id="input_9"
+        id=":r4:"
         inputmode="decimal"
         type="text"
         value=""
       />
       <span
         class="circuit-6"
-        id="currency-symbol_6"
+        id=":r3:"
       >
         €
       </span>
@@ -405,7 +405,7 @@ exports[`CurrencyInput Styles should render with default styles and format 1`] =
   >
     <label
       class="circuit-1"
-      for="input_4"
+      for=":r1:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -418,14 +418,14 @@ exports[`CurrencyInput Styles should render with default styles and format 1`] =
     >
       <span
         class="circuit-5"
-        id="currency-symbol_1"
+        id=":r0:"
       >
         $
       </span>
       <input
-        aria-describedby="currency-symbol_1 validation-hint_5"
+        aria-describedby=":r0: :r2:"
         class="circuit-6"
-        id="input_4"
+        id=":r1:"
         inputmode="decimal"
         type="text"
         value=""

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -20,13 +20,13 @@ import {
   ChangeEvent,
   ClipboardEvent,
   DragEvent,
+  useId,
 } from 'react';
 import { css } from '@emotion/react';
 import { Delete, Plus } from '@sumup/icons';
 
 import { ClickEvent } from '../../types/events';
 import styled, { StyleProps } from '../../styles/styled';
-import { uniqueId } from '../../util/id';
 import { focusOutline, hideVisually } from '../../styles/style-mixins';
 import { FieldWrapper, FieldLabel, FieldValidationHint } from '../FieldAtoms';
 import IconButton, { IconButtonProps } from '../IconButton';
@@ -339,8 +339,9 @@ export const ImageInput = ({
   }
 
   const inputRef = useRef<HTMLInputElement>(null);
-  const id = customId || uniqueId('image-input_');
-  const validationHintId = uniqueId('validation-hint_');
+  const id = useId();
+  const inputId = customId || id;
+  const validationHintId = useId();
   const descriptionIds = `${
     descriptionId ? `${descriptionId} ` : ''
   }${validationHintId}`;
@@ -436,7 +437,7 @@ export const ImageInput = ({
       <InputWrapper onPaste={handlePaste}>
         <HiddenInput
           ref={inputRef}
-          id={id}
+          id={inputId}
           type="file"
           accept="image/*"
           onChange={handleInputChange}
@@ -450,7 +451,7 @@ export const ImageInput = ({
           isLoading={isLoading}
           isDragging={isDragging}
           invalid={invalid}
-          htmlFor={id}
+          htmlFor={inputId}
           onDragEnter={handleDragging}
           onDragOver={handleDragging}
           onDragLeave={handleDragLeave}

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -307,15 +307,15 @@ exports[`ImageInput Styles should render with a custom component 1`] = `
     >
       <input
         accept="image/*"
-        aria-describedby="validation-hint_10"
+        aria-describedby=":r9:"
         aria-invalid="false"
         class="circuit-2"
-        id="image-input_9"
+        id=":r8:"
         type="file"
       />
       <label
         class="circuit-3"
-        for="image-input_9"
+        for=":r8:"
       >
         <span
           class="circuit-4"
@@ -728,15 +728,15 @@ exports[`ImageInput Styles should render with a giga button 1`] = `
     >
       <input
         accept="image/*"
-        aria-describedby="validation-hint_8"
+        aria-describedby=":r7:"
         aria-invalid="false"
         class="circuit-2"
-        id="image-input_7"
+        id=":r6:"
         type="file"
       />
       <label
         class="circuit-3"
-        for="image-input_7"
+        for=":r6:"
       >
         <span
           class="circuit-4"
@@ -1134,15 +1134,15 @@ exports[`ImageInput Styles should render with an existing image 1`] = `
     >
       <input
         accept="image/*"
-        aria-describedby="validation-hint_4"
+        aria-describedby=":r3:"
         aria-invalid="false"
         class="circuit-2"
-        id="image-input_3"
+        id=":r2:"
         type="file"
       />
       <label
         class="circuit-3"
-        for="image-input_3"
+        for=":r2:"
       >
         <span
           class="circuit-4"
@@ -1549,15 +1549,15 @@ exports[`ImageInput Styles should render with default styles 1`] = `
     >
       <input
         accept="image/*"
-        aria-describedby="validation-hint_2"
+        aria-describedby=":r1:"
         aria-invalid="false"
         class="circuit-2"
-        id="image-input_1"
+        id=":r0:"
         type="file"
       />
       <label
         class="circuit-3"
-        for="image-input_1"
+        for=":r0:"
       >
         <span
           class="circuit-4"
@@ -2012,15 +2012,15 @@ exports[`ImageInput Styles should render with invalid styles and an error messag
     >
       <input
         accept="image/*"
-        aria-describedby="validation-hint_6"
+        aria-describedby=":r5:"
         aria-invalid="true"
         class="circuit-2"
-        id="image-input_5"
+        id=":r4:"
         type="file"
       />
       <label
         class="circuit-3"
-        for="image-input_5"
+        for=":r4:"
       >
         <span
           class="circuit-4"
@@ -2098,7 +2098,7 @@ exports[`ImageInput Styles should render with invalid styles and an error messag
     >
       <span
         class="circuit-13"
-        id="validation-hint_6"
+        id=":r5:"
       >
         <div
           class="circuit-14"

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -18,13 +18,13 @@ import {
   Ref,
   InputHTMLAttributes,
   TextareaHTMLAttributes,
+  useId,
 } from 'react';
 import { css, Interpolation } from '@emotion/react';
 import { Theme } from '@sumup/design-tokens';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { typography, inputOutline } from '../../styles/style-mixins';
-import { uniqueId } from '../../util/id';
 import {
   FieldWrapper,
   FieldLabel,
@@ -265,8 +265,9 @@ export const Input = forwardRef(
       );
     }
 
-    const id = customId || uniqueId('input_');
-    const validationHintId = uniqueId('validation-hint_');
+    const id = useId();
+    const inputId = customId || id;
+    const validationHintId = useId();
     const descriptionIds = `${
       descriptionId ? `${descriptionId} ` : ''
     }${validationHintId}`;
@@ -279,7 +280,7 @@ export const Input = forwardRef(
 
     return (
       <FieldWrapper className={className} style={style} disabled={disabled}>
-        <FieldLabel htmlFor={id}>
+        <FieldLabel htmlFor={inputId}>
           <FieldLabelText
             label={label}
             hideLabel={hideLabel}
@@ -291,7 +292,7 @@ export const Input = forwardRef(
           {prefix}
           <StyledInput
             as={as}
-            id={id}
+            id={inputId}
             value={value}
             ref={ref}
             aria-describedby={descriptionIds}

--- a/packages/circuit-ui/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/packages/circuit-ui/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -75,7 +75,7 @@ exports[`Input Styles should prioritize disabled over error styles 1`] = `
   >
     <label
       class="circuit-1"
-      for="input_21"
+      for=":rk:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -87,11 +87,11 @@ exports[`Input Styles should prioritize disabled over error styles 1`] = `
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_22"
+        aria-describedby=":rl:"
         aria-invalid="true"
         class="circuit-5"
         disabled=""
-        id="input_21"
+        id=":rk:"
         value=""
       />
     </div>
@@ -178,7 +178,7 @@ exports[`Input Styles should prioritize disabled over warning styles 1`] = `
   >
     <label
       class="circuit-1"
-      for="input_23"
+      for=":rm:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -190,10 +190,10 @@ exports[`Input Styles should prioritize disabled over warning styles 1`] = `
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_24"
+        aria-describedby=":rn:"
         class="circuit-5"
         disabled=""
-        id="input_23"
+        id=":rm:"
         value=""
       />
     </div>
@@ -306,7 +306,7 @@ exports[`Input Styles should render with a description when passed the validatio
   >
     <label
       class="circuit-1"
-      for="input_7"
+      for=":r6:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -318,15 +318,15 @@ exports[`Input Styles should render with a description when passed the validatio
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_8"
+        aria-describedby=":r7:"
         class="circuit-5"
-        id="input_7"
+        id=":r6:"
         value=""
       />
     </div>
     <span
       class="circuit-6"
-      id="validation-hint_8"
+      id=":r7:"
     >
       Validation hint
     </span>
@@ -435,7 +435,7 @@ exports[`Input Styles should render with a prefix when passed the prefix prop 1`
   >
     <label
       class="circuit-1"
-      for="input_3"
+      for=":r2:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -451,9 +451,9 @@ exports[`Input Styles should render with a prefix when passed the prefix prop 1`
         style="width: 24px; height: 24px;"
       />
       <input
-        aria-describedby="validation-hint_4"
+        aria-describedby=":r3:"
         class="circuit-6"
-        id="input_3"
+        id=":r2:"
         value=""
       />
     </div>
@@ -566,7 +566,7 @@ exports[`Input Styles should render with a suffix when passed the suffix prop 1`
   >
     <label
       class="circuit-1"
-      for="input_5"
+      for=":r4:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -578,9 +578,9 @@ exports[`Input Styles should render with a suffix when passed the suffix prop 1`
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_6"
+        aria-describedby=":r5:"
         class="circuit-5"
-        id="input_5"
+        id=":r4:"
         value=""
       />
       <div
@@ -688,7 +688,7 @@ exports[`Input Styles should render with custom styles 1`] = `
   >
     <label
       class="circuit-1"
-      for="input_25"
+      for=":ro:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -700,9 +700,9 @@ exports[`Input Styles should render with custom styles 1`] = `
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_26"
+        aria-describedby=":rp:"
         class="circuit-5"
-        id="input_25"
+        id=":ro:"
         value=""
       />
     </div>
@@ -801,7 +801,7 @@ exports[`Input Styles should render with default styles 1`] = `
   >
     <label
       class="circuit-1"
-      for="input_1"
+      for=":r0:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -813,9 +813,9 @@ exports[`Input Styles should render with default styles 1`] = `
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_2"
+        aria-describedby=":r1:"
         class="circuit-5"
-        id="input_1"
+        id=":r0:"
         value=""
       />
     </div>
@@ -902,7 +902,7 @@ exports[`Input Styles should render with disabled styles when passed the disable
   >
     <label
       class="circuit-1"
-      for="input_19"
+      for=":ri:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -914,10 +914,10 @@ exports[`Input Styles should render with disabled styles when passed the disable
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_20"
+        aria-describedby=":rj:"
         class="circuit-5"
         disabled=""
-        id="input_19"
+        id=":ri:"
         value=""
       />
     </div>
@@ -1032,7 +1032,7 @@ exports[`Input Styles should render with invalid styles when passed the invalid 
   >
     <label
       class="circuit-1"
-      for="input_11"
+      for=":ra:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -1044,10 +1044,10 @@ exports[`Input Styles should render with invalid styles when passed the invalid 
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_12"
+        aria-describedby=":rb:"
         aria-invalid="true"
         class="circuit-5"
-        id="input_11"
+        id=":ra:"
         value=""
       />
     </div>
@@ -1147,7 +1147,7 @@ exports[`Input Styles should render with readonly styles when passed the readOnl
   >
     <label
       class="circuit-1"
-      for="input_17"
+      for=":rg:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -1159,9 +1159,9 @@ exports[`Input Styles should render with readonly styles when passed the readOnl
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_18"
+        aria-describedby=":rh:"
         class="circuit-5"
-        id="input_17"
+        id=":rg:"
         readonly=""
         value=""
       />
@@ -1262,7 +1262,7 @@ exports[`Input Styles should render with right aligned text 1`] = `
   >
     <label
       class="circuit-1"
-      for="input_15"
+      for=":re:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -1274,9 +1274,9 @@ exports[`Input Styles should render with right aligned text 1`] = `
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_16"
+        aria-describedby=":rf:"
         class="circuit-5"
-        id="input_15"
+        id=":re:"
         value=""
       />
     </div>
@@ -1375,7 +1375,7 @@ exports[`Input Styles should render with valid styles when passed the showValid 
   >
     <label
       class="circuit-1"
-      for="input_13"
+      for=":rc:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -1387,9 +1387,9 @@ exports[`Input Styles should render with valid styles when passed the showValid 
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_14"
+        aria-describedby=":rd:"
         class="circuit-5"
-        id="input_13"
+        id=":rc:"
         value=""
       />
     </div>
@@ -1504,7 +1504,7 @@ exports[`Input Styles should render with warning styles when passed the hasWarni
   >
     <label
       class="circuit-1"
-      for="input_9"
+      for=":r8:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -1516,9 +1516,9 @@ exports[`Input Styles should render with warning styles when passed the hasWarni
       class="circuit-4"
     >
       <input
-        aria-describedby="validation-hint_10"
+        aria-describedby=":r9:"
         class="circuit-5"
-        id="input_9"
+        id=":r8:"
         value=""
       />
     </div>

--- a/packages/circuit-ui/components/ModalContext/createUseModal.ts
+++ b/packages/circuit-ui/components/ModalContext/createUseModal.ts
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-import { useContext, useMemo, useCallback, useRef } from 'react';
-
-import { uniqueId } from '../../util/id';
+import { useContext, useCallback, useRef, useId } from 'react';
 
 import { ModalContext } from './ModalContext';
 import type { BaseModalProps, ModalComponent } from './types';
@@ -27,7 +25,7 @@ export function createUseModal<T extends BaseModalProps>(
     setModal: (props: Omit<T, 'isOpen'>) => void;
     removeModal: () => void;
   } => {
-    const id = useMemo(uniqueId, []);
+    const id = useId();
     const modalRef = useRef<Omit<T, 'isOpen'> | null>(null);
     const context = useContext(ModalContext);
 

--- a/packages/circuit-ui/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
+++ b/packages/circuit-ui/components/Pagination/__snapshots__/Pagination.spec.tsx.snap
@@ -1001,7 +1001,7 @@ select:not(:active)~.circuit-13 {
   >
     <label
       class="circuit-7"
-      for="select_1"
+      for=":r0:"
     >
       <span
         class="circuit-8 circuit-9"
@@ -1013,9 +1013,9 @@ select:not(:active)~.circuit-13 {
       class="circuit-10"
     >
       <select
-        aria-describedby="validation-hint_2"
+        aria-describedby=":r1:"
         class="circuit-11"
-        id="select_1"
+        id=":r0:"
       >
         <option
           value="1"

--- a/packages/circuit-ui/components/Pagination/components/PageSelect/__snapshots__/PageSelect.spec.tsx.snap
+++ b/packages/circuit-ui/components/Pagination/components/PageSelect/__snapshots__/PageSelect.spec.tsx.snap
@@ -126,7 +126,7 @@ select:not(:active)~.circuit-7 {
   >
     <label
       class="circuit-1"
-      for="select_1"
+      for=":r0:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -138,9 +138,9 @@ select:not(:active)~.circuit-7 {
       class="circuit-4"
     >
       <select
-        aria-describedby="validation-hint_2"
+        aria-describedby=":r1:"
         class="circuit-5"
-        id="select_1"
+        id=":r0:"
       >
         <option
           value="1"

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -20,7 +20,7 @@ import {
   Fragment,
   Ref,
   useEffect,
-  useMemo,
+  useId,
   useRef,
   KeyboardEvent,
   AnchorHTMLAttributes,
@@ -42,7 +42,6 @@ import { ClickEvent } from '../../types/events';
 import { EmotionAsPropType } from '../../types/prop-types';
 import styled, { StyleProps } from '../../styles/styled';
 import { listItem, shadow, typography } from '../../styles/style-mixins';
-import { uniqueId } from '../../util/id';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 import { useClickOutside } from '../../hooks/useClickOutside';
@@ -290,8 +289,8 @@ export const Popover = ({
   const zIndex = useStackContext();
   const triggerKey = useRef<TriggerKey | null>(null);
   const menuEl = useRef<HTMLDivElement>(null);
-  const triggerId = useMemo(() => uniqueId('trigger_'), []);
-  const menuId = useMemo(() => uniqueId('popover_'), []);
+  const triggerId = useId();
+  const menuId = useId();
 
   const sendEvent = useClickTrigger();
 

--- a/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
+++ b/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
@@ -198,10 +198,10 @@ exports[`Popover Styles should render popover on bottom 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_20"
+        aria-controls=":ra:"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_19"
+        id=":r9:"
       >
         Button
       </button>
@@ -216,14 +216,14 @@ exports[`Popover Styles should render popover on bottom 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_19"
+      aria-labelledby=":r9:"
       class="circuit-3"
-      id="popover_20"
+      id=":ra:"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="21"
+        data-focus-list=":rb:"
         role="menuitem"
       >
         <svg
@@ -246,7 +246,7 @@ exports[`Popover Styles should render popover on bottom 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="21"
+        data-focus-list=":rb:"
         role="menuitem"
       >
         <svg
@@ -467,10 +467,10 @@ exports[`Popover Styles should render popover on left 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_26"
+        aria-controls=":rd:"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_25"
+        id=":rc:"
       >
         Button
       </button>
@@ -485,14 +485,14 @@ exports[`Popover Styles should render popover on left 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_25"
+      aria-labelledby=":rc:"
       class="circuit-3"
-      id="popover_26"
+      id=":rd:"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="27"
+        data-focus-list=":re:"
         role="menuitem"
       >
         <svg
@@ -515,7 +515,7 @@ exports[`Popover Styles should render popover on left 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="27"
+        data-focus-list=":re:"
         role="menuitem"
       >
         <svg
@@ -736,10 +736,10 @@ exports[`Popover Styles should render popover on right 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_32"
+        aria-controls=":rg:"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_31"
+        id=":rf:"
       >
         Button
       </button>
@@ -754,14 +754,14 @@ exports[`Popover Styles should render popover on right 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_31"
+      aria-labelledby=":rf:"
       class="circuit-3"
-      id="popover_32"
+      id=":rg:"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="33"
+        data-focus-list=":rh:"
         role="menuitem"
       >
         <svg
@@ -784,7 +784,7 @@ exports[`Popover Styles should render popover on right 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="33"
+        data-focus-list=":rh:"
         role="menuitem"
       >
         <svg
@@ -1005,10 +1005,10 @@ exports[`Popover Styles should render popover on top 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_14"
+        aria-controls=":r7:"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_13"
+        id=":r6:"
       >
         Button
       </button>
@@ -1023,14 +1023,14 @@ exports[`Popover Styles should render popover on top 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_13"
+      aria-labelledby=":r6:"
       class="circuit-3"
-      id="popover_14"
+      id=":r7:"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="15"
+        data-focus-list=":r8:"
         role="menuitem"
       >
         <svg
@@ -1053,7 +1053,7 @@ exports[`Popover Styles should render popover on top 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="15"
+        data-focus-list=":r8:"
         role="menuitem"
       >
         <svg
@@ -1256,10 +1256,10 @@ exports[`Popover Styles should render with closed styles 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_8"
+        aria-controls=":r4:"
         aria-expanded="false"
         aria-haspopup="true"
-        id="trigger_7"
+        id=":r3:"
       >
         Button
       </button>
@@ -1274,14 +1274,14 @@ exports[`Popover Styles should render with closed styles 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_7"
+      aria-labelledby=":r3:"
       class="circuit-3"
-      id="popover_8"
+      id=":r4:"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="9"
+        data-focus-list=":r5:"
         role="menuitem"
       >
         <svg
@@ -1304,7 +1304,7 @@ exports[`Popover Styles should render with closed styles 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="9"
+        data-focus-list=":r5:"
         role="menuitem"
       >
         <svg
@@ -1525,10 +1525,10 @@ exports[`Popover Styles should render with default styles 1`] = `
       class="circuit-0"
     >
       <button
-        aria-controls="popover_2"
+        aria-controls=":r1:"
         aria-expanded="true"
         aria-haspopup="true"
-        id="trigger_1"
+        id=":r0:"
       >
         Button
       </button>
@@ -1543,14 +1543,14 @@ exports[`Popover Styles should render with default styles 1`] = `
     style="position: fixed; top: 0px; left: 0px; z-index: 30;"
   >
     <div
-      aria-labelledby="trigger_1"
+      aria-labelledby=":r0:"
       class="circuit-3"
-      id="popover_2"
+      id=":r1:"
       role="menu"
     >
       <button
         class="circuit-4"
-        data-focus-list="3"
+        data-focus-list=":r2:"
         role="menuitem"
       >
         <svg
@@ -1573,7 +1573,7 @@ exports[`Popover Styles should render with default styles 1`] = `
       />
       <button
         class="circuit-7"
-        data-focus-list="3"
+        data-focus-list=":r2:"
         role="menuitem"
       >
         <svg

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
+import { useId } from 'react';
 import { css, keyframes } from '@emotion/react';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { typography, hideVisually } from '../../styles/style-mixins';
-import { uniqueId } from '../../util/id';
 import { ReturnType } from '../../types/return-type';
 import { AccessibilityError } from '../../util/errors';
 
@@ -234,7 +234,7 @@ export function ProgressBar({
   ) {
     throw new AccessibilityError('ProgressBar', 'The `label` prop is missing.');
   }
-  const ariaId = uniqueId('progress-bar_');
+  const ariaId = useId();
   return (
     <ProgressBarWrapper {...props}>
       {max || value ? (

--- a/packages/circuit-ui/components/ProgressBar/__snapshots__/ProgressBar.spec.tsx.snap
+++ b/packages/circuit-ui/components/ProgressBar/__snapshots__/ProgressBar.spec.tsx.snap
@@ -62,7 +62,7 @@ exports[`ProgressBar step-based should render with a hidden label 1`] = `
   class="circuit-0"
 >
   <span
-    aria-labelledby="progress-bar_2"
+    aria-labelledby=":r1:"
     aria-valuemax="1"
     aria-valuemin="0"
     aria-valuenow="0.5"
@@ -73,7 +73,7 @@ exports[`ProgressBar step-based should render with a hidden label 1`] = `
   />
   <span
     class="circuit-2"
-    id="progress-bar_2"
+    id=":r1:"
   >
     A progress bar
   </span>
@@ -133,7 +133,7 @@ exports[`ProgressBar step-based should render with default styles 1`] = `
   class="circuit-0"
 >
   <span
-    aria-labelledby="progress-bar_1"
+    aria-labelledby=":r0:"
     aria-valuemax="1"
     aria-valuemin="0"
     aria-valuenow="0.5"
@@ -144,7 +144,7 @@ exports[`ProgressBar step-based should render with default styles 1`] = `
   />
   <span
     class="circuit-2"
-    id="progress-bar_1"
+    id=":r0:"
   >
     A progress bar
   </span>
@@ -233,13 +233,13 @@ exports[`ProgressBar time-based should render with a hidden label 1`] = `
   class="circuit-0"
 >
   <span
-    aria-labelledby="progress-bar_5"
+    aria-labelledby=":r4:"
     class="circuit-1"
     role="progressbar"
   />
   <span
     class="circuit-2"
-    id="progress-bar_5"
+    id=":r4:"
   >
     A progress bar
   </span>
@@ -319,13 +319,13 @@ exports[`ProgressBar time-based should render with default styles 1`] = `
   class="circuit-0"
 >
   <span
-    aria-labelledby="progress-bar_4"
+    aria-labelledby=":r3:"
     class="circuit-1"
     role="progressbar"
   />
   <span
     class="circuit-2"
-    id="progress-bar_4"
+    id=":r3:"
   >
     A progress bar
   </span>
@@ -421,14 +421,14 @@ exports[`ProgressBar time-based should render with loop styles 1`] = `
   class="circuit-0"
 >
   <span
-    aria-labelledby="progress-bar_7"
+    aria-labelledby=":r6:"
     class="circuit-1"
     loop=""
     role="progressbar"
   />
   <span
     class="circuit-2"
-    id="progress-bar_7"
+    id=":r6:"
   >
     A progress bar
   </span>
@@ -518,13 +518,13 @@ exports[`ProgressBar time-based should render with paused styles 1`] = `
   class="circuit-0"
 >
   <span
-    aria-labelledby="progress-bar_6"
+    aria-labelledby=":r5:"
     class="circuit-1"
     role="progressbar"
   />
   <span
     class="circuit-2"
-    id="progress-bar_6"
+    id=":r5:"
   >
     A progress bar
   </span>

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -13,12 +13,11 @@
  * limitations under the License.
  */
 
-import { Fragment, InputHTMLAttributes, Ref, forwardRef } from 'react';
+import { Fragment, InputHTMLAttributes, Ref, forwardRef, useId } from 'react';
 import { css } from '@emotion/react';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { hideVisually, focusOutline } from '../../styles/style-mixins';
-import { uniqueId } from '../../util/id';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import { AccessibilityError } from '../../util/errors';
 
@@ -216,7 +215,8 @@ export const RadioButton = forwardRef(
         'The `label` prop is missing.',
       );
     }
-    const id = customId || uniqueId('radio-button_');
+    const id = useId();
+    const inputId = customId || id;
     const handleChange = useClickEvent(onChange, tracking, 'radio-button');
 
     return (
@@ -225,7 +225,7 @@ export const RadioButton = forwardRef(
           {...props}
           type="radio"
           name={name}
-          id={id}
+          id={inputId}
           value={value}
           invalid={invalid}
           aria-invalid={invalid && 'true'}
@@ -235,7 +235,7 @@ export const RadioButton = forwardRef(
           ref={ref}
         />
         <RadioButtonLabel
-          htmlFor={id}
+          htmlFor={inputId}
           invalid={invalid}
           className={className}
           style={style}

--- a/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
@@ -127,13 +127,13 @@ exports[`RadioButton Styles should render with checked styles 1`] = `
   <input
     checked=""
     class="circuit-0"
-    id="radio-button_2"
+    id=":r1:"
     type="radio"
     value=""
   />
   <label
     class="circuit-1"
-    for="radio-button_2"
+    for=":r1:"
   >
     Label
   </label>
@@ -266,13 +266,13 @@ exports[`RadioButton Styles should render with default styles 1`] = `
 <div>
   <input
     class="circuit-0"
-    id="radio-button_1"
+    id=":r0:"
     type="radio"
     value=""
   />
   <label
     class="circuit-1"
-    for="radio-button_1"
+    for=":r0:"
   >
     Label
   </label>
@@ -406,13 +406,13 @@ exports[`RadioButton Styles should render with disabled styles 1`] = `
   <input
     class="circuit-0"
     disabled=""
-    id="radio-button_3"
+    id=":r2:"
     type="radio"
     value=""
   />
   <label
     class="circuit-1"
-    for="radio-button_3"
+    for=":r2:"
   >
     Label
   </label>
@@ -564,13 +564,13 @@ exports[`RadioButton Styles should render with invalid styles 1`] = `
   <input
     aria-invalid="true"
     class="circuit-0"
-    id="radio-button_4"
+    id=":r3:"
     type="radio"
     value=""
   />
   <label
     class="circuit-1"
-    for="radio-button_4"
+    for=":r3:"
   >
     Label
   </label>

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -18,11 +18,11 @@ import {
   InputHTMLAttributes,
   Ref,
   forwardRef,
+  useId,
 } from 'react';
 
 import styled from '../../styles/styled';
 import { typography } from '../../styles/style-mixins';
-import { uniqueId } from '../../util/id';
 import { RadioButton, RadioButtonProps } from '../RadioButton/RadioButton';
 import {
   FieldWrapper,
@@ -124,8 +124,9 @@ export const RadioButtonGroup = forwardRef(
         'The `label` prop is missing. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
-    const name = customName || uniqueId('radio-button-group_');
-    const validationHintId = uniqueId('validation-hint_');
+    const name = useId();
+    const groupName = customName || name;
+    const validationHintId = useId();
     const descriptionIds = `${
       descriptionId ? `${descriptionId} ` : ''
     }${validationHintId}`;
@@ -136,7 +137,7 @@ export const RadioButtonGroup = forwardRef(
         role="radiogroup"
         aria-describedby={descriptionIds}
         aria-orientation="vertical"
-        name={name}
+        name={groupName}
         // @ts-expect-error The `as` prop above changes the HTML element.
         ref={ref}
         disabled={disabled}
@@ -159,7 +160,7 @@ export const RadioButtonGroup = forwardRef(
                 style={style}
               >
                 <RadioButton
-                  {...{ ...rest, value, name, required, onChange }}
+                  {...{ ...rest, value, name: groupName, required, onChange }}
                   checked={value === activeValue}
                   label={optionLabel}
                 />

--- a/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
@@ -143,10 +143,10 @@ exports[`RadioButtonGroup Styles should render with default styles 1`] = `
 
 <div>
   <fieldset
-    aria-describedby="validation-hint_2"
+    aria-describedby=":r1:"
     aria-orientation="vertical"
     class=" circuit-0"
-    name="radio-button-group_1"
+    name=":r0:"
     role="radiogroup"
   >
     <legend
@@ -161,14 +161,14 @@ exports[`RadioButtonGroup Styles should render with default styles 1`] = `
     <div>
       <input
         class="circuit-4"
-        id="radio-button_3"
-        name="radio-button-group_1"
+        id=":r2:"
+        name=":r0:"
         type="radio"
         value="first"
       />
       <label
         class="circuit-5"
-        for="radio-button_3"
+        for=":r2:"
       >
         Option 1
       </label>
@@ -176,14 +176,14 @@ exports[`RadioButtonGroup Styles should render with default styles 1`] = `
     <div>
       <input
         class="circuit-4"
-        id="radio-button_4"
-        name="radio-button-group_1"
+        id=":r3:"
+        name=":r0:"
         type="radio"
         value="second"
       />
       <label
         class="circuit-5"
-        for="radio-button_4"
+        for=":r3:"
       >
         Option 2
       </label>
@@ -191,14 +191,14 @@ exports[`RadioButtonGroup Styles should render with default styles 1`] = `
     <div>
       <input
         class="circuit-4"
-        id="radio-button_5"
-        name="radio-button-group_1"
+        id=":r4:"
+        name=":r0:"
         type="radio"
         value="third"
       />
       <label
         class="circuit-5"
-        for="radio-button_5"
+        for=":r4:"
       >
         Option 3
       </label>

--- a/packages/circuit-ui/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/SearchInput/__snapshots__/SearchInput.spec.tsx.snap
@@ -85,7 +85,7 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
 >
   <label
     class="circuit-1"
-    for="input_3"
+    for=":r2:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -112,10 +112,10 @@ exports[`SearchInput should grey out icon when disabled 1`] = `
       />
     </svg>
     <input
-      aria-describedby="validation-hint_4"
+      aria-describedby=":r3:"
       class="circuit-6"
       disabled=""
-      id="input_3"
+      id=":r2:"
       type="text"
       value=""
     />
@@ -224,7 +224,7 @@ exports[`SearchInput should render with default styles 1`] = `
 >
   <label
     class="circuit-1"
-    for="input_1"
+    for=":r0:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -251,9 +251,9 @@ exports[`SearchInput should render with default styles 1`] = `
       />
     </svg>
     <input
-      aria-describedby="validation-hint_2"
+      aria-describedby=":r1:"
       class="circuit-6"
-      id="input_1"
+      id=":r0:"
       type="text"
       value=""
     />

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -13,12 +13,11 @@
  * limitations under the License.
  */
 
-import { ReactNode, Ref, SelectHTMLAttributes, forwardRef } from 'react';
+import { ReactNode, Ref, SelectHTMLAttributes, forwardRef, useId } from 'react';
 import { css } from '@emotion/react';
 import { ChevronDown, ChevronUp } from '@sumup/icons';
 import { Theme } from '@sumup/design-tokens';
 
-import { uniqueId } from '../../util/id';
 import styled, { StyleProps } from '../../styles/styled';
 import { typography, inputOutline } from '../../styles/style-mixins';
 import { ReturnType } from '../../types/return-type';
@@ -263,8 +262,9 @@ export const Select = forwardRef(
         'The `label` prop is missing. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
-    const id = customId || uniqueId('select_');
-    const validationHintId = uniqueId('validation-hint_');
+    const id = useId();
+    const selectId = customId || id;
+    const validationHintId = useId();
     const descriptionIds = `${
       descriptionId ? `${descriptionId} ` : ''
     }${validationHintId}`;
@@ -278,7 +278,7 @@ export const Select = forwardRef(
 
     return (
       <FieldWrapper className={className} style={style} disabled={disabled}>
-        <FieldLabel htmlFor={id}>
+        <FieldLabel htmlFor={selectId}>
           <FieldLabelText
             label={label}
             hideLabel={hideLabel}
@@ -289,7 +289,7 @@ export const Select = forwardRef(
         <SelectWrapper>
           {prefix}
           <SelectElement
-            id={id}
+            id={selectId}
             value={value}
             ref={ref}
             aria-describedby={descriptionIds}

--- a/packages/circuit-ui/components/Select/__snapshots__/Select.spec.tsx.snap
+++ b/packages/circuit-ui/components/Select/__snapshots__/Select.spec.tsx.snap
@@ -105,7 +105,7 @@ select:not(:active)~.circuit-7 {
   >
     <label
       class="circuit-1"
-      for="select_9"
+      for=":r8:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -117,11 +117,11 @@ select:not(:active)~.circuit-7 {
       class="circuit-4"
     >
       <select
-        aria-describedby="validation-hint_10"
+        aria-describedby=":r9:"
         aria-invalid="true"
         class="circuit-5"
         disabled=""
-        id="select_9"
+        id=":r8:"
       >
         <option
           value=""
@@ -307,7 +307,7 @@ select:not(:active)~.circuit-8 {
   >
     <label
       class="circuit-1"
-      for="select_13"
+      for=":rc:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -323,9 +323,9 @@ select:not(:active)~.circuit-8 {
         style="width: 24px; height: 24px;"
       />
       <select
-        aria-describedby="validation-hint_14"
+        aria-describedby=":rd:"
         class="circuit-6"
-        id="select_13"
+        id=":rc:"
       >
         <option
           value=""
@@ -514,7 +514,7 @@ select:not(:active)~.circuit-7 {
   >
     <label
       class="circuit-1"
-      for="select_11"
+      for=":ra:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -526,9 +526,9 @@ select:not(:active)~.circuit-7 {
       class="circuit-4"
     >
       <select
-        aria-describedby="validation-hint_12"
+        aria-describedby=":rb:"
         class="circuit-5"
-        id="select_11"
+        id=":ra:"
       >
         <option
           value=""
@@ -580,7 +580,7 @@ select:not(:active)~.circuit-7 {
     </div>
     <span
       class="circuit-8"
-      id="validation-hint_12"
+      id=":rb:"
     >
       This field is required.
     </span>
@@ -718,7 +718,7 @@ select:not(:active)~.circuit-7 {
   >
     <label
       class="circuit-1"
-      for="select_3"
+      for=":r2:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -730,9 +730,9 @@ select:not(:active)~.circuit-7 {
       class="circuit-4"
     >
       <select
-        aria-describedby="validation-hint_4"
+        aria-describedby=":r3:"
         class="circuit-5"
-        id="select_3"
+        id=":r2:"
       >
         <option
           value=""
@@ -907,7 +907,7 @@ select:not(:active)~.circuit-7 {
   >
     <label
       class="circuit-1"
-      for="select_1"
+      for=":r0:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -919,9 +919,9 @@ select:not(:active)~.circuit-7 {
       class="circuit-4"
     >
       <select
-        aria-describedby="validation-hint_2"
+        aria-describedby=":r1:"
         class="circuit-5"
-        id="select_1"
+        id=":r0:"
       >
         <option
           value=""
@@ -1084,7 +1084,7 @@ select:not(:active)~.circuit-7 {
   >
     <label
       class="circuit-1"
-      for="select_5"
+      for=":r4:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -1096,10 +1096,10 @@ select:not(:active)~.circuit-7 {
       class="circuit-4"
     >
       <select
-        aria-describedby="validation-hint_6"
+        aria-describedby=":r5:"
         class="circuit-5"
         disabled=""
-        id="select_5"
+        id=":r4:"
       >
         <option
           value=""
@@ -1275,7 +1275,7 @@ select:not(:active)~.circuit-7 {
   >
     <label
       class="circuit-1"
-      for="select_7"
+      for=":r6:"
     >
       <span
         class="circuit-2 circuit-3"
@@ -1287,10 +1287,10 @@ select:not(:active)~.circuit-7 {
       class="circuit-4"
     >
       <select
-        aria-describedby="validation-hint_8"
+        aria-describedby=":r7:"
         aria-invalid="true"
         class="circuit-5"
-        id="select_7"
+        id=":r6:"
       >
         <option
           value=""

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -13,12 +13,11 @@
  * limitations under the License.
  */
 
-import { Fragment, Ref, InputHTMLAttributes, forwardRef } from 'react';
+import { Fragment, Ref, InputHTMLAttributes, forwardRef, useId } from 'react';
 import { css } from '@emotion/react';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { hideVisually, focusOutline } from '../../styles/style-mixins';
-import { uniqueId } from '../../util/id';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 
 export type SelectorSize = 'kilo' | 'mega' | 'flexible';
@@ -183,7 +182,7 @@ export const Selector = forwardRef(
     {
       children,
       value,
-      id,
+      id: customId,
       name,
       disabled,
       multiple,
@@ -196,7 +195,8 @@ export const Selector = forwardRef(
     }: SelectorProps,
     ref: SelectorProps['ref'],
   ) => {
-    const inputId = id || uniqueId('selector_');
+    const id = useId();
+    const inputId = customId || id;
     const type = multiple ? 'checkbox' : 'radio';
     const handleChange = useClickEvent(onChange, tracking, 'selector');
 

--- a/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
+++ b/packages/circuit-ui/components/Selector/__snapshots__/Selector.spec.tsx.snap
@@ -60,7 +60,7 @@ HTMLCollection [
 <input
     checked=""
     class="circuit-0"
-    id="selector_3"
+    id=":r2:"
     name="name"
     type="radio"
     value="value"
@@ -128,7 +128,7 @@ HTMLCollection [
 
 <label
     class="circuit-0"
-    for="selector_3"
+    for=":r2:"
   >
     Label
   </label>,
@@ -194,7 +194,7 @@ HTMLCollection [
 
 <input
     class="circuit-0"
-    id="selector_1"
+    id=":r0:"
     name="name"
     type="radio"
     value="value"
@@ -262,7 +262,7 @@ HTMLCollection [
 
 <label
     class="circuit-0"
-    for="selector_1"
+    for=":r0:"
   >
     Label
   </label>,
@@ -329,7 +329,7 @@ HTMLCollection [
 <input
     class="circuit-0"
     disabled=""
-    id="selector_2"
+    id=":r1:"
     name="name"
     type="radio"
     value="value"
@@ -397,7 +397,7 @@ HTMLCollection [
 
 <label
     class="circuit-0"
-    for="selector_2"
+    for=":r1:"
   >
     Label
   </label>,

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -13,11 +13,10 @@
  * limitations under the License.
  */
 
-import { ReactNode, Ref, forwardRef, ChangeEventHandler } from 'react';
+import { ReactNode, Ref, forwardRef, ChangeEventHandler, useId } from 'react';
 import { css } from '@emotion/react';
 
 import styled, { StyleProps } from '../../styles/styled';
-import { uniqueId } from '../../util/id';
 import Selector from '../Selector';
 import { SelectorSize } from '../Selector/Selector';
 import { hideVisually, typography } from '../../styles/style-mixins';
@@ -154,7 +153,8 @@ export const SelectorGroup = forwardRef(
         'The `label` prop is required. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
-    const name = customName || uniqueId('selector-group_');
+    const name = useId();
+    const groupName = customName || name;
 
     if (!options) {
       return null;
@@ -166,7 +166,7 @@ export const SelectorGroup = forwardRef(
         {options.map(({ children, value, ...optionRest }) => (
           <OptionItem key={value}>
             <Selector
-              name={name}
+              name={groupName}
               onChange={onChange}
               multiple={multiple}
               value={value}

--- a/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/SelectorGroup/__snapshots__/SelectorGroup.spec.tsx.snap
@@ -175,14 +175,14 @@ exports[`SelectorGroup should render with default styles 1`] = `
     >
       <input
         class="circuit-3"
-        id="selector_2"
-        name="selector-group_1"
+        id=":r1:"
+        name=":r0:"
         type="radio"
         value="first"
       />
       <label
         class="circuit-4"
-        for="selector_2"
+        for=":r1:"
       >
         Option 1
       </label>
@@ -192,14 +192,14 @@ exports[`SelectorGroup should render with default styles 1`] = `
     >
       <input
         class="circuit-3"
-        id="selector_3"
-        name="selector-group_1"
+        id=":r2:"
+        name=":r0:"
         type="radio"
         value="second"
       />
       <label
         class="circuit-4"
-        for="selector_3"
+        for=":r2:"
       >
         Option 2
       </label>
@@ -209,14 +209,14 @@ exports[`SelectorGroup should render with default styles 1`] = `
     >
       <input
         class="circuit-3"
-        id="selector_4"
-        name="selector-group_1"
+        id=":r3:"
+        name=":r0:"
         type="radio"
         value="third"
       />
       <label
         class="circuit-4"
-        for="selector_4"
+        for=":r3:"
       >
         Option 3
       </label>
@@ -400,14 +400,14 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
     >
       <input
         class="circuit-3"
-        id="selector_18"
-        name="selector-group_17"
+        id=":rh:"
+        name=":rg:"
         type="radio"
         value="first"
       />
       <label
         class="circuit-4"
-        for="selector_18"
+        for=":rh:"
       >
         Option 1
       </label>
@@ -417,14 +417,14 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
     >
       <input
         class="circuit-3"
-        id="selector_19"
-        name="selector-group_17"
+        id=":ri:"
+        name=":rg:"
         type="radio"
         value="second"
       />
       <label
         class="circuit-4"
-        for="selector_19"
+        for=":ri:"
       >
         Option 2
       </label>
@@ -434,14 +434,14 @@ exports[`SelectorGroup should render with horizontal layout by default 1`] = `
     >
       <input
         class="circuit-3"
-        id="selector_20"
-        name="selector-group_17"
+        id=":rj:"
+        name=":rg:"
         type="radio"
         value="third"
       />
       <label
         class="circuit-4"
-        for="selector_20"
+        for=":rj:"
       >
         Option 3
       </label>

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
@@ -348,7 +348,7 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
           <a
             aria-current="page"
             class="circuit-3"
-            data-focus-list="1"
+            data-focus-list=":r0:"
             href="/shop"
           >
             <span
@@ -417,7 +417,7 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
             <li>
               <a
                 class="circuit-14"
-                data-focus-list="2"
+                data-focus-list=":r1:"
                 href="/shop/toys"
               >
                 <span
@@ -434,7 +434,7 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
             <li>
               <a
                 class="circuit-14"
-                data-focus-list="2"
+                data-focus-list=":r1:"
                 href="/shop/books"
               >
                 <span
@@ -660,7 +660,7 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
         <li>
           <a
             class="circuit-3"
-            data-focus-list="3"
+            data-focus-list=":r2:"
             href="/"
           >
             <span

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/__snapshots__/MobileNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/__snapshots__/MobileNavigation.spec.tsx.snap
@@ -539,11 +539,11 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
             >
               <li>
                 <button
-                  aria-controls="collapsible_2"
+                  aria-controls=":r1:"
                   aria-current="page"
                   aria-expanded="false"
                   class="circuit-10"
-                  data-focus-list="1"
+                  data-focus-list=":r0:"
                 >
                   <span
                     class="circuit-11"
@@ -591,7 +591,7 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
                 <ul
                   aria-hidden="true"
                   class="circuit-15"
-                  id="collapsible_2"
+                  id=":r1:"
                   role="list"
                   style="overflow-y: hidden; will-change: height; opacity: 0; height: 0px; visibility: hidden; transition: all 200ms ease-in-out;"
                 >
@@ -612,7 +612,7 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
                       <li>
                         <a
                           class="circuit-19"
-                          data-focus-list="3"
+                          data-focus-list=":r2:"
                           href="/shop/toys"
                         >
                           <span
@@ -629,7 +629,7 @@ exports[`MobileNavigation styles should render with secondary links 1`] = `
                       <li>
                         <a
                           class="circuit-19"
-                          data-focus-list="3"
+                          data-focus-list=":r2:"
                           href="/shop/books"
                         >
                           <span
@@ -1068,7 +1068,7 @@ exports[`MobileNavigation styles should render without secondary links 1`] = `
               <li>
                 <a
                   class="circuit-10"
-                  data-focus-list="4"
+                  data-focus-list=":r3:"
                   href="/"
                 >
                   <span

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/__snapshots__/SecondaryLinks.spec.tsx.snap
@@ -199,7 +199,7 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
       <li>
         <a
           class="circuit-2"
-          data-focus-list="1"
+          data-focus-list=":r0:"
           href="/shop/shirts"
         >
           <span
@@ -216,7 +216,7 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
       <li>
         <a
           class="circuit-2"
-          data-focus-list="1"
+          data-focus-list=":r0:"
           href="/shop/pants"
         >
           <span
@@ -239,7 +239,7 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
         <a
           aria-current="page"
           class="circuit-9"
-          data-focus-list="1"
+          data-focus-list=":r0:"
           href="/shop/socks"
         >
           <span
@@ -272,7 +272,7 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
       <li>
         <a
           class="circuit-2"
-          data-focus-list="1"
+          data-focus-list=":r0:"
           href="/shop/toys"
         >
           <span
@@ -289,7 +289,7 @@ exports[`SecondaryLinks styles should render with default styles 1`] = `
       <li>
         <a
           class="circuit-2"
-          data-focus-list="1"
+          data-focus-list=":r0:"
           href="/shop/books"
         >
           <span

--- a/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
@@ -17,10 +17,6 @@ import { render, userEvent, axe, waitFor } from '../../util/test-utils';
 
 import { SidePanel, SidePanelProps } from './SidePanel';
 
-jest.mock('../../util/id', () => ({
-  uniqueId: () => 'the_one',
-}));
-
 describe('SidePanel', () => {
   const baseProps: SidePanelProps = {
     backButtonLabel: 'Back',

--- a/packages/circuit-ui/components/SidePanel/SidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.tsx
@@ -13,13 +13,12 @@
  * limitations under the License.
  */
 
-import { UIEventHandler, useEffect, useMemo, useState } from 'react';
+import { UIEventHandler, useEffect, useId, useState } from 'react';
 import { css } from '@emotion/react';
 import { Props as ReactModalProps } from 'react-modal';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { isFunction } from '../../util/type-check';
-import { uniqueId } from '../../util/id';
 import { AccessibilityError } from '../../util/errors';
 
 import { MobileSidePanel } from './components/MobileSidePanel';
@@ -145,7 +144,7 @@ export const SidePanel = ({
   }
 
   const [isHeaderSticky, setHeaderSticky] = useState(false);
-  const headerAriaId = useMemo(() => uniqueId('side-panel-header_'), []);
+  const headerAriaId = useId();
 
   useEffect(() => {
     setHeaderSticky(false);

--- a/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanel.spec.tsx.snap
@@ -257,7 +257,7 @@ exports[`SidePanel should match the snapshot 1`] = `
       class="ReactModal__Overlay circuit-0"
     >
       <div
-        aria-labelledby="the_one"
+        aria-labelledby=":r0:"
         aria-modal="true"
         class="circuit-1"
         role="dialog"
@@ -271,7 +271,7 @@ exports[`SidePanel should match the snapshot 1`] = `
           >
             <h2
               class="circuit-4"
-              id="the_one"
+              id=":r0:"
             >
               Side panel title
             </h2>
@@ -590,7 +590,7 @@ exports[`SidePanel when the panel is on mobile resolution should match the snaps
       class="circuit-0"
     >
       <div
-        aria-labelledby="the_one"
+        aria-labelledby=":rd:"
         aria-modal="true"
         class="circuit-1"
         role="dialog"
@@ -604,7 +604,7 @@ exports[`SidePanel when the panel is on mobile resolution should match the snaps
           >
             <h2
               class="circuit-4"
-              id="the_one"
+              id=":rd:"
             >
               Side panel title
             </h2>

--- a/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanelContext.spec.tsx.snap
+++ b/packages/circuit-ui/components/SidePanel/__snapshots__/SidePanelContext.spec.tsx.snap
@@ -292,7 +292,7 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
       class="ReactModal__Overlay circuit-1"
     >
       <div
-        aria-labelledby="side-panel-header_2"
+        aria-labelledby=":r0:"
         aria-modal="true"
         class="circuit-2"
         role="dialog"
@@ -306,7 +306,7 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
           >
             <h2
               class="circuit-5"
-              id="side-panel-header_2"
+              id=":r0:"
             >
               Side panel title
             </h2>
@@ -642,7 +642,7 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
       class="circuit-1"
     >
       <div
-        aria-labelledby="side-panel-header_4"
+        aria-labelledby=":r1:"
         aria-modal="true"
         class="circuit-2"
         role="dialog"
@@ -656,7 +656,7 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
           >
             <h2
               class="circuit-5"
-              id="side-panel-header_4"
+              id=":r1:"
             >
               Side panel title
             </h2>
@@ -991,7 +991,7 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
       class="ReactModal__Overlay circuit-1"
     >
       <div
-        aria-labelledby="side-panel-header_6"
+        aria-labelledby=":r2:"
         aria-modal="true"
         class="circuit-2"
         role="dialog"
@@ -1005,7 +1005,7 @@ exports[`SidePanelContext SidePanelProvider render should render the side panel 
           >
             <h2
               class="circuit-5"
-              id="side-panel-header_6"
+              id=":r2:"
             >
               Side panel title
             </h2>

--- a/packages/circuit-ui/components/SidePanel/useSidePanel.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/useSidePanel.spec.tsx
@@ -18,7 +18,7 @@ import { renderHook } from '../../util/test-utils';
 import { useSidePanel } from './useSidePanel';
 import { SidePanelContext } from './SidePanelContext';
 
-const defaultId = 'the_one';
+const defaultId = '1';
 const testId = 'test';
 
 jest.mock('../../util/id', () => ({
@@ -26,6 +26,10 @@ jest.mock('../../util/id', () => ({
 }));
 
 describe('useSidePanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   const setSidePanel = jest.fn();
   const updateSidePanel = jest.fn();
   const removeSidePanel = jest.fn().mockResolvedValue(undefined);
@@ -61,8 +65,8 @@ describe('useSidePanel', () => {
 
     const expected = {
       ...panel,
-      group: defaultId,
-      id: defaultId,
+      group: ':r0:',
+      id: '1',
     };
     expect(setSidePanel).toHaveBeenCalledWith(expected);
   });
@@ -90,7 +94,7 @@ describe('useSidePanel', () => {
 
     const expected = {
       children: <p data-testid="children">Updated content</p>,
-      group: defaultId,
+      group: ':r2:',
     };
     expect(updateSidePanel).toHaveBeenCalledWith(expected);
   });
@@ -116,7 +120,7 @@ describe('useSidePanel', () => {
     result.current.setSidePanel(panel);
     result.current.removeSidePanel();
 
-    const expected = defaultId;
+    const expected = ':r4:';
     expect(removeSidePanel).toHaveBeenCalledWith(expected);
   });
 
@@ -141,7 +145,7 @@ describe('useSidePanel', () => {
 
     unmount();
 
-    const expected = defaultId;
+    const expected = ':r6:';
     expect(removeSidePanel).toHaveBeenCalledWith(expected);
   });
 });

--- a/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
@@ -16,14 +16,14 @@
 import {
   ReactNode,
   useContext,
-  useMemo,
   useCallback,
+  useId,
   useRef,
   useEffect,
 } from 'react';
 
-import { uniqueId } from '../../util/id';
 import { TrackingProps } from '../../hooks/useClickEvent';
+import { uniqueId } from '../../util/id';
 
 import { SidePanelContext, SidePanelContextProps } from './SidePanelContext';
 
@@ -84,7 +84,7 @@ type UseSidePanelHook = () => {
 };
 
 export const useSidePanel: UseSidePanelHook = () => {
-  const defaultGroup = useMemo(uniqueId, []);
+  const defaultGroup = useId();
   const bottomSidePanelGroupRef = useRef<
     SidePanelContextProps['group'] | undefined
   >();

--- a/packages/circuit-ui/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
+++ b/packages/circuit-ui/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
@@ -77,7 +77,7 @@ exports[`TextArea should prioritize disabled over error styles 1`] = `
 >
   <label
     class="circuit-1"
-    for="input_39"
+    for=":ri:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -89,11 +89,11 @@ exports[`TextArea should prioritize disabled over error styles 1`] = `
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_40"
+      aria-describedby=":rj:"
       aria-invalid="true"
       class="circuit-5"
       disabled=""
-      id="input_39"
+      id=":ri:"
     />
   </div>
   <span
@@ -180,7 +180,7 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
 >
   <label
     class="circuit-1"
-    for="input_43"
+    for=":rk:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -192,10 +192,10 @@ exports[`TextArea should prioritize disabled over warning styles 1`] = `
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_44"
+      aria-describedby=":rl:"
       class="circuit-5"
       disabled=""
-      id="input_43"
+      id=":rk:"
     />
   </div>
   <span
@@ -294,7 +294,7 @@ exports[`TextArea should render minRows props as rows when passed if rows is aut
 >
   <label
     class="circuit-1"
-    for="input_55"
+    for=":rq:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -306,9 +306,9 @@ exports[`TextArea should render minRows props as rows when passed if rows is aut
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_56"
+      aria-describedby=":rr:"
       class="circuit-5"
-      id="input_55"
+      id=":rq:"
       rows="3"
       style="resize: none; overflow-y: hidden; height: auto;"
     />
@@ -409,7 +409,7 @@ exports[`TextArea should render rows props when passed 1`] = `
 >
   <label
     class="circuit-1"
-    for="input_47"
+    for=":rm:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -421,9 +421,9 @@ exports[`TextArea should render rows props when passed 1`] = `
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_48"
+      aria-describedby=":rn:"
       class="circuit-5"
-      id="input_47"
+      id=":rm:"
       rows="3"
     />
   </div>
@@ -537,7 +537,7 @@ exports[`TextArea should render with a Tooltip when passed the validationHint pr
 >
   <label
     class="circuit-1"
-    for="input_15"
+    for=":r6:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -549,14 +549,14 @@ exports[`TextArea should render with a Tooltip when passed the validationHint pr
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_16"
+      aria-describedby=":r7:"
       class="circuit-5"
-      id="input_15"
+      id=":r6:"
     />
   </div>
   <span
     class="circuit-6"
-    id="validation-hint_16"
+    id=":r7:"
   >
     Validation hint
   </span>
@@ -666,7 +666,7 @@ exports[`TextArea should render with a prefix when passed the prefix prop 1`] = 
 >
   <label
     class="circuit-1"
-    for="input_7"
+    for=":r2:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -682,9 +682,9 @@ exports[`TextArea should render with a prefix when passed the prefix prop 1`] = 
       style="width: 24px; height: 24px;"
     />
     <textarea
-      aria-describedby="validation-hint_8"
+      aria-describedby=":r3:"
       class="circuit-6"
-      id="input_7"
+      id=":r2:"
     />
   </div>
   <span
@@ -797,7 +797,7 @@ exports[`TextArea should render with a suffix when passed the suffix prop 1`] = 
 >
   <label
     class="circuit-1"
-    for="input_11"
+    for=":r4:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -809,9 +809,9 @@ exports[`TextArea should render with a suffix when passed the suffix prop 1`] = 
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_12"
+      aria-describedby=":r5:"
       class="circuit-5"
-      id="input_11"
+      id=":r4:"
     />
     <div
       class="circuit-6"
@@ -914,7 +914,7 @@ exports[`TextArea should render with default styles 1`] = `
 >
   <label
     class="circuit-1"
-    for="input_3"
+    for=":r0:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -926,9 +926,9 @@ exports[`TextArea should render with default styles 1`] = `
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_4"
+      aria-describedby=":r1:"
       class="circuit-5"
-      id="input_3"
+      id=":r0:"
     />
   </div>
   <span
@@ -1015,7 +1015,7 @@ exports[`TextArea should render with disabled styled when passed the disabled pr
 >
   <label
     class="circuit-1"
-    for="input_35"
+    for=":rg:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -1027,10 +1027,10 @@ exports[`TextArea should render with disabled styled when passed the disabled pr
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_36"
+      aria-describedby=":rh:"
       class="circuit-5"
       disabled=""
-      id="input_35"
+      id=":rg:"
     />
   </div>
   <span
@@ -1145,7 +1145,7 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
 >
   <label
     class="circuit-1"
-    for="input_23"
+    for=":ra:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -1157,10 +1157,10 @@ exports[`TextArea should render with invalid styles when passed the invalid prop
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_24"
+      aria-describedby=":rb:"
       aria-invalid="true"
       class="circuit-5"
-      id="input_23"
+      id=":ra:"
     />
   </div>
   <span
@@ -1260,7 +1260,7 @@ exports[`TextArea should render with readonly styles when passed the readonly pr
 >
   <label
     class="circuit-1"
-    for="input_31"
+    for=":re:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -1272,9 +1272,9 @@ exports[`TextArea should render with readonly styles when passed the readonly pr
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_32"
+      aria-describedby=":rf:"
       class="circuit-5"
-      id="input_31"
+      id=":re:"
       readonly=""
     />
   </div>
@@ -1374,7 +1374,7 @@ exports[`TextArea should render with valid styles when passed the showValid prop
 >
   <label
     class="circuit-1"
-    for="input_27"
+    for=":rc:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -1386,9 +1386,9 @@ exports[`TextArea should render with valid styles when passed the showValid prop
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_28"
+      aria-describedby=":rd:"
       class="circuit-5"
-      id="input_27"
+      id=":rc:"
     />
   </div>
   <span
@@ -1503,7 +1503,7 @@ exports[`TextArea should render with warning styles when passed the hasWarning p
 >
   <label
     class="circuit-1"
-    for="input_19"
+    for=":r8:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -1515,9 +1515,9 @@ exports[`TextArea should render with warning styles when passed the hasWarning p
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_20"
+      aria-describedby=":r9:"
       class="circuit-5"
-      id="input_19"
+      id=":r8:"
     />
   </div>
   <span
@@ -1616,7 +1616,7 @@ exports[`TextArea should render without rows props when passed if rows is auto 1
 >
   <label
     class="circuit-1"
-    for="input_51"
+    for=":ro:"
   >
     <span
       class="circuit-2 circuit-3"
@@ -1628,9 +1628,9 @@ exports[`TextArea should render without rows props when passed if rows is auto 1
     class="circuit-4"
   >
     <textarea
-      aria-describedby="validation-hint_52"
+      aria-describedby=":rp:"
       class="circuit-5"
-      id="input_51"
+      id=":ro:"
       style="resize: none; overflow-y: hidden; height: auto;"
     />
   </div>

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -13,12 +13,11 @@
  * limitations under the License.
  */
 
-import { Ref, forwardRef } from 'react';
+import { Ref, forwardRef, useId } from 'react';
 import { css } from '@emotion/react';
 import { Theme } from '@sumup/design-tokens';
 
 import styled, { StyleProps } from '../../styles/styled';
-import { uniqueId } from '../../util/id';
 import { Body, BodyProps } from '../Body/Body';
 import { AccessibilityError } from '../../util/errors';
 import { FieldWrapper } from '../FieldAtoms';
@@ -103,13 +102,14 @@ export const Toggle = forwardRef(
       throw new AccessibilityError('Toggle', 'The `label` prop is missing.');
     }
 
-    const switchId = uniqueId('toggle-switch_');
-    const labelId = uniqueId('toggle-label_');
-    const explanationId = explanation ? uniqueId('toggle-explanation_') : '';
+    const switchId = useId();
+    const labelId = useId();
+    const explanationId = useId();
 
-    const descriptionIds = [descriptionId, explanationId]
+    const descriptionIds = [descriptionId, explanation && explanationId]
       .filter(Boolean)
       .join(' ');
+
     return (
       <FieldWrapper disabled={props.disabled} css={wrapperStyles}>
         <Switch

--- a/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -190,10 +190,10 @@ exports[`Toggle should render with default styles 1`] = `
   >
     <button
       aria-checked="false"
-      aria-describedby="toggle-explanation_3"
-      aria-labelledby="toggle-label_2"
+      aria-describedby=":r2:"
+      aria-labelledby=":r1:"
       class="circuit-1"
-      id="toggle-switch_1"
+      id=":r0:"
       role="switch"
       type="button"
     >
@@ -211,14 +211,14 @@ exports[`Toggle should render with default styles 1`] = `
     >
       <label
         class="circuit-5"
-        for="toggle-switch_1"
-        id="toggle-label_2"
+        for=":r0:"
+        id=":r1:"
       >
         Label
       </label>
       <p
         class="circuit-6"
-        id="toggle-explanation_3"
+        id=":r2:"
       >
         A longer explanation
       </p>

--- a/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/__snapshots__/TopNavigation.spec.tsx.snap
@@ -683,12 +683,12 @@ exports[`TopNavigation styles should match the snapshot 1`] = `
         class="circuit-17"
       >
         <button
-          aria-controls="popover_2"
+          aria-controls=":r1:"
           aria-expanded="false"
           aria-haspopup="true"
           aria-label="Open profile menu"
           class="circuit-18"
-          id="trigger_1"
+          id=":r0:"
           title="Open profile menu"
           type="button"
         >

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/__snapshots__/ProfileMenu.spec.tsx.snap
@@ -143,12 +143,12 @@ exports[`ProfileMenu Styles should render with a profile picture 1`] = `
     class="circuit-0"
   >
     <button
-      aria-controls="popover_2"
+      aria-controls=":r1:"
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Open profile menu"
       class="circuit-1"
-      id="trigger_1"
+      id=":r0:"
       title="Open profile menu"
       type="button"
     >
@@ -315,12 +315,12 @@ exports[`ProfileMenu Styles should render without a profile picture 1`] = `
     class="circuit-0"
   >
     <button
-      aria-controls="popover_7"
+      aria-controls=":r4:"
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Open profile menu"
       class="circuit-1"
-      id="trigger_6"
+      id=":r3:"
       title="Open profile menu"
       type="button"
     >

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
@@ -13,10 +13,9 @@
  * limitations under the License.
  */
 
-import { useState, useRef, useCallback, RefObject } from 'react';
+import { useState, useRef, useCallback, RefObject, useId } from 'react';
 
 import { ClickEvent } from '../../types/events';
-import { uniqueId } from '../../util/id';
 import { useAnimation } from '../useAnimation';
 
 const DEFAULT_HEIGHT = 'auto';
@@ -64,9 +63,10 @@ type Collapsible<T> = {
 export function useCollapsible<T extends HTMLElement = HTMLElement>({
   initialOpen = false,
   duration = 200,
-  id,
+  id: customId,
 }: CollapsibleOptions = {}): Collapsible<T> {
-  const contentId = id || uniqueId('collapsible_');
+  const id = useId();
+  const contentId = customId || id;
   const contentElement = useRef<T>(null);
   const [isOpen, setOpen] = useState(initialOpen);
   const [height, setHeight] = useState(getHeight(contentElement));

--- a/packages/circuit-ui/hooks/useFocusList/useFocusList.ts
+++ b/packages/circuit-ui/hooks/useFocusList/useFocusList.ts
@@ -13,9 +13,8 @@
  * limitations under the License.
  */
 
-import { KeyboardEvent, useCallback, useRef } from 'react';
+import { KeyboardEvent, useCallback, useId } from 'react';
 
-import { uniqueId } from '../../util/id';
 import { isArrowDown, isArrowUp } from '../../util/key-codes';
 
 export type FocusProps = {
@@ -28,29 +27,32 @@ export type FocusProps = {
  * Spread the props returned by the hook onto each list item.
  */
 export function useFocusList(): FocusProps {
-  const name = useRef(uniqueId());
+  const name = useId();
 
-  const onKeyDown = useCallback((event: KeyboardEvent) => {
-    if (!isArrowUp(event) && !isArrowDown(event)) {
-      return;
-    }
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!isArrowUp(event) && !isArrowDown(event)) {
+        return;
+      }
 
-    event.preventDefault();
+      event.preventDefault();
 
-    const items = document.querySelectorAll<HTMLElement>(
-      `[data-focus-list="${name.current}"]`,
-    );
-    const currentEl = event.target as HTMLElement;
-    const currentIndex = Array.from(items).indexOf(currentEl);
-    const newIndex = isArrowUp(event)
-      ? getPrevIndex(currentIndex, items.length)
-      : getNextIndex(currentIndex, items.length);
-    const newEl = items.item(newIndex);
+      const items = document.querySelectorAll<HTMLElement>(
+        `[data-focus-list="${name}"]`,
+      );
+      const currentEl = event.target as HTMLElement;
+      const currentIndex = Array.from(items).indexOf(currentEl);
+      const newIndex = isArrowUp(event)
+        ? getPrevIndex(currentIndex, items.length)
+        : getNextIndex(currentIndex, items.length);
+      const newEl = items.item(newIndex);
 
-    newEl.focus();
-  }, []);
+      newEl.focus();
+    },
+    [name],
+  );
 
-  return { 'data-focus-list': name.current, onKeyDown };
+  return { 'data-focus-list': name, onKeyDown };
 }
 
 function getPrevIndex(currentIndex: number, length: number): number {

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -84,7 +84,7 @@
     "@sumup/design-tokens": ">=5.0.0",
     "@sumup/icons": ">=2.9.0",
     "@sumup/intl": "1.x",
-    "react": ">=16.8.0 <19.0.0",
-    "react-dom": ">=16.8.0 <19.0.0"
+    "react": ">=18.0.0 <19.0.0",
+    "react-dom": ">=18.0.0 <19.0.0"
   }
 }


### PR DESCRIPTION
Addresses [DSYS-371](https://sumupteam.atlassian.net/browse/DSYS-371). Relates to #1998.

## Purpose

Circuit UI has supported [React 18](https://reactjs.org/blog/2022/03/29/react-v18.html) since #1554 while continuing to support older versions of React (>=16.8). React 18 introduced APIs to support the new concurrent rendering mode. Circuit UI must adopt these APIs, which requires raising the minimum React version to React 18.

## Approach and changes

- Raise the minimum version of the `react` and `react-dom` peer dependencies to >=18
- Deprecate the `uniqueId` util and replace it with the new [`useId` hook](https://beta.reactjs.org/reference/react/useId)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
