### PR TITLE
Fix tree-shaking of Circuit UI

### DIFF
--- a/.changeset/afraid-plums-draw.md
+++ b/.changeset/afraid-plums-draw.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed tree-shaking by retaining the original file structure in the build output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30560,6 +30560,32 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/vite-plugin-no-bundle": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-no-bundle/-/vite-plugin-no-bundle-2.0.2.tgz",
+      "integrity": "sha512-QtMJ0Dzml8mQzZ+Ta09fPJAgy6WXp5rN2w77KQEIV79OeAwkpnaaig/KwH9r6tZLMfa5LkMO7DmmOGQwtph+2A==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.12",
+        "micromatch": "^4.0.5"
+      }
+    },
+    "node_modules/vite-plugin-no-bundle/node_modules/fast-glob": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/vite-plugin-turbosnap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/vite-plugin-turbosnap/-/vite-plugin-turbosnap-1.0.2.tgz",
@@ -31266,7 +31292,7 @@
     },
     "packages/circuit-ui": {
       "name": "@sumup/circuit-ui",
-      "version": "7.0.0-next.4",
+      "version": "7.0.0-next.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
@@ -31278,8 +31304,8 @@
         "@emotion/jest": "^11.11.0",
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
-        "@sumup/design-tokens": "^6.0.0-next.0",
-        "@sumup/icons": "^3.0.0-next.1",
+        "@sumup/design-tokens": "^6.0.0-next.2",
+        "@sumup/icons": "^3.0.0-next.2",
         "@sumup/intl": "^1.5.0",
         "@testing-library/dom": "^9.3.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -31300,7 +31326,8 @@
         "react-swipeable": "^7.0.0",
         "typescript": "^5.0.4",
         "typescript-plugin-css-modules": "^5.0.1",
-        "vite": "^4.3.4"
+        "vite": "^4.3.4",
+        "vite-plugin-no-bundle": "^2.0.2"
       },
       "engines": {
         "node": ">=16"
@@ -31313,8 +31340,8 @@
         "@emotion/is-prop-valid": "1.x",
         "@emotion/react": "11.x",
         "@emotion/styled": "11.x",
-        "@sumup/design-tokens": ">=6.0.0-next.1",
-        "@sumup/icons": ">=3.0.0-next.1",
+        "@sumup/design-tokens": ">=6.0.0-next.2",
+        "@sumup/icons": ">=3.0.0-next.2",
         "@sumup/intl": "1.x",
         "react": ">=18.0.0 <19.0.0",
         "react-dom": ">=18.0.0 <19.0.0"
@@ -31322,12 +31349,12 @@
     },
     "packages/cna-template": {
       "name": "@sumup/cna-template",
-      "version": "3.2.0-next.0",
+      "version": "4.0.0-next.1",
       "license": "Apache-2.0"
     },
     "packages/design-tokens": {
       "name": "@sumup/design-tokens",
-      "version": "6.0.0-next.1",
+      "version": "6.0.0-next.2",
       "license": "Apache-2.0",
       "dependencies": {
         "browserslist": "^4.21.9",
@@ -31343,19 +31370,19 @@
     },
     "packages/eslint-plugin-circuit-ui": {
       "name": "@sumup/eslint-plugin-circuit-ui",
-      "version": "2.1.0",
+      "version": "3.0.0-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/utils": "^5.59.6"
       },
       "devDependencies": {
-        "@sumup/design-tokens": "^6.0.0-next",
+        "@sumup/design-tokens": "^6.0.0-next.2",
         "@tsconfig/node18": "^2.0.0",
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@sumup/circuit-ui": ">=7.0.0-next",
-        "@sumup/design-tokens": ">=5.3.0"
+        "@sumup/circuit-ui": ">=7.0.0-next.5",
+        "@sumup/design-tokens": ">=6.0.0-next.2"
       }
     },
     "packages/eslint-plugin-circuit-ui/node_modules/@typescript-eslint/scope-manager": {
@@ -31455,7 +31482,7 @@
     },
     "packages/icons": {
       "name": "@sumup/icons",
-      "version": "3.0.0-next.1",
+      "version": "3.0.0-next.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.21.8",
@@ -38583,8 +38610,8 @@
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
         "@floating-ui/react-dom": "^2.0.0",
-        "@sumup/design-tokens": "^6.0.0-next.0",
-        "@sumup/icons": "^3.0.0-next.1",
+        "@sumup/design-tokens": "^6.0.0-next.2",
+        "@sumup/icons": "^3.0.0-next.2",
         "@sumup/intl": "^1.5.0",
         "@testing-library/dom": "^9.3.0",
         "@testing-library/jest-dom": "^5.16.5",
@@ -38607,7 +38634,8 @@
         "react-swipeable": "^7.0.0",
         "typescript": "^5.0.4",
         "typescript-plugin-css-modules": "^5.0.1",
-        "vite": "^4.3.4"
+        "vite": "^4.3.4",
+        "vite-plugin-no-bundle": "^2.0.2"
       }
     },
     "@sumup/cna-template": {
@@ -38628,7 +38656,7 @@
     "@sumup/eslint-plugin-circuit-ui": {
       "version": "file:packages/eslint-plugin-circuit-ui",
       "requires": {
-        "@sumup/design-tokens": "^6.0.0-next",
+        "@sumup/design-tokens": "^6.0.0-next.2",
         "@tsconfig/node18": "^2.0.0",
         "@typescript-eslint/utils": "^5.59.6",
         "typescript": "^5.0.4"
@@ -54846,6 +54874,31 @@
         "pathe": "^1.1.0",
         "picocolors": "^1.0.0",
         "vite": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "vite-plugin-no-bundle": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-no-bundle/-/vite-plugin-no-bundle-2.0.2.tgz",
+      "integrity": "sha512-QtMJ0Dzml8mQzZ+Ta09fPJAgy6WXp5rN2w77KQEIV79OeAwkpnaaig/KwH9r6tZLMfa5LkMO7DmmOGQwtph+2A==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.12",
+        "micromatch": "^4.0.5"
+      },
+      "dependencies": {
+        "fast-glob": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+          "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        }
       }
     },
     "vite-plugin-turbosnap": {

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -64,7 +64,8 @@
     "react-swipeable": "^7.0.0",
     "typescript": "^5.0.4",
     "typescript-plugin-css-modules": "^5.0.1",
-    "vite": "^4.3.4"
+    "vite": "^4.3.4",
+    "vite-plugin-no-bundle": "^2.0.2"
   },
   "peerDependencies": {
     "@emotion/is-prop-valid": "1.x",

--- a/packages/circuit-ui/vite.config.ts
+++ b/packages/circuit-ui/vite.config.ts
@@ -80,7 +80,11 @@ export default defineConfig({
       ],
     },
   },
-  plugins: [noBundlePlugin({ root: './' })],
+  plugins: [
+    // @ts-expect-error vite-plugin-no-bundle is bundled in a non-standard way.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    (noBundlePlugin.default || noBundlePlugin)({ root: './' }),
+  ],
   test: {
     globals: true,
     environment: 'jsdom',

--- a/packages/circuit-ui/vite.config.ts
+++ b/packages/circuit-ui/vite.config.ts
@@ -17,6 +17,7 @@ import crypto from 'node:crypto';
 import path from 'node:path';
 
 import { UserConfig, defineConfig } from 'vite';
+import noBundlePlugin from 'vite-plugin-no-bundle';
 
 import {
   dependencies,
@@ -79,6 +80,7 @@ export default defineConfig({
       ],
     },
   },
+  plugins: [noBundlePlugin({ root: './' })],
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Purpose

While upgrading the Next.js template to Circuit UI v7, I discovered that Circuit UI can no longer be tree-shaken because Vite combines all code into a single file. I had assumed that bundlers were smart enough to tree-shake the code regardless.

## Approach and changes

- Use the [`vite-plugin-no-bundle`](https://github.com/ManBearTM/vite-plugin-no-bundle) to configure Vite to retain the original file structure

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements