### PR TITLE
Flag and fix renamed props in setToast calls

### DIFF
--- a/.changeset/little-feet-sell.md
+++ b/.changeset/little-feet-sell.md
@@ -1,0 +1,5 @@
+---
+'@sumup/eslint-plugin-circuit-ui': minor
+---
+
+Added support for flagging and fixing `setToast` calls to the `circuit-ui/no-renamed-props` rule.

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.spec.ts
@@ -99,5 +99,21 @@ ruleTester.run('no-renamed-props', noRenamedProps, {
       `,
       errors: [{ messageId: 'propValue' }],
     },
+    {
+      name: 'matched function with the old prop value',
+      code: `
+        setToast({
+          variant: 'notify',
+          body: 'Your toast is burnt.',
+        });
+      `,
+      output: `
+        setToast({
+          variant: 'warning',
+          body: 'Your toast is burnt.',
+        });
+      `,
+      errors: [{ messageId: 'propValue' }],
+    },
   ],
 });


### PR DESCRIPTION
## Purpose

In #2171, I added ESLint rules to help teams migrate to Circuit UI v7. The `circuit-ui/no-renamed-props` rule helps to update renamed component prop names and values. However, it didn't handle components that are programmatically rendered through hooks, such as `useNotificationToast`.

## Approach and changes

- Added support for flagging and fixing `setToast` calls to the `circuit-ui/no-renamed-props` rule

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
