### PR TITLE
Add missing prop type to CurrencyInput

### DIFF
--- a/.changeset/rare-taxis-exist.md
+++ b/.changeset/rare-taxis-exist.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Added a missing type for the `onValueChange` prop of the CurrencyInput.

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -15,7 +15,7 @@
 
 import { forwardRef, useId } from 'react';
 import { resolveCurrencyFormat } from '@sumup/intl';
-import { NumericFormat } from 'react-number-format';
+import { NumericFormat, NumericFormatProps } from 'react-number-format';
 
 import { clsx } from '../../styles/clsx.js';
 import Input, { InputElement, InputProps } from '../Input/index.js';
@@ -25,9 +25,10 @@ import classes from './CurrencyInput.module.css';
 
 export interface CurrencyInputProps
   extends Omit<
-    InputProps,
-    'placeholder' | 'ref' | 'value' | 'defaultValue' | 'type'
-  > {
+      InputProps,
+      'placeholder' | 'ref' | 'value' | 'defaultValue' | 'type'
+    >,
+    Pick<NumericFormatProps, 'onValueChange'> {
   /**
    * A ISO 4217 currency code, such as 'USD' for the US dollar,
    * 'EUR' for the Euro, or 'CNY' for the Chinese RMB.


### PR DESCRIPTION
## Purpose

The CurrencyInput uses `react-number-format` under the hood and forwards all remaining props to it. While we don't want to expose _all_ props of the third-party library since that would expose too many implementation details, the `onValueChange` prop is useful and should be officially supported.

## Approach and changes

- Added a missing type for the `onValueChange` prop of the CurrencyInput

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
