### PR TITLE
Add TransferIn, TransferOut, ThumbUp and ThumbDown icons

### DIFF
--- a/.changeset/lazy-ties-marry.md
+++ b/.changeset/lazy-ties-marry.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': minor
+---
+
+Added new icons in size 24: `TransferIn`, `TransferOut`, `ThumbUp` and `ThumbDown`.

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -952,6 +952,16 @@
       "size": "24"
     },
     {
+      "name": "transfer_in",
+      "category": "Finance",
+      "size": "24"
+    },
+    {
+      "name": "transfer_out",
+      "category": "Finance",
+      "size": "24"
+    },
+    {
       "name": "barcode",
       "category": "Miscellaneous",
       "size": "24"
@@ -1108,6 +1118,16 @@
     },
     {
       "name": "sim_card",
+      "category": "Miscellaneous",
+      "size": "24"
+    },
+    {
+      "name": "thumb_down",
+      "category": "Miscellaneous",
+      "size": "24"
+    },
+    {
+      "name": "thumb_up",
       "category": "Miscellaneous",
       "size": "24"
     },

--- a/packages/icons/web/v2/thumb_down_24.svg
+++ b/packages/icons/web/v2/thumb_down_24.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <path fill="currentColor" d="m9 21 5-5c2-2 2-3 2-5V7c0-2-2-4-4-4H6C3 3 2.5 4.5 2 7s-1 5-1 6 1 2 2 2h5c1 0 .5 1 0 2-.6 1.3-1 4 1 4Zm12-5a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2h-1a2 2 0 0 0-2 2v9c0 1.1.9 2 2 2h1Z"/>
+</svg>

--- a/packages/icons/web/v2/thumb_up_24.svg
+++ b/packages/icons/web/v2/thumb_up_24.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <path fill="currentColor" d="m15 3-5 5c-2 2-2 3-2 5v4c0 2 2 4 4 4h6c3 0 3.5-1.5 4-4s1-5 1-6-1-2-2-2h-5c-1 0-.5-1 0-2 .6-1.3 1-4-1-4ZM3 8a2 2 0 0 0-2 2v9c0 1.1.9 2 2 2h1a2 2 0 0 0 2-2v-9a2 2 0 0 0-2-2H3Z"/>
+</svg>

--- a/packages/icons/web/v2/transfer_in_24.svg
+++ b/packages/icons/web/v2/transfer_in_24.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M19 9a1 1 0 0 0 .72-.3l2.99-3a1 1 0 0 0-1.42-1.4L20 5.58V2a1 1 0 1 0-2 0v3.59l-1.28-1.3a1 1 0 0 0-1.42 1.42l3 2.99a1 1 0 0 0 .7.3Z"/>
+    <path fill="currentColor" fill-rule="evenodd" d="M18.41 17.41A2 2 0 0 0 19 16v-5a6 6 0 0 1-5.92-5H3a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h14a2 2 0 0 0 1.41-.59ZM5.5 16A2.5 2.5 0 0 0 3 13.5V16h2.5Zm0-8H3v2.5A2.5 2.5 0 0 0 5.5 8Zm6.5 4a2 2 0 1 0-4 0 2 2 0 0 0 4 0Zm5 1.5a2.5 2.5 0 0 0-2.5 2.5H17v-2.5Z" clip-rule="evenodd"/>
+    <path fill="currentColor" d="M23 13v8a1 1 0 0 1-.3.7s-.43.3-.7.3H6a2 2 0 0 1-2-2h17v-9a2 2 0 0 1 2 2Z"/>
+</svg>

--- a/packages/icons/web/v2/transfer_out_24.svg
+++ b/packages/icons/web/v2/transfer_out_24.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M19 1a1 1 0 0 1 .72.3l2.99 3a1 1 0 0 1-1.42 1.4L20 4.42V8a1 1 0 1 1-2 0V4.41l-1.28 1.3a1 1 0 0 1-1.42-1.42l3-2.99A1 1 0 0 1 19 1Z"/>
+    <path fill="currentColor" fill-rule="evenodd" d="M18.41 17.41A2 2 0 0 0 19 16v-5a6 6 0 0 1-5.92-5H3a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h14a2 2 0 0 0 1.41-.59ZM5.5 16A2.5 2.5 0 0 0 3 13.5V16h2.5Zm0-8H3v2.5A2.5 2.5 0 0 0 5.5 8Zm6.5 4a2 2 0 1 0-4 0 2 2 0 0 0 4 0Zm5 1.5a2.5 2.5 0 0 0-2.5 2.5H17v-2.5Z" clip-rule="evenodd"/>
+    <path fill="currentColor" d="M23 13v8a1 1 0 0 1-.3.7s-.43.3-.7.3H6a2 2 0 0 1-2-2h17v-9a2 2 0 0 1 2 2Z"/>
+</svg>


### PR DESCRIPTION
Addresses [PMNTSS-2312](https://sumupteam.atlassian.net/browse/PMNTSS-2312).

## Purpose

Add the `TransferIn`, `TransferOut`, `ThumbUp` and `ThumbDown` icons.

<img width="259" alt="Screenshot 2023-05-25 at 19 38 42" src="https://github.com/sumup-oss/circuit-ui/assets/9676303/af3b02fa-251b-4bbc-b10b-13bbda6e1e13">
<img width="259" alt="Screenshot 2023-05-25 at 19 38 49" src="https://github.com/sumup-oss/circuit-ui/assets/9676303/f553f062-ab43-4502-b729-9c59b415b860">

## Approach and changes

- Exported and optimized the svgs from [Figma](https://www.figma.com/file/LnhSTiHtYMVw3Ppw5QZVph/Circuit-UI-Foundation?type=design&node-id=11896-67&t=AdUeHcZ5ync8tFhZ-4).
- Updated the manifest.
- Created a changeset.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
