### PR TITLE
Fixes Selector component size padding

### DIFF
--- a/.changeset/smooth-kiwis-drive.md
+++ b/.changeset/smooth-kiwis-drive.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixes Selector component size padding

--- a/packages/circuit-ui/components/Selector/Selector.module.css
+++ b/packages/circuit-ui/components/Selector/Selector.module.css
@@ -103,11 +103,11 @@
 /* Sizes */
 
 .kilo {
-  padding: var(--cui-spacings-bit) var(--cui-spacings-mega);
+  padding: var(--cui-spacings-byte) var(--cui-spacings-kilo);
 }
 
 .mega {
-  padding: var(--cui-spacings-kilo) var(--cui-spacings-giga);
+  padding: var(--cui-spacings-kilo) var(--cui-spacings-mega);
 }
 
 .flexible {

--- a/packages/circuit-ui/components/Selector/Selector.module.css
+++ b/packages/circuit-ui/components/Selector/Selector.module.css
@@ -56,6 +56,7 @@
   height: 100%;
   color: var(--cui-fg-normal);
   text-align: center;
+  white-space: nowrap;
   cursor: pointer;
   background-color: var(--cui-bg-normal);
   border-radius: var(--cui-border-radius-byte);
@@ -100,6 +101,7 @@
   text-align: start;
 }
 
+
 /* Sizes */
 
 .kilo {
@@ -116,6 +118,10 @@
 
 .title {
   font-weight: var(--cui-font-weight-bold);
+}
+
+.description {
+  white-space: initial;
 }
 
 .icon {

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -175,7 +175,9 @@ export const Selector = forwardRef<HTMLInputElement, SelectorProps>(
           {hasDescription ? (
             <Fragment>
               <span className={classes.title}>{label || children}</span>
-              <span aria-hidden="true">{description}</span>
+              <span className={classes.description} aria-hidden="true">
+                {description}
+              </span>
             </Fragment>
           ) : (
             label || children


### PR DESCRIPTION
## Purpose

The `Selector` component uses incorrect padding custom variables for `kilo` and `mega`. 
The `Selector` title does not wrap 

## Approach and changes

* Adjust the padding to the size that correlates with the passed size property.
* Adjust the title to wrap.


## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
