### PR TITLE
Deprecate the AddItems icon

### DIFF
--- a/.changeset/sweet-mice-swim.md
+++ b/.changeset/sweet-mice-swim.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': minor
+---
+
+Deprecated the AddItems icon. Use the Add or Items icons instead.

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -28,6 +28,7 @@ import {
   Select,
   typography,
   BaseStyles,
+  Badge,
 } from '@sumup/circuit-ui';
 
 function groupBy(icons: IconsManifest['icons'], key: string) {
@@ -72,9 +73,11 @@ const Wrapper = styled.div`
   text-align: center;
   margin-top: ${(p) => p.theme.spacings.giga};
   margin-bottom: ${(p) => p.theme.spacings.giga};
+  position: relative;
 `;
 
-const Size = styled.p`
+const Size = styled.span`
+  display: block;
   color: var(--cui-fg-subtle);
   font-style: italic;
 `;
@@ -95,6 +98,13 @@ const iconStyles = (color: string) =>
       ? 'var(--cui-bg-strong)'
       : 'var(--cui-bg-normal)'};
   `;
+
+const badgeStyles = css`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-30deg);
+`;
 
 const Icons = () => {
   const [search, setSearch] = useState('');
@@ -189,6 +199,15 @@ const Icons = () => {
                       {icon.name}
                       {size === 'all' && <Size>{icon.size}</Size>}
                     </span>
+                    {icon.deprecation && (
+                      <Badge
+                        title={icon.deprecation}
+                        variant="notify"
+                        css={badgeStyles}
+                      >
+                        Deprecated
+                      </Badge>
+                    )}
                   </Wrapper>
                 );
               })}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9085,13 +9085,6 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/dedent": {
-      "version": "0.7.0",
-      "resolved": "https://registry.yarnpkg.com/@types/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-FV8znKQE5t2Quc5Go/eP1pypsFA= sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/detect-port": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.2.tgz",
@@ -9439,11 +9432,10 @@
       "license": "MIT"
     },
     "node_modules/@types/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha1-/IwoJeTtIUJHO0qBBk5uCBRj0bM= sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
+      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
+      "dev": true
     },
     "node_modules/@types/pretty-hrtime": {
       "version": "1.0.1",
@@ -24697,9 +24689,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -29975,7 +29967,7 @@
     },
     "packages/circuit-ui": {
       "name": "@sumup/circuit-ui",
-      "version": "6.7.0",
+      "version": "6.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
@@ -30197,18 +30189,16 @@
     },
     "packages/icons": {
       "name": "@sumup/icons",
-      "version": "2.23.0",
+      "version": "2.24.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.21.8",
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-react": "^7.18.6",
         "@types/babel__core": "^7.20.0",
-        "@types/dedent": "^0.7.0",
-        "@types/lodash": "^4.14.194",
+        "@types/prettier": "^2.7.2",
         "babel-plugin-inline-react-svg": "^2.0.2",
-        "dedent": "^0.7.0",
-        "lodash": "^4.17.21",
+        "prettier": "^2.8.8",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.0.4"
@@ -36822,11 +36812,9 @@
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-react": "^7.18.6",
         "@types/babel__core": "^7.20.0",
-        "@types/dedent": "^0.7.0",
-        "@types/lodash": "^4.14.194",
+        "@types/prettier": "^2.7.2",
         "babel-plugin-inline-react-svg": "^2.0.2",
-        "dedent": "^0.7.0",
-        "lodash": "^4.17.21",
+        "prettier": "^2.8.8",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.0.4"
@@ -37079,12 +37067,6 @@
       "requires": {
         "@types/ms": "*"
       }
-    },
-    "@types/dedent": {
-      "version": "0.7.0",
-      "resolved": "https://registry.yarnpkg.com/@types/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-FV8znKQE5t2Quc5Go/eP1pypsFA= sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==",
-      "dev": true
     },
     "@types/detect-port": {
       "version": "1.3.2",
@@ -37413,9 +37395,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha1-/IwoJeTtIUJHO0qBBk5uCBRj0bM= sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
+      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
     },
     "@types/pretty-hrtime": {
@@ -48997,9 +48979,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/packages/icons/CONTRIBUTING.md
+++ b/packages/icons/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This page outlines the process of contributing an icon to the `@sumup/icons` pac
 
 > Note that icons should be added by internal contributors with access to the SumUp [Figma icons library](https://www.figma.com/file/vnFVuPNlqF45rkw1u9toBC/SumUp-Iconography) (internal link). If you don't have access but would like to see an icon added to `@sumup/icons`, please [open an issue](https://github.com/sumup-oss/circuit-ui/issues/new).
 
-## Adding a new icon to `@sumup/icons`
+## Adding a new icon
 
 1. Create a new SVG file for each icon size in [`packages/web/icons/v2/`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/icons/web/v2) with the name `name_size.svg` (e.g. `add_items_24`—this will generate an `<AddItems />` component).
 2. Export the icon as SVG from the [Figma icons library](https://www.figma.com/file/vnFVuPNlqF45rkw1u9toBC/SumUp-Iconography) (internal link). If the icon isn't in the library, make a request with the design team first.
@@ -14,9 +14,9 @@ This page outlines the process of contributing an icon to the `@sumup/icons` pac
 5. Add an icon object to the icons manifest file at [`packages/icons/manifest.json`](https://github.com/sumup-oss/circuit-ui/blob/9146e47a21dcd6880f437d1a47a0c54d5a164bfd/packages/icons/manifest.json). The icons are manually ordered alphabetically by icon category, then name (should match the file name), and finally by size (descending).
 6. Build the icons package (`npx lerna run build --scope=@sumup/icons`) and run the Storybook (`npm run docs`). Verify that your icon renders correctly on the [Icons page](http://localhost:6006/?path=/docs/features-icons--docs) (local link).
 
-## Caveats
+### Caveats
 
-### Do not hardcode the icon's color
+#### Do not hardcode the icon's color
 
 Unless icons are a brand logo (e.g. the Mastercard logo), all SVG fills should always be `currentColor`. This lets developers style icons using CSS instead of overriding fill colors.
 
@@ -29,7 +29,7 @@ Unless icons are a brand logo (e.g. the Mastercard logo), all SVG fills should a
 
 You can test this by running Storybook and changing the icons color on the [Icons page](http://localhost:6006/?path=/docs/features-icons--docs) (local link).
 
-### Correct icon size
+#### Correct icon size
 
 Icons come in three sizes: `16` (16x16), `24` (24x24) and `32` (32x24).
 
@@ -39,7 +39,7 @@ If they don't (e.g. the SVG has `viewBox="0 0 24 25"`), check that you've copied
 
 _(Note: this can also be a symptom of another issue with the icon's placement on the Figma canvas. See "Beware clip-path" below.)_
 
-### Beware clip-path
+#### Beware clip-path
 
 If the SVG includes a `<g clip-path="">` element, there's a chance that the icon wasn't exported properly.
 
@@ -88,3 +88,8 @@ To fix this, copy the icon and paste it on a draft Figma file. Make sure that it
 ```
 
 </details>
+
+## Deprecating an icon
+
+1. Use the `deprecation` field in the icons manifest file at [`packages/icons/manifest.json`](https://github.com/sumup-oss/circuit-ui/blob/9146e47a21dcd6880f437d1a47a0c54d5a164bfd/packages/icons/manifest.json) to add a deprecation notice for the icon. Ideally, the notice should include a reason and recommend an alternative. The field supports markdown syntax. Add a [changeset](https://circuit.sumup.com/?path=/docs/contributing-release-process--docs#changesets) to release the change in a minor version.
+2. In the next major version of `@sumup/icons`, remove the icon from the manifest and delete the SVG.

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -13,7 +13,8 @@
     {
       "name": "add_items",
       "category": "Action",
-      "size": "24"
+      "size": "24",
+      "deprecation": "Use the `Add` or `Items` icons instead."
     },
     {
       "name": "chevron_down",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -35,11 +35,9 @@
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",
     "@types/babel__core": "^7.20.0",
-    "@types/dedent": "^0.7.0",
-    "@types/lodash": "^4.14.194",
+    "@types/prettier": "^2.7.2",
     "babel-plugin-inline-react-svg": "^2.0.2",
-    "dedent": "^0.7.0",
-    "lodash": "^4.17.21",
+    "prettier": "^2.8.8",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.0.4"


### PR DESCRIPTION
Closes #1717.

## Approach and changes

- Generate a JSDoc comment for deprecated icons
- Add a deprecation note for the AddItems icon
- Bonus: Replace `dedent` with `prettier`
- Bonus: Remove dependency on `lodash`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
