### PR TITLE
Various fixes for Storybook docs

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -84,4 +84,10 @@
     text-decoration: underline;
     text-underline-position: under;
   }
+  .sbdocs :is(em:not(.sb-anchor, .sb-unstyled, .sb-unstyled em)) {
+    font-style: italic;
+  }
+  .sbdocs :is(strong:not(.sb-anchor, .sb-unstyled, .sb-unstyled strong)) {
+    font-weight: 700;
+  }
 </style>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,6 +8,7 @@ export const parameters = {
   layout: 'centered',
   previewTabs: { 'storybook/docs/panel': { index: -1 } },
   actions: { argTypesRegex: '^on.*' },
+  controls: { expanded: true },
   options: {
     storySort: {
       order: ['Introduction', 'Features'],

--- a/packages/circuit-ui/components/Button/Button.stories.tsx
+++ b/packages/circuit-ui/components/Button/Button.stories.tsx
@@ -14,7 +14,6 @@
  */
 
 import { useState } from 'react';
-import { action } from '@storybook/addon-actions';
 import { Plus } from '@sumup/icons';
 
 import { Stack } from '../../../../.storybook/components';
@@ -88,19 +87,6 @@ export const WithIcon = (args: ButtonProps) => (
     )}
   >
     Add
-  </Button>
-);
-
-export const Tracking = (args: ButtonProps) => (
-  <Button
-    {...args}
-    onClick={action('Button Click')}
-    tracking={{
-      label: 'track-button',
-      customParameters: { key: 'value' },
-    }}
-  >
-    Track me
   </Button>
 );
 

--- a/packages/circuit-ui/components/TextArea/TextArea.mdx
+++ b/packages/circuit-ui/components/TextArea/TextArea.mdx
@@ -9,7 +9,7 @@ import * as Stories from './TextArea.stories';
 
 The `TextArea` component renders an input that allows multiple lines of text.
 
-<Story of={TextArea.Base} />
+<Story of={Stories.Base} />
 
 <Props />
 

--- a/packages/circuit-ui/hooks/useClickOutside/useClickOutside.mdx
+++ b/packages/circuit-ui/hooks/useClickOutside/useClickOutside.mdx
@@ -1,4 +1,4 @@
-import { MetaStatus, Story } from '../../../../.storybook/components';
+import { Meta, Status, Story } from '../../../../.storybook/components';
 import * as Stories from './useClickOutside.stories';
 
 <Meta of={Stories} />


### PR DESCRIPTION
## Purpose

Discovered several issues while working on #2105.

## Approach and changes

- Restore Storybook's formatting of bold and italic text
- Display documentation for props alongside their story controls
- Fix TextArea docs: wrong variable name
- Fix useClickOutside docs: typo in the imports
- Remove Button tracking docs: has been deprecated since #1997

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
