### PR TITLE
Add activeIcon to TopNavigation and SideNavigation links

### DIFF
--- a/.changeset/young-ducks-clap.md
+++ b/.changeset/young-ducks-clap.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added support for an `activeIcon` to the TopNavigation and SideNavigation links.

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
@@ -50,6 +50,15 @@ describe('PrimaryLink', () => {
     expect(getByRole('link')).toHaveAttribute('aria-current', 'page');
   });
 
+  it('should render with an active icon', () => {
+    const { getByTestId } = renderPrimaryLink(render, {
+      ...baseProps,
+      activeIcon: () => <div data-testid="active-icon" />,
+      isActive: true,
+    });
+    expect(getByTestId('active-icon')).toBeVisible();
+  });
+
   it.todo('should render with an external icon');
 
   it('should render with a suffix icon', () => {

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -32,7 +32,8 @@ export interface PrimaryLinkProps extends PrimaryLinkType {
 }
 
 export function PrimaryLink({
-  icon: Icon,
+  icon,
+  activeIcon,
   label,
   isActive,
   isExternal,
@@ -50,6 +51,8 @@ export function PrimaryLink({
     <Suffix className={classes.suffix} role="presentation" />
   );
   const isExternalLink = isExternal || props.target === '_blank';
+
+  const Icon = isActive && activeIcon ? activeIcon : icon;
 
   return (
     <Element

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -26,6 +26,10 @@ export interface PrimaryLinkProps
    */
   icon: IconComponentType;
   /**
+   * Display a different icon when the link is active.
+   */
+  activeIcon?: IconComponentType;
+  /**
    * Short label to describe the target of the link.
    */
   label: string;


### PR DESCRIPTION
## Purpose

In the current design, the icons in the top and primary navigation turn blue when active. Since we plan to switch from blue to black as our accent color, we must communicate the active state differently. The idea is to use outlined and filled icons for the default and active states, respectively.

## Approach and changes

- Add optional support for an `activeIcon` to the TopNavigation and SideNavigation links

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
