### PR TITLE
Extend validation for labels

### DIFF
--- a/.changeset/famous-kiwis-live.md
+++ b/.changeset/famous-kiwis-live.md
@@ -1,0 +1,7 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added additional validation for labels.
+
+Labels are required for form fields and other controls so those who use assistive technologies can tell what the control is for. Labels should concisely describe the control's purpose and need to be localized.

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -25,7 +25,10 @@ import type { ClickEvent } from '../../types/events.js';
 import type { AsPropType } from '../../types/prop-types.js';
 import { useComponents } from '../ComponentsContext/index.js';
 import Spinner from '../Spinner/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import utilityClasses from '../../styles/utility.js';
 import { clsx } from '../../styles/clsx.js';
 
@@ -113,11 +116,11 @@ export const Button = forwardRef<any, ButtonProps>(
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       isLoading !== undefined &&
-      !loadingLabel
+      !isSufficientlyLabelled(loadingLabel)
     ) {
       throw new AccessibilityError(
         'Button',
-        "The `loadingLabel` prop is missing. Remove the `isLoading` prop if you don't intend to use the Button's loading state.",
+        "The `loadingLabel` prop is missing or invalid. Remove the `isLoading` prop if you don't intend to use the Button's loading state.",
       );
     }
     const { Link } = useComponents();

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -23,7 +23,10 @@ import {
 import { Checkmark } from '@sumup/icons';
 
 import { FieldValidationHint, FieldWrapper } from '../Field/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { clsx } from '../../styles/clsx.js';
 import utilityClasses from '../../styles/utility.js';
@@ -93,9 +96,12 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
-      !label
+      !isSufficientlyLabelled(label)
     ) {
-      throw new AccessibilityError('Checkbox', 'The `label` prop is missing.');
+      throw new AccessibilityError(
+        'Checkbox',
+        'The `label` prop is missing or invalid.',
+      );
     }
 
     return (

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
@@ -28,7 +28,10 @@ import {
   FieldSet,
   FieldLegend,
 } from '../Field/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { isEmpty } from '../../util/helpers.js';
 
 import classes from './CheckboxGroup.module.css';
@@ -149,11 +152,11 @@ export const CheckboxGroup = forwardRef(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
-      !label
+      !isSufficientlyLabelled(label)
     ) {
       throw new AccessibilityError(
         'CheckboxGroup',
-        'The `label` prop is missing. Pass `hideLabel` if you intend to hide the label visually.',
+        'The `label` prop is missing or invalid. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
 

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -17,7 +17,10 @@ import { forwardRef } from 'react';
 
 import { IconButton, IconButtonProps } from '../IconButton/IconButton.js';
 import { Skeleton } from '../Skeleton/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
 
 import classes from './Hamburger.module.css';
@@ -59,16 +62,16 @@ export const Hamburger = forwardRef<any, HamburgerProps>(
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      if (!activeLabel) {
+      if (!isSufficientlyLabelled(activeLabel)) {
         throw new AccessibilityError(
           'Hamburger',
-          'The `activeLabel` prop is missing.',
+          'The `activeLabel` prop is missing or invalid.',
         );
       }
-      if (!inactiveLabel) {
+      if (!isSufficientlyLabelled(inactiveLabel)) {
         throw new AccessibilityError(
           'Hamburger',
-          'The `inactiveLabel` prop is missing.',
+          'The `inactiveLabel` prop is missing or invalid.',
         );
       }
     }

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -19,7 +19,10 @@ import type { IconProps } from '@sumup/icons';
 import utilityClasses from '../../styles/utility.js';
 import { clsx } from '../../styles/clsx.js';
 import { Button, ButtonProps } from '../Button/Button.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 
 import classes from './IconButton.module.css';
 
@@ -51,11 +54,11 @@ export const IconButton = forwardRef<any, IconButtonProps>(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
-      !label
+      !isSufficientlyLabelled(label)
     ) {
       throw new AccessibilityError(
         'IconButton',
-        'The `label` prop is missing.',
+        'The `label` prop is missing or invalid.',
       );
     }
 

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -34,7 +34,10 @@ import {
 } from '../Field/index.js';
 import IconButton from '../IconButton/index.js';
 import Spinner from '../Spinner/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
 
 import classes from './ImageInput.module.css';
@@ -110,22 +113,22 @@ export const ImageInput = ({
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'
   ) {
-    if (!label) {
+    if (!isSufficientlyLabelled(label)) {
       throw new AccessibilityError(
         'ImageInput',
-        'The `label` prop is missing.',
+        'The `label` prop is missing or invalid.',
       );
     }
-    if (!clearButtonLabel) {
+    if (!isSufficientlyLabelled(clearButtonLabel)) {
       throw new AccessibilityError(
         'ImageInput',
-        'The `clearButtonLabel` prop is missing.',
+        'The `clearButtonLabel` prop is missing or invalid.',
       );
     }
-    if (!loadingLabel) {
+    if (!isSufficientlyLabelled(loadingLabel)) {
       throw new AccessibilityError(
         'ImageInput',
-        'The `loadingLabel` prop is missing.',
+        'The `loadingLabel` prop is missing or invalid.',
       );
     }
   }

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -28,7 +28,10 @@ import {
   FieldValidationHint,
 } from '../Field/index.js';
 import { ReturnType } from '../../types/return-type.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
 
 import classes from './Input.module.css';
@@ -134,11 +137,11 @@ export const Input = forwardRef<InputElement, InputProps>(
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       props.type !== 'hidden' &&
-      !label
+      !isSufficientlyLabelled(label)
     ) {
       throw new AccessibilityError(
         'Input',
-        'The `label` prop is missing. Pass `hideLabel` if you intend to hide the label visually.',
+        'The `label` prop is missing or invalid. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
 

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -24,7 +24,10 @@ import {
 } from '../ModalContext/index.js';
 import CloseButton from '../CloseButton/index.js';
 import { StackContext } from '../StackContext/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
 
 import classes from './Modal.module.css';
@@ -93,11 +96,11 @@ export const Modal: ModalComponent<ModalProps> = ({
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     !preventClose &&
-    !closeButtonLabel
+    !isSufficientlyLabelled(closeButtonLabel)
   ) {
     throw new AccessibilityError(
       'Modal',
-      "The `closeButtonLabel` prop is missing. Pass it in `setModal`, or pass `preventClose` if you intend to hide the Modal's close button.",
+      "The `closeButtonLabel` prop is missing or invalid. Pass it in `setModal`, or pass `preventClose` if you intend to hide the Modal's close button.",
     );
   }
 

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -17,7 +17,10 @@ import { HTMLAttributes, ReactElement } from 'react';
 import { ChevronLeft, ChevronRight } from '@sumup/icons';
 
 import IconButton from '../IconButton/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
 
 import { PageSelect } from './components/PageSelect/index.js';
@@ -82,22 +85,22 @@ export const Pagination = ({
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'
   ) {
-    if (!label) {
+    if (!isSufficientlyLabelled(label)) {
       throw new AccessibilityError(
         'Pagination',
-        'The `label` prop is missing.',
+        'The `label` prop is missing or invalid.',
       );
     }
-    if (!previousLabel) {
+    if (!isSufficientlyLabelled(previousLabel)) {
       throw new AccessibilityError(
         'Pagination',
-        'The `previousLabel` prop is missing.',
+        'The `previousLabel` prop is missing or invalid.',
       );
     }
-    if (!nextLabel) {
+    if (!isSufficientlyLabelled(nextLabel)) {
       throw new AccessibilityError(
         'Pagination',
-        'The `nextLabel` prop is missing.',
+        'The `nextLabel` prop is missing or invalid.',
       );
     }
   }

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -16,7 +16,10 @@
 import { HTMLAttributes, useId } from 'react';
 
 import { ReturnType } from '../../types/return-type.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import utilityClasses from '../../styles/utility.js';
 import { clsx } from '../../styles/clsx.js';
 
@@ -100,9 +103,12 @@ export function ProgressBar({
   if (
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
-    !label
+    !isSufficientlyLabelled(label)
   ) {
-    throw new AccessibilityError('ProgressBar', 'The `label` prop is missing.');
+    throw new AccessibilityError(
+      'ProgressBar',
+      'The `label` prop is missing or invalid.',
+    );
   }
   const ariaId = useId();
   return (

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -15,7 +15,10 @@
 
 import { InputHTMLAttributes, forwardRef, useId } from 'react';
 
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { FieldWrapper, FieldDescription } from '../Field/index.js';
 import { clsx } from '../../styles/clsx.js';
 import utilityClasses from '../../styles/utility.js';
@@ -58,11 +61,11 @@ export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
-      !label
+      !isSufficientlyLabelled(label)
     ) {
       throw new AccessibilityError(
         'RadioButton',
-        'The `label` prop is missing.',
+        'The `label` prop is missing or invalid.',
       );
     }
     const id = useId();

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -28,7 +28,10 @@ import {
   FieldLegend,
   FieldSet,
 } from '../Field/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { isEmpty } from '../../util/helpers.js';
 
 export interface RadioButtonGroupProps
@@ -135,11 +138,11 @@ export const RadioButtonGroup = forwardRef(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
-      !label
+      !isSufficientlyLabelled(label)
     ) {
       throw new AccessibilityError(
         'RadioButtonGroup',
-        'The `label` prop is missing. Pass `hideLabel` if you intend to hide the label visually.',
+        'The `label` prop is missing or invalid. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
 

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -19,7 +19,10 @@ import { Search, Close } from '@sumup/icons';
 import Input from '../Input/index.js';
 import type { InputElement, InputProps } from '../Input/index.js';
 import IconButton from '../IconButton/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { clsx } from '../../styles/clsx.js';
 import type { ClickEvent } from '../../types/events.js';
@@ -53,11 +56,11 @@ export const SearchInput = forwardRef<InputElement, SearchInputProps>(
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       onClear &&
-      !clearLabel
+      !isSufficientlyLabelled(clearLabel)
     ) {
       throw new AccessibilityError(
         'SearchInput',
-        'The `clearLabel` prop is missing. Omit the `onClear` prop if you intend to disable the input clearing functionality.',
+        'The `clearLabel` prop is missing or invalid. Omit the `onClear` prop if you intend to disable the input clearing functionality.',
       );
     }
 

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -29,7 +29,10 @@ import {
   FieldLabelText,
   FieldValidationHint,
 } from '../Field/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
 
 import classes from './Select.module.css';
@@ -129,11 +132,11 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
-      !label
+      !isSufficientlyLabelled(label)
     ) {
       throw new AccessibilityError(
         'Select',
-        'The `label` prop is missing. Pass `hideLabel` if you intend to hide the label visually.',
+        'The `label` prop is missing or invalid. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
     const id = useId();

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -15,7 +15,10 @@
 
 import { Fragment, InputHTMLAttributes, forwardRef, useId } from 'react';
 
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { FieldWrapper } from '../Field/index.js';
 import { clsx } from '../../styles/clsx.js';
 import utilityClasses from '../../styles/utility.js';
@@ -104,9 +107,12 @@ export const Selector = forwardRef<HTMLInputElement, SelectorProps>(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
-      !label
+      !isSufficientlyLabelled(label)
     ) {
-      throw new AccessibilityError('Selector', 'The `label` prop is missing.');
+      throw new AccessibilityError(
+        'Selector',
+        'The `label` prop is missing or invalid.',
+      );
     }
 
     const hasDescription = Boolean(description);

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -16,7 +16,10 @@
 import { forwardRef, FieldsetHTMLAttributes, useId } from 'react';
 
 import { Selector, SelectorProps, SelectorSize } from '../Selector/Selector.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import {
   FieldLabelText,
   FieldLegend,
@@ -148,11 +151,11 @@ export const SelectorGroup = forwardRef<
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
-      !label
+      !isSufficientlyLabelled(label)
     ) {
       throw new AccessibilityError(
         'SelectorGroup',
-        'The `label` prop is required. Pass `hideLabel` if you intend to hide the label visually.',
+        'The `label` prop is missing or invalid. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
 

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
@@ -16,7 +16,10 @@
 import { useEffect } from 'react';
 
 import { useMedia } from '../../hooks/useMedia/index.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { usePrevious } from '../../hooks/usePrevious/index.js';
 
 import { DesktopNavigation } from './components/DesktopNavigation/index.js';
@@ -47,22 +50,22 @@ export function SideNavigation({
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'
   ) {
-    if (!closeButtonLabel) {
+    if (!isSufficientlyLabelled(closeButtonLabel)) {
       throw new AccessibilityError(
         'SideNavigation',
-        'The `closeButtonLabel` prop is missing.',
+        'The `closeButtonLabel` prop is missing or invalid.',
       );
     }
-    if (!primaryNavigationLabel) {
+    if (!isSufficientlyLabelled(primaryNavigationLabel)) {
       throw new AccessibilityError(
         'SideNavigation',
-        'The `primaryNavigationLabel` prop is missing.',
+        'The `primaryNavigationLabel` prop is missing or invalid.',
       );
     }
-    if (!secondaryNavigationLabel) {
+    if (!isSufficientlyLabelled(secondaryNavigationLabel)) {
       throw new AccessibilityError(
         'SideNavigation',
-        'The `secondaryNavigationLabel` prop is missing.',
+        'The `secondaryNavigationLabel` prop is missing or invalid.',
       );
     }
   }

--- a/packages/circuit-ui/components/SidePanel/SidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.tsx
@@ -17,7 +17,10 @@ import { UIEventHandler, useEffect, useId, useState } from 'react';
 import type { Props as ReactModalProps } from 'react-modal';
 
 import { isFunction } from '../../util/type-check.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 
 import { MobileSidePanel } from './components/MobileSidePanel/index.js';
 import { DesktopSidePanel } from './components/DesktopSidePanel/index.js';
@@ -73,16 +76,16 @@ export const SidePanel = ({
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'
   ) {
-    if (!closeButtonLabel) {
+    if (!isSufficientlyLabelled(closeButtonLabel)) {
       throw new AccessibilityError(
         'SidePanel',
-        'The `closeButtonLabel` prop is missing.',
+        'The `closeButtonLabel` prop is missing or invalid.',
       );
     }
-    if (onBack && !backButtonLabel) {
+    if (onBack && !isSufficientlyLabelled(backButtonLabel)) {
       throw new AccessibilityError(
         'SidePanel',
-        'The `backButtonLabel` prop is missing.',
+        'The `backButtonLabel` prop is missing or invalid.',
       );
     }
   }

--- a/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
+++ b/packages/circuit-ui/components/Sidebar/components/Aggregator/Aggregator.tsx
@@ -24,7 +24,10 @@ import styled, { StyleProps } from '../../../../styles/styled.js';
 import { Child, hasSelectedChild, getIcon } from '../../SidebarService.js';
 import { SubNavList } from '../SubNavList/index.js';
 import { NavLabel } from '../NavLabel/index.js';
-import { AccessibilityError } from '../../../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../../../util/errors.js';
 
 export interface AggregatorProps {
   /**
@@ -119,9 +122,12 @@ export function Aggregator({
   if (
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
-    !label
+    !isSufficientlyLabelled(label)
   ) {
-    throw new AccessibilityError('Aggregator', 'The `label` prop is missing.');
+    throw new AccessibilityError(
+      'Aggregator',
+      'The `label` prop is missing or invalid.',
+    );
   }
   const [isOpen, setIsOpen] = useState(false);
   const selectedChild = hasSelectedChild(children);

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -18,7 +18,10 @@ import type { ThHTMLAttributes } from 'react';
 import SortArrow from '../SortArrow/index.js';
 import { CellAlignment, SortParams } from '../../types.js';
 import { ClickEvent } from '../../../../types/events.js';
-import { AccessibilityError } from '../../../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../../../util/errors.js';
 import { clsx } from '../../../../styles/clsx.js';
 
 import classes from './TableHeader.module.css';
@@ -75,11 +78,11 @@ export function TableHeader({
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
     sortParams.sortable &&
-    !sortParams.sortLabel
+    !isSufficientlyLabelled(sortParams.sortLabel)
   ) {
     throw new AccessibilityError(
       'Table',
-      'The `sortLabel` prop is missing. Omit the `sortable` prop if you intend to disable the row sorting functionality.',
+      'The `sortLabel` prop is missing or invalid. Omit the `sortable` prop if you intend to disable the row sorting functionality.',
     );
   }
   return (

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -17,7 +17,10 @@ import { forwardRef, HTMLAttributes, ButtonHTMLAttributes } from 'react';
 import type { IconComponentType } from '@sumup/icons';
 
 import type { ClickEvent } from '../../types/events.js';
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
 import utilityClasses from '../../styles/utility.js';
 import CloseButton from '../CloseButton/index.js';
@@ -86,11 +89,11 @@ export const Tag = forwardRef<HTMLDivElement & HTMLButtonElement, TagProps>(
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
       onRemove &&
-      !removeButtonLabel
+      !isSufficientlyLabelled(removeButtonLabel)
     ) {
       throw new AccessibilityError(
         'Tag',
-        'The `removeButtonLabel` prop is missing. Omit the `onRemove` prop if you intend to disable the tag removing functionality.',
+        'The `removeButtonLabel` prop is missing or invalid. Omit the `onRemove` prop if you intend to disable the tag removing functionality.',
       );
     }
     const Element = onClick ? 'button' : 'div';

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -15,7 +15,10 @@
 
 import { ButtonHTMLAttributes, forwardRef, useId } from 'react';
 
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { FieldDescription, FieldWrapper } from '../Field/index.js';
 import { clsx } from '../../styles/clsx.js';
 import utilityClasses from '../../styles/utility.js';
@@ -68,20 +71,23 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      if (!label) {
-        throw new AccessibilityError('Toggle', 'The `label` prop is missing.');
-      }
-
-      if (!checkedLabel) {
+      if (!isSufficientlyLabelled(label)) {
         throw new AccessibilityError(
           'Toggle',
-          'The `checkedLabel` prop is missing.',
+          'The `label` prop is missing or invalid.',
         );
       }
-      if (!uncheckedLabel) {
+
+      if (!isSufficientlyLabelled(checkedLabel)) {
         throw new AccessibilityError(
           'Toggle',
-          'The `checkedLabel` prop is missing.',
+          'The `checkedLabel` prop is missing or invalid.',
+        );
+      }
+      if (!isSufficientlyLabelled(uncheckedLabel)) {
+        throw new AccessibilityError(
+          'Toggle',
+          'The `checkedLabel` prop is missing or invalid.',
         );
       }
     }

--- a/packages/circuit-ui/util/errors.spec.tsx
+++ b/packages/circuit-ui/util/errors.spec.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2022, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import { isSufficientlyLabelled } from './errors.js';
+
+describe('errors', () => {
+  describe('isSufficientlyLabelled', () => {
+    describe('should return false', () => {
+      test('when the label and labelId are missing', () => {
+        const label = undefined;
+        const labelId = undefined;
+        expect(isSufficientlyLabelled(label, labelId)).toBe(false);
+      });
+
+      test('when the label is an empty string', () => {
+        const label = ' ';
+        const labelId = undefined;
+        expect(isSufficientlyLabelled(label, labelId)).toBe(false);
+      });
+
+      test('when the labelId is an empty string', () => {
+        const label = undefined;
+        const labelId = ' ';
+        expect(isSufficientlyLabelled(label, labelId)).toBe(false);
+      });
+    });
+
+    describe('should return true', () => {
+      test('when the label is a valid string', () => {
+        const label = 'Email address';
+        const labelId = undefined;
+        expect(isSufficientlyLabelled(label, labelId)).toBe(true);
+      });
+
+      // Labels shouldn't contain structured markup since it is ignored
+      // by screen readers. We allow this only as an escape hatch to use
+      // at your own risk.
+      test('when the label is defined but not a string', () => {
+        const label = <div>Label</div>;
+        const labelId = undefined;
+        // @ts-expect-error We're testing for this error.
+        expect(isSufficientlyLabelled(label, labelId)).toBe(true);
+      });
+
+      test('when the label is undefined but the labelId is a valid string', () => {
+        const label = undefined;
+        const labelId = ':r1:';
+        expect(isSufficientlyLabelled(label, labelId)).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/circuit-ui/util/errors.ts
+++ b/packages/circuit-ui/util/errors.ts
@@ -16,6 +16,8 @@
 /* eslint-disable max-classes-per-file */
 import React from 'react';
 
+import { isString } from './type-check.js';
+
 export class CircuitError extends Error {
   constructor(componentName: string, message: string) {
     super(`[${componentName}] ${message}`);
@@ -67,4 +69,23 @@ export class AccessibilityError extends CircuitError {
     super(componentName, message);
     this.name = 'AccessibilityError';
   }
+}
+
+/**
+ * Validates that either a valid label or label id (`aria-labelledby`) exists.
+ *
+ * Labels shouldn't contain structured markup since it is ignored by screen
+ * readers. We allow this only as an escape hatch to use at your own risk.
+ */
+export function isSufficientlyLabelled(
+  label?: string,
+  labelId?: string,
+): boolean {
+  if (label) {
+    return isString(label) ? Boolean(label.trim()) : true;
+  }
+  if (labelId) {
+    return isString(labelId) ? Boolean(labelId.trim()) : true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Purpose

Labels are required for form fields and other controls so those who use assistive technologies can tell what the control is for. Labels should concisely describe the control's purpose and need to be localized. Circuit UI throws helpful errors during local development when a label is missing. 

Some developers are trying to hack around this by passing a single space as the label. Please don't do this! You'd break the application for your users.

## Approach and changes

- Make the label validation more robust

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
