### PR TITLE
Account for scrollbar in expanded SideNavigation

### DIFF
--- a/.changeset/eight-rats-look.md
+++ b/.changeset/eight-rats-look.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Reduced the breakpoint for the expanded SideNavigation on wide viewpoints to account for scroll bars.

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -53,7 +53,9 @@ export interface DesktopNavigationProps {
 
 const PRIMARY_NAVIGATION_WIDTH = '48px';
 const PRIMARY_NAVIGATION_OPENED_WIDTH = '220px';
-const LARGE_SCREEN_BREAKPOINT = '1920px'; // max breakpoint in circuit-ui is 1280px therefore we decided to hardcode for now
+// The maximum breakpoint in the design tokens is 1280px, so we need to
+// hardcode this value. It's slightly below 1920px to account for scroll bars.
+const LARGE_SCREEN_BREAKPOINT = '1900px';
 
 const wrapperStyles = ({ theme }: StyleProps) => css`
   ${theme.mq.untilTera} {

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/__snapshots__/DesktopNavigation.spec.tsx.snap
@@ -56,7 +56,7 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   width: 220px;
 }
 
-@media only screen and (min-width: 1920px) {
+@media only screen and (min-width: 1900px) {
   .circuit-1 {
     width: 220px;
   }
@@ -217,7 +217,7 @@ exports[`DesktopNavigation styles should render with secondary links 1`] = `
   border-right: 1px solid var(--cui-border-divider);
 }
 
-@media only screen and (min-width: 1920px) {
+@media only screen and (min-width: 1900px) {
   .circuit-7 {
     margin-left: 220px;
   }
@@ -512,7 +512,7 @@ exports[`DesktopNavigation styles should render without secondary links 1`] = `
   width: 220px;
 }
 
-@media only screen and (min-width: 1920px) {
+@media only screen and (min-width: 1900px) {
   .circuit-1 {
     width: 220px;
   }


### PR DESCRIPTION
Addresses a [Slack thread](https://sumup.slack.com/archives/C42E59X5E/p1684487050989949).

## Purpose

The SideNavigation is supposed to be fully expanded on viewports wider than 1920px. This can cause a flicker on monitors that measure exactly 1920px since the viewport size is reduced by the scrollbar which is present on most pages. When opening a modal, the page content is locked in place, so the scroll bar disappears and the side navigation is expanded.

## Approach and changes

- Reduce the breakpoint to 1900px (scrollbars tend to be 12-20px wide)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
