### PR TITLE
Add field wrapper around RadioButtons

### DIFF
--- a/.changeset/light-donuts-wonder.md
+++ b/.changeset/light-donuts-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Wrapped the RadioButton in a `div` that receives any styles passed through the `style` or `className` props, including via the Emotion.js `css` prop. This might break custom styles.

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -13,12 +13,13 @@
  * limitations under the License.
  */
 
-import { Fragment, InputHTMLAttributes, Ref, forwardRef, useId } from 'react';
+import { InputHTMLAttributes, Ref, forwardRef, useId } from 'react';
 import { css } from '@emotion/react';
 
 import styled, { StyleProps } from '../../styles/styled.js';
 import { hideVisually, focusOutline } from '../../styles/style-mixins.js';
 import { AccessibilityError } from '../../util/errors.js';
+import { FieldWrapper } from '../FieldAtoms/FieldWrapper.js';
 
 export interface RadioButtonProps
   extends InputHTMLAttributes<HTMLInputElement> {
@@ -210,7 +211,7 @@ export const RadioButton = forwardRef(
     const inputId = customId || id;
 
     return (
-      <Fragment>
+      <FieldWrapper className={className} style={style} disabled={disabled}>
         <RadioButtonInput
           {...props}
           type="radio"
@@ -231,7 +232,7 @@ export const RadioButton = forwardRef(
         >
           {label}
         </RadioButtonLabel>
-      </Fragment>
+      </FieldWrapper>
     );
   },
 );

--- a/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButton/__snapshots__/RadioButton.spec.tsx.snap
@@ -1,7 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`RadioButton > Styles > should render with checked styles 1`] = `
-.circuit-0 {
+.circuit-0.cui-field-disabled {
+  pointer-events: none;
+}
+
+.circuit-1 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -13,34 +17,34 @@ exports[`RadioButton > Styles > should render with checked styles 1`] = `
   width: 1px;
 }
 
-.circuit-0:hover+label::before {
+.circuit-1:hover+label::before {
   border-color: var(--cui-border-normal-hovered);
 }
 
-.circuit-0:focus+label::before {
+.circuit-1:focus+label::before {
   outline: 0;
   box-shadow: 0 0 0 4px var(--cui-border-focus);
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:focus+label::before::-moz-focus-inner {
+.circuit-1:focus+label::before::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-0:focus:not(:focus-visible)+label::before {
+.circuit-1:focus:not(:focus-visible)+label::before {
   box-shadow: none;
   border-color: var(--cui-border-normal);
 }
 
-.circuit-0:checked:focus:not(:focus-visible)+label::before {
+.circuit-1:checked:focus:not(:focus-visible)+label::before {
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:checked+label::before {
+.circuit-1:checked+label::before {
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:checked+label::after {
+.circuit-1:checked+label::after {
   -webkit-transform: translateY(-50%) scale(1, 1);
   -moz-transform: translateY(-50%) scale(1, 1);
   -ms-transform: translateY(-50%) scale(1, 1);
@@ -48,34 +52,34 @@ exports[`RadioButton > Styles > should render with checked styles 1`] = `
   opacity: 1;
 }
 
-.circuit-0:disabled+label,
-.circuit-0[disabled]+label {
+.circuit-1:disabled+label,
+.circuit-1[disabled]+label {
   pointer-events: none;
   color: var(--cui-fg-normal-disabled);
 }
 
-.circuit-0:disabled+label::before,
-.circuit-0[disabled]+label::before {
+.circuit-1:disabled+label::before,
+.circuit-1[disabled]+label::before {
   border-color: var(--cui-border-strong-disabled);
   background-color: var(--cui-bg-normal-disabled);
 }
 
-.circuit-0:disabled+label::after,
-.circuit-0[disabled]+label::after {
+.circuit-1:disabled+label::after,
+.circuit-1[disabled]+label::after {
   background-color: var(--cui-fg-on-strong-disabled);
 }
 
-.circuit-0:disabled:checked+label::before,
-.circuit-0[disabled]:checked+label::before {
+.circuit-1:disabled:checked+label::before,
+.circuit-1[disabled]:checked+label::before {
   border-color: var(--cui-border-accent-disabled);
 }
 
-.circuit-0:disabled:checked+label::after,
-.circuit-0[disabled]:checked+label::after {
+.circuit-1:disabled:checked+label::after,
+.circuit-1[disabled]:checked+label::after {
   background-color: var(--cui-fg-accent-disabled);
 }
 
-.circuit-1 {
+.circuit-2 {
   color: var(--cui-fg-normal);
   display: inline-block;
   padding-left: 26px;
@@ -83,7 +87,7 @@ exports[`RadioButton > Styles > should render with checked styles 1`] = `
   cursor: pointer;
 }
 
-.circuit-1::before {
+.circuit-2::before {
   box-sizing: border-box;
   height: 18px;
   width: 18px;
@@ -103,7 +107,7 @@ exports[`RadioButton > Styles > should render with checked styles 1`] = `
   transition: border 120ms ease-in-out;
 }
 
-.circuit-1::after {
+.circuit-2::after {
   box-sizing: border-box;
   height: 10px;
   width: 10px;
@@ -124,24 +128,32 @@ exports[`RadioButton > Styles > should render with checked styles 1`] = `
 }
 
 <div>
-  <input
-    checked=""
-    class="circuit-0"
-    id=":r1:"
-    type="radio"
-    value=""
-  />
-  <label
-    class="circuit-1"
-    for=":r1:"
+  <div
+    class=" circuit-0"
   >
-    Label
-  </label>
+    <input
+      checked=""
+      class="circuit-1"
+      id=":r1:"
+      type="radio"
+      value=""
+    />
+    <label
+      class="circuit-2"
+      for=":r1:"
+    >
+      Label
+    </label>
+  </div>
 </div>
 `;
 
 exports[`RadioButton > Styles > should render with default styles 1`] = `
-.circuit-0 {
+.circuit-0.cui-field-disabled {
+  pointer-events: none;
+}
+
+.circuit-1 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -153,34 +165,34 @@ exports[`RadioButton > Styles > should render with default styles 1`] = `
   width: 1px;
 }
 
-.circuit-0:hover+label::before {
+.circuit-1:hover+label::before {
   border-color: var(--cui-border-normal-hovered);
 }
 
-.circuit-0:focus+label::before {
+.circuit-1:focus+label::before {
   outline: 0;
   box-shadow: 0 0 0 4px var(--cui-border-focus);
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:focus+label::before::-moz-focus-inner {
+.circuit-1:focus+label::before::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-0:focus:not(:focus-visible)+label::before {
+.circuit-1:focus:not(:focus-visible)+label::before {
   box-shadow: none;
   border-color: var(--cui-border-normal);
 }
 
-.circuit-0:checked:focus:not(:focus-visible)+label::before {
+.circuit-1:checked:focus:not(:focus-visible)+label::before {
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:checked+label::before {
+.circuit-1:checked+label::before {
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:checked+label::after {
+.circuit-1:checked+label::after {
   -webkit-transform: translateY(-50%) scale(1, 1);
   -moz-transform: translateY(-50%) scale(1, 1);
   -ms-transform: translateY(-50%) scale(1, 1);
@@ -188,34 +200,34 @@ exports[`RadioButton > Styles > should render with default styles 1`] = `
   opacity: 1;
 }
 
-.circuit-0:disabled+label,
-.circuit-0[disabled]+label {
+.circuit-1:disabled+label,
+.circuit-1[disabled]+label {
   pointer-events: none;
   color: var(--cui-fg-normal-disabled);
 }
 
-.circuit-0:disabled+label::before,
-.circuit-0[disabled]+label::before {
+.circuit-1:disabled+label::before,
+.circuit-1[disabled]+label::before {
   border-color: var(--cui-border-strong-disabled);
   background-color: var(--cui-bg-normal-disabled);
 }
 
-.circuit-0:disabled+label::after,
-.circuit-0[disabled]+label::after {
+.circuit-1:disabled+label::after,
+.circuit-1[disabled]+label::after {
   background-color: var(--cui-fg-on-strong-disabled);
 }
 
-.circuit-0:disabled:checked+label::before,
-.circuit-0[disabled]:checked+label::before {
+.circuit-1:disabled:checked+label::before,
+.circuit-1[disabled]:checked+label::before {
   border-color: var(--cui-border-accent-disabled);
 }
 
-.circuit-0:disabled:checked+label::after,
-.circuit-0[disabled]:checked+label::after {
+.circuit-1:disabled:checked+label::after,
+.circuit-1[disabled]:checked+label::after {
   background-color: var(--cui-fg-accent-disabled);
 }
 
-.circuit-1 {
+.circuit-2 {
   color: var(--cui-fg-normal);
   display: inline-block;
   padding-left: 26px;
@@ -223,7 +235,7 @@ exports[`RadioButton > Styles > should render with default styles 1`] = `
   cursor: pointer;
 }
 
-.circuit-1::before {
+.circuit-2::before {
   box-sizing: border-box;
   height: 18px;
   width: 18px;
@@ -243,7 +255,7 @@ exports[`RadioButton > Styles > should render with default styles 1`] = `
   transition: border 120ms ease-in-out;
 }
 
-.circuit-1::after {
+.circuit-2::after {
   box-sizing: border-box;
   height: 10px;
   width: 10px;
@@ -264,23 +276,31 @@ exports[`RadioButton > Styles > should render with default styles 1`] = `
 }
 
 <div>
-  <input
-    class="circuit-0"
-    id=":r0:"
-    type="radio"
-    value=""
-  />
-  <label
-    class="circuit-1"
-    for=":r0:"
+  <div
+    class=" circuit-0"
   >
-    Label
-  </label>
+    <input
+      class="circuit-1"
+      id=":r0:"
+      type="radio"
+      value=""
+    />
+    <label
+      class="circuit-2"
+      for=":r0:"
+    >
+      Label
+    </label>
+  </div>
 </div>
 `;
 
 exports[`RadioButton > Styles > should render with disabled styles 1`] = `
-.circuit-0 {
+.circuit-0.cui-field-disabled {
+  pointer-events: none;
+}
+
+.circuit-1 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -292,34 +312,34 @@ exports[`RadioButton > Styles > should render with disabled styles 1`] = `
   width: 1px;
 }
 
-.circuit-0:hover+label::before {
+.circuit-1:hover+label::before {
   border-color: var(--cui-border-normal-hovered);
 }
 
-.circuit-0:focus+label::before {
+.circuit-1:focus+label::before {
   outline: 0;
   box-shadow: 0 0 0 4px var(--cui-border-focus);
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:focus+label::before::-moz-focus-inner {
+.circuit-1:focus+label::before::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-0:focus:not(:focus-visible)+label::before {
+.circuit-1:focus:not(:focus-visible)+label::before {
   box-shadow: none;
   border-color: var(--cui-border-normal);
 }
 
-.circuit-0:checked:focus:not(:focus-visible)+label::before {
+.circuit-1:checked:focus:not(:focus-visible)+label::before {
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:checked+label::before {
+.circuit-1:checked+label::before {
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:checked+label::after {
+.circuit-1:checked+label::after {
   -webkit-transform: translateY(-50%) scale(1, 1);
   -moz-transform: translateY(-50%) scale(1, 1);
   -ms-transform: translateY(-50%) scale(1, 1);
@@ -327,34 +347,34 @@ exports[`RadioButton > Styles > should render with disabled styles 1`] = `
   opacity: 1;
 }
 
-.circuit-0:disabled+label,
-.circuit-0[disabled]+label {
+.circuit-1:disabled+label,
+.circuit-1[disabled]+label {
   pointer-events: none;
   color: var(--cui-fg-normal-disabled);
 }
 
-.circuit-0:disabled+label::before,
-.circuit-0[disabled]+label::before {
+.circuit-1:disabled+label::before,
+.circuit-1[disabled]+label::before {
   border-color: var(--cui-border-strong-disabled);
   background-color: var(--cui-bg-normal-disabled);
 }
 
-.circuit-0:disabled+label::after,
-.circuit-0[disabled]+label::after {
+.circuit-1:disabled+label::after,
+.circuit-1[disabled]+label::after {
   background-color: var(--cui-fg-on-strong-disabled);
 }
 
-.circuit-0:disabled:checked+label::before,
-.circuit-0[disabled]:checked+label::before {
+.circuit-1:disabled:checked+label::before,
+.circuit-1[disabled]:checked+label::before {
   border-color: var(--cui-border-accent-disabled);
 }
 
-.circuit-0:disabled:checked+label::after,
-.circuit-0[disabled]:checked+label::after {
+.circuit-1:disabled:checked+label::after,
+.circuit-1[disabled]:checked+label::after {
   background-color: var(--cui-fg-accent-disabled);
 }
 
-.circuit-1 {
+.circuit-2 {
   color: var(--cui-fg-normal);
   display: inline-block;
   padding-left: 26px;
@@ -362,7 +382,7 @@ exports[`RadioButton > Styles > should render with disabled styles 1`] = `
   cursor: pointer;
 }
 
-.circuit-1::before {
+.circuit-2::before {
   box-sizing: border-box;
   height: 18px;
   width: 18px;
@@ -382,7 +402,7 @@ exports[`RadioButton > Styles > should render with disabled styles 1`] = `
   transition: border 120ms ease-in-out;
 }
 
-.circuit-1::after {
+.circuit-2::after {
   box-sizing: border-box;
   height: 10px;
   width: 10px;
@@ -403,24 +423,32 @@ exports[`RadioButton > Styles > should render with disabled styles 1`] = `
 }
 
 <div>
-  <input
-    class="circuit-0"
-    disabled=""
-    id=":r2:"
-    type="radio"
-    value=""
-  />
-  <label
-    class="circuit-1"
-    for=":r2:"
+  <div
+    class=" cui-field-disabled circuit-0"
   >
-    Label
-  </label>
+    <input
+      class="circuit-1"
+      disabled=""
+      id=":r2:"
+      type="radio"
+      value=""
+    />
+    <label
+      class="circuit-2"
+      for=":r2:"
+    >
+      Label
+    </label>
+  </div>
 </div>
 `;
 
 exports[`RadioButton > Styles > should render with invalid styles 1`] = `
-.circuit-0 {
+.circuit-0.cui-field-disabled {
+  pointer-events: none;
+}
+
+.circuit-1 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -432,34 +460,34 @@ exports[`RadioButton > Styles > should render with invalid styles 1`] = `
   width: 1px;
 }
 
-.circuit-0:hover+label::before {
+.circuit-1:hover+label::before {
   border-color: var(--cui-border-normal-hovered);
 }
 
-.circuit-0:focus+label::before {
+.circuit-1:focus+label::before {
   outline: 0;
   box-shadow: 0 0 0 4px var(--cui-border-focus);
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:focus+label::before::-moz-focus-inner {
+.circuit-1:focus+label::before::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-0:focus:not(:focus-visible)+label::before {
+.circuit-1:focus:not(:focus-visible)+label::before {
   box-shadow: none;
   border-color: var(--cui-border-normal);
 }
 
-.circuit-0:checked:focus:not(:focus-visible)+label::before {
+.circuit-1:checked:focus:not(:focus-visible)+label::before {
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:checked+label::before {
+.circuit-1:checked+label::before {
   border-color: var(--cui-border-accent);
 }
 
-.circuit-0:checked+label::after {
+.circuit-1:checked+label::after {
   -webkit-transform: translateY(-50%) scale(1, 1);
   -moz-transform: translateY(-50%) scale(1, 1);
   -ms-transform: translateY(-50%) scale(1, 1);
@@ -467,43 +495,43 @@ exports[`RadioButton > Styles > should render with invalid styles 1`] = `
   opacity: 1;
 }
 
-.circuit-0:disabled+label,
-.circuit-0[disabled]+label {
+.circuit-1:disabled+label,
+.circuit-1[disabled]+label {
   pointer-events: none;
   color: var(--cui-fg-normal-disabled);
 }
 
-.circuit-0:disabled+label::before,
-.circuit-0[disabled]+label::before {
+.circuit-1:disabled+label::before,
+.circuit-1[disabled]+label::before {
   border-color: var(--cui-border-strong-disabled);
   background-color: var(--cui-bg-normal-disabled);
 }
 
-.circuit-0:disabled+label::after,
-.circuit-0[disabled]+label::after {
+.circuit-1:disabled+label::after,
+.circuit-1[disabled]+label::after {
   background-color: var(--cui-fg-on-strong-disabled);
 }
 
-.circuit-0:disabled:checked+label::before,
-.circuit-0[disabled]:checked+label::before {
+.circuit-1:disabled:checked+label::before,
+.circuit-1[disabled]:checked+label::before {
   border-color: var(--cui-border-accent-disabled);
 }
 
-.circuit-0:disabled:checked+label::after,
-.circuit-0[disabled]:checked+label::after {
+.circuit-1:disabled:checked+label::after,
+.circuit-1[disabled]:checked+label::after {
   background-color: var(--cui-fg-accent-disabled);
 }
 
-.circuit-0:hover+label::before,
-.circuit-0:focus+label::before {
+.circuit-1:hover+label::before,
+.circuit-1:focus+label::before {
   border-color: var(--cui-border-danger-hovered);
 }
 
-.circuit-0:checked+label::before {
+.circuit-1:checked+label::before {
   border-color: var(--cui-border-danger);
 }
 
-.circuit-1 {
+.circuit-2 {
   color: var(--cui-fg-normal);
   display: inline-block;
   padding-left: 26px;
@@ -511,7 +539,7 @@ exports[`RadioButton > Styles > should render with invalid styles 1`] = `
   cursor: pointer;
 }
 
-.circuit-1::before {
+.circuit-2::before {
   box-sizing: border-box;
   height: 18px;
   width: 18px;
@@ -531,7 +559,7 @@ exports[`RadioButton > Styles > should render with invalid styles 1`] = `
   transition: border 120ms ease-in-out;
 }
 
-.circuit-1::after {
+.circuit-2::after {
   box-sizing: border-box;
   height: 10px;
   width: 10px;
@@ -551,28 +579,32 @@ exports[`RadioButton > Styles > should render with invalid styles 1`] = `
   transition: transform 120ms ease-in-out,opacity 120ms ease-in-out;
 }
 
-.circuit-1:not(:focus)::before {
+.circuit-2:not(:focus)::before {
   border-color: var(--cui-border-danger);
   background-color: var(--cui-bg-danger);
 }
 
-.circuit-1:not(:focus)::after {
+.circuit-2:not(:focus)::after {
   background-color: var(--cui-fg-danger);
 }
 
 <div>
-  <input
-    aria-invalid="true"
-    class="circuit-0"
-    id=":r3:"
-    type="radio"
-    value=""
-  />
-  <label
-    class="circuit-1"
-    for=":r3:"
+  <div
+    class=" circuit-0"
   >
-    Label
-  </label>
+    <input
+      aria-invalid="true"
+      class="circuit-1"
+      id=":r3:"
+      type="radio"
+      value=""
+    />
+    <label
+      class="circuit-2"
+      for=":r3:"
+    >
+      Label
+    </label>
+  </div>
 </div>
 `;

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -152,21 +152,17 @@ export const RadioButtonGroup = forwardRef(
           />
         </Legend>
         {options &&
-          options.map(
-            ({ label: optionLabel, value, className, style, ...rest }) => (
-              <div
-                key={value && value.toString()}
-                className={className}
-                style={style}
-              >
-                <RadioButton
-                  {...{ ...rest, value, name: groupName, required, onChange }}
-                  checked={value === activeValue}
-                  label={optionLabel}
-                />
-              </div>
-            ),
-          )}
+          options.map((option) => (
+            <RadioButton
+              {...option}
+              key={option.label}
+              name={groupName}
+              required={required}
+              onChange={onChange}
+              checked={option.value === activeValue}
+              invalid={invalid}
+            />
+          ))}
         <FieldValidationHint
           id={validationHintId}
           invalid={invalid}

--- a/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
+++ b/packages/circuit-ui/components/RadioButtonGroup/__snapshots__/RadioButtonGroup.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`RadioButtonGroup > Styles > should render with default styles 1`] = `
   color: var(--cui-fg-normal-disabled);
 }
 
-.circuit-3 {
+.circuit-4 {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -31,34 +31,34 @@ exports[`RadioButtonGroup > Styles > should render with default styles 1`] = `
   width: 1px;
 }
 
-.circuit-3:hover+label::before {
+.circuit-4:hover+label::before {
   border-color: var(--cui-border-normal-hovered);
 }
 
-.circuit-3:focus+label::before {
+.circuit-4:focus+label::before {
   outline: 0;
   box-shadow: 0 0 0 4px var(--cui-border-focus);
   border-color: var(--cui-border-accent);
 }
 
-.circuit-3:focus+label::before::-moz-focus-inner {
+.circuit-4:focus+label::before::-moz-focus-inner {
   border: 0;
 }
 
-.circuit-3:focus:not(:focus-visible)+label::before {
+.circuit-4:focus:not(:focus-visible)+label::before {
   box-shadow: none;
   border-color: var(--cui-border-normal);
 }
 
-.circuit-3:checked:focus:not(:focus-visible)+label::before {
+.circuit-4:checked:focus:not(:focus-visible)+label::before {
   border-color: var(--cui-border-accent);
 }
 
-.circuit-3:checked+label::before {
+.circuit-4:checked+label::before {
   border-color: var(--cui-border-accent);
 }
 
-.circuit-3:checked+label::after {
+.circuit-4:checked+label::after {
   -webkit-transform: translateY(-50%) scale(1, 1);
   -moz-transform: translateY(-50%) scale(1, 1);
   -ms-transform: translateY(-50%) scale(1, 1);
@@ -66,34 +66,34 @@ exports[`RadioButtonGroup > Styles > should render with default styles 1`] = `
   opacity: 1;
 }
 
-.circuit-3:disabled+label,
-.circuit-3[disabled]+label {
+.circuit-4:disabled+label,
+.circuit-4[disabled]+label {
   pointer-events: none;
   color: var(--cui-fg-normal-disabled);
 }
 
-.circuit-3:disabled+label::before,
-.circuit-3[disabled]+label::before {
+.circuit-4:disabled+label::before,
+.circuit-4[disabled]+label::before {
   border-color: var(--cui-border-strong-disabled);
   background-color: var(--cui-bg-normal-disabled);
 }
 
-.circuit-3:disabled+label::after,
-.circuit-3[disabled]+label::after {
+.circuit-4:disabled+label::after,
+.circuit-4[disabled]+label::after {
   background-color: var(--cui-fg-on-strong-disabled);
 }
 
-.circuit-3:disabled:checked+label::before,
-.circuit-3[disabled]:checked+label::before {
+.circuit-4:disabled:checked+label::before,
+.circuit-4[disabled]:checked+label::before {
   border-color: var(--cui-border-accent-disabled);
 }
 
-.circuit-3:disabled:checked+label::after,
-.circuit-3[disabled]:checked+label::after {
+.circuit-4:disabled:checked+label::after,
+.circuit-4[disabled]:checked+label::after {
   background-color: var(--cui-fg-accent-disabled);
 }
 
-.circuit-4 {
+.circuit-5 {
   color: var(--cui-fg-normal);
   display: inline-block;
   padding-left: 26px;
@@ -101,7 +101,7 @@ exports[`RadioButtonGroup > Styles > should render with default styles 1`] = `
   cursor: pointer;
 }
 
-.circuit-4::before {
+.circuit-5::before {
   box-sizing: border-box;
   height: 18px;
   width: 18px;
@@ -121,7 +121,7 @@ exports[`RadioButtonGroup > Styles > should render with default styles 1`] = `
   transition: border 120ms ease-in-out;
 }
 
-.circuit-4::after {
+.circuit-5::after {
   box-sizing: border-box;
   height: 10px;
   width: 10px;
@@ -158,46 +158,52 @@ exports[`RadioButtonGroup > Styles > should render with default styles 1`] = `
         Choose an option
       </span>
     </legend>
-    <div>
+    <div
+      class=" circuit-0"
+    >
       <input
-        class="circuit-3"
+        class="circuit-4"
         id=":r2:"
         name=":r0:"
         type="radio"
         value="first"
       />
       <label
-        class="circuit-4"
+        class="circuit-5"
         for=":r2:"
       >
         Option 1
       </label>
     </div>
-    <div>
+    <div
+      class=" circuit-0"
+    >
       <input
-        class="circuit-3"
+        class="circuit-4"
         id=":r3:"
         name=":r0:"
         type="radio"
         value="second"
       />
       <label
-        class="circuit-4"
+        class="circuit-5"
         for=":r3:"
       >
         Option 2
       </label>
     </div>
-    <div>
+    <div
+      class=" circuit-0"
+    >
       <input
-        class="circuit-3"
+        class="circuit-4"
         id=":r4:"
         name=":r0:"
         type="radio"
         value="third"
       />
       <label
-        class="circuit-4"
+        class="circuit-5"
         for=":r4:"
       >
         Option 3


### PR DESCRIPTION
Addresses #1875.

## Purpose

In v6, we wrapped all form fields in a `div` to make them easier to style. From the [migration guide](https://github.com/sumup-oss/circuit-ui/blob/main/MIGRATION.md#markup-changes):

> Form components are now all wrapped in a `div` that receives any styles passed through the `style` or `className` attributes, including via the Emotion.js `css` prop. This might break custom styles.

We missed doing this for the RadioButton component.

## Approach and changes

- Wrap the RadioButton component in the FieldWrapper atom and remove the superflous `div` from the RadioButtonGroup

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
