### PR TITLE
Be more specific about the invalid code

### DIFF
--- a/.changeset/tough-clouds-listen.md
+++ b/.changeset/tough-clouds-listen.md
@@ -1,0 +1,5 @@
+---
+'@sumup/eslint-plugin-circuit-ui': patch
+---
+
+Made the reported node more specific.

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-components/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-components/index.ts
@@ -64,7 +64,7 @@ export const noDeprecatedComponents = createRule({
           }
 
           context.report({
-            node,
+            node: specifier,
             messageId: 'deprecated',
             data: component,
           });

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.ts
@@ -95,7 +95,7 @@ export const noDeprecatedProps = createRule({
             }
 
             context.report({
-              node,
+              node: attribute,
               messageId: 'deprecated',
               data: { component, prop, alternative },
             });

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
@@ -114,7 +114,7 @@ export const noRenamedProps = createRule({
         }
 
         context.report({
-          node,
+          node: attribute,
           messageId: 'propName',
           data: { component, current, replacement },
           fix(fixer) {
@@ -151,7 +151,7 @@ export const noRenamedProps = createRule({
         }
 
         context.report({
-          node,
+          node: attribute,
           messageId: 'propValue',
           data: { component, prop, current, replacement },
           fix(fixer) {


### PR DESCRIPTION
Fixes #2171.

## Purpose

The ESLint rules that were added in #2171 highlight too much code when reporting linting issues:

<img width="326" alt="Screenshot 2023-07-04 at 22 48 29" src="https://github.com/sumup-oss/circuit-ui/assets/11017722/16dabb9f-148b-4d10-8738-1fee6747972b">

<img width="238" alt="Screenshot 2023-07-04 at 22 48 15" src="https://github.com/sumup-oss/circuit-ui/assets/11017722/ac9d5e84-dffe-45e0-ad8b-7823e93dca59">

This makes it difficult for developers to pinpoint and understand the actual issue.

## Approach and changes

- Report more specific nodes

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
