### PR TITLE
Deprecate the `uniqueId` util

### DIFF
--- a/.changeset/late-weeks-appear.md
+++ b/.changeset/late-weeks-appear.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Deprecated the `uniqueId` util. Use the official [`useId` hook](https://beta.reactjs.org/reference/react/useId) instead.
+Deprecated the `uniqueId` util. If your app is already using React 18, use the official [`useId` hook](https://beta.reactjs.org/reference/react/useId) instead. `uniqueId` will be removed from Circuit UI v7, along with dropping support for React <18.

--- a/.changeset/late-weeks-appear.md
+++ b/.changeset/late-weeks-appear.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Deprecated the `uniqueId` util. Use the official [`useId` hook](https://beta.reactjs.org/reference/react/useId) instead.

--- a/packages/circuit-ui/util/id.ts
+++ b/packages/circuit-ui/util/id.ts
@@ -17,6 +17,11 @@
 
 let idCounter = 0;
 
+/**
+ * @deprecated
+ *
+ * Use the official [`useId` hook](https://beta.reactjs.org/reference/react/useId) instead.
+ */
 export function uniqueId(prefix = ''): string {
   idCounter += 1;
   return `${prefix}${idCounter}`;


### PR DESCRIPTION
Addresses [DSYS-373](https://sumupteam.atlassian.net/browse/DSYS-373).

## Purpose

[React 18](https://reactjs.org/blog/2022/03/29/react-v18.html) introduces APIs to support the new concurrent rendering mode. The new [`useId` hook](https://beta.reactjs.org/reference/react/useId) is intended to generate unique IDs that can be passed to accessibility attributes. We've been using a custom `uniqueId` util that isn't compatible with concurrent rendering.

## Approach and changes

- Deprecate the `uniqueId` util

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
