### PR TITLE
Increase css specificity for ListItem child

### DIFF
--- a/.changeset/smooth-pianos-worry.md
+++ b/.changeset/smooth-pianos-worry.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Increase css specificity for ListItem child

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.module.css
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.module.css
@@ -77,7 +77,7 @@
   border-top-width: 0;
 }
 
-.child {
+li .child {
   border: none;
   border-radius: calc(
     var(--cui-border-radius-mega) - var(--cui-border-width-mega)


### PR DESCRIPTION

## Purpose

The CSS rule for the item has a border, and the child's rule removes it. The CSS specificity for both the item and the child has the same weight. This causes double borders on both the Item and the child.

## Approach and changes

Increases the child CSS rule specificity by one.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
