### PR TITLE
Add new 16 size 'ArrowSlanted' icon

### DIFF
--- a/.changeset/curvy-emus-sneeze.md
+++ b/.changeset/curvy-emus-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@sumup/icons': minor
+---
+
+Add new 16 size 'ArrowSlanted' icon

--- a/.changeset/curvy-emus-sneeze.md
+++ b/.changeset/curvy-emus-sneeze.md
@@ -2,4 +2,4 @@
 '@sumup/icons': minor
 ---
 
-Add new 16 size 'ArrowSlanted' icon
+Added new icon `ArrowSlanted` in size 16.

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -1217,6 +1217,11 @@
       "size": "16"
     },
     {
+      "name": "arrow_slanted",
+      "category": "Navigation",
+      "size": "16"
+    },
+    {
       "name": "hamburger_menu",
       "category": "Navigation",
       "size": "24"

--- a/packages/icons/web/v2/arrow_slanted_16.svg
+++ b/packages/icons/web/v2/arrow_slanted_16.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16">
+    <path fill="currentColor" d="M3.9 3a1 1 0 0 1 1-1h8a1 1 0 0 1 1 1v8a1 1 0 1 1-2 0V5.407l-8.193 8.192a1 1 0 0 1-1.414-1.414L10.478 4H4.899a1 1 0 0 1-1-1Z"/>
+</svg>


### PR DESCRIPTION
Addresses [SA-71156](https://sumupteam.atlassian.net/browse/SA-71156)

## Purpose

This PR introduces the 16px ArrowSlanted icon to icons lib. Icon will be later used in Online Store custom domain settings and Theme Editor. 

## Approach and changes

1. Add icon in svg format
2. Update icon's manifest
3. Run changeset for minor update

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
