### PR TITLE
Fix invalid input styles

### DIFF
--- a/.changeset/clean-cars-nail.md
+++ b/.changeset/clean-cars-nail.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the invalid styles for the Input and Select components.

--- a/packages/circuit-ui/components/Input/Input.module.css
+++ b/packages/circuit-ui/components/Input/Input.module.css
@@ -47,23 +47,23 @@
 
 /* Validations */
 
-.base[aria-invalid] {
+.base[aria-invalid="true"] {
   box-shadow: 0 0 0 1px var(--cui-border-danger);
 }
 
-.base[aria-invalid]:hover {
+.base[aria-invalid="true"]:hover {
   box-shadow: 0 0 0 1px var(--cui-border-danger-hovered);
 }
 
-.base[aria-invalid]:focus {
+.base[aria-invalid="true"]:focus {
   box-shadow: 0 0 0 2px var(--cui-border-danger);
 }
 
-.base[aria-invalid]:active {
+.base[aria-invalid="true"]:active {
   box-shadow: 0 0 0 1px var(--cui-border-danger-pressed);
 }
 
-.base[aria-invalid]:not(:focus):not([disabled])::placeholder {
+.base[aria-invalid="true"]:not(:focus):not([disabled])::placeholder {
   color: var(--cui-fg-danger);
 }
 

--- a/packages/circuit-ui/components/Select/Select.module.css
+++ b/packages/circuit-ui/components/Select/Select.module.css
@@ -54,19 +54,19 @@
 
 /* Validations */
 
-.base[aria-invalid] {
+.base[aria-invalid="true"] {
   box-shadow: 0 0 0 1px var(--cui-border-danger);
 }
 
-.base[aria-invalid]:hover {
+.base[aria-invalid="true"]:hover {
   box-shadow: 0 0 0 1px var(--cui-border-danger-hovered);
 }
 
-.base[aria-invalid]:focus {
+.base[aria-invalid="true"]:focus {
   box-shadow: 0 0 0 2px var(--cui-border-danger);
 }
 
-.base[aria-invalid]:active {
+.base[aria-invalid="true"]:active {
   box-shadow: 0 0 0 1px var(--cui-border-danger-pressed);
 }
 


### PR DESCRIPTION
## Purpose

Invalid styles are applied when the Input or Select has the `aria-invalid` attribute, even when the value is `false`.

## Approach and changes

- Narrow the invalid style selector to target `aria-invalid="true"` only

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
