### PR TITLE
Fix broken Storybook links in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Refer to the `package.json` files in each package for other helpful scripts.
 
 ### Changesets
 
-Circuit UI uses [changesets](https://github.com/atlassian/changesets) for versioning. As a contributor you can add a changeset for your changes by running `npm run changeset`. Read more in our [release process docs](https://circuit.sumup.com/?path=/docs/introduction-contributing-release-process--page).
+Circuit UI uses [changesets](https://github.com/atlassian/changesets) for versioning. As a contributor you can add a changeset for your changes by running `npm run changeset`. Read more in our [release process docs](https://circuit.sumup.com/?path=/docs/contributing-release-process--docs).
 
 ### Troubleshooting
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -279,7 +279,7 @@ This version also includes a number of accessibility and visual fixes. While the
 - The `ButtonGroup` component now switches between a secondary button (on viewports of at least `mq.kilo`) and a tertiary button (on viewports narrower than `mq.kilo`) using CSS media queries, instead of rendering three buttons and conditionally hiding one. Tests (e.g. using `@testing-library`) should now query the secondary button without using `*AllBy` queries. Snapshots might also be affected.
 - Typography design tokens now use the `rem` unit. Ensure that your global styles do not override the root font-size. See [The Surprising Truth About Pixels and Accessibility](https://www.joshwcomeau.com/css/surprising-truth-about-pixels-and-accessibility/).
 - The `Popover` component was migrated from Popper (deprecated) to Floating UI. If your app uses Popper directly, we recommend migrating to Floating UI to avoid duplicating dependencies. See [Migrating from Popper 2 to Floating UI](https://floating-ui.com/docs/migration#__next)
-- Circuit UI's browser support policy was updated. The library now supports browsers with support for [dynamic module imports](https://caniuse.com/es6-module-dynamic-import). See the [Browser Support](https://circuit.sumup.com/?path=/docs/introduction-browser-support--page) documentation for details.
+- Circuit UI's browser support policy was updated. The library now supports browsers with support for [dynamic module imports](https://caniuse.com/es6-module-dynamic-import). See the [Browser Support](https://circuit.sumup.com/?path=/docs/introduction-browser-support--docs) documentation for details.
 - If your app uses TypeScript, an upgrade of the `@types/react` package in Circuit UI may clash with the version installed in your app. If your app is on React 18, upgrade `@types/react` to `^18.0.25` to fix the issue. If your app is on React 17, upgrade `@types/react` to `^17.0.52` and [extend the React namespace](https://github.com/sumup-oss/circuit-ui/pull/1831#issuecomment-1307485956). More details on [the DefinitelyTyped PR that introduced the issue](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63076).
 
 ## From v4.x to v5
@@ -290,7 +290,7 @@ Circuit UI v5 is a maintenance release, primarily removing deprecated components
 
 ### Explicit browser support
 
-Starting in v5, Circuit UI is explicit about which browsers it supports. Refer to the [browser support documentation](https://circuit.sumup.com/?path=/docs/introduction-browser-support--page) for details.
+Starting in v5, Circuit UI is explicit about which browsers it supports. Refer to the [browser support documentation](https://circuit.sumup.com/?path=/docs/contributing-browser-support--docs) for details.
 
 Here's what you need to be mindful of when migrating:
 
@@ -530,7 +530,7 @@ module.exports = {
 
 ### New brand icons
 
-Circuit v4 ships with the [new brand icons](https://circuit.sumup.com/?path=/story/features-icons--page) from `@sumup/icons` v2.
+Circuit v4 ships with the [new brand icons](https://circuit.sumup.com/?path=/docs/features-icons--docs) from `@sumup/icons` v2.
 
 #### Overview of `@sumup/icons` v2
 
@@ -716,7 +716,7 @@ Modals in Circuit v3 are accessible by default, have a streamlined UI and behavi
 
 Refer to [the Modal stories](https://circuit.sumup.com/?path=/story/components-modal--base) for usage examples.
 
-> ⚠️ You might notice browser UI obscuring parts of your application on mobile viewports. Your application needs to ensure its content stays within CSS safe areas using [CSS `env`](<https://developer.mozilla.org/en-US/docs/Web/CSS/env()>). See [Getting started](https://circuit.sumup.com/?path=/docs/introduction-getting-started--page) for help with configuring the viewport.
+> ⚠️ You might notice browser UI obscuring parts of your application on mobile viewports. Your application needs to ensure its content stays within CSS safe areas using [CSS `env`](<https://developer.mozilla.org/en-US/docs/Web/CSS/env()>). See [Getting started](https://circuit.sumup.com/?path=/docs/introduction-getting-started--docs) for help with configuring the viewport.
 
 #### Popover
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 Here are a few helpful links for getting started with Circuit UI:
 
 - [Documentation](https://circuit.sumup.com/) - Learn how to use Circuit UI and view the components in Storybook.
-- [Getting started](https://circuit.sumup.com/?path=/docs/introduction-getting-started--page) - Set up a new app with Circuit UI or add it to an existing project.
-- [Theming](https://circuit.sumup.com/?path=/docs/features-theme--page) - Learn about our foundations such as colors, spacing, and typography.
-- [Contribute](https://circuit.sumup.com/?path=/docs/introduction-contributing-overview--page) - File a bug report, suggest a change, or open a pull request.
+- [Getting started](https://circuit.sumup.com/?path=/docs/introduction-getting-started--docs) - Set up a new app with Circuit UI or add it to an existing project.
+- [Theming](https://circuit.sumup.com/?path=/docs/features-theme--docs) - Learn about our foundations such as colors, spacing, and typography.
+- [Contribute](https://circuit.sumup.com/?path=/docs/contributing-overview--docs) - File a bug report, suggest a change, or open a pull request.
 
 ## Packages
 

--- a/docs/contributing/7-contributing-icons.mdx
+++ b/docs/contributing/7-contributing-icons.mdx
@@ -16,7 +16,7 @@ This page outlines the process of contributing an icon to the `@sumup/icons` pac
 3. Paste the SVG into your file and verify the code — refer to the "Caveats" section below.
 4. Commit the icons, they will automatically be optimized in the precommit hook using `svgo`.
 5. Add an icon object to the icons manifest file at [`packages/icons/manifest.json`](https://github.com/sumup-oss/circuit-ui/blob/9146e47a21dcd6880f437d1a47a0c54d5a164bfd/packages/icons/manifest.json). The icons are manually ordered alphabetically by icon category, then name (should match the file name), and finally by size (descending).
-6. Build the icons package (`npx lerna run build --scope=@sumup/icons`) and run the Storybook (`npm run docs`). Verify that your icon renders correctly on the [Icons page](http://localhost:6006/?path=/docs/features-icons--page) (local link).
+6. Build the icons package (`npx lerna run build --scope=@sumup/icons`) and run the Storybook (`npm run docs`). Verify that your icon renders correctly on the [Icons page](http://localhost:6006/?path=/docs/features-icons--docs) (local link).
 
 ## Caveats
 
@@ -31,7 +31,7 @@ Unless icons are a brand logo (e.g. the Mastercard logo), all SVG fills should a
 </svg>
 ```
 
-You can test this by running Storybook and changing the icons color on the [Icons page](http://localhost:6006/?path=/docs/features-icons--page) (local link).
+You can test this by running Storybook and changing the icons color on the [Icons page](http://localhost:6006/?path=/docs/features-icons--docs) (local link).
 
 ### Correct icon size
 

--- a/packages/circuit-ui/CHANGELOG.md
+++ b/packages/circuit-ui/CHANGELOG.md
@@ -116,7 +116,7 @@
 
 ### Minor Changes
 
-- [#1880](https://github.com/sumup-oss/circuit-ui/pull/1880) [`38dcc5c1`](https://github.com/sumup-oss/circuit-ui/commit/38dcc5c13a44a2331a744d2ddda5c0b1617d4f72) Thanks [@robinmetral](https://github.com/robinmetral)! - Added semantic color tokens as CSS custom properties to the `BaseStyles`. See the [documentation](https://circuit.sumup.com/?path=/docs/features-theme--page) for details.
+- [#1880](https://github.com/sumup-oss/circuit-ui/pull/1880) [`38dcc5c1`](https://github.com/sumup-oss/circuit-ui/commit/38dcc5c13a44a2331a744d2ddda5c0b1617d4f72) Thanks [@robinmetral](https://github.com/robinmetral)! - Added semantic color tokens as CSS custom properties to the `BaseStyles`. See the [documentation](https://circuit.sumup.com/?path=/docs/features-theme--docs) for details.
 
 ## 6.0.0
 
@@ -305,7 +305,7 @@
 
 * [#1529](https://github.com/sumup-oss/circuit-ui/pull/1529) [`fa2101e5`](https://github.com/sumup-oss/circuit-ui/commit/fa2101e56031d8341cc392817aa1436308f2d181) Thanks [@robinmetral](https://github.com/robinmetral)! - Removed the deprecated `showValid` option from the `inputOutline` style mixin.
 
-- [#1542](https://github.com/sumup-oss/circuit-ui/pull/1542) [`2c62d308`](https://github.com/sumup-oss/circuit-ui/commit/2c62d3087a7a772e5feb0126cc39ad5c84b564f4) Thanks [@robinmetral](https://github.com/robinmetral)! - Optimized Circuit UI for modern browsers. Refer to the [browser support policy](https://circuit.sumup.com/?path=/docs/introduction-browser-support--page) for details.
+- [#1542](https://github.com/sumup-oss/circuit-ui/pull/1542) [`2c62d308`](https://github.com/sumup-oss/circuit-ui/commit/2c62d3087a7a772e5feb0126cc39ad5c84b564f4) Thanks [@robinmetral](https://github.com/robinmetral)! - Optimized Circuit UI for modern browsers. Refer to the [browser support policy](https://circuit.sumup.com/?path=/docs/introduction-browser-support--docs) for details.
 
 * [#1552](https://github.com/sumup-oss/circuit-ui/pull/1552) [`4e6a3750`](https://github.com/sumup-oss/circuit-ui/commit/4e6a375010aed43dcf5abc6b57c0503747b42b4b) Thanks [@robinmetral](https://github.com/robinmetral)! - Removed the deprecated `children` prop from the `ButtonGroup` component. Use the `actions` prop instead.
 

--- a/packages/circuit-ui/README.md
+++ b/packages/circuit-ui/README.md
@@ -33,6 +33,6 @@ yarn add react react-dom @emotion/react @emotion/styled @sumup/design-tokens @su
 Here are a few helpful links for getting started with Circuit UI:
 
 - [Documentation](https://circuit.sumup.com/) - Learn how to use Circuit UI and view the components in Storybook.
-- [Getting started](https://circuit.sumup.com/?path=/docs/introduction-getting-started--page) - Set up a new app with Circuit UI or add it to an existing project.
-- [Theming](https://circuit.sumup.com/?path=/docs/features-theme--page) - Learn about our foundations such as colors, spacing, and typography.
-- [Contribute](https://circuit.sumup.com/?path=/docs/introduction-contributing-overview--page) - File a bug report, suggest a change, or open a pull request.
+- [Getting started](https://circuit.sumup.com/?path=/docs/introduction-getting-started--docs) - Set up a new app with Circuit UI or add it to an existing project.
+- [Theming](https://circuit.sumup.com/?path=/docs/features-theme--docs) - Learn about our foundations such as colors, spacing, and typography.
+- [Contribute](https://circuit.sumup.com/?path=/docs/contributing-overview--docs) - File a bug report, suggest a change, or open a pull request.


### PR DESCRIPTION
Addresses #ticket-number.

## Purpose

Links to the Storybook pages of in the Markdown files are broken. 

## Approach and changes

- Hard-code the Storybook url

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
