### PR TITLE
Update ImageInput component prop types

### DIFF
--- a/.changeset/khaki-baboons-deliver.md
+++ b/.changeset/khaki-baboons-deliver.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Changed the signature of the ImageInput's `component` prop. The `component` should now accept `aria-hidden` instead of `alt`.

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -43,10 +43,11 @@ export interface ImageInputProps
    */
   label: string;
   /**
-   * The visual component to render as an image input. It should accept an src
-   * prop to render the image.
+   * The visual component to render as an image input.
+   * It should accept a `src` prop to render the image, and `aria-hidden` to
+   * hide it from assistive technology.
    */
-  component: (props: { src?: string; alt: string }) => JSX.Element;
+  component: (props: { 'src'?: string; 'aria-hidden': 'true' }) => JSX.Element;
   /**
    * A callback function to call when the user has selected an image.
    */
@@ -458,7 +459,7 @@ export const ImageInput = ({
           onDrop={handleDrop}
         >
           <span css={hideVisually()}>{label}</span>
-          <Component src={src || previewImage} alt="" />
+          <Component src={src || previewImage} aria-hidden="true" />
         </Label>
         {src ? (
           <ActionButton

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -1151,6 +1151,7 @@ exports[`ImageInput > Styles > should render with an existing image 1`] = `
         </span>
         <img
           alt=""
+          aria-hidden="true"
           class="circuit-5"
           src="/images/illustration-coffee.jpg"
         />


### PR DESCRIPTION
Effectively reverts https://github.com/sumup-oss/circuit-ui/pull/1970.

## Purpose

The ImageInput accepts a `component` prop to render the selected image. This image should be hidden from screen reader users. `aria-hidden` is more appropriate than `alt` since it works for any HTML element, not just `img`.

## Approach and changes

- Update the `component` prop's function signature

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
