### PR TITLE
Fix/enable custom class in TopNavigation to be passed to PopOver

### DIFF
--- a/.changeset/blue-buses-cough.md
+++ b/.changeset/blue-buses-cough.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Inside `TopNavigation`, extended `ProfileMenu`'s props to accept a class name to be passed to the `ProfileMenu`'s `PopOver` component. Passed an empty array for the `fallbackPlacements` prop to the `PopOver` used by `TopNavigation` to disable the flipping behavior.

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
@@ -67,6 +67,7 @@ export const baseArgs: TopNavigationProps = {
         destructive: true,
       },
     ],
+    className: 'custom-class-name',
   },
   links: [
     {

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -84,6 +84,10 @@ export interface ProfileMenuProps extends ProfileProps {
    * Function that is called when opening and closing the ProfileMenu.
    */
   onToggle?: (isOpen: boolean) => void;
+  /**
+   * className for the Popover component.
+   */
+  className?: string | undefined;
 }
 
 export function ProfileMenu({
@@ -91,6 +95,7 @@ export function ProfileMenu({
   label,
   actions,
   onToggle,
+  className,
 }: ProfileMenuProps): JSX.Element {
   const [isOpen, setOpen] = useState(false);
   const offset = { mainAxis: 8, crossAxis: -16 };
@@ -111,6 +116,7 @@ export function ProfileMenu({
       actions={actions}
       placement="bottom-end"
       offset={offset}
+      className={className}
     />
   );
 }

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -115,6 +115,7 @@ export function ProfileMenu({
       )}
       actions={actions}
       placement="bottom-end"
+      fallbackPlacements={[]}
       offset={offset}
       className={className}
     />


### PR DESCRIPTION
Addresses [#WE-1430](https://sumupteam.atlassian.net/browse/WE-1430).

## Purpose
The profile menu in the `TopNavigation` exhibits a [bug](https://sumup.slack.com/archives/C01UDSPMVPU/p1697794654883329) when the number of profile items is large, and the vertical space to display the items is limited (e.g., at higher screen resolutions). The PopOver, which is the component used to render the profile menu, attempts to fit within the available space. However, when it is unable to do so, it relocates to the left and becomes hidden. 
After [consulting with the designers and the design system team](https://sumup.slack.com/archives/CURHLN94K/p1698415796879919), we’re considering a solution for this. At higher resolutions, the PopOver should remain in the same position, and scrolling should be enabled within the profile menu itself.
This requires making a change to the CUI `TopNavigation` to enable custom behaviour for the child `PopOver` component.


## Approach and changes

- Pass an empty array [] for the `fallbackPlacements` prop to the `Popover` inside `TopNavigation` to disable the `PopOver` flipping behavior.
- Extend the `TopNavigation`'s `ProfileMenu` props to accept a `className` to be passed to `Popover`. This will allow us to pass custom css to the `PopOver`. For example, in ze-dashboard, we could enable fixed height and scrollability on the `PopOver` from the `TopNavigation`.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
