### PR TITLE
Simplify style mixin function signature

### DIFF
--- a/.changeset/tall-avocados-sin.md
+++ b/.changeset/tall-avocados-sin.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Simplified the function signature of the style mixins that no longer require the `theme` parameter (`shadow`, `focusOutline`, `focusVisible`, and `inputOutline`).

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -87,7 +87,7 @@ const primaryWrapperStyles = ({ theme }: StyleProps) => css`
 
   &:hover,
   &:focus-within {
-    ${shadow(theme)};
+    ${shadow()};
     width: ${PRIMARY_NAVIGATION_OPENED_WIDTH};
   }
 

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
@@ -54,7 +54,7 @@ const Header = styled.header(headerStyles);
 
 const hamburgerStyles = (theme: Theme) => css`
   padding: ${theme.spacings.mega};
-  ${focusVisible('inset')()};
+  ${focusVisible('inset')};
 
   border-radius: 0;
   /* The !important below is necessary to override the default hover styles. */
@@ -77,7 +77,7 @@ const logoStyles = ({ theme }: StyleProps) => css`
 
   a,
   button {
-    ${focusVisible('inset')()};
+    ${focusVisible('inset')};
   }
 
   svg {

--- a/packages/circuit-ui/styles/style-mixins.spec.tsx
+++ b/packages/circuit-ui/styles/style-mixins.spec.tsx
@@ -143,14 +143,7 @@ describe('Style helpers', () => {
 
   describe('shadow', () => {
     it('should match the snapshot', () => {
-      const { styles } = shadow({ theme: light });
-      expect(styles).toMatchInlineSnapshot(
-        '"box-shadow:0 3px 8px 0 rgba(0, 0, 0, 0.2);label:shadow;"',
-      );
-    });
-
-    it('should match the snapshot with options', () => {
-      const { styles } = shadow()({ theme: light });
+      const { styles } = shadow();
       expect(styles).toMatchInlineSnapshot(
         '"box-shadow:0 3px 8px 0 rgba(0, 0, 0, 0.2);label:shadow;"',
       );
@@ -209,7 +202,7 @@ describe('Style helpers', () => {
     });
 
     it('should match the snapshot with an inset outline', () => {
-      const { styles } = focusOutline('inset')();
+      const { styles } = focusOutline('inset');
       expect(styles).toMatchInlineSnapshot(
         '"outline:0;box-shadow:inset 0 0 0 4px var(--cui-border-focus);&::-moz-focus-inner{border:0;};label:focusOutline;"',
       );
@@ -225,7 +218,7 @@ describe('Style helpers', () => {
     });
 
     it('should match the snapshot with an inset outline', () => {
-      const { styles } = focusVisible('inset')();
+      const { styles } = focusVisible('inset');
       expect(styles).toMatchInlineSnapshot(
         '"&:focus{outline:0;box-shadow:inset 0 0 0 4px var(--cui-border-focus);&::-moz-focus-inner{border:0;}}&:focus:not(:focus-visible){box-shadow:none;};label:focusVisible;"',
       );
@@ -252,7 +245,7 @@ describe('Style helpers', () => {
 
   describe('inputOutline', () => {
     it('should match the snapshot', () => {
-      const { styles } = inputOutline(light);
+      const { styles } = inputOutline({});
       expect(styles).toMatchInlineSnapshot(
         '"box-shadow:0 0 0 1px var(--cui-border-normal);&:hover{box-shadow:0 0 0 1px var(--cui-border-normal-hovered);}&:focus{box-shadow:0 0 0 2px var(--cui-border-accent);}&:active{box-shadow:0 0 0 1px var(--cui-border-accent);};label:inputOutline;"',
       );
@@ -260,7 +253,6 @@ describe('Style helpers', () => {
 
     it('should match the snapshot when disabled', () => {
       const { styles } = inputOutline({
-        theme: light,
         disabled: true,
       });
       expect(styles).toMatchInlineSnapshot(
@@ -270,7 +262,6 @@ describe('Style helpers', () => {
 
     it('should match the snapshot when invalid', () => {
       const { styles } = inputOutline({
-        theme: light,
         invalid: true,
       });
       expect(styles).toMatchInlineSnapshot(
@@ -280,7 +271,6 @@ describe('Style helpers', () => {
 
     it('should match the snapshot when it has a warning', () => {
       const { styles } = inputOutline({
-        theme: light,
         hasWarning: true,
       });
       expect(styles).toMatchInlineSnapshot(

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -14,7 +14,6 @@
  */
 
 import styled from '@emotion/styled';
-import { Theme } from '@sumup/design-tokens';
 
 import { Stack } from '../../../.storybook/components';
 import Button from '../components/Button';
@@ -139,10 +138,10 @@ export const FocusVisible = () => (
 
 export const InputOutline = () => (
   <Stack>
-    <Box css={inputOutline} />
-    <Box css={(theme: Theme) => inputOutline({ theme, disabled: true })} />
-    <Box css={(theme: Theme) => inputOutline({ theme, invalid: true })} />
-    <Box css={(theme: Theme) => inputOutline({ theme, hasWarning: true })} />
+    <Box css={inputOutline({})} />
+    <Box css={inputOutline({ disabled: true })} />
+    <Box css={inputOutline({ invalid: true })} />
+    <Box css={inputOutline({ hasWarning: true })} />
   </Stack>
 );
 

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -124,18 +124,7 @@ export const spacing = (
  * Adds a drop shadow to an element to visually elevate it above the
  * surrounding content.
  */
-// TODO: Simplify the function signature in the next major.
-export function shadow(options?: never): (args: ThemeArgs) => SerializedStyles;
-export function shadow(args: ThemeArgs): SerializedStyles;
-export function shadow(
-  argsOrOptions?: ThemeArgs | never,
-): SerializedStyles | ((args: ThemeArgs) => SerializedStyles) {
-  if (!argsOrOptions) {
-    return (): SerializedStyles => css`
-      box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
-    `;
-  }
-
+export function shadow(): SerializedStyles {
   return css`
     box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   `;
@@ -195,17 +184,9 @@ export const center = (): SerializedStyles => css`
 /**
  * Visually communicates to the user that an element is focused.
  */
-// TODO: Simplify the function signature in the next major.
-export function focusOutline(
-  options: 'inset',
-): (args?: ThemeArgs) => SerializedStyles;
-export function focusOutline(args?: ThemeArgs): SerializedStyles;
-export function focusOutline(
-  argsOrOptions?: ThemeArgs | 'inset',
-): SerializedStyles | ((args?: ThemeArgs) => SerializedStyles) {
-  if (typeof argsOrOptions === 'string') {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    return (_args?: ThemeArgs): SerializedStyles => css`
+export function focusOutline(options?: 'inset' | ThemeArgs): SerializedStyles {
+  if (options === 'inset') {
+    return css`
       outline: 0;
       box-shadow: inset 0 0 0 4px var(--cui-border-focus);
 
@@ -229,17 +210,9 @@ export function focusOutline(
  * the user agent determines via heuristics that the focus should be
  * made evident on the element.
  */
-// TODO: Simplify the function signature in the next major.
-export function focusVisible(
-  options: 'inset',
-): (args?: ThemeArgs) => SerializedStyles;
-export function focusVisible(args?: ThemeArgs): SerializedStyles;
-export function focusVisible(
-  argsOrOptions?: ThemeArgs | 'inset',
-): SerializedStyles | ((args?: ThemeArgs) => SerializedStyles) {
-  if (typeof argsOrOptions === 'string') {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    return (_args?: ThemeArgs): SerializedStyles => css`
+export function focusVisible(options?: 'inset' | ThemeArgs): SerializedStyles {
+  if (options === 'inset') {
+    return css`
       &:focus {
         outline: 0;
         box-shadow: inset 0 0 0 4px var(--cui-border-focus);
@@ -302,21 +275,11 @@ export const hideScrollbar = (): SerializedStyles => css`
  * Visually communicates to the user that an element is hovered, focused, or
  * active in the disabled, invalid, and warning states.
  */
-// TODO: Remove `theme` from the function signature in the next major.
-export const inputOutline = (
-  args:
-    | Theme
-    | {
-        theme: Theme;
-        disabled?: boolean;
-        invalid?: boolean;
-        hasWarning?: boolean;
-      },
-): SerializedStyles => {
-  const options = isTheme(args)
-    ? { disabled: false, invalid: false, hasWarning: false }
-    : args;
-
+export const inputOutline = (options: {
+  disabled?: boolean;
+  invalid?: boolean;
+  hasWarning?: boolean;
+}): SerializedStyles => {
   switch (true) {
     case options.disabled: {
       return css`
@@ -409,7 +372,7 @@ export const listItem = (
       cursor: pointer;
     }
 
-    ${focusVisible('inset')()};
+    ${focusVisible('inset')};
 
     &:active {
       background-color: var(--cui-bg-normal-pressed);
@@ -477,7 +440,7 @@ export const navigationItem = (
         : 'var(--cui-fg-normal-pressed)'};
     }
 
-    ${focusVisible('inset')()};
+    ${focusVisible('inset')};
 
     &:disabled,
     &[disabled] {


### PR DESCRIPTION
Addresses [DSYS-371](https://sumupteam.atlassian.net/browse/DSYS-371).

## Purpose

Since migrating the color tokens to CSS custom properties (#1944) the `shadow`, `focusOutline`, `focusVisible`, and `inputOutline` style mixins don't require the `theme` parameter anymore.

## Approach and changes

- Remove the `theme` parameter from the style mixins that don't need it anymore

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
