### PR TITLE
Fix validation hint icon alignment

### DIFF
--- a/.changeset/nine-wasps-invent.md
+++ b/.changeset/nine-wasps-invent.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the alignment of the field validation hint icon.

--- a/packages/circuit-ui/components/FieldAtoms/FieldValidationHint.tsx
+++ b/packages/circuit-ui/components/FieldAtoms/FieldValidationHint.tsx
@@ -32,7 +32,7 @@ export interface FieldValidationHintProps
 }
 
 const wrapperStyles = ({ theme }: StyleProps) => css`
-  display: block;
+  display: flex;
   margin-top: ${theme.spacings.bit};
   color: var(--cui-fg-subtle);
   transition: color ${theme.transitions.default};
@@ -86,11 +86,14 @@ const Wrapper = styled('span')<FieldValidationHintProps>(
 
 const iconWrapperStyles = ({ theme }: StyleProps) =>
   css`
-    display: inline-block;
-    position: relative;
+    display: block;
+    align-self: flex-start;
+    flex-shrink: 0;
     width: ${theme.iconSizes.kilo};
     height: ${theme.iconSizes.kilo};
-    vertical-align: text-top;
+    margin-top: calc(
+      (${theme.typography.body.two.lineHeight} - ${theme.iconSizes.kilo}) / 2
+    );
     margin-right: ${theme.spacings.bit};
   `;
 

--- a/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
+++ b/packages/circuit-ui/components/ImageInput/__snapshots__/ImageInput.spec.tsx.snap
@@ -1983,7 +1983,10 @@ exports[`ImageInput Styles should render with invalid styles and an error messag
 .circuit-13 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   margin-top: 4px;
   color: var(--cui-fg-subtle);
   -webkit-transition: color 120ms ease-in-out;
@@ -2002,11 +2005,18 @@ exports[`ImageInput Styles should render with invalid styles and an error messag
 }
 
 .circuit-14 {
-  display: inline-block;
-  position: relative;
+  display: block;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: flex-start;
+  align-self: flex-start;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   width: 16px;
   height: 16px;
-  vertical-align: text-top;
+  margin-top: calc(
+        (1.25rem - 16px) / 2
+      );
   margin-right: 4px;
 }
 

--- a/packages/circuit-ui/components/Input/__snapshots__/Input.spec.tsx.snap
+++ b/packages/circuit-ui/components/Input/__snapshots__/Input.spec.tsx.snap
@@ -295,7 +295,10 @@ exports[`Input Styles should render with a description when passed the validatio
 .circuit-6 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   margin-top: 4px;
   color: var(--cui-fg-subtle);
   -webkit-transition: color 120ms ease-in-out;

--- a/packages/circuit-ui/components/Select/__snapshots__/Select.spec.tsx.snap
+++ b/packages/circuit-ui/components/Select/__snapshots__/Select.spec.tsx.snap
@@ -503,7 +503,10 @@ select:not(:active)~.circuit-7 {
 .circuit-8 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   margin-top: 4px;
   color: var(--cui-fg-subtle);
   -webkit-transition: color 120ms ease-in-out;

--- a/packages/circuit-ui/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
+++ b/packages/circuit-ui/components/TextArea/__snapshots__/TextArea.spec.tsx.snap
@@ -531,7 +531,10 @@ exports[`TextArea should render with a Tooltip when passed the validationHint pr
 .circuit-6 {
   font-size: 0.875rem;
   line-height: 1.25rem;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   margin-top: 4px;
   color: var(--cui-fg-subtle);
   -webkit-transition: color 120ms ease-in-out;


### PR DESCRIPTION
## Purpose

The validation icon should be center-aligned with the text. The text shouldn't wrap around the icon.

_Before_

<img width="268" alt="Screenshot 2023-06-22 at 20 26 28" src="https://github.com/sumup-oss/circuit-ui/assets/11017722/6e5e9fab-9375-4d5b-8312-a3854c4c8ed2">

_After_

<img width="269" alt="Screenshot 2023-06-22 at 20 30 19" src="https://github.com/sumup-oss/circuit-ui/assets/11017722/5ee3bc5d-67df-4c9f-8210-3fc1eedc72d8">

## Approach and changes

- Use flexbox to align the icon

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
