### PR TITLE
Fix CNA automated tests

### DIFF
--- a/.github/workflows/cna.yml
+++ b/.github/workflows/cna.yml
@@ -33,4 +33,4 @@ jobs:
 
       - name: Test app
         working-directory: ./test-app
-        run: npx start-server-and-test start http://localhost:3000 "node ../scripts/verify-template.js"
+        run: npx start-server-and-test start 0.0.0.0:3000 "node ../scripts/verify-template.js"


### PR DESCRIPTION
## Purpose

The tests have been failing for about three months and I didn't notice at all (?)

This wasn't an issue with the app, which always built properly, but with the automated test suite (a.k.a. puppeteer checking that the thing opens when the app is built and ran with `next start`)

## Approach and changes

This is a bit of a mess. Looks like at the core it's an issue that a `start-server-and-test` subdependency (`wait-on`) has with Node.js v18 (so might have started when we bumped Node.js versions in our version matrices?). Ref: https://github.com/jeffbski/wait-on/issues/137

Expectedly, a lot of people seem to be running into the issue and are reporting this in the `start-server-amd-test` repo. This issue thread for example: https://github.com/bahmutov/start-server-and-test/issues/181 suggests various solutions, which I've tried locally without success.

In the end what worked was the opposite of one of the suggested solutions: switching the watched URL from `localhost:3000` to `0.0.0.0:3000`. This worked locally, [worked in CI](https://github.com/sumup-oss/circuit-ui/actions/runs/4733040634) (ran the workflow on this branch), so I think it's safe to merge.

I don't really understand why this solves it but this seems like a viable short-term fix—long term, if this doesn't get fixed upstream and starts happening again, I'd suggest exploring alternatives to `start-server-and-test` (which would probably be more straightforward and cleaner than attempting to patch the subdep).

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* (n/a) Unit and integration tests
* (n/a) Meets minimum browser support
* (n/a) Meets accessibility requirements
