### PR TITLE
Externalize subpath imports of node modules

### DIFF
--- a/.changeset/light-pumas-shop.md
+++ b/.changeset/light-pumas-shop.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Externalized subpath imports of node modules.

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "dev": "vite",
     "start": "npm run dev",
-    "build": "vite build && tsc -p tsconfig.build.json",
+    "build": "vite build && tsc -p tsconfig.build.json && rm -rf dist/node_modules",
     "lint": "foundry run eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "npm run lint -- --fix",
     "test": "vitest"

--- a/packages/circuit-ui/vite.config.ts
+++ b/packages/circuit-ui/vite.config.ts
@@ -77,6 +77,10 @@ export default defineConfig({
         ...Object.keys(dependencies),
         ...Object.keys(peerDependencies),
         ...Object.keys(optionalDependencies),
+        // Subfolder imports
+        'react/jsx-runtime',
+        '@emotion/react/jsx-runtime',
+        'react-dates/initialize.js',
       ],
     },
   },


### PR DESCRIPTION
## Purpose

I discovered that subpath imports from the `node_modules` folder were copied into the `dist` folder and published to npm. This caused dependency resolution errors in the consuming apps and potentially duplicate bundling of peer dependencies such as `react` and `@emotion/react`.

## Approach and changes

- Added the subpath imports to the `externals` config option
- Cleaned up the `dist/node_modules` folder as part of the build script. It only contains empty folders and no files now, but I wanted to tidy it up anyway. That way, if files sneak into the folder in the future, the issue should be caught in CI.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
