### PR TITLE
Truncate input placeholders

### DIFF
--- a/.changeset/few-waves-bow.md
+++ b/.changeset/few-waves-bow.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Truncated placeholders using an ellipsis when they overflow the input.

--- a/packages/circuit-ui/components/Input/Input.module.css
+++ b/packages/circuit-ui/components/Input/Input.module.css
@@ -35,6 +35,10 @@
   transition: color var(--cui-transitions-default);
 }
 
+.base:placeholder-shown {
+  text-overflow: ellipsis;
+}
+
 .base:disabled,
 .base[disabled] {
   background-color: var(--cui-bg-normal-disabled);
@@ -47,23 +51,23 @@
 
 /* Validations */
 
-.base[aria-invalid="true"] {
+.base[aria-invalid='true'] {
   box-shadow: 0 0 0 1px var(--cui-border-danger);
 }
 
-.base[aria-invalid="true"]:hover {
+.base[aria-invalid='true']:hover {
   box-shadow: 0 0 0 1px var(--cui-border-danger-hovered);
 }
 
-.base[aria-invalid="true"]:focus {
+.base[aria-invalid='true']:focus {
   box-shadow: 0 0 0 2px var(--cui-border-danger);
 }
 
-.base[aria-invalid="true"]:active {
+.base[aria-invalid='true']:active {
   box-shadow: 0 0 0 1px var(--cui-border-danger-pressed);
 }
 
-.base[aria-invalid="true"]:not(:focus):not([disabled])::placeholder {
+.base[aria-invalid='true']:not(:focus):not([disabled])::placeholder {
   color: var(--cui-fg-danger);
 }
 


### PR DESCRIPTION
Based on @a5e's [Slack message](https://sumup.slack.com/archives/CURHLN94K/p1692709300344159).

## Purpose

Placeholders should be short and designed to be at most the length of the value we expect the user to enter. In the rare case that this isn't possible, the placeholder should be truncated using an ellipsis to indicate the overflow.

<img width="314" alt="Screenshot 2023-08-28 at 17 27 02" src="https://github.com/sumup-oss/circuit-ui/assets/11017722/42ca784f-d9ce-4215-ad44-ad10baa53d3f">

## Approach and changes

- Truncate input placeholders using an ellipsis

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
