### PR TITLE
Remove the Tag's icons from the accessibility tree

### DIFF
--- a/.changeset/warm-ducks-bake.md
+++ b/.changeset/warm-ducks-bake.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed the Icon's prefix and suffix icons from the accessibility tree.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22492,9 +22492,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
-      "integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
+      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -32760,7 +32760,7 @@
     },
     "packages/circuit-ui": {
       "name": "@sumup/circuit-ui",
-      "version": "7.0.0",
+      "version": "7.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.1",
@@ -32805,9 +32805,9 @@
         "react-dates": ">=21.8"
       },
       "peerDependencies": {
-        "@emotion/is-prop-valid": "1.x",
-        "@emotion/react": "11.x",
-        "@emotion/styled": "11.x",
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@emotion/react": "^11.11.0",
+        "@emotion/styled": "^11.11.0",
         "@sumup/design-tokens": ">=6.0.0",
         "@sumup/icons": ">=3.0.0",
         "@sumup/intl": "1.x",
@@ -32817,7 +32817,7 @@
     },
     "packages/cna-template": {
       "name": "@sumup/cna-template",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "Apache-2.0"
     },
     "packages/design-tokens": {
@@ -32986,7 +32986,7 @@
     },
     "packages/remix-template": {
       "name": "@sumup/remix-template-circuit-ui",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@remix-run/css-bundle": "^1.18.1",
         "@remix-run/node": "^1.18.1",
@@ -49318,9 +49318,9 @@
       "dev": true
     },
     "magic-string": {
-      "version": "0.30.2",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
-      "integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
+      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
       "dev": true,
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.4.15"

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -13,12 +13,8 @@
  * limitations under the License.
  */
 
-import {
-  forwardRef,
-  HTMLAttributes,
-  ButtonHTMLAttributes,
-  ComponentType,
-} from 'react';
+import { forwardRef, HTMLAttributes, ButtonHTMLAttributes } from 'react';
+import type { IconComponentType } from '@sumup/icons';
 
 import type { ClickEvent } from '../../types/events.js';
 import { AccessibilityError } from '../../util/errors.js';
@@ -32,11 +28,11 @@ type BaseProps = {
   /**
    * Render prop that should render a leading-aligned icon or element.
    */
-  prefix?: ComponentType<{ className: string }>;
+  prefix?: IconComponentType;
   /**
    * Render prop that should render a trailing-aligned icon or element.
    */
-  suffix?: ComponentType<{ className: string }>;
+  suffix?: IconComponentType;
   /**
    * Triggers selected styles on the tag.
    */
@@ -115,11 +111,11 @@ export const Tag = forwardRef<HTMLDivElement & HTMLButtonElement, TagProps>(
           ref={ref}
           {...props}
         >
-          {Prefix && <Prefix className={classes.prefix} />}
+          {Prefix && <Prefix className={classes.prefix} aria-hidden="true" />}
 
           {children}
 
-          {Suffix && <Suffix className={classes.suffix} />}
+          {Suffix && <Suffix className={classes.suffix} aria-hidden="true" />}
         </Element>
 
         {isRemovable && (


### PR DESCRIPTION
## Purpose

The prefix and suffix icons inside the Tag component are purely presentational and shouldn't be announced to screen reader users.

## Approach and changes

- Hide the icons from the accessibility tree

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
