### PR TITLE
Silence headline element errors in test environments

### DIFF
--- a/.changeset/poor-buses-grab.md
+++ b/.changeset/poor-buses-grab.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Silenced the error for a missing `as` prop in the Title, Headline, and SubHeadline components in test environments.

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -38,7 +38,11 @@ export interface HeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
  */
 export const Headline = forwardRef<HTMLHeadingElement, HeadlineProps>(
   ({ className, as, size = 'one', ...props }, ref) => {
-    if (process.env.NODE_ENV !== 'production' && !as) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !as
+    ) {
       throw new CircuitError('Headline', 'The `as` prop is required.');
     }
 

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -41,6 +41,7 @@ export const Headline = forwardRef<HTMLHeadingElement, HeadlineProps>(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
+      !process.env.UNSAFE_DISABLE_ELEMENT_ERRORS &&
       !as
     ) {
       throw new CircuitError('Headline', 'The `as` prop is required.');

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -35,7 +35,11 @@ export interface SubHeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
  */
 export const SubHeadline = forwardRef<HTMLHeadingElement, SubHeadlineProps>(
   ({ className, as, ...props }, ref) => {
-    if (process.env.NODE_ENV !== 'production' && !as) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !as
+    ) {
       throw new CircuitError('SubHeadline', 'The `as` prop is required.');
     }
 

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -38,6 +38,7 @@ export const SubHeadline = forwardRef<HTMLHeadingElement, SubHeadlineProps>(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
+      !process.env.UNSAFE_DISABLE_ELEMENT_ERRORS &&
       !as
     ) {
       throw new CircuitError('SubHeadline', 'The `as` prop is required.');

--- a/packages/circuit-ui/components/Title/Title.tsx
+++ b/packages/circuit-ui/components/Title/Title.tsx
@@ -38,7 +38,11 @@ export interface TitleProps extends HTMLAttributes<HTMLHeadingElement> {
  */
 export const Title = forwardRef<HTMLHeadingElement, TitleProps>(
   ({ className, as, size = 'one', ...props }, ref) => {
-    if (process.env.NODE_ENV !== 'production' && !as) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !as
+    ) {
       throw new CircuitError('Title', 'The `as` prop is required.');
     }
 

--- a/packages/circuit-ui/components/Title/Title.tsx
+++ b/packages/circuit-ui/components/Title/Title.tsx
@@ -41,6 +41,7 @@ export const Title = forwardRef<HTMLHeadingElement, TitleProps>(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
+      !process.env.UNSAFE_DISABLE_ELEMENT_ERRORS &&
       !as
     ) {
       throw new CircuitError('Title', 'The `as` prop is required.');


### PR DESCRIPTION
## Purpose

The migration of a very large codebase is blocked because many JS files are missing the `as` prop on the Title, Headline and SubHeadline components, which breaks the unit tests. 

## Approach and changes

- Silence the missing `as` prop error in test environments

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
