### PR TITLE
Add optional label to Checkbox

### DIFF
--- a/.changeset/nervous-flowers-joke.md
+++ b/.changeset/nervous-flowers-joke.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added support for an optional label to the Checkbox component.

--- a/packages/circuit-ui/components/Checkbox/Checkbox.module.css
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.module.css
@@ -126,3 +126,7 @@
   background-color: var(--cui-bg-accent-strong-disabled);
   border-color: var(--cui-border-accent-disabled);
 }
+
+.optional {
+  color: var(--cui-fg-subtle);
+}

--- a/packages/circuit-ui/components/Checkbox/Checkbox.module.css
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.module.css
@@ -1,14 +1,14 @@
 .label {
   position: relative;
   display: inline-block;
-  padding-left: 26px;
+  min-height: 18px;
   color: var(--cui-fg-normal);
   cursor: pointer;
 }
 
 .base + .label::before {
   position: absolute;
-  top: var(--cui-spacings-kilo);
+  top: calc(var(--cui-typography-body-one-line-height) / 2);
   left: 0;
   box-sizing: border-box;
   display: block;
@@ -18,7 +18,7 @@
   background-color: var(--cui-bg-normal);
   border: 1px solid var(--cui-border-normal);
   border-radius: 3px;
-  box-shadow: 0;
+  box-shadow: none;
   transition: border var(--cui-transitions-default),
     background-color var(--cui-transitions-default);
   transform: translateY(-50%);
@@ -125,6 +125,10 @@
 .base[disabled]:checked + .label::before {
   background-color: var(--cui-bg-accent-strong-disabled);
   border-color: var(--cui-border-accent-disabled);
+}
+
+.label-text {
+  padding-left: 26px;
 }
 
 .optional {

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -49,6 +49,10 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
    * An information or error message, displayed below the checkbox.
    */
   validationHint?: string;
+  /**
+   * Label to indicate that the checkbox is optional.
+   */
+  optionalLabel?: string;
   children?: never;
 }
 
@@ -64,6 +68,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       name,
       disabled,
       validationHint,
+      optionalLabel,
       className,
       style,
       invalid,
@@ -118,6 +123,9 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
         />
         <label htmlFor={id} className={classes.label}>
           {label || children}
+          {optionalLabel ? (
+            <span className={classes.optional}>{` (${optionalLabel})`}</span>
+          ) : null}
           <Checkmark aria-hidden="true" data-symbol="checked" />
           <IndeterminateIcon aria-hidden="true" data-symbol="indeterminate" />
         </label>

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -122,10 +122,12 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           )}
         />
         <label htmlFor={id} className={classes.label}>
-          {label || children}
-          {optionalLabel ? (
-            <span className={classes.optional}>{` (${optionalLabel})`}</span>
-          ) : null}
+          <span className={classes['label-text']}>
+            {label || children}
+            {optionalLabel ? (
+              <span className={classes.optional}>{` (${optionalLabel})`}</span>
+            ) : null}
+          </span>
           <Checkmark aria-hidden="true" data-symbol="checked" />
           <IndeterminateIcon aria-hidden="true" data-symbol="indeterminate" />
         </label>

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
@@ -33,12 +33,11 @@ import { isEmpty } from '../../util/helpers.js';
 
 import classes from './CheckboxGroup.module.css';
 
-// TODO: Remove the label and value overrides in the next major.
+// TODO: Remove the value override in the next major.
 type Options = Omit<
   CheckboxProps,
-  'onChange' | 'validationHint' | 'name' | 'value'
+  'onChange' | 'validationHint' | 'name' | 'value' | 'optionalLabel'
 > & {
-  label: string;
   value: string | number;
 };
 


### PR DESCRIPTION
## Purpose

Most form inputs support an `optionalLabel` prop to mark the input as optional when it isn't required. The Checkbox component was missing this prop so far.

## Approach and changes

- Added support for an optional label to the Checkbox component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
