### PR TITLE
Hide Button's loading label

### DIFF
--- a/.changeset/six-buttons-dream.md
+++ b/.changeset/six-buttons-dream.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Hid the Button's loading label in JSDOM environments.

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -151,7 +151,11 @@ export const Button = forwardRef<any, ButtonProps>(
         )}
         ref={ref}
       >
-        <Spinner className={classes.spinner} size="byte">
+        <Spinner
+          className={classes.spinner}
+          size="byte"
+          aria-hidden={!isLoading}
+        >
           <span className={utilityClasses.hideVisually}>{loadingLabel}</span>
         </Spinner>
         <span className={classes.content}>

--- a/packages/circuit-ui/components/Sidebar/__snapshots__/Sidebar.spec.tsx.snap
+++ b/packages/circuit-ui/components/Sidebar/__snapshots__/Sidebar.spec.tsx.snap
@@ -101,6 +101,7 @@ exports[`Sidebar > should render and match snapshot when open 1`] = `
     type="button"
   >
     <span
+      aria-hidden="true"
       class="_base_2b3edd _byte_2b3edd _spinner_892426"
     >
       <span
@@ -219,6 +220,7 @@ exports[`Sidebar > should render and match the snapshot when closed 1`] = `
     type="button"
   >
     <span
+      aria-hidden="true"
       class="_base_2b3edd _byte_2b3edd _spinner_892426"
     >
       <span

--- a/packages/circuit-ui/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
@@ -24,6 +24,7 @@ exports[`CloseButton > styles > should render and match snapshot when not visibl
   type="button"
 >
   <span
+    aria-hidden="true"
     class="_base_2b3edd _byte_2b3edd _spinner_892426"
   >
     <span
@@ -83,6 +84,7 @@ exports[`CloseButton > styles > should render and match snapshot when visible 1`
   type="button"
 >
   <span
+    aria-hidden="true"
     class="_base_2b3edd _byte_2b3edd _spinner_892426"
   >
     <span


### PR DESCRIPTION
## Purpose

The Button's loading label is hidden from the accessibility tree using CSS (`visibility: hidden`). Switching to CSS Modules means that these styles are no longer serialized in a JSDOM environment, leading `@testing-library/react` to consider the element as visible.

## Approach and changes

- Hide the loading label using the `aria-hidden` HTML attribute when not loading

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
