### PR TITLE
Add workflow to mark stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: 'Label stale issues and PRs'
+on:
+  schedule:
+    # Every day from Monday through Thursday at 7am UTC
+    - cron: '0 7 * * 1-4'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs. Add a comment explaining why the issue is still relevant to prevent it from being closed.'
+          stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs. Add a comment explaining why the pull request is still relevant to prevent it from being closed.'


### PR DESCRIPTION
## Purpose

This repository is accumulating many old issues and pull requests. Adding automation to remind contributors to follow up on them should hopefully reduce the number of stale issues.

## Approach and changes

- Add a GitHub Action workflow to label issues and pull requests as "stale" after 60 days of inactivity and close them after a further 7 days

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
