### PR TITLE
Increase IconButton CSS specificity

### DIFF
--- a/.changeset/swift-apes-rhyme.md
+++ b/.changeset/swift-apes-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Increase IconButton css specificity

--- a/package-lock.json
+++ b/package-lock.json
@@ -22425,9 +22425,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.4.tgz",
+      "integrity": "sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -32652,7 +32652,7 @@
     },
     "packages/circuit-ui": {
       "name": "@sumup/circuit-ui",
-      "version": "7.1.6",
+      "version": "7.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.1",
@@ -49153,9 +49153,9 @@
       "dev": true
     },
     "magic-string": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.4.tgz",
+      "integrity": "sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==",
       "dev": true,
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.4.15"

--- a/packages/circuit-ui/components/IconButton/IconButton.module.css
+++ b/packages/circuit-ui/components/IconButton/IconButton.module.css
@@ -1,8 +1,8 @@
 /* Sizes */
-.kilo {
+button.kilo, a.kilo {
   padding: calc(var(--cui-spacings-byte) - var(--cui-border-width-kilo));
 }
 
-.giga {
+button.giga, a.giga {
   padding: calc(var(--cui-spacings-kilo) - var(--cui-border-width-kilo));
 }

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.module.css
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.module.css
@@ -27,7 +27,7 @@
   height: 100%;
 }
 
-.hamburger{
+button.hamburger{
   padding: var(--cui-spacings-mega);
 
   /* The !important below is necessary to override the default hover styles. */


### PR DESCRIPTION
Addresses #ticket-number.

## Purpose

`IconButton` sizes CSS rules are overwritten by the Button size rules, causing the Icon button to have Button padding instead of the IconButton padding. 

## Approach and changes

Increases the IconButton size rules by a weight of 1.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
