### PR TITLE
Forward refs to notification components (#2007

### DIFF
--- a/.changeset/sweet-jobs-visit.md
+++ b/.changeset/sweet-jobs-visit.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Forward `ref`s to the NotificationBanner, NotificationFullscreen, and NotificationInline components.

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.spec.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.spec.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { createRef } from 'react';
+
 import { render, axe, userEvent } from '../../util/test-utils';
 
 import {
@@ -68,6 +70,15 @@ describe('NotificationBanner', () => {
       expect(container.querySelector('img')).toHaveStyle(
         'object-position: bottom',
       );
+    });
+
+    it('should accept a working ref', () => {
+      const ref = createRef<HTMLDivElement>();
+      const { container } = render(
+        <NotificationBanner ref={ref} {...baseProps} />,
+      );
+      const wrapper = container.querySelector('div');
+      expect(ref.current).toBe(wrapper);
     });
   });
 

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -21,6 +21,7 @@ import {
   RefObject,
   useEffect,
   HTMLAttributes,
+  forwardRef,
 } from 'react';
 import { css } from '@emotion/react';
 
@@ -33,6 +34,7 @@ import Image, { ImageProps } from '../Image';
 import CloseButton from '../CloseButton';
 import { useAnimation } from '../../hooks/useAnimation';
 import { TrackingProps } from '../../hooks/useClickEvent';
+import { applyMultipleRefs } from '../../util/refs';
 
 type Action = ButtonProps & {
   variant: 'primary' | 'tertiary';
@@ -213,72 +215,80 @@ const StyledCloseButton = styled(CloseButton)(closeButtonStyles);
  * The NotificationBanner displays a notification with text, a call-to-action,
  * and optionally an image.
  */
-export function NotificationBanner({
-  headline,
-  body,
-  action,
-  variant = 'system',
-  image,
-  onClose,
-  closeButtonLabel,
-  tracking,
-  isVisible = true,
-  ...props
-}: NotificationBannerProps): JSX.Element {
-  const contentElement = useRef(null);
-  const [isOpen, setOpen] = useState(isVisible);
-  const [height, setHeight] = useState(getHeight(contentElement));
-  const [, setAnimating] = useAnimation();
-  useEffect(() => {
-    setAnimating({
-      duration: 200,
-      onStart: () => {
-        setHeight(getHeight(contentElement));
-        // Delaying the state update until the next animation frame ensures
-        // that browsers render the new height before the animation starts.
-        window.requestAnimationFrame(() => {
-          setOpen(isVisible);
-        });
-      },
-      onEnd: () => {
-        setHeight(DEFAULT_HEIGHT);
-      },
-    });
-  }, [isVisible, setAnimating]);
+export const NotificationBanner = forwardRef<
+  HTMLDivElement,
+  NotificationBannerProps
+>(
+  (
+    {
+      headline,
+      body,
+      action,
+      variant = 'system',
+      image,
+      onClose,
+      closeButtonLabel,
+      tracking,
+      isVisible = true,
+      ...props
+    },
+    ref,
+  ): JSX.Element => {
+    const contentElement = useRef<HTMLDivElement>(null);
+    const [isOpen, setOpen] = useState(isVisible);
+    const [height, setHeight] = useState(getHeight(contentElement));
+    const [, setAnimating] = useAnimation();
+    useEffect(() => {
+      setAnimating({
+        duration: 200,
+        onStart: () => {
+          setHeight(getHeight(contentElement));
+          // Delaying the state update until the next animation frame ensures
+          // that browsers render the new height before the animation starts.
+          window.requestAnimationFrame(() => {
+            setOpen(isVisible);
+          });
+        },
+        onEnd: () => {
+          setHeight(DEFAULT_HEIGHT);
+        },
+      });
+    }, [isVisible, setAnimating]);
 
-  return (
-    <NotificationBannerWrapper
-      ref={contentElement}
-      style={{
-        opacity: isOpen ? 1 : 0,
-        height: isOpen ? height : 0,
-        visibility: isOpen ? 'visible' : 'hidden',
-      }}
-      variant={variant}
-      {...props}
-    >
-      <Content>
-        <ResponsiveHeadline as="h2">{headline}</ResponsiveHeadline>
-        <ResponsiveBody>{body}</ResponsiveBody>
-        <ResponsiveButton {...action} />
-      </Content>
-      {image && image.src && <StyledImage {...image} />}
-      {onClose && closeButtonLabel && (
-        <StyledCloseButton
-          notificationVariant={variant}
-          label={closeButtonLabel}
-          size="kilo"
-          onClick={onClose}
-          tracking={
-            tracking
-              ? { component: 'notification-close', ...tracking }
-              : undefined
-          }
-        />
-      )}
-    </NotificationBannerWrapper>
-  );
-}
+    return (
+      <NotificationBannerWrapper
+        ref={applyMultipleRefs(ref, contentElement)}
+        style={{
+          opacity: isOpen ? 1 : 0,
+          height: isOpen ? height : 0,
+          visibility: isOpen ? 'visible' : 'hidden',
+        }}
+        variant={variant}
+        {...props}
+      >
+        <Content>
+          <ResponsiveHeadline as="h2">{headline}</ResponsiveHeadline>
+          <ResponsiveBody>{body}</ResponsiveBody>
+          <ResponsiveButton {...action} />
+        </Content>
+        {image && image.src && <StyledImage {...image} />}
+        {onClose && closeButtonLabel && (
+          <StyledCloseButton
+            notificationVariant={variant}
+            label={closeButtonLabel}
+            size="kilo"
+            onClick={onClose}
+            tracking={
+              tracking
+                ? { component: 'notification-close', ...tracking }
+                : undefined
+            }
+          />
+        )}
+      </NotificationBannerWrapper>
+    );
+  },
+);
 
 export function getHeight(element: RefObject<HTMLElement>): string {
   if (!element || !element.current) {

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.spec.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.spec.tsx
@@ -14,6 +14,7 @@
  */
 
 import { Plus } from '@sumup/icons';
+import { createRef } from 'react';
 
 import { render, axe } from '../../util/test-utils';
 
@@ -58,6 +59,15 @@ describe('NotificationFullscreen', () => {
       const props = { ...baseProps, image: { svg: Plus, alt: '' } };
       const { container } = renderNotificationFullscreen(props);
       expect(container).toMatchSnapshot();
+    });
+
+    it('should accept a working ref', () => {
+      const ref = createRef<HTMLDivElement>();
+      const { container } = render(
+        <NotificationFullscreen ref={ref} {...baseProps} />,
+      );
+      const wrapper = container.querySelector('div');
+      expect(ref.current).toBe(wrapper);
     });
   });
 

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { FC, HTMLAttributes, ReactNode, SVGProps } from 'react';
+import { FC, HTMLAttributes, ReactNode, SVGProps, forwardRef } from 'react';
 import { css } from '@emotion/react';
 
 import Body from '../Body';
@@ -98,17 +98,14 @@ const centeredStyles = css`
  * The `NotificationFullscreen` component provides important information or
  * feedback as part of a process flow.
  */
-export const NotificationFullscreen = ({
-  image,
-  headline,
-  body,
-  actions,
-  ...props
-}: NotificationFullscreenProps): JSX.Element => {
+export const NotificationFullscreen = forwardRef<
+  HTMLDivElement,
+  NotificationFullscreenProps
+>(({ image, headline, body, actions, ...props }, ref): JSX.Element => {
   const headlineLabel = isString(headline) ? headline : headline.label;
   const headlineElement = isString(headline) ? 'h2' : headline.as;
   return (
-    <div css={wrapperStyles} {...props}>
+    <div ref={ref} css={wrapperStyles} {...props}>
       <NotificationImage image={image} />
       <Headline
         css={cx(spacing({ top: 'giga', bottom: 'byte' }), centeredStyles)}
@@ -123,4 +120,4 @@ export const NotificationFullscreen = ({
       )}
     </div>
   );
-};
+});

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { createRef } from 'react';
+
 import { axe, render, userEvent, waitFor } from '../../util/test-utils';
 
 import {
@@ -104,6 +106,15 @@ describe('NotificationInline', () => {
         },
       });
       expect(baseElement).toMatchSnapshot();
+    });
+
+    it('should accept a working ref', () => {
+      const ref = createRef<HTMLDivElement>();
+      const { container } = render(
+        <NotificationInline ref={ref} {...baseProps} />,
+      );
+      const wrapper = container.querySelector('div');
+      expect(ref.current).toBe(wrapper);
     });
   });
 


### PR DESCRIPTION
Fixes #1828.

## Purpose

> As a rule all components should forward refs to either the wrapping element (for patterns like notifications) or to the core HTML element (such as the `input` for inputs).

– @robinmetral in https://github.com/sumup-oss/circuit-ui/issues/1828#issuecomment-1306046484

## Approach and changes

- Forward `ref`s to the NotificationBanner, NotificationFullscreen, and NotificationInline components

I didn't add `ref`s to the NotificationModal and NotificationToast components since those aren't rendered directly by developers.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
