### PR TITLE
Fix Checkbox component custom id

### DIFF
--- a/.changeset/neat-gifts-deliver.md
+++ b/.changeset/neat-gifts-deliver.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fix Checkbox custom id

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -127,7 +127,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             utilityClasses.hideVisually,
           )}
         />
-        <label htmlFor={id} className={classes.label}>
+        <label htmlFor={checkboxId} className={classes.label}>
           <span className={classes['label-text']}>
             {label || children}
             {optionalLabel ? (


### PR DESCRIPTION
## Purpose

Custom IDs passed to `Checkbox` component are not respected. This causes the component not to be clickable since the label would have a `for` that does not match the `id` passed to the input. 
 
## Approach and changes

Passes the correct ID to the label.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
