### PR TITLE
Fix primary navigation width on wide viewports

### DIFF
--- a/.changeset/wild-geckos-report.md
+++ b/.changeset/wild-geckos-report.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the primary SideNavigation width on wide viewports.

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.module.css
@@ -16,6 +16,12 @@
   }
 }
 
+@media (min-width: 1900px) {
+  .wrapper {
+    min-width: var(--primary-navigation-width-open);
+  }
+}
+
 .primary {
   position: fixed;
   top: var(--top-navigation-height, 0);


### PR DESCRIPTION
## Purpose

The SideNavigation overlaps the main content on extra-wide viewports when only primary links (and no secondary ones) are shown.

## Approach and changes

- Increase the width of the navigation wrapper on extra-wide viewports

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
