### PR TITLE
Widen SelectorGroup's icon prop type

### DIFF
--- a/.changeset/slimy-weeks-rescue.md
+++ b/.changeset/slimy-weeks-rescue.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Widened the type for the SelectorGroup's new `icon` prop.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20.5]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -14,6 +14,7 @@
  */
 
 import {
+  ComponentType,
   Fragment,
   InputHTMLAttributes,
   createContext,
@@ -21,7 +22,6 @@ import {
   useContext,
   useId,
 } from 'react';
-import type { IconComponentType } from '@sumup/icons';
 
 import {
   AccessibilityError,
@@ -49,7 +49,7 @@ export interface SelectorProps
   /**
    * Display an icon in addition to the text to help to identify the option.
    */
-  icon?: IconComponentType;
+  icon?: ComponentType<{ 'className': string; 'aria-hidden': 'true' }>;
   /**
    * Value string for input.
    */


### PR DESCRIPTION
Improves #2238.

## Purpose

#2238 added support for icons inside SelectorGroup options. Currently, the prop type only allows icons from `@sumup/icons`, but small images or illustrations should be supported as well. 

## Approach and changes

- Widen the prop type for the SelectorGroup's icon prop

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
