### PR TITLE
Log error on unsupported icon size

### DIFF
--- a/.changeset/fair-carrots-nail.md
+++ b/.changeset/fair-carrots-nail.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': minor
+---
+
+Log (not throw) an error when an icon is passed an unsupported size.

--- a/packages/icons/scripts/web.ts
+++ b/packages/icons/scripts/web.ts
@@ -81,7 +81,7 @@ function buildComponentFile(component: Component): string {
   const sizes = icons.map((icon) => parseInt(icon.size)).sort();
   const defaultSize = sizes.includes(24) ? '24' : Math.min(...sizes).toString();
   const sizeMap = icons.map((icon) => `'${icon.size}': ${icon.name},`);
-  const invalidSizeError = `The '\${size}' size is not supported by the '${
+  const invalidSizeWarning = `The '\${size}' size is not supported by the '${
     component.name
   }' icon. Please use one of the available sizes: '${sizes.join("', '")}'.`;
 
@@ -105,7 +105,7 @@ function buildComponentFile(component: Component): string {
         process.env.NODE_ENV !== 'test' &&
         !sizeMap[size]
       ) {
-        throw new Error(\`${invalidSizeError}\`);
+        console.warn(new Error(\`${invalidSizeWarning}\`));
       }
 
       return <Icon {...props} />;


### PR DESCRIPTION
## Purpose

Since #1615, the Button component configures the size of its icon based on its own size for convenience. However, if the icon doesn't support the configured size, it'll throw an error during development.

## Approach and changes

- Log the unsupported size warning instead of throwing an error. The icon will fall back to a supported size.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
