### PR TITLE
Remove duplicate id from the validation hint icon in form components

### DIFF
--- a/.changeset/tasty-ghosts-smell.md
+++ b/.changeset/tasty-ghosts-smell.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Remove duplicate id from the validation hint icon in form components.

--- a/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
+++ b/packages/circuit-ui/components/Checkbox/__snapshots__/Checkbox.spec.tsx.snap
@@ -629,11 +629,6 @@ exports[`Checkbox Styles should render with invalid styles and an error message 
   height: 16px;
   vertical-align: text-top;
   margin-right: 4px;
-  color: var(--cui-fg-danger);
-}
-
-.cui-field-disabled .circuit-4 {
-  color: var(--cui-fg-danger-disabled);
 }
 
 <div>
@@ -676,7 +671,6 @@ exports[`Checkbox Styles should render with invalid styles and an error message 
       >
         <div
           class="circuit-4"
-          id="validation_hint-8"
         >
           <svg
             fill="none"

--- a/packages/circuit-ui/components/FieldAtoms/FieldValidationHint.tsx
+++ b/packages/circuit-ui/components/FieldAtoms/FieldValidationHint.tsx
@@ -104,21 +104,21 @@ const getIcon = (props: FieldValidationHintProps) => {
     }
     case props.invalid: {
       return (
-        <IconWrapper {...props}>
+        <IconWrapper>
           <Alert role="presentation" size="16" />
         </IconWrapper>
       );
     }
     case props.hasWarning: {
       return (
-        <IconWrapper {...props}>
+        <IconWrapper>
           <Notify role="presentation" size="16" />
         </IconWrapper>
       );
     }
     case props.showValid: {
       return (
-        <IconWrapper {...props}>
+        <IconWrapper>
           <Confirm role="presentation" size="16" />
         </IconWrapper>
       );

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -2001,11 +2001,6 @@ exports[`ImageInput Styles should render with invalid styles and an error messag
   height: 16px;
   vertical-align: text-top;
   margin-right: 4px;
-  color: var(--cui-fg-danger);
-}
-
-.cui-field-disabled .circuit-14 {
-  color: var(--cui-fg-danger-disabled);
 }
 
 <div>
@@ -2107,7 +2102,6 @@ exports[`ImageInput Styles should render with invalid styles and an error messag
       >
         <div
           class="circuit-14"
-          id="validation-hint_6"
         >
           <svg
             fill="none"


### PR DESCRIPTION
## Purpose

<img width="401" alt="Screenshot 2023-03-14 at 18 25 58" src="https://user-images.githubusercontent.com/11017722/225072368-6a1b0201-c0ac-4994-9365-54d36f7b518a.png">

## Approach and changes

- Don't forward props to validation hint icon

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
