### PR TITLE
Add ESLint rules for Circuit UI v7

### DIFF
--- a/.changeset/afraid-maps-know.md
+++ b/.changeset/afraid-maps-know.md
@@ -1,0 +1,6 @@
+---
+'@sumup/eslint-plugin-circuit-ui': minor
+---
+
+
+Added `circuit-ui/no-deprecated-props` rule to warn when using deprecated component props.

--- a/.changeset/breezy-eagles-lick.md
+++ b/.changeset/breezy-eagles-lick.md
@@ -1,0 +1,5 @@
+---
+'@sumup/eslint-plugin-circuit-ui': minor
+---
+
+Added `circuit-ui/no-renamed-props` rule to update renamed component prop names and values.

--- a/.changeset/few-cobras-unite.md
+++ b/.changeset/few-cobras-unite.md
@@ -1,0 +1,5 @@
+---
+'@sumup/eslint-plugin-circuit-ui': minor
+---
+
+Added `circuit-ui/no-deprecated-components` rule to warn when using deprecated components.

--- a/.changeset/hip-seahorses-enjoy.md
+++ b/.changeset/hip-seahorses-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@sumup/eslint-plugin-circuit-ui': major
+---
+
+Added `@sumup/circuit-ui >=6.8.0` as a required peer dependency.

--- a/packages/eslint-plugin-circuit-ui/README.md
+++ b/packages/eslint-plugin-circuit-ui/README.md
@@ -43,5 +43,6 @@ Rules are configured under the rules section:
 ## Supported Rules
 
 - [`no-invalid-custom-properties`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-invalid-custom-properties)
+- [`no-deprecated-components`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-deprecated-components)
 - [`no-deprecated-props`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-deprecated-props)
 - [`no-renamed-props`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-renamed-props)

--- a/packages/eslint-plugin-circuit-ui/README.md
+++ b/packages/eslint-plugin-circuit-ui/README.md
@@ -43,3 +43,4 @@ Rules are configured under the rules section:
 ## Supported Rules
 
 - [`no-invalid-custom-properties`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-invalid-custom-properties)
+- [`no-renamed-props`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-renamed-props)

--- a/packages/eslint-plugin-circuit-ui/README.md
+++ b/packages/eslint-plugin-circuit-ui/README.md
@@ -43,4 +43,5 @@ Rules are configured under the rules section:
 ## Supported Rules
 
 - [`no-invalid-custom-properties`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-invalid-custom-properties)
+- [`no-deprecated-props`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-deprecated-props)
 - [`no-renamed-props`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-renamed-props)

--- a/packages/eslint-plugin-circuit-ui/index.ts
+++ b/packages/eslint-plugin-circuit-ui/index.ts
@@ -14,11 +14,13 @@
  */
 
 import { noInvalidCustomProperties } from './no-invalid-custom-properties';
+import { noDeprecatedComponents } from './no-deprecated-components';
 import { noDeprecatedProps } from './no-deprecated-props';
 import { noRenamedProps } from './no-renamed-props';
 
 export const rules = {
   'no-invalid-custom-properties': noInvalidCustomProperties,
+  'no-deprecated-components': noDeprecatedComponents,
   'no-deprecated-props': noDeprecatedProps,
   'no-renamed-props': noRenamedProps,
 };

--- a/packages/eslint-plugin-circuit-ui/index.ts
+++ b/packages/eslint-plugin-circuit-ui/index.ts
@@ -14,7 +14,9 @@
  */
 
 import { noInvalidCustomProperties } from './no-invalid-custom-properties';
+import { noRenamedProps } from './no-renamed-props';
 
 export const rules = {
   'no-invalid-custom-properties': noInvalidCustomProperties,
+  'no-renamed-props': noRenamedProps,
 };

--- a/packages/eslint-plugin-circuit-ui/index.ts
+++ b/packages/eslint-plugin-circuit-ui/index.ts
@@ -14,9 +14,11 @@
  */
 
 import { noInvalidCustomProperties } from './no-invalid-custom-properties';
+import { noDeprecatedProps } from './no-deprecated-props';
 import { noRenamedProps } from './no-renamed-props';
 
 export const rules = {
   'no-invalid-custom-properties': noInvalidCustomProperties,
+  'no-deprecated-props': noDeprecatedProps,
   'no-renamed-props': noRenamedProps,
 };

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-components/README.md
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-components/README.md
@@ -1,0 +1,39 @@
+# Remove deprecated components (`no-deprecated-components`)
+
+Occasionally, components are removed from Circuit UI. This rule flags uses of deprecated components.
+
+## Rule Details
+
+A component is removed in two stages:
+
+1. The component is marked as deprecated in a minor release. In this phase, setting the rule's error level to `warn` (or `1`) is recommended.
+2. The component is removed in the next major release. In this phase, setting the rule's error level to `error` (or `2`) is recommended.
+
+When upgrading Circuit UI, it is recommended to upgrade to the latest minor version, remove or replace the component using the suggestions from this rule, then upgrade to the next major.
+
+Examples of **incorrect** code for this rule:
+
+```tsx
+// Since Circuit UI v6.4
+import { RadioButton, Selector } from '@sumup/circuit-ui';
+```
+
+Examples of **correct** code for this rule:
+
+```tsx
+// Since Circuit UI v6.4
+import { RadioButtonGroup, SelectorGroup } from '@sumup/circuit-ui';
+```
+
+### Options
+
+n/a
+
+## When Not To Use It
+
+n/a
+
+## Further Reading
+
+- [Migration guide](https://github.com/sumup-oss/circuit-ui/blob/main/MIGRATION.md)
+- [Circuit UI release notes](https://github.com/sumup-oss/circuit-ui/blob/main/packages/circuit-ui/CHANGELOG.md)

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-components/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-components/index.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2023, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// We disable the rule in this file because we explicitly test invalid cases
+/* eslint-disable @sumup/circuit-ui/no-invalid-custom-properties */
+
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+import { noDeprecatedComponents } from '.';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('no-deprecated-components', noDeprecatedComponents, {
+  valid: [
+    {
+      name: 'similar component from Circuit UI',
+      code: `
+        import { RadioButtonGroup } from '@sumup/circuit-ui';
+      `,
+    },
+    {
+      name: 'matched component from different package',
+      code: `
+        import { RadioButton } from 'material-ui';
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'matched component from Circuit UI',
+      code: `
+        import { RadioButton } from '@sumup/circuit-ui';
+      `,
+      errors: [{ messageId: 'deprecated' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-components/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-components/index.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2023, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/${name}`,
+);
+
+const components = [
+  {
+    name: 'RadioButton',
+    alternative: 'Use the RadioButtonGroup component instead.',
+  },
+  {
+    name: 'Selector',
+    alternative: 'Use the SelectorGroup component instead.',
+  },
+];
+
+export const noDeprecatedComponents = createRule({
+  name: 'no-deprecated-components',
+  meta: {
+    type: 'suggestion',
+    schema: [],
+    docs: {
+      description: 'Deprecated components should be removed or replaced',
+      recommended: 'warn',
+    },
+    messages: {
+      deprecated: 'The {{name}} component has been deprecated. {{alternative}}',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      'ImportDeclaration:has(Literal[value="@sumup/circuit-ui"])': (
+        node: TSESTree.ImportDeclaration,
+      ) => {
+        node.specifiers.forEach((specifier) => {
+          if (specifier.type !== 'ImportSpecifier') {
+            return;
+          }
+
+          const component = components.find(
+            ({ name }) => name === specifier.imported.name,
+          );
+
+          if (!component) {
+            return;
+          }
+
+          context.report({
+            node,
+            messageId: 'deprecated',
+            data: component,
+          });
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/README.md
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/README.md
@@ -1,0 +1,56 @@
+# Remove deprecated component props (`no-deprecated-props`)
+
+Occasionally, props are removed from Circuit UI components. This rule flags uses of deprecated props.
+
+## Rule Details
+
+A component prop is removed in two stages:
+
+1. The prop is marked as deprecated in a minor release. In this phase, setting the rule's error level to `warn` (or `1`) is recommended.
+2. The prop is removed in the next major release. In this phase, setting the rule's error level to `error` (or `2`) is recommended.
+
+When upgrading Circuit UI, it is recommended to upgrade to the latest minor version, remove or replace the prop using the suggestions from this rule, then upgrade to the next major.
+
+Note that the rule can only lint direct uses of a component. Wrapped instances such as styled components are not supported.
+
+Examples of **incorrect** code for this rule:
+
+```tsx
+// Since Circuit UI v6.4
+function Component() {
+  return (
+    <div>
+      <Button tracking={{ label: 'login' }} />
+      <Checkbox tracking={{ label: 'terms' }} />
+      {/* ...any many other components */}
+    </div>
+  );
+}
+```
+
+Examples of **correct** code for this rule:
+
+```tsx
+// Since Circuit UI v6.4
+function Component() {
+  return (
+    <div>
+      <Button />
+      <Checkbox />
+    </div>
+  );
+}
+```
+
+### Options
+
+n/a
+
+## When Not To Use It
+
+n/a
+
+## Further Reading
+
+- [Migration guide](https://github.com/sumup-oss/circuit-ui/blob/main/MIGRATION.md)
+- [Circuit UI release notes](https://github.com/sumup-oss/circuit-ui/blob/main/packages/circuit-ui/CHANGELOG.md)

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2023, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// We disable the rule in this file because we explicitly test invalid cases
+/* eslint-disable @sumup/circuit-ui/no-invalid-custom-properties */
+
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+import { noDeprecatedProps } from '.';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('no-deprecated-props', noDeprecatedProps, {
+  valid: [
+    {
+      name: 'matched component without the deprecated prop',
+      code: `
+        function Component() {
+          return <Button />
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'matched component with the deprecated prop',
+      code: `
+        function Component() {
+          return <Button tracking={{ label: 'button' }} />
+        }
+      `,
+      errors: [{ messageId: 'deprecated' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2023, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ESLintUtils, TSESLint, TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/${name}`,
+);
+
+type Config = {
+  components: string[];
+  props: [string];
+  alternative: string;
+};
+
+const mappings: Config[] = [
+  {
+    components: [
+      'Anchor',
+      'Button',
+      'Header',
+      'Carousel',
+      'Checkbox',
+      'Hamburger',
+      'ListItem',
+      'NotificationBanner',
+      'NotificationInline',
+      'NotificationToast',
+      'Pagination',
+      'Popover',
+      'RadioButton',
+      'Select',
+      'Selector',
+      'Step',
+      'Tag',
+      // Sidebar
+      'Aggregator',
+      'NavItem',
+    ],
+    props: ['tracking'],
+    alternative:
+      'Use an `onClick` handler to dispatch user interaction events instead.',
+  },
+];
+
+export const noDeprecatedProps = createRule({
+  name: 'no-deprecated-props',
+  meta: {
+    type: 'suggestion',
+    schema: [],
+    docs: {
+      description: 'Deprecated component props should be removed or replaced',
+      recommended: 'warn',
+    },
+    messages: {
+      deprecated:
+        "The {{component}}'s `{{prop}}` prop has been deprecated. {{alternative}}",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return mappings.reduce((visitors, config) => {
+      config.components.forEach((component) => {
+        // eslint-disable-next-line no-param-reassign
+        visitors[`JSXElement:has(JSXIdentifier[name="${component}"])`] = (
+          node: TSESTree.JSXElement,
+        ) => {
+          const { props, alternative } = config;
+
+          node.openingElement.attributes.forEach((attribute) => {
+            if (
+              attribute.type !== 'JSXAttribute' ||
+              attribute.name.type !== 'JSXIdentifier'
+            ) {
+              return;
+            }
+
+            const prop = attribute.name.name;
+
+            if (!props.includes(prop)) {
+              return;
+            }
+
+            context.report({
+              node,
+              messageId: 'deprecated',
+              data: { component, prop, alternative },
+            });
+          });
+        };
+      });
+      return visitors;
+    }, {} as TSESLint.RuleListener);
+  },
+});

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/README.md
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/README.md
@@ -1,0 +1,71 @@
+# Update renamed component props (`no-renamed-props`)
+
+Occasionally, Circuit UI's component props are renamed for consistency. This rule flags uses of outdated prop names and values and can automatically update them.
+
+## Rule Details
+
+A component prop or its values are renamed in two stages:
+
+1. Support for the new name(s) is added in a minor release. The old name(s) are marked as deprecated in the same release. In this phase, setting the rule's error level to `warn` (or `1`) is recommended.
+2. The old name(s) are removed in the next major release. In this phase, setting the rule's error level to `error` (or `2`) is recommended.
+
+When upgrading Circuit UI, it is recommended to upgrade to the latest minor version, update the prop names using the suggestions from this rule, then upgrade to the next major.
+
+Note that the rule can only lint direct uses of a component. Wrapped instances such as styled components are not supported.
+
+Examples of **incorrect** code for this rule:
+
+```tsx
+// Since Circuit UI v6.8
+function Component() {
+  return (
+    <Toggle explanation="Description" />
+  );
+}
+
+// Since Circuit UI v6.4
+function Component() {
+  return (
+    <div>
+      <Badge variant="confirm" />
+      <NotificationInline variant="confirm" />
+      <NotificationToast variant="confirm" />
+    </div>
+  );
+}
+```
+
+Examples of **correct** code for this rule:
+
+```tsx
+// Since Circuit UI v6.8
+function Component() {
+  return (
+    <Toggle description="Description" />
+  );
+}
+
+// Since Circuit UI v6.4
+function Component() {
+  return (
+    <div>
+      <Badge variant="success" />
+      <NotificationInline variant="success" />
+      <NotificationToast variant="success" />
+    </div>
+  );
+}
+```
+
+### Options
+
+n/a
+
+## When Not To Use It
+
+n/a
+
+## Further Reading
+
+- [Migration guide](https://github.com/sumup-oss/circuit-ui/blob/main/MIGRATION.md)
+- [Circuit UI release notes](https://github.com/sumup-oss/circuit-ui/blob/main/packages/circuit-ui/CHANGELOG.md)

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2023, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// We disable the rule in this file because we explicitly test invalid cases
+/* eslint-disable @sumup/circuit-ui/no-invalid-custom-properties */
+
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+import { noRenamedProps } from '.';
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+ruleTester.run('no-renamed-props', noRenamedProps, {
+  valid: [
+    {
+      name: 'matched component with the correct prop name',
+      code: `
+        function Component() {
+          return <Toggle description="Description" />
+        }
+      `,
+    },
+    {
+      name: 'matched component with the correct prop value',
+      code: `
+        function Component() {
+          return <Badge variant="success" />
+        }
+      `,
+    },
+    {
+      name: 'unrelated component with the old prop value',
+      code: `
+        function Component() {
+          return <Button variant="confirm" />
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'matched component with the old prop name',
+      code: `
+        function Component() {
+          return <Toggle explanation="Description" />
+        }
+      `,
+      output: `
+        function Component() {
+          return <Toggle description="Description" />
+        }
+      `,
+      errors: [{ messageId: 'propName' }],
+    },
+    {
+      name: 'matched component with the old prop value',
+      code: `
+        function Component() {
+          return <Badge variant="confirm" />
+        }
+      `,
+      output: `
+        function Component() {
+          return <Badge variant="success" />
+        }
+      `,
+      errors: [{ messageId: 'propValue' }],
+    },
+    {
+      name: 'matched component with the old prop value as an expression',
+      code: `
+        function Component() {
+          return <Badge variant={'confirm'} />
+        }
+      `,
+      output: `
+        function Component() {
+          return <Badge variant="success" />
+        }
+      `,
+      errors: [{ messageId: 'propValue' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
@@ -1,0 +1,195 @@
+/**
+ * Copyright 2023, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ESLintUtils, TSESTree, TSESLint } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/${name}`,
+);
+
+type PropNameConfig = {
+  type: 'name';
+  component: string;
+  props: Record<string, string>;
+};
+
+type PropValuesConfig = {
+  type: 'values';
+  component: string;
+  prop: string;
+  values: Record<string, string>;
+};
+
+const configs: (PropNameConfig | PropValuesConfig)[] = [
+  {
+    type: 'name',
+    component: 'Toggle',
+    props: {
+      explanation: 'description',
+    },
+  },
+  {
+    type: 'values',
+    component: 'Badge',
+    prop: 'variant',
+    values: {
+      confirm: 'success',
+      notify: 'warning',
+      alert: 'danger',
+    },
+  },
+  {
+    type: 'values',
+    component: 'NotificationInline',
+    prop: 'variant',
+    values: {
+      confirm: 'success',
+      notify: 'warning',
+      alert: 'danger',
+    },
+  },
+  {
+    type: 'values',
+    component: 'NotificationToast',
+    prop: 'variant',
+    values: {
+      confirm: 'success',
+      notify: 'warning',
+      alert: 'danger',
+    },
+  },
+];
+
+export const noRenamedProps = createRule({
+  name: 'no-renamed-props',
+  meta: {
+    type: 'suggestion',
+    schema: [],
+    fixable: 'code',
+    docs: {
+      description: 'Component props should use the latest names',
+      recommended: 'error',
+    },
+    messages: {
+      propName:
+        "The {{component}}'s `{{current}}` prop has been renamed to '{{replacement}}'.",
+      propValue:
+        "The {{component}}'s `{{prop}}` prop values have been renamed. Replace '{{current}}' with '{{replacement}}'.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    function replacePropName(
+      node: TSESTree.JSXElement,
+      config: PropNameConfig,
+    ) {
+      const { component, props } = config;
+
+      node.openingElement.attributes.forEach((attribute) => {
+        if (
+          attribute.type !== 'JSXAttribute' ||
+          attribute.name.type !== 'JSXIdentifier'
+        ) {
+          return;
+        }
+
+        const current = attribute.name.name;
+        const replacement = props[current];
+
+        if (!replacement) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'propName',
+          data: { component, current, replacement },
+          fix(fixer) {
+            return fixer.replaceText(
+              attribute.name as TSESTree.JSXIdentifier,
+              replacement,
+            );
+          },
+        });
+      });
+    }
+
+    function replacePropValues(
+      node: TSESTree.JSXElement,
+      config: PropValuesConfig,
+    ) {
+      const { component, prop, values } = config;
+
+      node.openingElement.attributes.forEach((attribute) => {
+        if (attribute.type !== 'JSXAttribute' || attribute.name.name !== prop) {
+          return;
+        }
+
+        const current = getAttributeValue(attribute);
+
+        if (!current) {
+          return;
+        }
+
+        const replacement = values[current];
+
+        if (!replacement) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'propValue',
+          data: { component, prop, current, replacement },
+          fix(fixer) {
+            return fixer.replaceText(
+              attribute.value as TSESTree.Literal,
+              `"${replacement}"`,
+            );
+          },
+        });
+      });
+    }
+
+    return configs.reduce((visitors, config) => {
+      // eslint-disable-next-line no-param-reassign
+      visitors[`JSXElement:has(JSXIdentifier[name="${config.component}"])`] = (
+        node: TSESTree.JSXElement,
+      ) => {
+        if (config.type === 'name') {
+          replacePropName(node, config);
+        }
+        if (config.type === 'values') {
+          replacePropValues(node, config);
+        }
+      };
+      return visitors;
+    }, {} as TSESLint.RuleListener);
+  },
+});
+
+function getAttributeValue(attribute: TSESTree.JSXAttribute): string | null {
+  if (attribute.value?.type === 'Literal') {
+    return attribute.value.value as string;
+  }
+  if (
+    attribute.value?.type === 'JSXExpressionContainer' &&
+    attribute.value.expression.type === 'Literal'
+  ) {
+    return attribute.value.expression.value as string;
+  }
+  return null;
+}

--- a/packages/eslint-plugin-circuit-ui/package.json
+++ b/packages/eslint-plugin-circuit-ui/package.json
@@ -34,6 +34,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
+    "@sumup/circuit-ui": ">=6.8.0",
     "@sumup/design-tokens": ">=5.3.0"
   }
 }


### PR DESCRIPTION
## Purpose

Circuit UI v7 will contain some breaking changes, such as removing or renaming components and props. These changes were introduced as deprecations in v6.4 and v6.8 to give developers time to migrate their code. In addition, the ESLint rules introduced in this PR will help developers to find and automatically apply these changes in their code.

## Approach and changes

- Added 3 new ESLint rules:
	- `circuit-ui/no-renamed-props`: update renamed component prop names and values
	- `circuit-ui/no-deprecated-props`: warn when using deprecated component props
	- `circuit-ui/no-deprecated-components`: warn when using deprecated components
- Add Circuit UI v6.8+ as a required peer dependency to the ESLint plugin

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
