### PR TITLE
Fix style specificity conflicts

### DIFF
--- a/.changeset/eight-ads-bake.md
+++ b/.changeset/eight-ads-bake.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Increased the specificity of nested component styles.

--- a/packages/circuit-ui/components/AspectRatio/AspectRatio.module.css
+++ b/packages/circuit-ui/components/AspectRatio/AspectRatio.module.css
@@ -7,7 +7,7 @@
   overflow: hidden;
 }
 
-.child {
+.base .child {
   position: absolute;
   top: 0;
   right: 0;

--- a/packages/circuit-ui/components/Button/Button.module.css
+++ b/packages/circuit-ui/components/Button/Button.module.css
@@ -193,7 +193,7 @@
   margin-right: var(--cui-spacings-byte);
 }
 
-.spinner {
+.base .spinner {
   position: absolute;
   visibility: hidden;
   opacity: 0;
@@ -201,7 +201,7 @@
     visibility var(--cui-transitions-default);
 }
 
-[aria-busy="true"] .spinner {
+.base[aria-busy="true"] .spinner {
   visibility: inherit;
   opacity: 1;
 }

--- a/packages/circuit-ui/components/CalendarTag/__snapshots__/CalendarTag.spec.tsx.snap
+++ b/packages/circuit-ui/components/CalendarTag/__snapshots__/CalendarTag.spec.tsx.snap
@@ -4,10 +4,10 @@ exports[`CalendarTag > should render with default styles 1`] = `
 <div>
   <div>
     <div
-      class="_container_5b7d65"
+      class="_base_5b7d65"
     >
       <button
-        class="_base_5b7d65 _focus-visible_73b4bb"
+        class="_content_5b7d65 _focus-visible_73b4bb"
         type="button"
       >
         Dates

--- a/packages/circuit-ui/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.tsx.snap
+++ b/packages/circuit-ui/components/CalendarTagTwoStep/__snapshots__/CalendarTagTwoStep.spec.tsx.snap
@@ -4,10 +4,10 @@ exports[`CalendarTagTwoStep > should render with default styles 1`] = `
 <div>
   <div>
     <div
-      class="_container_5b7d65"
+      class="_base_5b7d65"
     >
       <button
-        class="_base_5b7d65 _focus-visible_73b4bb"
+        class="_content_5b7d65 _focus-visible_73b4bb"
         type="button"
       >
         Dates

--- a/packages/circuit-ui/components/Header/Header.module.css
+++ b/packages/circuit-ui/components/Header/Header.module.css
@@ -15,7 +15,7 @@
   }
 }
 
-.title {
+.base .title {
   margin-left: var(--cui-spacings-mega);
   font-size: var(--cui-typography-headline-four-font-size);
   font-weight: var(--cui-font-weight-bold);

--- a/packages/circuit-ui/components/ImageInput/ImageInput.module.css
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.module.css
@@ -1,4 +1,4 @@
-.wrapper {
+.base {
   position: relative;
   display: inline-block;
   text-align: center;
@@ -7,7 +7,6 @@
 .input:focus + label > *:last-child {
   outline: 0;
   box-shadow: 0 0 0 4px var(--cui-border-focus);
-
 }
 
 .input:focus + label > *:last-child::-moz-focus-inner {
@@ -18,11 +17,11 @@
   box-shadow: none;
 }
 
-.label {
+.base .label {
   cursor: pointer;
 }
 
-.label::before {
+.base .label::before {
   position: absolute;
   top: 0;
   left: 0%;
@@ -36,16 +35,16 @@
   transition: opacity var(--cui-transitions-default);
 }
 
-.label > *:last-child {
+.base .label > *:last-child {
   transition: box-shadow var(--cui-transitions-default);
 }
 
 @supports (-webkit-filter: brightness(1)) or (filter: brightness(1)) {
-  .label{
+  .base .label {
     transition: filter var(--cui-transitions-default);
   }
 
-  .label::before {
+  .base .label::before {
     content: none;
   }
 }
@@ -72,7 +71,8 @@
 
 @supports (-webkit-filter: brightness(1)) or (filter: brightness(1)) {
   .label.loading {
-    filter: brightness(0.6);}
+    filter: brightness(0.6);
+  }
 }
 
 .label:not(.loading):hover::before {
@@ -109,8 +109,9 @@
 }
 
 @supports (-webkit-filter: brightness(1)) or (filter: brightness(1)) {
-  .label.dragging{
-    filter: brightness(0.9);}
+  .label.dragging {
+    filter: brightness(0.9);
+  }
 }
 
 [data-disabled="true"] .label {
@@ -122,22 +123,22 @@
   border-color: var(--cui-border-danger-hovered);
 }
 
-.label:active  > button {
+.label:active > button {
   background-color: var(--cui-bg-danger-pressed);
   border-color: var(--cui-border-danger-pressed);
 }
 
-.button {
+.base .button {
   position: absolute;
   right: calc(-1 * var(--cui-spacings-bit));
   bottom: calc(-1 * var(--cui-spacings-bit));
 }
 
-.button.add {
+.base .button.add {
   pointer-events: none;
 }
 
-.spinner {
+.base .spinner {
   position: absolute;
   top: calc(50% - 16px);
   left: calc(50% - 16px);
@@ -151,7 +152,7 @@
     visibility var(--cui-transitions-default);
 }
 
-.spinner.loading {
+.base .spinner.loading {
   visibility: inherit;
   opacity: 1;
 }

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -229,7 +229,7 @@ export const ImageInput = ({
 
   return (
     <FieldWrapper className={className} style={style} disabled={disabled}>
-      <div onPaste={handlePaste} className={classes.wrapper}>
+      <div onPaste={handlePaste} className={classes.base}>
         <input
           className={clsx(classes.input, utilityClasses.hideVisually)}
           ref={inputRef}

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.module.css
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.module.css
@@ -28,33 +28,35 @@
   padding-right: var(--cui-spacings-byte);
 }
 
-.headline {
+/* Child elements */
+
+.base .headline {
   margin-bottom: var(--cui-spacings-byte);
   font-size: var(--cui-typography-headline-four-font-size);
   line-height: var(--cui-typography-headline-four-line-height);
 }
 
 @media (min-width: 768px) {
-  .headline {
+  .base .headline {
     font-size: var(--cui-typography-headline-three-font-size);
     line-height: var(--cui-typography-headline-three-line-height);
   }
 }
 
-.body {
+.base .body {
   margin-bottom: var(--cui-spacings-byte);
   font-size: var(--cui-typography-body-two-font-size);
   line-height: var(--cui-typography-body-two-line-height);
 }
 
 @media (min-width: 768px) {
-  .body {
+  .base .body {
     font-size: var(--cui-typography-body-one-font-size);
     line-height: var(--cui-typography-body-one-line-height);
   }
 }
 
-.image {
+.base .image {
   width: var(--notification-image-width);
   min-width: 0;
   height: auto;
@@ -63,24 +65,24 @@
   object-position: var(--notification-image-align);
 }
 
-.button {
+.base .button {
   padding-top: calc(var(--cui-spacings-bit) - var(--cui-border-width-kilo));
   padding-bottom: calc(var(--cui-spacings-bit) - var(--cui-border-width-kilo));
 }
 
 @media (min-width: 768px) {
-  .kilo {
+  .base .button.kilo {
     padding-top: calc(var(--cui-spacings-bit) - var(--cui-border-width-kilo));
     padding-bottom: calc(var(--cui-spacings-bit) - var(--cui-border-width-kilo));
   }
 
-  .giga {
+  .base .button.giga {
     padding-top: calc(var(--cui-spacings-kilo) - var(--cui-border-width-kilo));
     padding-bottom: calc(var(--cui-spacings-kilo) - var(--cui-border-width-kilo));
   }
 }
 
-.close {
+.base .close {
   position: absolute;
   top: var(--cui-spacings-byte);
   right: var(--cui-spacings-byte);

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -100,12 +100,13 @@ export type NotificationBannerProps = BaseProps & CloseProps;
 function NotificationImage({
   align = 'center',
   width = 200,
+  className,
   ...props
 }: NotificationImageProps) {
   return (
     <Image
       {...props}
-      className={classes.image}
+      className={clsx(classes.image, className)}
       style={{
         '--notification-image-align': align,
         '--notification-image-width': `${width}px`,

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.module.css
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.module.css
@@ -5,27 +5,27 @@
   max-width: 420px;
 }
 
-.image {
+.base .image {
   max-width: 280px;
   height: 160px;
   object-fit: contain;
 }
 
-.image svg {
+.base .image svg {
   width: 100%;
   height: 100%;
 }
 
-.headline {
+.base .headline {
   margin-top: var(--cui-spacings-giga);
   margin-bottom: var(--cui-spacings-byte);
   text-align: center;
 }
 
-.body {
+.base .body {
   text-align: center;
 }
 
-.buttons {
+.base .buttons {
   margin-top: var(--cui-spacings-giga);
 }

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.module.css
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.module.css
@@ -64,24 +64,24 @@
   padding-left: var(--cui-spacings-mega);
 }
 
-.button {
+.base .button {
   margin-top: var(--cui-spacings-byte);
   font-weight: bold;
   color: var(--cui-fg-normal);
   text-decoration-line: underline;
 }
 
-.button:hover {
+.base .button:hover {
   color: var(--cui-fg-normal-hovered);
 }
 
-.button:active,
-.button[aria-expanded='true'],
-.button[aria-pressed='true'] {
+.base .button:active,
+.base .button[aria-expanded="true"],
+.base .button[aria-pressed="true"] {
   color: var(--cui-fg-normal-pressed);
 }
 
-.close {
+.base .close {
   flex-grow: 0;
   flex-shrink: 0;
   align-self: flex-start;

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.module.css
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.module.css
@@ -51,43 +51,43 @@
   }
 }
 
-.close {
+.base .close {
   position: absolute;
   top: var(--cui-spacings-byte);
   right: var(--cui-spacings-byte);
 }
 
 @media (min-width: 480px) {
-  .close {
+  .base .close {
     top: var(--cui-spacings-mega);
     right: var(--cui-spacings-mega);
   }
 }
 
-.image {
+.base .image {
   max-width: 232px;
   height: 120px;
   object-fit: contain;
   margin: 0 auto var(--cui-spacings-giga);
 }
 
-.image svg {
+.base .image svg {
   width: 100%;
   height: 100%;
 }
 
 /* Prevent the headline from being overlapped by the close button */
-.headline {
+.base .headline {
   max-width: 80%;
   margin-right: auto;
   margin-bottom: var(--cui-spacings-byte);
   margin-left: auto;
 }
 
-.image + .headline {
+.base .image + .headline {
   max-width: 100%;
 }
 
-.buttons {
+.base .buttons {
   margin-top: var(--cui-spacings-giga);
 }

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.module.css
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.module.css
@@ -65,7 +65,7 @@
   padding-left: var(--cui-spacings-mega);
 }
 
-.close {
+.base .close {
   flex-grow: 0;
   flex-shrink: 0;
   align-self: flex-start;

--- a/packages/circuit-ui/components/Pagination/Pagination.module.css
+++ b/packages/circuit-ui/components/Pagination/Pagination.module.css
@@ -6,12 +6,12 @@
   padding: var(--cui-spacings-kilo);
 }
 
-.prev {
+.base .prev {
   flex-shrink: 0;
   margin-right: var(--cui-spacings-kilo);
 }
 
-.next {
+.base .next {
   flex-shrink: 0;
   margin-left: var(--cui-spacings-kilo);
 }

--- a/packages/circuit-ui/components/Pagination/components/PageList/PageList.module.css
+++ b/packages/circuit-ui/components/Pagination/components/PageList/PageList.module.css
@@ -1,16 +1,15 @@
-
 .base {
   display: flex;
   justify-content: center;
   list-style: none;
 }
 
-.button {
+.base .button {
   min-width: 34px;
   padding: var(--cui-spacings-bit);
   margin-right: var(--cui-spacings-bit);
 }
 
-li:last-child .button {
+.base li:last-child .button {
   margin-right: 0;
 }

--- a/packages/circuit-ui/components/SearchInput/SearchInput.module.css
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.module.css
@@ -5,7 +5,7 @@
   appearance: none;
 }
 
-.clear-button {
+.base .clear-button {
   padding: var(--cui-spacings-mega);
   border: none;
   border-radius: var(--cui-border-radius-byte);

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.module.css
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.module.css
@@ -94,10 +94,6 @@
   box-shadow: 0 0 0 4px var(--cui-border-focus);
 }
 
-.base[aria-sort]:focus-within::after::-moz-focus-inner {
-  border: 0;
-}
-
 .base[aria-sort]:focus-within,
 .base[aria-sort]:hover {
   color: var(--cui-fg-accent-hovered);

--- a/packages/circuit-ui/components/Tag/Tag.module.css
+++ b/packages/circuit-ui/components/Tag/Tag.module.css
@@ -1,11 +1,11 @@
-.container {
+.base {
   --tag-border-width: var(--cui-border-width-kilo);
 
   position: relative;
   display: inline-block;
 }
 
-.base {
+.content {
   display: inline-flex;
   align-items: center;
   padding: calc(var(--cui-spacings-bit) - 1px) var(--cui-spacings-kilo);
@@ -23,11 +23,11 @@
     border-color var(--cui-transitions-default);
 }
 
-.removable {
+.removable .content {
   padding-right: calc(var(--cui-spacings-bit) + var(--cui-spacings-tera));
 }
 
-.selected {
+.selected .content {
   color: var(--cui-fg-on-strong);
   background-color: var(--cui-bg-accent-strong);
   border-color: var(--cui-border-accent);
@@ -35,31 +35,31 @@
 
 /* Interactive */
 
-button.base {
+button.content {
   text-align: left;
   cursor: pointer;
   outline: 0;
 }
 
-button.base:hover {
+button.content:hover {
   color: var(--cui-fg-normal-hovered);
   background-color: var(--cui-bg-normal-hovered);
   border-color: var(--cui-border-normal-hovered);
 }
 
-button.base:active {
+button.content:active {
   color: var(--cui-fg-normal-pressed);
   background-color: var(--cui-bg-normal-pressed);
   border-color: var(--cui-border-normal-pressed);
 }
 
-button.selected:hover {
+.selected button.content:hover {
   color: var(--cui-fg-on-strong-hovered);
   background-color: var(--cui-bg-accent-strong-hovered);
   border-color: var(--cui-border-accent-hovered);
 }
 
-button.selected:active {
+.selected button.content:active {
   color: var(--cui-fg-on-strong-pressed);
   background-color: var(--cui-bg-accent-strong-pressed);
   border-color: var(--cui-border-accent-pressed);
@@ -68,16 +68,16 @@ button.selected:active {
 .prefix {
   flex-shrink: 0;
   margin-right: var(--cui-spacings-bit);
-  margin-left: calc(-1 *var(--cui-spacings-bit));
+  margin-left: calc(-1 * var(--cui-spacings-bit));
 }
 
 .suffix {
   flex-shrink: 0;
-  margin-right: calc(-1 *var(--cui-spacings-bit));
+  margin-right: calc(-1 * var(--cui-spacings-bit));
   margin-left: var(--cui-spacings-bit);
 }
 
-.remove-button {
+.base .remove-button {
   position: absolute;
   top: 50%;
   right: var(--tag-border-width);

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -101,13 +101,19 @@ export const Tag = forwardRef<HTMLDivElement & HTMLButtonElement, TagProps>(
     const isRemovable = onRemove && removeButtonLabel;
 
     return (
-      <div className={clsx(classes.container, className)} style={style}>
+      <div
+        className={clsx(
+          classes.base,
+          isRemovable && classes.removable,
+          selected && classes.selected,
+          className,
+        )}
+        style={style}
+      >
         <Element
           className={clsx(
-            classes.base,
-            isRemovable && classes.removable,
+            classes.content,
             onClick && utilityClasses.focusVisible,
-            selected && classes.selected,
           )}
           type={onClick && 'button'}
           onClick={onClick}


### PR DESCRIPTION
## Purpose

Vite's CSS ordering appears broken (https://github.com/vitejs/vite/issues/11662, https://github.com/vitejs/vite/issues/4890, https://github.com/vitejs/vite/issues/7504). The order of the styles in the single CSS file that Vite outputs does not match the import order (or any other discernable order, for that matter). CSS order matters because between style rules with the same specificity, the last one wins. 

## Approach and changes

- Manually increase the specificity of some nested component styles. This likely doesn't fix all style specificity issues, and new issues could be introduced in the future. The proper way to fix this is to fix Vite.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
