### PR TITLE
Throw error for missing `as` prop

### DIFF
--- a/.changeset/rude-bikes-scream.md
+++ b/.changeset/rude-bikes-scream.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a helpful error message when the Title, Headline or SubHeadline components are missing the `as` prop.

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -16,6 +16,7 @@
 import { HTMLAttributes, forwardRef } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
+import { CircuitError } from '../../util/errors.js';
 
 import classes from './Headline.module.css';
 
@@ -36,13 +37,19 @@ export interface HeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
  * A flexible headline component capable of rendering any HTML heading element.
  */
 export const Headline = forwardRef<HTMLHeadingElement, HeadlineProps>(
-  ({ className, as: Element, size = 'one', ...props }, ref) => (
-    <Element
-      {...props}
-      ref={ref}
-      className={clsx(classes.base, classes[size], className)}
-    />
-  ),
+  ({ className, as: Element, size = 'one', ...props }, ref) => {
+    if (process.env.NODE_ENV !== 'production' && !Element) {
+      throw new CircuitError('Headline', 'The `as` prop is required.');
+    }
+
+    return (
+      <Element
+        {...props}
+        ref={ref}
+        className={clsx(classes.base, classes[size], className)}
+      />
+    );
+  },
 );
 
 Headline.displayName = 'Headline';

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -16,6 +16,7 @@
 import { HTMLAttributes, forwardRef } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
+import { CircuitError } from '../../util/errors.js';
 
 import classes from './SubHeadline.module.css';
 
@@ -33,9 +34,15 @@ export interface SubHeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
  * element, except h1.
  */
 export const SubHeadline = forwardRef<HTMLHeadingElement, SubHeadlineProps>(
-  ({ className, as: Element, ...props }, ref) => (
-    <Element {...props} ref={ref} className={clsx(classes.base, className)} />
-  ),
+  ({ className, as: Element, ...props }, ref) => {
+    if (process.env.NODE_ENV !== 'production' && !Element) {
+      throw new CircuitError('SubHeadline', 'The `as` prop is required.');
+    }
+
+    return (
+      <Element {...props} ref={ref} className={clsx(classes.base, className)} />
+    );
+  },
 );
 
 SubHeadline.displayName = 'SubHeadline';

--- a/packages/circuit-ui/components/Title/Title.tsx
+++ b/packages/circuit-ui/components/Title/Title.tsx
@@ -16,6 +16,7 @@
 import { HTMLAttributes, forwardRef } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
+import { CircuitError } from '../../util/errors.js';
 
 import classes from './Title.module.css';
 
@@ -36,13 +37,19 @@ export interface TitleProps extends HTMLAttributes<HTMLHeadingElement> {
  * A flexible title component capable of rendering any HTML heading element.
  */
 export const Title = forwardRef<HTMLHeadingElement, TitleProps>(
-  ({ className, as: Element, size = 'one', ...props }, ref) => (
-    <Element
-      {...props}
-      ref={ref}
-      className={clsx(classes.base, classes[size], className)}
-    />
-  ),
+  ({ className, as: Element, size = 'one', ...props }, ref) => {
+    if (process.env.NODE_ENV !== 'production' && !Element) {
+      throw new CircuitError('Title', 'The `as` prop is required.');
+    }
+
+    return (
+      <Element
+        {...props}
+        ref={ref}
+        className={clsx(classes.base, classes[size], className)}
+      />
+    );
+  },
 );
 
 Title.displayName = 'Title';


### PR DESCRIPTION
## Purpose

The Title, Headline, and SubHeadline components no longer default to the `h2` element. Developers need to specify the element explicitly so that they are forced to consider the correct heading level. 

When the `as` prop is missing, React throws a generic error message that makes it difficult to pinpoint in which component the error occurred.

## Approach and changes

- Added a helpful error message when the `as` prop isn't provided to the Title, Headline, and SubHeadline components

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
