### PR TITLE
Fix Button text disappearing

### DIFF
--- a/.changeset/four-toes-tan.md
+++ b/.changeset/four-toes-tan.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the Button text disappearing when a parent element has `aria-busy="true"`.

--- a/packages/circuit-ui/components/Button/Button.module.css
+++ b/packages/circuit-ui/components/Button/Button.module.css
@@ -217,7 +217,7 @@
   transform: scale3d(1, 1, 1);
 }
 
-[aria-busy="true"] .content {
+.base[aria-busy="true"] .content {
   visibility: hidden;
   opacity: 0;
   transform: scale3d(0, 0, 0);


### PR DESCRIPTION
## Purpose

The Button text disappears when a parent element has `aria-busy="true"`. A rogue global CSS selector causes this.

## Approach and changes

- Scope the CSS selector to the Button element

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
