### PR TITLE
Add Transit icon

### DIFF
--- a/.changeset/three-clocks-live.md
+++ b/.changeset/three-clocks-live.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': minor
+---
+
+Added a new icon in size 16: `Transit`.

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -1246,6 +1246,11 @@
       "size": "16"
     },
     {
+      "name": "transit",
+      "category": "Notification",
+      "size": "16"
+    },
+    {
       "name": "account",
       "category": "Product and feature",
       "size": "24"

--- a/packages/icons/web/v2/transit_16.svg
+++ b/packages/icons/web/v2/transit_16.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16">
+    <path fill="currentColor" fill-rule="evenodd" d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0Zm5.745 8.67a1.064 1.064 0 0 1-.035.037l-3.001 3.002a1 1 0 0 1-1.415-1.415L10.59 9H9a1 1 0 0 1 0-2h1.589L9.298 5.71a1 1 0 1 1 1.414-1.415l2.998 2.998a1 1 0 0 1 .035 1.377ZM2 8a1 1 0 0 1 1-1h2a1 1 0 0 1 0 2H3a1 1 0 0 1-1-1Z" clip-rule="evenodd"/>
+</svg>


### PR DESCRIPTION
Addresses [PMNTSS-2297](https://sumupteam.atlassian.net/jira/software/c/projects/PMNTSS/boards/1639?modal=detail&selectedIssue=PMNTSS-2297).

## Purpose

Add the Transit icon for the in transit payout status

<img width="1439" alt="Screenshot 2023-05-12 at 11 37 30" src="https://github.com/sumup-oss/circuit-ui/assets/35171489/3e83d5c9-5522-4119-8282-e8c099b6e006">

## Approach and changes

- Add the Transit icon in size 16;
- Update the manifest.json file;
- Add a .changeset.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
