### PR TITLE
Restore support for styling a TableHeader

### DIFF
--- a/.changeset/unlucky-pumas-arrive.md
+++ b/.changeset/unlucky-pumas-arrive.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed forwarding a custom `className` to the TableHeader component.

--- a/packages/circuit-ui/components/Table/components/TableCell/TableCell.tsx
+++ b/packages/circuit-ui/components/Table/components/TableCell/TableCell.tsx
@@ -16,6 +16,7 @@
 import { TdHTMLAttributes, forwardRef } from 'react';
 
 import { clsx } from '../../../../styles/clsx.js';
+import type { CellAlignment } from '../../types.js';
 
 import classes from './TableCell.module.css';
 
@@ -25,7 +26,7 @@ export interface TableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
   /**
    * Aligns the content of the Cell with text-align.
    */
-  align?: 'left' | 'right' | 'center';
+  align?: CellAlignment;
   /**
    * Adds heading styles to placeholder Cell.
    */

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.spec.tsx
@@ -22,6 +22,24 @@ import TableHeader from './index.js';
 const children = 'Foo';
 
 describe('TableHeader', () => {
+  it('should merge a custom class name with the default ones', () => {
+    const className = 'foo';
+    const { container } = render(
+      <TableHeader
+        sortParams={{
+          sortable: true,
+          sortLabel: 'Sort in ascending order',
+          isSorted: false,
+        }}
+        className={className}
+      >
+        {children}
+      </TableHeader>,
+    );
+    const tableHeader = container.querySelector('th');
+    expect(tableHeader?.className).toContain(className);
+  });
+
   it('should have no accessibility violations', async () => {
     const { container } = render(
       <TableHeader

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -68,6 +68,7 @@ export function TableHeader({
   fixed = false,
   isHovered = false,
   sortParams = { sortable: false },
+  className,
   onClick,
   ...props
 }: TableHeaderProps) {
@@ -90,6 +91,7 @@ export function TableHeader({
         isHovered && classes.hover,
         fixed && classes.fixed,
         condensed && classes.condensed,
+        className,
       )}
       scope={scope}
       aria-label={sortParams.sortLabel}

--- a/packages/circuit-ui/components/Table/types.ts
+++ b/packages/circuit-ui/components/Table/types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ThHTMLAttributes } from 'react';
+import { ReactNode } from 'react';
 
 export type SortByValue = boolean | number | string | Date;
 
@@ -45,8 +45,10 @@ type SortableRowCell = {
   sortByValue?: SortByValue;
 };
 
-type CellObject = ThHTMLAttributes<HTMLTableCellElement> & {
+type CellObject = {
+  'children': ReactNode;
   'align'?: CellAlignment;
+  'className'?: string;
   'data-testid'?: string;
 };
 

--- a/packages/circuit-ui/components/Table/types.ts
+++ b/packages/circuit-ui/components/Table/types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react';
+import { ThHTMLAttributes } from 'react';
 
 export type SortByValue = boolean | number | string | Date;
 
@@ -45,8 +45,7 @@ type SortableRowCell = {
   sortByValue?: SortByValue;
 };
 
-type CellObject = {
-  'children': ReactNode;
+type CellObject = ThHTMLAttributes<HTMLTableCellElement> & {
   'align'?: CellAlignment;
   'data-testid'?: string;
 };


### PR DESCRIPTION
## Purpose

The TableHeader component used to (unofficially) support a custom class name. It wasn't part of the TypeScript interface but was forwarded to the underlying HTML element regardless. I found some cases where this was used in the wild, so I decided to restore the feature and make it official.

## Approach and changes

- Forward a custom `className` to the TableHeader component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
