### PR TITLE
Fixes missing className prop passed to the Popover component

### DIFF
--- a/.changeset/popular-bobcats-learn.md
+++ b/.changeset/popular-bobcats-learn.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixes missing className prop passed to the Popover component

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -116,6 +116,11 @@ type OnToggle = (open: boolean | ((prevOpen: boolean) => boolean)) => void;
 
 export interface PopoverProps {
   /**
+   * The class name to add to the Popover wrapper element.
+   * Defaults to ''.
+   */
+  className?: string;
+  /**
    * Determines whether the Popover is open or closed.
    */
   isOpen: boolean;
@@ -168,6 +173,7 @@ export const Popover = ({
   fallbackPlacements = ['top', 'right', 'left'],
   component: Component,
   offset,
+  className = '',
   ...props
 }: PopoverProps): JSX.Element | null => {
   const zIndex = useStackContext();
@@ -303,7 +309,7 @@ export const Popover = ({
         <div
           {...props}
           ref={refs.setFloating}
-          className={clsx(classes.wrapper, isOpen && classes.open)}
+          className={clsx(classes.wrapper, isOpen && classes.open, className)}
           // @ts-expect-error z-index can be a string
           style={
             isMobile


### PR DESCRIPTION
## Purpose

`className` passed for the Popover component is being overwritten by the className prop defined on the component.

## Approach and changes

Passes the passed `className` prop to class names.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
