### PR TITLE
Fix incorrect SearchInput padding

### DIFF
--- a/.changeset/big-lamps-raise.md
+++ b/.changeset/big-lamps-raise.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed unnecessary padding in the SearchInput component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32760,7 +32760,7 @@
     },
     "packages/circuit-ui": {
       "name": "@sumup/circuit-ui",
-      "version": "7.0.2",
+      "version": "7.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.1",

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -71,18 +71,23 @@ export const SearchInput = forwardRef<InputElement, SearchInputProps>(
         value={value}
         type="search"
         renderPrefix={(renderProps) => <Search size="16" {...renderProps} />}
-        renderSuffix={(renderProps) =>
-          value && onClear && clearLabel ? (
-            <IconButton
-              {...renderProps}
-              onClick={onClick}
-              label={clearLabel}
-              className={clsx(renderProps.className, classes['clear-button'])}
-            >
-              <Close size="16" />
-            </IconButton>
-          ) : null
-        }
+        {...(value && onClear && clearLabel
+          ? {
+              renderSuffix: (renderProps) => (
+                <IconButton
+                  {...renderProps}
+                  onClick={onClick}
+                  label={clearLabel}
+                  className={clsx(
+                    renderProps.className,
+                    classes['clear-button'],
+                  )}
+                >
+                  <Close size="16" />
+                </IconButton>
+              ),
+            }
+          : {})}
         inputClassName={clsx(classes.base, inputClassName)}
         {...props}
         ref={applyMultipleRefs(localRef, ref)}


### PR DESCRIPTION
## Purpose

Remove the padding due to passing a function to `Input` prop `renderSuffix`.

## Approach and changes

Use optional spreading to only pass the prop when needed.

_Before:_
<img width="843" alt="Screenshot 2023-08-22 at 14 32 06" src="https://github.com/sumup-oss/circuit-ui/assets/1247692/db2653e1-ceef-4b09-bd4e-aceb3cb84ceb">


_After:_
<img width="848" alt="Screenshot 2023-08-22 at 14 31 33" src="https://github.com/sumup-oss/circuit-ui/assets/1247692/6025d18d-d3f0-465d-84ea-a6669e711b53">


## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
