### PR TITLE
Fixes Radio Button top position

### DIFF
--- a/.changeset/ten-pumas-wonder.md
+++ b/.changeset/ten-pumas-wonder.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixes Radio Button top position

--- a/packages/circuit-ui/components/RadioButton/RadioButton.module.css
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.module.css
@@ -8,7 +8,7 @@
 
 .label::before {
   position: absolute;
-  top: calc(var(--cui-typography-body-one-line-height) / 2);
+  top: 50%;
   left: 0;
   box-sizing: border-box;
   display: block;
@@ -26,7 +26,7 @@
 
 .label::after {
   position: absolute;
-  top: calc(var(--cui-typography-body-one-line-height) / 2);
+  top: 50%;
   left: var(--cui-spacings-bit);
   box-sizing: border-box;
   display: block;


### PR DESCRIPTION
## Purpose

#2163 changed the radio button's top position from percentage-based to fixed pixels. The change is acceptable for radio buttons with a single label but does not position itself for radios with descriptions or custom height radios.

## Approach and changes

Reverts the change to be percentage-based.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
