### PR TITLE
Fix types resolution

### DIFF
--- a/.changeset/purple-papayas-bake.md
+++ b/.changeset/purple-papayas-bake.md
@@ -1,0 +1,7 @@
+---
+'@sumup/design-tokens': patch
+'@sumup/circuit-ui': patch
+'@sumup/icons': patch
+---
+
+Added `types` field to the `package.json` file to fix the type resolution.

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -3,6 +3,8 @@
   "version": "7.0.0-next.3",
   "description": "SumUp's React UI component library",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": "./dist/index.js",
   "sideEffects": false,
   "files": [

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -3,6 +3,8 @@
   "version": "6.0.0-next.0",
   "description": "Visual primitives such as typography, color, and spacing that are shared across platforms.",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": "./dist/index.js",
   "sideEffects": false,
   "files": [

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -4,6 +4,7 @@
   "description": "A collection of icons by SumUp",
   "type": "module",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
     "./manifest.json": "./manifest.json",


### PR DESCRIPTION
## Purpose

The package entry points are defined using the `exports` field since #2061. TypeScript [is supposed to](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) be able to resolve the types relative to the path(s) defined in the `exports` field, but testing the latest `next` release proves otherwise.

## Approach and changes

- Add back the `types` field in the `package.json` files

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
