### PR TITLE
Use Toggle explanation as description, not label

### DIFF
--- a/.changeset/poor-dolphins-help.md
+++ b/.changeset/poor-dolphins-help.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Changed the Toggle's explanation to be associated with the switch button as its description instead of being included in the label to provide a better experience to screen reader users.

--- a/.changeset/poor-dolphins-help.md
+++ b/.changeset/poor-dolphins-help.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Changed the Toggle's `explanation` to be associated with the switch button as its description instead of being included in its label. This provides a better experience to screen reader users.
+Moved the Toggle's `explanation` outside the switch button's `label` and connected it to the switch button using `aria-describedby` to provide a better experience to screen reader users. This affects the component's markup and might be a breaking change in instances customizing the Toggle's styles.

--- a/.changeset/poor-dolphins-help.md
+++ b/.changeset/poor-dolphins-help.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Changed the Toggle's explanation to be associated with the switch button as its description instead of being included in the label to provide a better experience to screen reader users.
+Changed the Toggle's `explanation` to be associated with the switch button as its description instead of being included in its label. This provides a better experience to screen reader users.

--- a/packages/circuit-ui/components/Toggle/Toggle.spec.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.spec.tsx
@@ -15,7 +15,7 @@
 
 import { createRef } from 'react';
 
-import { create, render, renderToHtml, axe } from '../../util/test-utils';
+import { render, axe } from '../../util/test-utils';
 
 import { Toggle } from './Toggle';
 
@@ -31,8 +31,8 @@ describe('Toggle', () => {
    * Style tests.
    */
   it('should render with default styles', () => {
-    const actual = create(<Toggle {...defaultProps} />);
-    expect(actual).toMatchSnapshot();
+    const { container } = render(<Toggle {...defaultProps} />);
+    expect(container).toMatchSnapshot();
   });
 
   describe('business logic', () => {
@@ -45,6 +45,26 @@ describe('Toggle', () => {
       const button = container.querySelector('button');
       expect(tref.current).toBe(button);
     });
+
+    it('should accept a custom description via aria-describedby', () => {
+      const customDescription = 'Custom description';
+      const customDescriptionId = 'customDescriptionId';
+      const { getByRole } = render(
+        <>
+          <span id={customDescriptionId}>{customDescription}</span>
+          <Toggle aria-describedby={customDescriptionId} {...defaultProps} />,
+        </>,
+      );
+      const toggleEl = getByRole('switch');
+
+      expect(toggleEl).toHaveAttribute(
+        'aria-describedby',
+        expect.stringContaining(customDescriptionId),
+      );
+      expect(toggleEl).toHaveAccessibleDescription(
+        `${customDescription} ${defaultProps.explanation}`,
+      );
+    });
   });
 
   /**
@@ -52,8 +72,8 @@ describe('Toggle', () => {
    * See https://inclusive-components.design/toggle-button/
    */
   it('should meet accessibility guidelines', async () => {
-    const wrapper = renderToHtml(<Toggle {...defaultProps} />);
-    const actual = await axe(wrapper);
+    const { container } = render(<Toggle {...defaultProps} />);
+    const actual = await axe(container);
     expect(actual).toHaveNoViolations();
   });
 });

--- a/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
@@ -26,6 +26,7 @@ const baseArgs = {
   label: 'Short label',
   checkedLabel: 'on',
   uncheckedLabel: 'off',
+  disabled: false,
 };
 
 export const Base = (args: ToggleProps) => {

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -86,7 +86,15 @@ const wrapperStyles = (theme: Theme) => css`
  * A toggle component with support for labels and additional explanations.
  */
 export const Toggle = forwardRef(
-  ({ label, explanation, ...props }: ToggleProps, ref: ToggleProps['ref']) => {
+  (
+    {
+      label,
+      explanation,
+      'aria-describedby': descriptionId,
+      ...props
+    }: ToggleProps,
+    ref: ToggleProps['ref'],
+  ) => {
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
@@ -97,13 +105,17 @@ export const Toggle = forwardRef(
 
     const switchId = uniqueId('toggle-switch_');
     const labelId = uniqueId('toggle-label_');
-    const descriptionId = explanation ? uniqueId('toggle-explanation_') : '';
+    const explanationId = explanation ? uniqueId('toggle-explanation_') : '';
+
+    const descriptionIds = [descriptionId, explanationId]
+      .filter(Boolean)
+      .join(' ');
     return (
       <FieldWrapper disabled={props.disabled} css={wrapperStyles}>
         <Switch
           {...props}
           aria-labelledby={labelId}
-          aria-describedby={descriptionId}
+          aria-describedby={descriptionIds}
           id={switchId}
           ref={ref}
         />
@@ -112,7 +124,7 @@ export const Toggle = forwardRef(
             {label}
           </ToggleLabel>
           {explanation && (
-            <ToggleExplanation size="two" variant="subtle" id={descriptionId}>
+            <ToggleExplanation size="two" variant="subtle" id={explanationId}>
               {explanation}
             </ToggleExplanation>
           )}

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -61,7 +61,7 @@ const labelStyles = () => css`
   }
 `;
 
-// This component is rendered with as a `label` element below.
+// This component is rendered as a `label` element below.
 const ToggleLabel = styled(Body)<{ htmlFor: string }>(labelStyles);
 
 const explanationStyles = () => css`

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -44,25 +44,29 @@ export interface ToggleProps extends SwitchProps {
 const textWrapperStyles = ({ theme }: StyleProps) => css`
   display: block;
   margin-left: ${theme.spacings.kilo};
-  cursor: pointer;
 
   ${theme.mq.untilKilo} {
     margin-left: 0;
     margin-right: ${theme.spacings.kilo};
   }
+`;
+
+const ToggleTextWrapper = styled('div')(textWrapperStyles);
+
+const labelStyles = () => css`
+  cursor: pointer;
 
   .${CLASS_DISABLED} & {
     color: var(--cui-fg-normal-disabled);
   }
 `;
 
-const ToggleTextWrapper = styled('label')(textWrapperStyles);
+// This component is rendered with as a `label` element below.
+const ToggleLabel = styled(Body)<{ htmlFor: string }>(labelStyles);
 
-const explanationStyles = css`
-  color: var(--cui-fg-subtle);
-
+const explanationStyles = () => css`
   .${CLASS_DISABLED} & {
-    color: var(--cui-fg-normal-disabled);
+    color: var(--cui-fg-subtle-disabled);
   }
 `;
 
@@ -93,13 +97,24 @@ export const Toggle = forwardRef(
 
     const switchId = uniqueId('toggle-switch_');
     const labelId = uniqueId('toggle-label_');
+    const descriptionId = explanation ? uniqueId('toggle-explanation_') : '';
     return (
       <FieldWrapper disabled={props.disabled} css={wrapperStyles}>
-        <Switch {...props} aria-labelledby={labelId} id={switchId} ref={ref} />
-        <ToggleTextWrapper id={labelId} htmlFor={switchId}>
-          <Body>{label}</Body>
+        <Switch
+          {...props}
+          aria-labelledby={labelId}
+          aria-describedby={descriptionId}
+          id={switchId}
+          ref={ref}
+        />
+        <ToggleTextWrapper>
+          <ToggleLabel as="label" id={labelId} htmlFor={switchId}>
+            {label}
+          </ToggleLabel>
           {explanation && (
-            <ToggleExplanation size="two">{explanation}</ToggleExplanation>
+            <ToggleExplanation size="two" variant="subtle" id={descriptionId}>
+              {explanation}
+            </ToggleExplanation>
           )}
         </ToggleTextWrapper>
       </FieldWrapper>

--- a/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -184,43 +184,45 @@ exports[`Toggle should render with default styles 1`] = `
   color: var(--cui-fg-subtle-disabled);
 }
 
-<div
-  class="circuit-0"
->
-  <button
-    aria-checked="false"
-    aria-describedby="toggle-explanation_3"
-    aria-labelledby="toggle-label_2"
-    class="circuit-1"
-    id="toggle-switch_1"
-    role="switch"
-    type="button"
-  >
-    <span
-      class="circuit-2"
-    />
-    <span
-      class="circuit-3"
-    >
-      off
-    </span>
-  </button>
+<div>
   <div
-    class="circuit-4"
+    class="circuit-0"
   >
-    <label
-      class="circuit-5"
-      for="toggle-switch_1"
-      id="toggle-label_2"
+    <button
+      aria-checked="false"
+      aria-describedby="toggle-explanation_3"
+      aria-labelledby="toggle-label_2"
+      class="circuit-1"
+      id="toggle-switch_1"
+      role="switch"
+      type="button"
     >
-      Label
-    </label>
-    <p
-      class="circuit-6"
-      id="toggle-explanation_3"
+      <span
+        class="circuit-2"
+      />
+      <span
+        class="circuit-3"
+      >
+        off
+      </span>
+    </button>
+    <div
+      class="circuit-4"
     >
-      A longer explanation
-    </p>
+      <label
+        class="circuit-5"
+        for="toggle-switch_1"
+        id="toggle-label_2"
+      >
+        Label
+      </label>
+      <p
+        class="circuit-6"
+        id="toggle-explanation_3"
+      >
+        A longer explanation
+      </p>
+    </div>
   </div>
 </div>
 `;

--- a/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
+++ b/packages/circuit-ui/components/Toggle/__snapshots__/Toggle.spec.tsx.snap
@@ -153,7 +153,6 @@ exports[`Toggle should render with default styles 1`] = `
 .circuit-4 {
   display: block;
   margin-left: 12px;
-  cursor: pointer;
 }
 
 @media (max-width: 479px) {
@@ -163,14 +162,15 @@ exports[`Toggle should render with default styles 1`] = `
   }
 }
 
-.cui-field-disabled .circuit-4 {
-  color: var(--cui-fg-normal-disabled);
-}
-
 .circuit-5 {
   font-weight: 400;
   font-size: 1rem;
   line-height: 1.5rem;
+  cursor: pointer;
+}
+
+.cui-field-disabled .circuit-5 {
+  color: var(--cui-fg-normal-disabled);
 }
 
 .circuit-6 {
@@ -181,7 +181,7 @@ exports[`Toggle should render with default styles 1`] = `
 }
 
 .cui-field-disabled .circuit-6 {
-  color: var(--cui-fg-normal-disabled);
+  color: var(--cui-fg-subtle-disabled);
 }
 
 <div
@@ -189,6 +189,7 @@ exports[`Toggle should render with default styles 1`] = `
 >
   <button
     aria-checked="false"
+    aria-describedby="toggle-explanation_3"
     aria-labelledby="toggle-label_2"
     class="circuit-1"
     id="toggle-switch_1"
@@ -204,21 +205,22 @@ exports[`Toggle should render with default styles 1`] = `
       off
     </span>
   </button>
-  <label
+  <div
     class="circuit-4"
-    for="toggle-switch_1"
-    id="toggle-label_2"
   >
-    <p
+    <label
       class="circuit-5"
+      for="toggle-switch_1"
+      id="toggle-label_2"
     >
       Label
-    </p>
+    </label>
     <p
       class="circuit-6"
+      id="toggle-explanation_3"
     >
       A longer explanation
     </p>
-  </label>
+  </div>
 </div>
 `;


### PR DESCRIPTION
## Purpose

The Toggle component includes an optional `explanation` prop to provide additional context. Currently, the explanation is read out as part of the switch button label, which can be annoying for screen reader users.

## Approach and changes

- Fix the Toggle explanation's disabled color
- Associate the Toggle's explanation with the switch button as a description instead of including it in the label

⚠️ There's one downside to this approach: Clicking or tapping the explanation no longer toggles the switch button.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
