### PR TITLE
Fix Popover item alignment

### DIFF
--- a/.changeset/smart-ears-appear.md
+++ b/.changeset/smart-ears-appear.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the alignment of wrapped Popover items.

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -100,6 +100,7 @@ const itemWrapperStyles = () => css`
   justify-content: flex-start;
   align-items: center;
   width: 100%;
+  text-align: left;
 `;
 
 const PopoverItemWrapper = styled('button', {

--- a/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
+++ b/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
@@ -88,6 +88,7 @@ exports[`Popover Styles should render popover on bottom 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -157,6 +158,7 @@ exports[`Popover Styles should render popover on bottom 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -355,6 +357,7 @@ exports[`Popover Styles should render popover on left 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -424,6 +427,7 @@ exports[`Popover Styles should render popover on left 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -622,6 +626,7 @@ exports[`Popover Styles should render popover on right 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -691,6 +696,7 @@ exports[`Popover Styles should render popover on right 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -889,6 +895,7 @@ exports[`Popover Styles should render popover on top 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -958,6 +965,7 @@ exports[`Popover Styles should render popover on top 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -1138,6 +1146,7 @@ exports[`Popover Styles should render with closed styles 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -1207,6 +1216,7 @@ exports[`Popover Styles should render with closed styles 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -1405,6 +1415,7 @@ exports[`Popover Styles should render with default styles 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }
@@ -1474,6 +1485,7 @@ exports[`Popover Styles should render with default styles 1`] = `
   -ms-flex-align: center;
   align-items: center;
   width: 100%;
+  text-align: left;
   font-size: 1rem;
   line-height: 1.5rem;
 }


### PR DESCRIPTION
## Purpose

Popover items are center-aligned when wrapped:

![Screenshot 2023-04-12 at 15 31 12](https://user-images.githubusercontent.com/11017722/231485073-29005589-0600-43ca-97b8-a9c21047cebf.png)

## Approach and changes

- Explicitly left-align Popover items

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
