### PR TITLE
Add icons to SelectorGroup options

### DIFF
--- a/.changeset/rotten-starfishes-remain.md
+++ b/.changeset/rotten-starfishes-remain.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added support for icons to illustrate SelectorGroup options.

--- a/packages/circuit-ui/components/Selector/Selector.module.css
+++ b/packages/circuit-ui/components/Selector/Selector.module.css
@@ -117,3 +117,7 @@
 .title {
   font-weight: var(--cui-font-weight-bold);
 }
+
+.icon {
+  margin-bottom: var(--cui-spacings-bit);
+}

--- a/packages/circuit-ui/components/Selector/Selector.module.css
+++ b/packages/circuit-ui/components/Selector/Selector.module.css
@@ -28,7 +28,7 @@
 
 .base:disabled + .label::before,
 .base[disabled] + .label::before {
-  border: var(--cui-border-width-mega) solid var(--cui-border-normal-disabled);
+  border: var(--cui-border-width-kilo) solid var(--cui-border-normal-disabled);
 }
 
 .base:disabled:checked + .label,

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -21,6 +21,7 @@ import {
   useContext,
   useId,
 } from 'react';
+import type { IconComponentType } from '@sumup/icons';
 
 import {
   AccessibilityError,
@@ -45,6 +46,10 @@ export interface SelectorProps
    * A more detailed description of the input's purpose.
    */
   description?: string;
+  /**
+   * Display an icon in addition to the text to help to identify the option.
+   */
+  icon?: IconComponentType;
   /**
    * Value string for input.
    */
@@ -90,6 +95,7 @@ export const Selector = forwardRef<HTMLInputElement, SelectorProps>(
     {
       label,
       description,
+      'icon': Icon,
       value,
       'id': customId,
       name,
@@ -165,6 +171,7 @@ export const Selector = forwardRef<HTMLInputElement, SelectorProps>(
             hasDescription && classes['has-description'],
           )}
         >
+          {Icon && <Icon className={classes.icon} aria-hidden="true" />}
           {hasDescription ? (
             <Fragment>
               <span className={classes.title}>{label || children}</span>

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.mdx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.mdx
@@ -42,6 +42,12 @@ Use the `description` prop to add relevant context to each option.
 
 <Story of={Stories.WithDescriptions} />
 
+### Icons
+
+Use the `icon` prop to illustrate the option visually.
+
+<Story of={Stories.WithIcons} />
+
 ## Validations
 
 Use the `validationHint` to communicate the expected response to users. Use the `invalid` prop to require a change.

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
@@ -15,6 +15,7 @@
 
 import { ChangeEvent, FocusEvent, useState } from 'react';
 import { action } from '@storybook/addon-actions';
+import { CardReaderAir, CardReaderSolo, MobilePhone } from '@sumup/icons';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 import { Selector, SelectorProps } from '../Selector/Selector.js';
@@ -121,6 +122,35 @@ WithDescriptions.args = {
       label: 'Mango',
       description: 'Alphonso, Dasheri, or Haden',
       value: 'mango',
+    },
+  ],
+};
+
+export const WithIcons = (args: SelectorGroupProps) => (
+  <SelectorGroup {...args} />
+);
+
+WithIcons.args = {
+  name: 'icons',
+  label: 'Choose a device',
+  options: [
+    {
+      icon: CardReaderSolo,
+      label: 'SumUp Solo',
+      value: 'solo',
+      description: 'Accepts payments as a standalone device',
+    },
+    {
+      icon: CardReaderAir,
+      label: 'SumUp Air',
+      value: 'air',
+      description: 'Requires the free SumUp app to accept payments',
+    },
+    {
+      icon: MobilePhone,
+      label: 'Phone',
+      value: 'phone',
+      description: 'Accept payments using the free SumUp app',
     },
   ],
 };


### PR DESCRIPTION
## Purpose

Sometimes, it can be helpful to visualize the options inside a SelectorGroup:

<img width="549" alt="Screenshot 2023-09-05 at 11 26 06" src="https://github.com/sumup-oss/circuit-ui/assets/11017722/ef3617a7-32f3-4191-9d6f-d045a429136e">

## Approach and changes

- Added the `icon` prop to the SelectorGroups options

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
