### PR TITLE
Fix style SearchInput clear icon

### DIFF
--- a/.changeset/cuddly-cats-begin.md
+++ b/.changeset/cuddly-cats-begin.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fix style SearchInput clear icon

--- a/packages/circuit-ui/components/SearchInput/SearchInput.module.css
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.module.css
@@ -5,7 +5,7 @@
   appearance: none;
 }
 
-.base .clear-button {
+.base + .clear-button {
   padding: var(--cui-spacings-mega);
   border: none;
   border-radius: var(--cui-border-radius-byte);


### PR DESCRIPTION
## Purpose

The SearchInput clear icon styles were not applied, due to the icon being suffixed next to the input element.
![image](https://github.com/sumup-oss/circuit-ui/assets/61180525/b0915300-0bf3-422e-b0d9-adeda4f3c3ec)

## Approach and changes

Fixes the CSS rule for that icon

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
