### PR TITLE
Deprecate the Checkbox's `children` prop

### DIFF
--- a/.changeset/olive-mugs-wait.md
+++ b/.changeset/olive-mugs-wait.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Added an optional `label` prop to the `Checkbox` component, and deprecated the legacy `children` prop. The `label` prop will become required in v7. This aligns with the `RadioButton` component's API.
+Added an optional `label` prop to the `Checkbox` component, and deprecated the legacy `children` prop. The `label` prop will become required in the next major version. This aligns with the `RadioButton` component's API.

--- a/.changeset/olive-mugs-wait.md
+++ b/.changeset/olive-mugs-wait.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Deprecated the Checkbox's `children` prop. Use the `label` prop instead. This matches the RadioButton component.
+Added an optional `label` prop to the `Checkbox` component, and deprecated the legacy `children` prop. The `label` prop will become required in v7. This aligns with the `RadioButton` component's API.

--- a/.changeset/olive-mugs-wait.md
+++ b/.changeset/olive-mugs-wait.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Deprecated the Checkbox's `children` prop. Use the `label` prop instead. This matches the RadioButton component.

--- a/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.spec.tsx
@@ -20,7 +20,7 @@ import { render, axe, userEvent } from '../../util/test-utils';
 import { Checkbox } from './Checkbox';
 
 const defaultProps = {
-  children: 'Label',
+  label: 'Label',
   onChange: jest.fn(),
 };
 
@@ -92,7 +92,7 @@ describe('Checkbox', () => {
         const { getByRole } = render(<Checkbox {...defaultProps} />);
         const inputEl = getByRole('checkbox');
 
-        expect(inputEl).toHaveAccessibleName(defaultProps.children);
+        expect(inputEl).toHaveAccessibleName(defaultProps.label);
       });
 
       it('should optionally have an accessible description', () => {

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -22,8 +22,14 @@ import { hideVisually, focusOutline } from '../../styles/style-mixins';
 import { uniqueId } from '../../util/id';
 import { useClickEvent, TrackingProps } from '../../hooks/useClickEvent';
 import { FieldValidationHint, FieldWrapper } from '../FieldAtoms';
+import { deprecate } from '../../util/logger';
+import { AccessibilityError } from '../../util/errors';
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+  /**
+   * A clear and concise description of the option's purpose.
+   */
+  label?: string;
   /**
    * Triggers error styles on the component.
    */
@@ -40,6 +46,12 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
    * The ref to the HTML DOM element.
    */
   ref?: Ref<HTMLInputElement>;
+  /**
+   * @deprecated
+   *
+   * Use the `label` prop instead.
+   */
+  children?: InputHTMLAttributes<HTMLInputElement>['children'];
 }
 
 const labelBaseStyles = css`
@@ -173,6 +185,7 @@ export const Checkbox = forwardRef(
   (
     {
       onChange,
+      label,
       children,
       value,
       'id': customId,
@@ -188,6 +201,22 @@ export const Checkbox = forwardRef(
     }: CheckboxProps,
     ref: CheckboxProps['ref'],
   ) => {
+    if (process.env.NODE_ENV !== 'production' && children) {
+      deprecate(
+        'Checkbox',
+        'The `children` has been deprecated. Use the `label` prop instead.',
+      );
+    }
+
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !label &&
+      !children
+    ) {
+      throw new AccessibilityError('Checkbox', 'The `label` prop is missing.');
+    }
+
     const id = customId || uniqueId('checkbox_');
     const validationHintId = uniqueId('validation_hint-');
     const descriptionIds = `${
@@ -210,7 +239,7 @@ export const Checkbox = forwardRef(
           onChange={handleChange}
         />
         <CheckboxLabel htmlFor={id}>
-          {children}
+          {label || children}
           <Checkmark aria-hidden="true" />
         </CheckboxLabel>
         <FieldValidationHint

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -27,7 +27,7 @@ import { AccessibilityError } from '../../util/errors';
 
 export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   /**
-   * A clear and concise description of the option's purpose.
+   * A clear and concise description of the input's purpose.
    */
   label?: string;
   /**
@@ -204,7 +204,7 @@ export const Checkbox = forwardRef(
     if (process.env.NODE_ENV !== 'production' && children) {
       deprecate(
         'Checkbox',
-        'The `children` has been deprecated. Use the `label` prop instead.',
+        'The `children` prop has been deprecated. Use the `label` prop instead.',
       );
     }
 

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -40,6 +40,7 @@ export interface RadioButtonProps
    * Additional data that is dispatched with the tracking event.
    */
   tracking?: TrackingProps;
+  children?: never;
 }
 
 type LabelElProps = Pick<RadioButtonProps, 'invalid'>;


### PR DESCRIPTION
Addresses #1875.

## Purpose

The Checkbox and RadioButton components cover similar use cases and should have a matching API. Currently, the Checkbox component uses `children` for the option label, while the RadioButton component uses the `label` prop. The option label should be a simple string since screen readers cannot express other semantic elements as part of the label. We use the `label` prop name to signal this constraint.

## Approach and changes

- Mark the Checkbox's `children` prop as deprecated and encourage the use of the `label` prop instead
- Prevent using the `children` prop on the RadioButton component. Technically, this is a breaking change; however, this didn't work before either and would be an incorrect component use.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
