### PR TITLE
Rename component variants to match semantic colors

### DIFF
--- a/.changeset/tasty-maps-check.md
+++ b/.changeset/tasty-maps-check.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added the `success`, `warning`, and `danger` variants to the Badge, NotificationInline, and NotificationToast components and deprecated the `confirm`, `notify`, and `alert` variants.

--- a/packages/circuit-ui/components/Badge/Badge.spec.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.spec.tsx
@@ -15,7 +15,7 @@
 
 import { createRef } from 'react';
 
-import { create, render, renderToHtml, axe } from '../../util/test-utils';
+import { render, axe } from '../../util/test-utils';
 
 import { Badge } from './Badge';
 
@@ -24,20 +24,29 @@ describe('Badge', () => {
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(<Badge />);
-    expect(actual).toMatchSnapshot();
+    const { container } = render(<Badge />);
+    expect(container).toMatchSnapshot();
   });
 
-  const variants = ['neutral', 'confirm', 'notify', 'alert', 'promo'] as const;
+  const variants = [
+    'neutral',
+    'success',
+    'warning',
+    'danger',
+    'promo',
+    'confirm',
+    'notify',
+    'alert',
+  ] as const;
 
   it.each(variants)('should render with %s styles', (variant) => {
-    const actual = create(<Badge variant={variant} />);
-    expect(actual).toMatchSnapshot();
+    const { container } = render(<Badge variant={variant} />);
+    expect(container).toMatchSnapshot();
   });
 
   it('should have the correct circle styles', () => {
-    const actual = create(<Badge circle />);
-    expect(actual).toMatchSnapshot();
+    const { container } = render(<Badge circle />);
+    expect(container).toMatchSnapshot();
   });
 
   describe('business logic', () => {
@@ -56,8 +65,8 @@ describe('Badge', () => {
    * Accessibility tests.
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<Badge />);
-    const actual = await axe(wrapper);
+    const { container } = render(<Badge />);
+    const actual = await axe(container);
     expect(actual).toHaveNoViolations();
   });
 });

--- a/packages/circuit-ui/components/Badge/Badge.stories.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.stories.tsx
@@ -22,52 +22,42 @@ export default {
   component: Badge,
 };
 
-/* eslint-disable no-param-reassign */
-export const Base = (args: BadgeProps) => {
-  delete args.onClick;
-  return <Badge {...args} />;
-};
+export const Base = (args: BadgeProps) => <Badge {...args} />;
 
 Base.args = {
   children: 'Badge',
 };
 
-export const Variants = (args: BadgeProps) => {
-  delete args.onClick;
-  return (
-    <Stack>
-      <Badge {...args} variant="neutral">
-        Neutral
-      </Badge>
-      <Badge {...args} variant="confirm">
-        Confirm
-      </Badge>
-      <Badge {...args} variant="notify">
-        Notify
-      </Badge>
-      <Badge {...args} variant="alert">
-        Alert
-      </Badge>
-      <Badge {...args} variant="promo">
-        Promo
-      </Badge>
-    </Stack>
-  );
-};
+export const Variants = (args: BadgeProps) => (
+  <Stack>
+    <Badge {...args} variant="neutral">
+      Neutral
+    </Badge>
+    <Badge {...args} variant="success">
+      Success
+    </Badge>
+    <Badge {...args} variant="warning">
+      Warning
+    </Badge>
+    <Badge {...args} variant="danger">
+      Danger
+    </Badge>
+    <Badge {...args} variant="promo">
+      Promo
+    </Badge>
+  </Stack>
+);
 
-export const Circular = (args: BadgeProps) => {
-  delete args.onClick;
-  return (
-    <Stack>
-      <Badge {...args} circle>
-        1
-      </Badge>
-      <Badge {...args} circle>
-        42
-      </Badge>
-      <Badge {...args} circle>
-        999
-      </Badge>
-    </Stack>
-  );
-};
+export const Circular = (args: BadgeProps) => (
+  <Stack>
+    <Badge {...args} circle>
+      1
+    </Badge>
+    <Badge {...args} circle>
+      42
+    </Badge>
+    <Badge {...args} circle>
+      999
+    </Badge>
+  </Stack>
+);

--- a/packages/circuit-ui/components/Badge/Badge.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.tsx
@@ -13,17 +13,35 @@
  * limitations under the License.
  */
 
-import { Ref, forwardRef, HTMLAttributes } from 'react';
+import { Ref, HTMLAttributes } from 'react';
 import { css } from '@emotion/react';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { typography } from '../../styles/style-mixins';
+import { withDeprecation } from '../../util/logger';
 
 export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * Choose from 4 style variants. Default: 'neutral'.
+   * Choose the style variant. Default: 'neutral'.
    */
-  variant?: 'neutral' | 'confirm' | 'notify' | 'alert' | 'promo';
+  variant?:
+    | 'neutral'
+    | 'success'
+    | 'warning'
+    | 'danger'
+    | 'promo'
+    /**
+     * @deprecated
+     */
+    | 'confirm'
+    /**
+     * @deprecated
+     */
+    | 'notify'
+    /**
+     * @deprecated
+     */
+    | 'alert';
   /**
    * Use the circular badge to indicate a count of items related to an element.
    */
@@ -44,20 +62,22 @@ const baseStyles = ({ theme }: StyleProps) => css`
 `;
 
 const variantStyles = ({ variant = 'neutral' }: BadgeProps) => {
-  // TODO: Align variant names with token names in the next major.
   switch (variant) {
+    case 'success':
     case 'confirm': {
       return css`
         background-color: var(--cui-bg-success-strong);
         color: var(--cui-fg-on-strong);
       `;
     }
+    case 'warning':
     case 'notify': {
       return css`
         background-color: var(--cui-bg-warning-strong);
         color: var(--cui-fg-on-strong);
       `;
     }
+    case 'danger':
     case 'alert': {
       return css`
         background-color: var(--cui-bg-danger-strong);
@@ -100,6 +120,10 @@ const circleStyles = ({ circle = false, children }: BadgeProps) =>
     width: ${isDynamicWidth(children) ? 'auto' : '24px'};
   `;
 
+/**
+ * A badge communicates the status of an element or the count of items
+ * related to an element.
+ */
 const StyledBadge = styled('div')<BadgeProps>(
   typography('two'),
   baseStyles,
@@ -107,12 +131,21 @@ const StyledBadge = styled('div')<BadgeProps>(
   circleStyles,
 );
 
-/**
- * A badge communicates the status of an element or the count of items
- * related to an element.
- */
-export const Badge = forwardRef((props: BadgeProps, ref: BadgeProps['ref']) => (
-  <StyledBadge ref={ref} {...props} />
-));
+StyledBadge.displayName = 'Badge';
 
-Badge.displayName = 'Badge';
+export const Badge =
+  process.env.NODE_ENV === 'production'
+    ? StyledBadge
+    : withDeprecation(StyledBadge, ({ variant }) => {
+        const deprecatedMap: Record<string, string> = {
+          confirm: 'success',
+          notify: 'warning',
+          alert: 'danger',
+        };
+
+        if (variant && deprecatedMap[variant]) {
+          return `The "${variant}" variant has been deprecated. Use "${deprecatedMap[variant]}" instead.`;
+        }
+
+        return null;
+      });

--- a/packages/circuit-ui/components/Badge/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/circuit-ui/components/Badge/__snapshots__/Badge.spec.tsx.snap
@@ -29,9 +29,11 @@ exports[`Badge should have the correct circle styles 1`] = `
   width: 24px;
 }
 
-<div
-  class="circuit-0"
-/>
+<div>
+  <div
+    class="circuit-0"
+  />
+</div>
 `;
 
 exports[`Badge should render with alert styles 1`] = `
@@ -48,9 +50,11 @@ exports[`Badge should render with alert styles 1`] = `
   color: var(--cui-fg-on-strong);
 }
 
-<div
-  class="circuit-0"
-/>
+<div>
+  <div
+    class="circuit-0"
+  />
+</div>
 `;
 
 exports[`Badge should render with confirm styles 1`] = `
@@ -67,9 +71,32 @@ exports[`Badge should render with confirm styles 1`] = `
   color: var(--cui-fg-on-strong);
 }
 
-<div
-  class="circuit-0"
-/>
+<div>
+  <div
+    class="circuit-0"
+  />
+</div>
+`;
+
+exports[`Badge should render with danger styles 1`] = `
+.circuit-0 {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  border-radius: 999999px;
+  display: inline-block;
+  padding: 2px 8px;
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: 0.25px;
+  background-color: var(--cui-bg-danger-strong);
+  color: var(--cui-fg-on-strong);
+}
+
+<div>
+  <div
+    class="circuit-0"
+  />
+</div>
 `;
 
 exports[`Badge should render with default styles 1`] = `
@@ -86,9 +113,11 @@ exports[`Badge should render with default styles 1`] = `
   color: var(--cui-fg-normal);
 }
 
-<div
-  class="circuit-0"
-/>
+<div>
+  <div
+    class="circuit-0"
+  />
+</div>
 `;
 
 exports[`Badge should render with neutral styles 1`] = `
@@ -105,9 +134,11 @@ exports[`Badge should render with neutral styles 1`] = `
   color: var(--cui-fg-normal);
 }
 
-<div
-  class="circuit-0"
-/>
+<div>
+  <div
+    class="circuit-0"
+  />
+</div>
 `;
 
 exports[`Badge should render with notify styles 1`] = `
@@ -124,9 +155,11 @@ exports[`Badge should render with notify styles 1`] = `
   color: var(--cui-fg-on-strong);
 }
 
-<div
-  class="circuit-0"
-/>
+<div>
+  <div
+    class="circuit-0"
+  />
+</div>
 `;
 
 exports[`Badge should render with promo styles 1`] = `
@@ -143,7 +176,51 @@ exports[`Badge should render with promo styles 1`] = `
   color: var(--cui-fg-on-strong);
 }
 
-<div
-  class="circuit-0"
-/>
+<div>
+  <div
+    class="circuit-0"
+  />
+</div>
+`;
+
+exports[`Badge should render with success styles 1`] = `
+.circuit-0 {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  border-radius: 999999px;
+  display: inline-block;
+  padding: 2px 8px;
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: 0.25px;
+  background-color: var(--cui-bg-success-strong);
+  color: var(--cui-fg-on-strong);
+}
+
+<div>
+  <div
+    class="circuit-0"
+  />
+</div>
+`;
+
+exports[`Badge should render with warning styles 1`] = `
+.circuit-0 {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  border-radius: 999999px;
+  display: inline-block;
+  padding: 2px 8px;
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: 0.25px;
+  background-color: var(--cui-bg-warning-strong);
+  color: var(--cui-fg-on-strong);
+}
+
+<div>
+  <div
+    class="circuit-0"
+  />
+</div>
 `;

--- a/packages/circuit-ui/components/Notification/constants.ts
+++ b/packages/circuit-ui/components/Notification/constants.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2023, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FC } from 'react';
+import { Alert, Confirm, IconProps, Info, Notify } from '@sumup/icons';
+
+export type NotificationVariant =
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  /**
+   * @deprecated
+   */
+  | 'confirm'
+  /**
+   * @deprecated
+   */
+  | 'notify'
+  /**
+   * @deprecated
+   */
+  | 'alert';
+
+export const NOTIFICATION_ICONS: Record<
+  NotificationVariant,
+  FC<IconProps<'16' | '24'>>
+> = {
+  info: Info,
+  success: Confirm,
+  confirm: Confirm,
+  warning: Notify,
+  notify: Notify,
+  danger: Alert,
+  alert: Alert,
+};
+
+export const NOTIFICATION_COLORS: Record<
+  NotificationVariant,
+  { border: string; fg: string }
+> = {
+  info: {
+    border: '--cui-border-accent',
+    fg: '--cui-fg-accent',
+  },
+  success: {
+    border: '--cui-border-success',
+    fg: '--cui-fg-success',
+  },
+  confirm: {
+    border: '--cui-border-success',
+    fg: '--cui-fg-success',
+  },
+  warning: {
+    border: '--cui-border-warning',
+    fg: '--cui-fg-warning',
+  },
+  notify: {
+    border: '--cui-border-warning',
+    fg: '--cui-fg-warning',
+  },
+  danger: {
+    border: '--cui-border-danger',
+    fg: '--cui-fg-danger',
+  },
+  alert: {
+    border: '--cui-border-danger',
+    fg: '--cui-fg-danger',
+  },
+};
+
+export const DEPRECATED_VARIANTS: Record<string, string> = {
+  confirm: 'success',
+  notify: 'warning',
+  alert: 'danger',
+};

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.mdx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.mdx
@@ -18,10 +18,10 @@ The `NotificationInline` component renders an inline notification within the con
 
 <Story of={Stories.Variants} />
 
-- Use the 'Info' variant for informational, neutral messages.
-- Use the 'Confirm' variant the successful messages.
-- Use the 'Notify' variant for warning messages, and other information a user should be aware of.
-- Use the 'Alert' variant for error messages. Be descriptive and give users clear next steps.
+- Use the 'info' variant for informational, neutral messages.
+- Use the 'success' variant the successful messages.
+- Use the 'warning' variant for warning messages, and other information a user should be aware of.
+- Use the 'danger' variant for error messages. Be descriptive and give users clear next steps.
 
 ### Dismissable notifications
 

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
@@ -47,8 +47,11 @@ describe('NotificationInline', () => {
 
     const variants: NotificationInlineProps['variant'][] = [
       'info',
+      'success',
       'confirm',
+      'warning',
       'notify',
+      'danger',
       'alert',
     ];
 

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
@@ -27,7 +27,7 @@ export default {
   component: NotificationInline,
 };
 
-const variants = ['info', 'confirm', 'notify', 'alert'] as const;
+const variants = ['info', 'success', 'warning', 'danger'] as const;
 
 const StackInlineMessages = styled.div`
   display: flex;

--- a/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationInline/__snapshots__/NotificationInline.spec.tsx.snap
@@ -240,6 +240,126 @@ exports[`NotificationInline styles should render notification inline with confir
 </body>
 `;
 
+exports[`NotificationInline styles should render notification inline with danger styles 1`] = `
+.circuit-0 {
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: var(--cui-bg-normal);
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid var(--cui-border-danger);
+}
+
+.circuit-2 {
+  position: relative;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: var(--cui-fg-danger);
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-5 {
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <div
+        class="circuit-1"
+      >
+        <div
+          class="circuit-2"
+        >
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <span
+          class="circuit-3"
+        />
+        <div
+          class="circuit-4"
+        >
+          <p
+            class="circuit-5"
+          >
+            This is an inline message
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`NotificationInline styles should render notification inline with info styles 1`] = `
 .circuit-0 {
   overflow: hidden;
@@ -361,6 +481,248 @@ exports[`NotificationInline styles should render notification inline with info s
 `;
 
 exports[`NotificationInline styles should render notification inline with notify styles 1`] = `
+.circuit-0 {
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: var(--cui-bg-normal);
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid var(--cui-border-warning);
+}
+
+.circuit-2 {
+  position: relative;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: var(--cui-fg-warning);
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-5 {
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <div
+        class="circuit-1"
+      >
+        <div
+          class="circuit-2"
+        >
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <span
+          class="circuit-3"
+        />
+        <div
+          class="circuit-4"
+        >
+          <p
+            class="circuit-5"
+          >
+            This is an inline message
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationInline styles should render notification inline with success styles 1`] = `
+.circuit-0 {
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: var(--cui-bg-normal);
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid var(--cui-border-success);
+}
+
+.circuit-2 {
+  position: relative;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: var(--cui-fg-success);
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-5 {
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 1; height: 0px; visibility: visible;"
+    >
+      <div
+        class="circuit-1"
+      >
+        <div
+          class="circuit-2"
+        >
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <span
+          class="circuit-3"
+        />
+        <div
+          class="circuit-4"
+        >
+          <p
+            class="circuit-5"
+          >
+            This is an inline message
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationInline styles should render notification inline with warning styles 1`] = `
 .circuit-0 {
   overflow: hidden;
   will-change: height;

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.mdx
@@ -18,10 +18,10 @@ The `NotificationToast` component provides quick status messages to the user. A 
 
 <Story of={Stories.Variants} />
 
-- Use the 'Info' variant for informational, neutral messages.
-- Use the 'Confirm' variant the successful messages.
-- Use the 'Notify' variant for warning messages, and other information a user should be aware of.
-- Use the 'Alert' variant for error messages.
+- Use the 'info' variant for informational, neutral messages.
+- Use the 'success' variant the successful messages.
+- Use the 'warning' variant for warning messages, and other information a user should be aware of.
+- Use the 'danger' variant for error messages.
 
 ### Toast with headline
 
@@ -50,6 +50,7 @@ export function App({}) {
 
   const handleClick = () => {
     setToast({
+      variant: 'success',
       body: 'This is a toast message',
     });
   };

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
@@ -69,8 +69,11 @@ describe('NotificationToast', () => {
 
     const variants: NotificationToastProps['variant'][] = [
       'info',
+      'success',
       'confirm',
+      'warning',
       'notify',
+      'danger',
       'alert',
     ];
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
@@ -21,7 +21,7 @@ import {
   waitForElementToBeRemoved,
 } from '../../util/test-utils';
 import Button from '../Button';
-import { ToastProvider } from '../ToastContext';
+import { ToastProvider } from '../ToastContext/ToastContext';
 
 import {
   NotificationToast,

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -31,16 +31,24 @@ export default {
 };
 
 const TOASTS = [
-  { body: 'An update is available.', variant: 'info', iconLabel: '' },
-  { body: 'Unexpected error occurred.', variant: 'alert', iconLabel: '' },
+  {
+    body: 'An update is available.',
+    variant: 'info',
+    iconLabel: '',
+  },
+  {
+    body: 'Unexpected error occurred.',
+    variant: 'danger',
+    iconLabel: '',
+  },
   {
     body: 'There was a problem with your request.',
-    variant: 'notify',
+    variant: 'warning',
     iconLabel: 'warning',
   },
   {
     body: 'You successfully updated your data.',
-    variant: 'confirm',
+    variant: 'success',
     iconLabel: '',
   },
 ] as NotificationToastProps[];
@@ -69,7 +77,7 @@ export const Base = (toast: NotificationToastProps): JSX.Element => {
   );
 };
 
-const variants = ['info', 'confirm', 'notify', 'alert'] as const;
+const variants = ['info', 'success', 'warning', 'danger'] as const;
 
 const StackToasts = styled.div`
   display: flex;

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -13,16 +13,8 @@
  * limitations under the License.
  */
 
-import {
-  FC,
-  HTMLAttributes,
-  RefObject,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { HTMLAttributes, RefObject, useEffect, useRef, useState } from 'react';
 import { css } from '@emotion/react';
-import { Alert, Confirm, IconProps, Info, Notify } from '@sumup/icons';
 
 import styled, { StyleProps } from '../../styles/styled';
 import { useAnimation } from '../../hooks/useAnimation';
@@ -33,34 +25,22 @@ import { ClickEvent } from '../../types/events';
 import { BaseToastProps, createUseToast } from '../ToastContext';
 import { hideVisually } from '../../styles/style-mixins';
 import { deprecate } from '../../util/logger';
+import {
+  DEPRECATED_VARIANTS,
+  NOTIFICATION_COLORS,
+  NOTIFICATION_ICONS,
+  NotificationVariant,
+} from '../Notification/constants';
 
 const TRANSITION_DURATION = 200;
 const DEFAULT_HEIGHT = 'auto';
-
-type Variant =
-  | 'info'
-  | 'success'
-  | 'warning'
-  | 'danger'
-  /**
-   * @deprecated
-   */
-  | 'confirm'
-  /**
-   * @deprecated
-   */
-  | 'notify'
-  /**
-   * @deprecated
-   */
-  | 'alert';
 
 export type NotificationToastProps = HTMLAttributes<HTMLDivElement> &
   BaseToastProps & {
     /**
      * The toast's variant. Default: `info`.
      */
-    variant?: Variant;
+    variant?: NotificationVariant;
     /**
      * An optional headline for structured toast content.
      */
@@ -89,49 +69,8 @@ export type NotificationToastProps = HTMLAttributes<HTMLDivElement> &
     iconLabel?: string;
   };
 
-const iconMap: Record<Variant, FC<IconProps<'16' | '24'>>> = {
-  info: Info,
-  success: Confirm,
-  confirm: Confirm,
-  warning: Notify,
-  notify: Notify,
-  danger: Alert,
-  alert: Alert,
-};
-
-const colorMap: Record<Variant, { border: string; fg: string }> = {
-  info: {
-    border: '--cui-border-accent',
-    fg: '--cui-fg-accent',
-  },
-  success: {
-    border: '--cui-border-success',
-    fg: '--cui-fg-success',
-  },
-  confirm: {
-    border: '--cui-border-success',
-    fg: '--cui-fg-success',
-  },
-  warning: {
-    border: '--cui-border-warning',
-    fg: '--cui-fg-warning',
-  },
-  notify: {
-    border: '--cui-border-warning',
-    fg: '--cui-fg-warning',
-  },
-  danger: {
-    border: '--cui-border-danger',
-    fg: '--cui-fg-danger',
-  },
-  alert: {
-    border: '--cui-border-danger',
-    fg: '--cui-fg-danger',
-  },
-};
-
 type NotificationToastWrapperProps = {
-  variant: Variant;
+  variant: NotificationVariant;
 };
 
 const toastWrapperStyles = ({
@@ -140,7 +79,8 @@ const toastWrapperStyles = ({
 }: NotificationToastWrapperProps & StyleProps) => css`
   background-color: var(--cui-bg-elevated);
   border-radius: ${theme.borderRadius.byte};
-  border: ${theme.borderWidth.mega} solid var(${colorMap[variant].border});
+  border: ${theme.borderWidth.mega} solid
+    var(${NOTIFICATION_COLORS[variant].border});
   overflow: hidden;
   will-change: height;
   transition: opacity ${TRANSITION_DURATION}ms ease-in-out,
@@ -171,14 +111,14 @@ const contentStyles = ({ theme }: StyleProps) => css`
 const Content = styled('div')(contentStyles);
 
 const IconWrapper = styled.div(
-  ({ variant }: { variant: Variant }) =>
+  ({ variant }: { variant: NotificationVariant }) =>
     css`
       position: relative;
       align-self: flex-start;
       flex-grow: 0;
       flex-shrink: 0;
       line-height: 0;
-      color: var(${colorMap[variant].fg});
+      color: var(${NOTIFICATION_COLORS[variant].fg});
     `,
 );
 
@@ -205,16 +145,10 @@ export function NotificationToast({
   ...props
 }: NotificationToastProps): JSX.Element {
   if (process.env.NODE_ENV !== 'production') {
-    const deprecatedMap: Record<string, string> = {
-      confirm: 'success',
-      notify: 'warning',
-      alert: 'danger',
-    };
-
-    if (deprecatedMap[variant]) {
+    if (DEPRECATED_VARIANTS[variant]) {
       deprecate(
         'NotificationToast',
-        `The "${variant}" variant has been deprecated. Use "${deprecatedMap[variant]}" instead.`,
+        `The "${variant}" variant has been deprecated. Use "${DEPRECATED_VARIANTS[variant]}" instead.`,
       );
     }
   }
@@ -241,7 +175,7 @@ export function NotificationToast({
     });
   }, [isVisible, setAnimating]);
 
-  const Icon = iconMap[variant];
+  const Icon = NOTIFICATION_ICONS[variant];
 
   return (
     <NotificationToastWrapper

--- a/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
+++ b/packages/circuit-ui/components/NotificationToast/__snapshots__/NotificationToast.spec.tsx.snap
@@ -903,6 +903,303 @@ exports[`NotificationToast styles should render with confirm variant styles 1`] 
 </body>
 `;
 
+exports[`NotificationToast styles should render with danger variant styles 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 2px solid var(--cui-border-danger);
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 12px 16px;
+}
+
+.circuit-2 {
+  position: relative;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: var(--cui-fg-danger);
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-5 {
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.circuit-6 {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: var(--cui-bg-normal);
+  border-color: var(--cui-border-normal);
+  color: var(--cui-fg-normal);
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-6:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-6:disabled,
+.circuit-6[disabled] {
+  pointer-events: none;
+}
+
+.circuit-6:hover {
+  background-color: var(--cui-bg-normal-hovered);
+  border-color: var(--cui-border-normal-hovered);
+  color: var(--cui-fg-normal-hovered);
+}
+
+.circuit-6:active,
+.circuit-6[aria-expanded='true'],
+.circuit-6[aria-pressed='true'] {
+  background-color: var(--cui-bg-normal-pressed);
+  border-color: var(--cui-border-normal-pressed);
+  color: var(--cui-fg-normal-pressed);
+}
+
+.circuit-6:disabled,
+.circuit-6[disabled] {
+  background-color: var(--cui-bg-normal-disabled);
+  border-color: var(--cui-border-normal-disabled);
+  color: var(--cui-fg-normal-disabled);
+}
+
+.circuit-7 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 0; height: 0px; visibility: hidden;"
+    >
+      <div
+        class="circuit-1"
+      >
+        <div
+          class="circuit-2"
+        >
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm4.71 14.29c.186.19.29.445.29.71a1 1 0 0 1-1 1c-.265 0-.52-.104-.71-.29l-3.29-3.29-3.29 3.29c-.19.186-.444.29-.71.29a1 1 0 0 1-1-1c0-.265.104-.52.29-.71l3.29-3.29-3.29-3.29a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l3.29 3.29 3.29-3.29c.19-.186.444-.29.71-.29a1 1 0 0 1 1 1c0 .266-.104.52-.29.71L13.408 12l3.29 3.29z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <span
+          class="circuit-3"
+        />
+        <div
+          class="circuit-4"
+        >
+          <p
+            class="circuit-5"
+          >
+            This is a toast message
+          </p>
+        </div>
+        <button
+          aria-hidden="true"
+          class="circuit-6"
+          tabindex="-1"
+          title="-"
+          type="button"
+        >
+          <span
+            class="circuit-7"
+          >
+            <span
+              class="circuit-3"
+            />
+          </span>
+          <span
+            class="circuit-9"
+          >
+            <svg
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+            <span
+              class="circuit-3"
+            >
+              -
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`NotificationToast styles should render with default styles 1`] = `
 @keyframes animation-0 {
   0% {
@@ -1498,6 +1795,602 @@ exports[`NotificationToast styles should render with info variant styles 1`] = `
 `;
 
 exports[`NotificationToast styles should render with notify variant styles 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 2px solid var(--cui-border-warning);
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 12px 16px;
+}
+
+.circuit-2 {
+  position: relative;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: var(--cui-fg-warning);
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-5 {
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.circuit-6 {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: var(--cui-bg-normal);
+  border-color: var(--cui-border-normal);
+  color: var(--cui-fg-normal);
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-6:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-6:disabled,
+.circuit-6[disabled] {
+  pointer-events: none;
+}
+
+.circuit-6:hover {
+  background-color: var(--cui-bg-normal-hovered);
+  border-color: var(--cui-border-normal-hovered);
+  color: var(--cui-fg-normal-hovered);
+}
+
+.circuit-6:active,
+.circuit-6[aria-expanded='true'],
+.circuit-6[aria-pressed='true'] {
+  background-color: var(--cui-bg-normal-pressed);
+  border-color: var(--cui-border-normal-pressed);
+  color: var(--cui-fg-normal-pressed);
+}
+
+.circuit-6:disabled,
+.circuit-6[disabled] {
+  background-color: var(--cui-bg-normal-disabled);
+  border-color: var(--cui-border-normal-disabled);
+  color: var(--cui-fg-normal-disabled);
+}
+
+.circuit-7 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 0; height: 0px; visibility: hidden;"
+    >
+      <div
+        class="circuit-1"
+      >
+        <div
+          class="circuit-2"
+        >
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clip-rule="evenodd"
+              d="M14.544 3.481c-1.13-1.975-3.958-1.975-5.088 0L1.398 17.556C.268 19.53 1.681 22 3.942 22h16.116c2.261 0 3.675-2.47 2.544-4.444L14.544 3.48zM11 8a1 1 0 0 1 2 0v5a1 1 0 0 1-2 0V8zm1 11a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"
+              fill="currentColor"
+              fill-rule="evenodd"
+            />
+          </svg>
+        </div>
+        <span
+          class="circuit-3"
+        />
+        <div
+          class="circuit-4"
+        >
+          <p
+            class="circuit-5"
+          >
+            This is a toast message
+          </p>
+        </div>
+        <button
+          aria-hidden="true"
+          class="circuit-6"
+          tabindex="-1"
+          title="-"
+          type="button"
+        >
+          <span
+            class="circuit-7"
+          >
+            <span
+              class="circuit-3"
+            />
+          </span>
+          <span
+            class="circuit-9"
+          >
+            <svg
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+            <span
+              class="circuit-3"
+            >
+              -
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationToast styles should render with success variant styles 1`] = `
+@keyframes animation-0 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -ms-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+    -moz-transform: rotate(360deg);
+    -ms-transform: rotate(360deg);
+    transform: rotate(360deg);
+  }
+}
+
+.circuit-0 {
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 2px solid var(--cui-border-success);
+  overflow: hidden;
+  will-change: height;
+  -webkit-transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+  transition: opacity 200ms ease-in-out,height 200ms ease-in-out,visibility 200ms ease-in-out;
+}
+
+.circuit-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 12px 16px;
+}
+
+.circuit-2 {
+  position: relative;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  line-height: 0;
+  color: var(--cui-fg-success);
+}
+
+.circuit-3 {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.circuit-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  padding-right: 40px;
+  padding-left: 16px;
+}
+
+.circuit-5 {
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+.circuit-6 {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  width: auto;
+  height: auto;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  font-weight: 700;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 999999px;
+  -webkit-transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,color 120ms ease-in-out,background-color 120ms ease-in-out,border-color 120ms ease-in-out;
+  background-color: var(--cui-bg-normal);
+  border-color: var(--cui-border-normal);
+  color: var(--cui-fg-normal);
+  padding: calc(12px - 1px) calc(24px - 1px);
+  position: relative;
+  overflow: hidden;
+  padding: calc(8px - 1px);
+  border-color: transparent!important;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  margin-top: -4px;
+  margin-bottom: -4px;
+  margin-left: auto;
+}
+
+.circuit-6:focus {
+  outline: 0;
+  box-shadow: 0 0 0 4px var(--cui-border-focus);
+}
+
+.circuit-6:focus::-moz-focus-inner {
+  border: 0;
+}
+
+.circuit-6:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.circuit-6:disabled,
+.circuit-6[disabled] {
+  pointer-events: none;
+}
+
+.circuit-6:hover {
+  background-color: var(--cui-bg-normal-hovered);
+  border-color: var(--cui-border-normal-hovered);
+  color: var(--cui-fg-normal-hovered);
+}
+
+.circuit-6:active,
+.circuit-6[aria-expanded='true'],
+.circuit-6[aria-pressed='true'] {
+  background-color: var(--cui-bg-normal-pressed);
+  border-color: var(--cui-border-normal-pressed);
+  color: var(--cui-fg-normal-pressed);
+}
+
+.circuit-6:disabled,
+.circuit-6[disabled] {
+  background-color: var(--cui-bg-normal-disabled);
+  border-color: var(--cui-border-normal-disabled);
+  color: var(--cui-fg-normal-disabled);
+}
+
+.circuit-7 {
+  display: block;
+  border-radius: 100%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  -webkit-animation: animation-0 1s infinite linear;
+  animation: animation-0 1s infinite linear;
+  transform-origin: 50% 50%;
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  opacity: 0;
+  visibility: hidden;
+  -webkit-transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+.circuit-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  opacity: 1;
+  visibility: inherit;
+  -webkit-transform: scale3d(1, 1, 1);
+  -moz-transform: scale3d(1, 1, 1);
+  -ms-transform: scale3d(1, 1, 1);
+  transform: scale3d(1, 1, 1);
+  -webkit-transition: opacity 120ms ease-in-out,-webkit-transform 120ms ease-in-out,visibility 120ms ease-in-out;
+  transition: opacity 120ms ease-in-out,transform 120ms ease-in-out,visibility 120ms ease-in-out;
+}
+
+<body>
+  <div>
+    <div
+      class="circuit-0"
+      style="opacity: 0; height: 0px; visibility: hidden;"
+    >
+      <div
+        class="circuit-1"
+      >
+        <div
+          class="circuit-2"
+        >
+          <svg
+            fill="none"
+            height="24"
+            role="presentation"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.988 1A10.994 10.994 0 1 0 12 1h-.012zm5.77 7.64-7 8a1.008 1.008 0 0 1-1.48.07l-3-3a1.013 1.013 0 0 1-.29-.71 1 1 0 0 1 1-1c.266 0 .52.104.71.29l2.22 2.23 6.3-7.16a1 1 0 1 1 1.54 1.28z"
+              fill="currentColor"
+            />
+          </svg>
+        </div>
+        <span
+          class="circuit-3"
+        />
+        <div
+          class="circuit-4"
+        >
+          <p
+            class="circuit-5"
+          >
+            This is a toast message
+          </p>
+        </div>
+        <button
+          aria-hidden="true"
+          class="circuit-6"
+          tabindex="-1"
+          title="-"
+          type="button"
+        >
+          <span
+            class="circuit-7"
+          >
+            <span
+              class="circuit-3"
+            />
+          </span>
+          <span
+            class="circuit-9"
+          >
+            <svg
+              fill="none"
+              height="16"
+              role="presentation"
+              viewBox="0 0 16 16"
+              width="16"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                clip-rule="evenodd"
+                d="M1.293 1.293a1 1 0 0 1 1.414 0L8 6.586l5.293-5.293a1 1 0 1 1 1.414 1.414L9.414 8l5.293 5.293a1 1 0 0 1-1.414 1.414L8 9.414l-5.293 5.293a1 1 0 0 1-1.414-1.414L6.586 8 1.293 2.707a1 1 0 0 1 0-1.414z"
+                fill="currentColor"
+                fill-rule="evenodd"
+              />
+            </svg>
+            <span
+              class="circuit-3"
+            >
+              -
+            </span>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`NotificationToast styles should render with warning variant styles 1`] = `
 @keyframes animation-0 {
   0% {
     -webkit-transform: rotate(0deg);

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -84,10 +84,7 @@ function SecondaryLink({
             {label}
           </Body>
         </Skeleton>
-        {badge && (
-          // @ts-expect-error The as prop isn't typed here, safe to ignore
-          <Badge variant="promo" as="span" {...badge} />
-        )}
+        {badge && <Badge variant="promo" as="span" {...badge} />}
       </SecondaryAnchor>
     </li>
   );


### PR DESCRIPTION
## Purpose

The new semantic color tokens (#1880) use different names for the _confirm_, _notify_, and _alert_ variants. In the interest of (cross-platform) consistency, we're aligning the component variant names. This essentially reverts #1440 🤷‍♂️ The deprecated variant names will be removed in the next major version.

## Approach and changes

- Added the `success`, `warning`, and `danger` variants to the Badge, NotificationInline, and NotificationToast components
- Deprecated the `confirm`, `notify`, and `alert` variants

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
