### PR TITLE
Publish packages with provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "bugs": {
     "url": "https://github.com/sumup-oss/circuit-ui/issues"
   },
+  "publishConfig": {
+    "provenance": true
+  },  
   "homepage": "https://github.com/sumup-oss/circuit-ui#readme",
   "scripts": {
     "start": "lerna run start --stream",


### PR DESCRIPTION
Publishes package with [provenance](https://docs.npmjs.com/generating-provenance-statements).

See: https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools
See: https://github.com/changesets/changesets/issues/1152
