### PR TITLE
Make Popover dividers presentational

### DIFF
--- a/.changeset/fuzzy-emus-add.md
+++ b/.changeset/fuzzy-emus-add.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Marked `Popover` dividers as presentational to ensure that the right number of items is announced by screen readers.

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -18,7 +18,14 @@ import { Delete, Add, Download, IconProps } from '@sumup/icons';
 import { Placement } from '@floating-ui/react-dom';
 import * as Collector from '@sumup/collector';
 
-import { act, axe, RenderFn, render, userEvent } from '../../util/test-utils';
+import {
+  act,
+  axe,
+  RenderFn,
+  render,
+  userEvent,
+  screen,
+} from '../../util/test-utils';
 import { ClickEvent } from '../../types/events';
 
 import {
@@ -166,9 +173,9 @@ describe('Popover', () => {
     it('should open the popover when clicking the trigger element', async () => {
       const isOpen = false;
       const onToggle = jest.fn(createStateSetter(isOpen));
-      const { getByRole } = renderPopover({ ...baseProps, isOpen, onToggle });
+      renderPopover({ ...baseProps, isOpen, onToggle });
 
-      const popoverTrigger = getByRole('button');
+      const popoverTrigger = screen.getByRole('button');
 
       await userEvent.click(popoverTrigger);
 
@@ -186,9 +193,9 @@ describe('Popover', () => {
       async (_, key) => {
         const isOpen = false;
         const onToggle = jest.fn(createStateSetter(isOpen));
-        const { getByRole } = renderPopover({ ...baseProps, isOpen, onToggle });
+        renderPopover({ ...baseProps, isOpen, onToggle });
 
-        const popoverTrigger = getByRole('button');
+        const popoverTrigger = screen.getByRole('button');
 
         popoverTrigger.focus();
         await userEvent.keyboard(key);
@@ -208,9 +215,9 @@ describe('Popover', () => {
     });
 
     it('should close the popover when clicking the trigger element', async () => {
-      const { getByRole } = renderPopover(baseProps);
+      renderPopover(baseProps);
 
-      const popoverTrigger = getByRole('button');
+      const popoverTrigger = screen.getByRole('button');
 
       await userEvent.click(popoverTrigger);
 
@@ -225,9 +232,9 @@ describe('Popover', () => {
     ])(
       'should close the popover when pressing the %s key on the trigger element',
       async (_, key) => {
-        const { getByRole } = renderPopover(baseProps);
+        renderPopover(baseProps);
 
-        const popoverTrigger = getByRole('button');
+        const popoverTrigger = screen.getByRole('button');
 
         popoverTrigger.focus();
         await userEvent.keyboard(key);
@@ -247,9 +254,9 @@ describe('Popover', () => {
     });
 
     it('should close the popover when clicking a popover item', async () => {
-      const { getAllByRole } = renderPopover(baseProps);
+      renderPopover(baseProps);
 
-      const popoverItems = getAllByRole('menuitem');
+      const popoverItems = screen.getAllByRole('menuitem');
 
       await userEvent.click(popoverItems[0]);
 
@@ -261,7 +268,7 @@ describe('Popover', () => {
       const isOpen = false;
       const onToggle = jest.fn(createStateSetter(isOpen));
 
-      const { getAllByRole, rerender } = renderPopover({
+      const { rerender } = renderPopover({
         ...baseProps,
         isOpen,
         onToggle,
@@ -271,7 +278,7 @@ describe('Popover', () => {
         rerender(<Popover {...baseProps} isOpen />);
       });
 
-      const popoverItems = getAllByRole('menuitem');
+      const popoverItems = screen.getAllByRole('menuitem');
 
       expect(popoverItems[0]).toHaveFocus();
 
@@ -279,13 +286,13 @@ describe('Popover', () => {
     });
 
     it('should move focus to the trigger element after closing', async () => {
-      const { getByRole, rerender } = renderPopover(baseProps);
+      const { rerender } = renderPopover(baseProps);
 
       act(() => {
         rerender(<Popover {...baseProps} isOpen={false} />);
       });
 
-      const popoverTrigger = getByRole('button');
+      const popoverTrigger = screen.getByRole('button');
 
       expect(popoverTrigger).toHaveFocus();
 
@@ -301,6 +308,17 @@ describe('Popover', () => {
         const actual = await axe(container);
         expect(actual).toHaveNoViolations();
       });
+    });
+
+    it('should render items as role=menuitem and dividers as role=presentation', async () => {
+      renderPopover(baseProps);
+
+      const items = screen.getAllByRole('menuitem');
+      const dividers = screen.getAllByRole('presentation');
+      expect(items.length).toBe(2);
+      expect(dividers.length).toBe(1);
+
+      await flushMicrotasks();
     });
   });
 });

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -455,7 +455,7 @@ export const Popover = ({
           >
             {actions.map((action, index) =>
               isDivider(action) ? (
-                <Hr css={dividerStyles} key={index} />
+                <Hr css={dividerStyles} role="presentation" key={index} />
               ) : (
                 <PopoverItem
                   key={index}

--- a/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
+++ b/packages/circuit-ui/components/Popover/__snapshots__/Popover.spec.tsx.snap
@@ -243,6 +243,7 @@ exports[`Popover Styles should render popover on bottom 1`] = `
       </button>
       <hr
         class="circuit-6"
+        role="presentation"
       />
       <button
         class="circuit-7"
@@ -512,6 +513,7 @@ exports[`Popover Styles should render popover on left 1`] = `
       </button>
       <hr
         class="circuit-6"
+        role="presentation"
       />
       <button
         class="circuit-7"
@@ -781,6 +783,7 @@ exports[`Popover Styles should render popover on right 1`] = `
       </button>
       <hr
         class="circuit-6"
+        role="presentation"
       />
       <button
         class="circuit-7"
@@ -1050,6 +1053,7 @@ exports[`Popover Styles should render popover on top 1`] = `
       </button>
       <hr
         class="circuit-6"
+        role="presentation"
       />
       <button
         class="circuit-7"
@@ -1301,6 +1305,7 @@ exports[`Popover Styles should render with closed styles 1`] = `
       </button>
       <hr
         class="circuit-6"
+        role="presentation"
       />
       <button
         class="circuit-7"
@@ -1570,6 +1575,7 @@ exports[`Popover Styles should render with default styles 1`] = `
       </button>
       <hr
         class="circuit-6"
+        role="presentation"
       />
       <button
         class="circuit-7"


### PR DESCRIPTION
Closes #1660 

## Purpose

This ensures that dividers are not announced as items when the parent `role=menu` is focused. See the issue for details

## Approach and changes

- added `role=presentation` to Popover dividers
- added a test for it
- updated the Popover spec to use `screen` in queries

### Before and after

There are 3 items and 1 divider on the [Popover component's Base story](https://circuit.sumup.com/?path=/story/components-popover--base). Screen readers should announce 3 items and exclude the divider.

| `role=separator` (implicit) | `role=presentation` |
| --- | --- |
| <img width="717" alt="VoiceOver on Safari announces 3 items for the menu on the Popover Base story" src="https://github.com/sumup-oss/circuit-ui/assets/35560568/c29cd181-6069-4c43-92f7-76ffb81609e1"> | <img width="767" alt="VoiceOver on Safari announces 3 items for the menu on the Popover Base story" src="https://github.com/sumup-oss/circuit-ui/assets/35560568/8617f4da-3527-4010-a8ab-fa4efacbc4b4"> |

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
