### PR TITLE
Fix useCollapsible content overflow

### DIFF
--- a/.changeset/lazy-llamas-tap.md
+++ b/.changeset/lazy-llamas-tap.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Don't crop content overflow when the `useCollapsible` hook is expanded.

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.spec.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.spec.ts
@@ -143,14 +143,14 @@ describe('useCollapsible', () => {
         'ref': { current: null },
         'id': expect.any(String),
         'style': {
-          overflowY: 'hidden',
+          overflowY: 'visible',
           willChange: 'height',
           opacity: 1,
           height: 'auto',
           transition: 'all 200ms ease-in-out',
           visibility: 'visible',
         },
-        'aria-hidden': null,
+        'aria-hidden': undefined,
       });
 
       expect(actual).toEqual(expected);
@@ -191,7 +191,7 @@ describe('useCollapsible', () => {
 
   describe('getHeight', () => {
     it('should return "auto" when the element is falsy', () => {
-      const element = null;
+      const element = { current: null };
       const actual = getHeight(element);
       const expected = 'auto';
       expect(actual).toBe(expected);

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
@@ -27,6 +27,8 @@ export type CollapsibleOptions = {
   id?: string;
 };
 
+type Overflow = 'visible' | 'hidden';
+
 type ButtonProps = {
   'onClick': (event: ClickEvent) => void;
   'aria-controls': string;
@@ -37,12 +39,12 @@ type ContentProps<T> = {
   'ref': RefObject<T>;
   'id': string;
   'style': {
-    overflowY: 'hidden';
+    overflowY: Overflow;
     willChange: 'height';
     opacity: 1 | 0;
     height: string | 0;
   };
-  'aria-hidden': null | 'true';
+  'aria-hidden': undefined | 'true';
 };
 
 type Collapsible<T> = {
@@ -70,6 +72,9 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
   const contentElement = useRef<T>(null);
   const [isOpen, setOpen] = useState(initialOpen);
   const [height, setHeight] = useState(getHeight(contentElement));
+  const [overflow, setOverflow] = useState<Overflow>(
+    initialOpen ? 'visible' : 'hidden',
+  );
   const [isAnimating, setAnimating] = useAnimation();
 
   const toggleOpen = useCallback(() => {
@@ -77,6 +82,7 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
       duration,
       onStart: () => {
         setHeight(getHeight(contentElement));
+        setOverflow('hidden');
         // Delaying the state update until the next animation frame ensures that
         // the browsers renders the new height before the animation starts.
         window.requestAnimationFrame(() => {
@@ -85,6 +91,7 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
       },
       onEnd: () => {
         setHeight(DEFAULT_HEIGHT);
+        setOverflow('visible');
       },
     });
   }, [setAnimating, duration]);
@@ -107,7 +114,7 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
       'ref': contentElement,
       'id': contentId,
       'style': {
-        overflowY: 'hidden',
+        overflowY: overflow,
         willChange: 'height',
         opacity: isOpen ? 1 : 0,
         height: isOpen ? height : 0,
@@ -115,7 +122,7 @@ export function useCollapsible<T extends HTMLElement = HTMLElement>({
         transition: `all ${duration}ms ease-in-out`,
         ...props.style,
       },
-      'aria-hidden': isOpen ? null : 'true',
+      'aria-hidden': isOpen ? undefined : 'true',
     }),
   };
 }


### PR DESCRIPTION
Fixes #1112.

## Purpose

The `useCollapsible` hook needs to hide content overflow during the transition from the closed to the open state (and vice versa). Currently, the overflow is also hidden when the content is expanded. This disrupts components with outlines such as the Input and Button components.

## Approach and changes

- Only hide content overflow during the transition.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
