### PR TITLE
Add type exports for subpaths

### DIFF
--- a/.changeset/hip-owls-shave.md
+++ b/.changeset/hip-owls-shave.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Added types for subpath exports.

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -16,6 +16,13 @@
     },
     "./styles.css": "./dist/style.css"
   },
+  "typesVersions": {
+    "*": {
+      "legacy": [
+        "./dist/legacy.d.ts"
+      ]
+    }
+  },
   "sideEffects": false,
   "files": [
     "dist"

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -6,8 +6,14 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js",
-    "./legacy": "./dist/legacy.js",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./legacy": {
+      "types": "./dist/legacy.d.ts",
+      "default": "./dist/legacy.js"
+    },
     "./styles.css": "./dist/style.css"
   },
   "sideEffects": false,


### PR DESCRIPTION
## Purpose

TypeScript isn't able to resolve the types for subpath exports (e.g. `@sumup/circuit-ui/legacy`).

## Approach and changes

- Added conditional export conditions when using `moduleResolution: nodeNext` in consuming apps
- Added `typesVersions` when using `moduleResolution: node` in consuming apps

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
