### PR TITLE
Add version switcher

### DIFF
--- a/.storybook/addons/versions/index.tsx
+++ b/.storybook/addons/versions/index.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import {
+  Icons,
+  IconButton,
+  WithTooltip,
+  TooltipLinkList,
+} from '@storybook/components';
+import { useParameter } from '@storybook/manager-api';
+
+type Version = {
+  name:
+    | `v${number}`
+    | `v${number}.${number}`
+    | `v${number}.${number}.${number}`;
+  url: string;
+};
+
+type VersionsParameter = { current?: string; previous: Version[] };
+
+export const PARAM_KEY = 'versions';
+const DEFAULT_CONFIG: VersionsParameter = { previous: [] };
+
+export function Versions() {
+  const config = useParameter<VersionsParameter>(PARAM_KEY, DEFAULT_CONFIG);
+
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+
+  return (
+    <WithTooltip
+      placement="top"
+      closeOnOutsideClick
+      tooltip={() => (
+        <TooltipLinkList
+          links={config.previous.map((version) => ({
+            id: version.name,
+            title: version.name,
+            onClick: () => {
+              window.open(version.url, '_blank');
+              setIsTooltipVisible(false);
+            },
+            value: version.name,
+          }))}
+        />
+      )}
+      onVisibleChange={setIsTooltipVisible}
+    >
+      <IconButton
+        key="versions"
+        title="Switch to previous versions of the documentation"
+        active={isTooltipVisible}
+      >
+        {config.current} <Icons icon="arrowdown" />
+      </IconButton>
+    </WithTooltip>
+  );
+}

--- a/.storybook/manager.tsx
+++ b/.storybook/manager.tsx
@@ -1,6 +1,7 @@
-import { addons } from '@storybook/addons';
+import { addons, types } from '@storybook/addons';
 
 import { getTheme } from './themes';
+import { PARAM_KEY as VERSIONS_PARAM_KEY, Versions } from './addons/versions';
 
 addons.setConfig({
   isFullscreen: false,
@@ -23,5 +24,17 @@ addons.register('auto-theme-switcher', (api) => {
     const updatedTheme = getTheme(event.matches);
 
     api.setOptions({ theme: updatedTheme });
+  });
+});
+
+/**
+ * Switch to older version of the documentation
+ */
+addons.register('version-switcher', () => {
+  addons.add(VERSIONS_PARAM_KEY, {
+    type: types.TOOL,
+    title: 'Versions',
+    match: ({ viewMode }) => !!(viewMode && viewMode?.match(/^(story|docs)$/)),
+    render: Versions,
   });
 });

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,6 +8,13 @@ import { DocsContainer } from './components';
 
 export const parameters = {
   layout: 'centered',
+  versions: {
+    current: 'v7',
+    previous: [
+      { name: 'v6', url: 'https://circuit-v6.sumup-vercel.app' },
+      { name: 'v5', url: 'https://circuit-v5.sumup-vercel.app' },
+    ],
+  },
   previewTabs: { 'storybook/docs/panel': { index: -1 } },
   actions: { argTypesRegex: '^on.*' },
   controls: { expanded: true },
@@ -35,12 +42,12 @@ export const globalTypes = {
           icon: 'paintbrush',
         },
         {
-          title: 'Light',
+          title: 'Light (WIP)',
           value: 'light',
           icon: 'circle',
         },
         {
-          title: 'Dark',
+          title: 'Dark (WIP)',
           value: 'dark',
           icon: 'circlehollow',
         },


### PR DESCRIPTION
## Purpose

Some apps take longer to upgrade to the latest version. Teams should be able to find documentation for legacy versions until they're ready to upgrade.

## Approach and changes

- Deploy legacy major versions ([v5](https://circuit-v5.sumup-vercel.app) and [v6](https://circuit-v6.sumup-vercel.app)) to dedicated domains
- Add a theme switcher to the Storybook toolbar

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
