### PR TITLE
Deprecate the tracking props (#1997

### DIFF
--- a/.changeset/great-flowers-yell.md
+++ b/.changeset/great-flowers-yell.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Deprecated the `tracking` and `trackingLabel` props in all components. Use event handlers to dispatch user interaction events instead. `@sumup/collector` will be removed from `@sumup/circuit-ui` in the next major version.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -38,7 +38,9 @@ export interface BaseProps extends BodyProps {
    */
   onClick?: (event: ClickEvent) => void;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
   /**

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -76,7 +76,9 @@ export interface BaseProps {
    */
   'onClick'?: (event: ClickEvent) => void;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   'tracking'?: TrackingProps;
   /**

--- a/packages/circuit-ui/components/CalendarTag/CalendarTag.js
+++ b/packages/circuit-ui/components/CalendarTag/CalendarTag.js
@@ -14,7 +14,6 @@
  */
 
 import { Component } from 'react';
-import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { START_DATE } from 'react-dates/constants';
@@ -46,11 +45,15 @@ class CalendarTag extends Component {
       component: PropTypes.string,
       customParameters: PropTypes.object,
     }),
+    /**
+     * Function that's called when the date tag is clicked.
+     */
+    onClick: PropTypes.func,
   };
 
   state = { startDate: null, endDate: null, focusedInput: null };
 
-  buttonRef = null; // eslint-disable-line react/sort-comp
+  tagRef = null; // eslint-disable-line react/sort-comp
 
   handleDatesChange = ({ startDate, endDate }) => {
     this.setState({ startDate, endDate });
@@ -64,10 +67,14 @@ class CalendarTag extends Component {
     this.setState({ focusedInput });
   };
 
-  handleButtonClick = () =>
+  handleTagClick = (event) => {
+    if (this.props.onClick) {
+      this.props.onClick(event);
+    }
     this.setState(({ focusedInput }) => ({
       focusedInput: focusedInput !== null ? null : START_DATE,
     }));
+  };
 
   getDateRangePreview = () => {
     const { startDate, endDate } = this.state;
@@ -79,19 +86,13 @@ class CalendarTag extends Component {
     return `${toDate(startDate)} - ${toDate(endDate)}`;
   };
 
-  handleButtonRef = (ref) => {
-    this.buttonRef = ref;
+  handleTagRef = (ref) => {
+    this.tagRef = ref;
   };
 
   handleOutsideClick = ({ target }) => {
-    if (this.buttonRef) {
-      // TODO: May be implement forwardRef after we upgrade to 16.3 or elementRef
-      // eslint-disable-next-line react/no-find-dom-node
-      const buttonDomNode = findDOMNode(this.buttonRef);
-
-      if (!buttonDomNode.contains(target)) {
-        this.handleFocusChange(null);
-      }
+    if (this.tagRef && !this.tagRef.contains(target)) {
+      this.handleFocusChange(null);
     }
   };
 
@@ -104,8 +105,8 @@ class CalendarTag extends Component {
       <div {...props}>
         <Tag
           selected={isOpen}
-          ref={this.handleButtonRef}
-          onClick={this.handleButtonClick}
+          ref={this.handleTagRef}
+          onClick={this.handleTagClick}
           tracking={{
             component: 'calendar-tag',
             ...tracking,

--- a/packages/circuit-ui/components/CalendarTag/CalendarTag.js
+++ b/packages/circuit-ui/components/CalendarTag/CalendarTag.js
@@ -37,7 +37,9 @@ class CalendarTag extends Component {
      */
     onDatesRangeChange: PropTypes.func.isRequired,
     /**
-     * Additional data that is dispatched with the tracking event.
+     * @deprecated
+     *
+     * Use an `onClick` handler to dispatch user interaction events instead.
      */
     tracking: PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/packages/circuit-ui/components/CalendarTagTwoStep/CalendarTagTwoStep.js
+++ b/packages/circuit-ui/components/CalendarTagTwoStep/CalendarTagTwoStep.js
@@ -14,7 +14,6 @@
  */
 
 import { Component } from 'react';
-import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
@@ -82,6 +81,10 @@ export default class CalendarTagTwoStep extends Component {
       component: PropTypes.string,
       customParameters: PropTypes.object,
     }),
+    /**
+     * Function that's called when the date tag is clicked.
+     */
+    onClick: PropTypes.func,
   };
 
   static defaultProps = {
@@ -92,7 +95,7 @@ export default class CalendarTagTwoStep extends Component {
 
   state = { startDate: null, endDate: null, focusedInput: null };
 
-  buttonRef = null; // eslint-disable-line react/sort-comp
+  tagRef = null; // eslint-disable-line react/sort-comp
 
   handleDatesChange = ({ startDate, endDate }) => {
     this.setState({ startDate, endDate });
@@ -105,10 +108,14 @@ export default class CalendarTagTwoStep extends Component {
   handleClear = () =>
     this.setState({ startDate: null, endDate: null, focusedInput: null });
 
-  handleButtonClick = () =>
+  handleTagClick = (event) => {
+    if (this.props.onClick) {
+      this.props.onClick(event);
+    }
     this.setState(({ focusedInput }) => ({
       focusedInput: focusedInput !== null ? null : START_DATE,
     }));
+  };
 
   getDateRangePreview = () => {
     const { startDate, endDate } = this.state;
@@ -120,19 +127,13 @@ export default class CalendarTagTwoStep extends Component {
     return `${toDate(startDate)} - ${toDate(endDate)}`;
   };
 
-  handleButtonRef = (ref) => {
-    this.buttonRef = ref;
+  handleTagRef = (ref) => {
+    this.tagRef = ref;
   };
 
   handleOutsideClick = ({ target }) => {
-    if (this.buttonRef) {
-      // TODO: May be implement forwardRef after we upgrade to 16.3 or elementRef
-      // eslint-disable-next-line react/no-find-dom-node
-      const buttonDomNode = findDOMNode(this.buttonRef);
-
-      if (!buttonDomNode.contains(target)) {
-        this.handleFocusChange(null);
-      }
+    if (this.tagRef && !this.tagRef.contains(target)) {
+      this.handleFocusChange(null);
     }
   };
 
@@ -158,8 +159,8 @@ export default class CalendarTagTwoStep extends Component {
       <div {...props}>
         <Tag
           selected={isOpen || isFilled}
-          ref={this.handleButtonRef}
-          onClick={this.handleButtonClick}
+          ref={this.handleTagRef}
+          onClick={this.handleTagClick}
           tracking={{ component: 'calendar-tag-two-step', ...tracking }}
         >
           {this.getDateRangePreview()}

--- a/packages/circuit-ui/components/CalendarTagTwoStep/CalendarTagTwoStep.js
+++ b/packages/circuit-ui/components/CalendarTagTwoStep/CalendarTagTwoStep.js
@@ -73,7 +73,9 @@ export default class CalendarTagTwoStep extends Component {
      */
     confirmText: PropTypes.string,
     /**
-     * Additional data that is dispatched with the tracking event.
+     * @deprecated
+     *
+     * Use an `onClick` handler to dispatch user interaction events instead.
      */
     tracking: PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/packages/circuit-ui/components/Card/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Card/components/Header/Header.tsx
@@ -46,7 +46,9 @@ export type CardHeaderProps = {
    */
   children?: ReactNode;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClose` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 } & CloseProps &

--- a/packages/circuit-ui/components/Carousel/Carousel.js
+++ b/packages/circuit-ui/components/Carousel/Carousel.js
@@ -227,7 +227,9 @@ Carousel.propTypes = {
    */
   children: PropTypes.oneOfType([childrenPropType, childrenRenderPropType]),
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use custom event handlers to dispatch user interaction events instead.
    */
   tracking: PropTypes.shape({
     label: PropTypes.string.isRequired,

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -33,7 +33,9 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
    */
   validationHint?: string;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onChange` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
   /**

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -38,7 +38,9 @@ export interface HamburgerProps
    */
   inactiveLabel: string;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
   isLoading?: never;

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -89,7 +89,9 @@ interface BaseProps {
    */
   href?: string;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
   /**

--- a/packages/circuit-ui/components/ModalContext/types.ts
+++ b/packages/circuit-ui/components/ModalContext/types.ts
@@ -30,7 +30,9 @@ export interface BaseModalProps
    */
   onClose?: OnClose;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Dispatch user interaction events when calling `setModal` and `removeModal` instead.
    */
   tracking?: TrackingProps;
 }

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -89,7 +89,9 @@ interface BaseProps extends Omit<HTMLAttributes<HTMLDivElement>, 'action'> {
    */
   action: Action;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClose` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
   /**

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -84,7 +84,9 @@ export type BaseProps = HTMLAttributes<HTMLDivElement> & {
    */
   isVisible?: boolean;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClose` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
   /**

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -57,7 +57,9 @@ export type NotificationToastProps = HTMLAttributes<HTMLDivElement> &
      */
     isVisible: boolean;
     /**
-     * Additional data that is dispatched with the tracking event.
+     * @deprecated
+     *
+     * Use an `onClose` handler to dispatch user interaction events instead.
      */
     tracking?: TrackingProps;
     /**

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -63,7 +63,9 @@ export interface PaginationProps {
    */
   totalLabel?: (totalPages: number) => string;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onChange` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 }

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -77,7 +77,9 @@ export interface BaseProps {
    */
   disabled?: boolean;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
   /**
@@ -263,7 +265,9 @@ export interface PopoverProps {
     'aria-expanded': boolean;
   }) => JSX.Element;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onToggle` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 }

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -228,7 +228,7 @@ export interface PopoverProps {
    */
   isOpen: boolean;
   /**
-   * Function that is called when toggles the Popover.
+   * Function that is called when opening and closing the Popover.
    */
   onToggle: OnToggle;
   /**

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -37,7 +37,9 @@ export interface RadioButtonProps
    */
   ref?: Ref<HTMLInputElement>;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onChange` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 }

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -105,7 +105,9 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
    */
   ref?: Ref<HTMLSelectElement>;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onChange` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 }

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -58,7 +58,9 @@ export interface SelectorProps
    */
   ref?: Ref<HTMLInputElement>;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onChange` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 }

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -126,6 +126,9 @@ function SecondaryGroup({
 
 export interface SecondaryLinksProps {
   secondaryGroups: SecondaryGroupProps[];
+  /**
+   * @deprecated
+   */
   trackingLabel?: string;
 }
 

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -52,7 +52,9 @@ export interface PrimaryLinkProps
    */
   secondaryGroups?: SecondaryGroupProps[];
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 }
@@ -68,6 +70,8 @@ export interface SecondaryGroupProps {
    */
   secondaryLinks: SecondaryLinkProps[];
   /**
+   * @deprecated
+   *
    * An optional label that is added to the element tree when clicking a nested
    * secondary navigation link.
    */
@@ -92,7 +96,9 @@ export interface SecondaryLinkProps {
    */
   isActive?: boolean;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
   /**

--- a/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
@@ -62,7 +62,9 @@ export type SidePanelHookProps = {
    */
   onClose?: Callback;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Dispatch user interaction events when calling `setSidePanel` and `removeSidePanel` instead.
    */
   tracking?: TrackingProps;
 };

--- a/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
@@ -52,7 +52,9 @@ export interface AggregatorProps {
    */
   onClick?: (event: ClickEvent) => void;
   /**
-   * Additional data that is dispatched with click tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 }

--- a/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/NavItem/NavItem.tsx
@@ -59,7 +59,9 @@ export interface NavItemProps {
    */
   onClick?: (event: ClickEvent) => void;
   /**
-   * Additional data that is dispatched with click tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 }

--- a/packages/circuit-ui/components/Step/types.ts
+++ b/packages/circuit-ui/components/Step/types.ts
@@ -116,7 +116,9 @@ export interface StepOptions {
    */
   onPrevious?: (stateAndHelpers: StateAndHelpers) => void;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use custom event handlers to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 }

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -42,7 +42,9 @@ type BaseProps = {
    */
   onClick?: (event: ClickEvent) => void;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
   /**

--- a/packages/circuit-ui/components/ToastContext/types.ts
+++ b/packages/circuit-ui/components/ToastContext/types.ts
@@ -24,7 +24,9 @@ export interface BaseToastProps {
    */
   onClose?: OnClose;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Dispatch user interaction events when calling `setToast` and `removeToast` instead.
    */
   tracking?: TrackingProps;
   /**

--- a/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
+++ b/packages/circuit-ui/components/Toggle/components/Switch/Switch.tsx
@@ -35,7 +35,9 @@ export interface SwitchProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    */
   uncheckedLabel: string;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onChange` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
   /**

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.spec.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.spec.tsx
@@ -13,7 +13,13 @@
  * limitations under the License.
  */
 
-import { act, axe, render } from '../../../../util/test-utils';
+import {
+  act,
+  axe,
+  render,
+  screen,
+  userEvent,
+} from '../../../../util/test-utils';
 import { PopoverProps } from '../../../Popover';
 
 import { ProfileMenu } from './ProfileMenu';
@@ -56,6 +62,25 @@ describe('ProfileMenu', () => {
       const { container } = render(<ProfileMenu {...baseProps} />);
 
       expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('Logic', () => {
+    it('should call the onToggle callback with the popover open state', async () => {
+      const onToggle = jest.fn();
+
+      render(<ProfileMenu {...baseProps} onToggle={onToggle} />);
+
+      const profileEl = screen.getByRole('button');
+
+      await userEvent.click(profileEl);
+
+      expect(onToggle).toHaveBeenCalledWith(true);
+
+      await userEvent.click(profileEl);
+
+      expect(onToggle).toHaveBeenCalledWith(false);
+      expect(onToggle).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { useState, ButtonHTMLAttributes } from 'react';
+import { useState, ButtonHTMLAttributes, useEffect } from 'react';
 import { css } from '@emotion/react';
 import { ChevronDown, Profile as ProfileIcon } from '@sumup/icons';
 import { TrackingElement } from '@sumup/collector';
@@ -154,9 +154,13 @@ export interface ProfileMenuProps extends ProfileProps {
   /**
    * @deprecated
    *
-   * TODO: Figure out alternative.
+   * Use an `onToggle` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
+  /**
+   * Function that is called when opening and closing the ProfileMenu.
+   */
+  onToggle?: (isOpen: boolean) => void;
 }
 
 export function ProfileMenu({
@@ -164,11 +168,18 @@ export function ProfileMenu({
   label,
   actions,
   isActive,
+  onToggle,
   trackingLabel,
   tracking,
 }: ProfileMenuProps): JSX.Element {
   const [isOpen, setOpen] = useState(false);
   const offset = { mainAxis: 8, crossAxis: -16 };
+
+  useEffect(() => {
+    if (onToggle) {
+      onToggle(isOpen);
+    }
+  }, [onToggle, isOpen]);
 
   return (
     <TrackingElement

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -145,12 +145,16 @@ export interface ProfileMenuProps extends ProfileProps {
    */
   actions: PopoverProps['actions'];
   /**
+   * @deprecated
+   *
    * An optional label that is added to the element tree when clicking
    * a profile action.
    */
   trackingLabel?: string;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * TODO: Figure out alternative.
    */
   tracking?: TrackingProps;
 }

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -77,7 +77,9 @@ export interface UtilityLinkProps
    */
   isActive?: boolean;
   /**
-   * Additional data that is dispatched with the tracking event.
+   * @deprecated
+   *
+   * Use an `onClick` handler to dispatch user interaction events instead.
    */
   tracking?: TrackingProps;
 }


### PR DESCRIPTION
Addresses [DSYS-372](https://sumupteam.atlassian.net/browse/DSYS-372).

## Purpose

`@sumup/collector` has been deprecated and will be removed from Circuit UI in the next major version. Developers should use event handlers to dispatch user interaction events instead.

## Approach and changes

- Deprecate the `tracking` and `trackingLabel` props in all components
- Add additional event handler props to the CalendarTag, CalendarTagTwoStep, and ProfileMenu components

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
