### PR TITLE
Switch to font-display: optional

### DIFF
--- a/.changeset/tidy-knives-tap.md
+++ b/.changeset/tidy-knives-tap.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Changed the font-display of Aktiv Grotesk, Circuit UI's default font family, from `swap` to `optional`. If the font family is not available locally or cached, a fallback font is used. This reduces the cumulative layout shift (CLS) and largest contentful paint (LCP). The visual difference is minimal.

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -6,7 +6,7 @@
   @font-face {
     font-family: 'aktiv-grotesk';
     font-weight: 400;
-    font-display: swap;
+    font-display: optional;
     src: url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff2')
         format('woff2'),
       url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff')
@@ -17,7 +17,7 @@
   @font-face {
     font-family: 'aktiv-grotesk';
     font-weight: 700;
-    font-display: swap;
+    font-display: optional;
     src: url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff2')
         format('woff2'),
       url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff')

--- a/packages/circuit-ui/components/BaseStyles/BaseStylesService.ts
+++ b/packages/circuit-ui/components/BaseStyles/BaseStylesService.ts
@@ -29,7 +29,7 @@ export const createBaseStyles = ({
   @font-face {
     font-family: 'aktiv-grotesk';
     font-weight: 400;
-    font-display: swap;
+    font-display: optional;
     src: url('${FONTS_BASE_URL}/aktiv-grotest-400.woff2') format('woff2'),
       url('${FONTS_BASE_URL}/aktiv-grotest-400.woff') format('woff'),
       url('${FONTS_BASE_URL}/aktiv-grotest-400.eot') format('embedded-opentype');
@@ -37,7 +37,7 @@ export const createBaseStyles = ({
   @font-face {
     font-family: 'aktiv-grotesk';
     font-weight: 700;
-    font-display: swap;
+    font-display: optional;
     src: url('${FONTS_BASE_URL}/aktiv-grotest-700.woff2') format('woff2'),
       url('${FONTS_BASE_URL}/aktiv-grotest-700.woff') format('woff'),
       url('${FONTS_BASE_URL}/aktiv-grotest-700.eot') format('embedded-opentype');

--- a/packages/circuit-ui/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
+++ b/packages/circuit-ui/components/BaseStyles/__snapshots__/BaseStylesService.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`BaseStylesService > should return the global base styles 1`] = `
   @font-face {
     font-family: 'aktiv-grotesk';
     font-weight: 400;
-    font-display: swap;
+    font-display: optional;
     src: url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff2') format('woff2'),
       url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff') format('woff'),
       url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.eot') format('embedded-opentype');
@@ -16,7 +16,7 @@ exports[`BaseStylesService > should return the global base styles 1`] = `
   @font-face {
     font-family: 'aktiv-grotesk';
     font-weight: 700;
-    font-display: swap;
+    font-display: optional;
     src: url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff2') format('woff2'),
       url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff') format('woff'),
       url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.eot') format('embedded-opentype');


### PR DESCRIPTION
Closes #1001.

## Purpose

Reduce the layout shift to improve the user experience on page load.

## Approach and changes

- Switch from `font-display: swap` to `font-display: optional` for the default Aktiv Grotesk font

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
