### PR TITLE
Fix Popover compatibility with server-side rendering

### DIFF
--- a/.changeset/good-lamps-taste.md
+++ b/.changeset/good-lamps-taste.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-[Popover]: safeguarding `isMobile` by returning false if window is not defined for SSR
+Fixed compatibility of the Popover component with server-side rendering.

--- a/.changeset/good-lamps-taste.md
+++ b/.changeset/good-lamps-taste.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+[Popover]: safeguarding `isMobile` by returning false if window is not defined for SSR

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -45,6 +45,7 @@ import { useStackContext } from '../StackContext/index.js';
 import { isFunction } from '../../util/type-check.js';
 import { useLatest } from '../../hooks/useLatest/index.js';
 import { usePrevious } from '../../hooks/usePrevious/index.js';
+import { useMedia } from '../../hooks/useMedia/index.js';
 import { clsx } from '../../styles/clsx.js';
 import sharedClasses from '../../styles/shared.js';
 
@@ -211,10 +212,7 @@ export const Popover = ({
   const focusProps = useFocusList();
   const prevOpen = usePrevious(isOpen);
 
-  const isMobile =
-    typeof window === 'undefined'
-      ? false
-      : window.matchMedia('(max-width: 479px)').matches;
+  const isMobile = useMedia('(max-width: 479px)');
 
   const mobileStyles = {
     position: 'fixed',

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -211,7 +211,10 @@ export const Popover = ({
   const focusProps = useFocusList();
   const prevOpen = usePrevious(isOpen);
 
-  const isMobile = window.matchMedia('(max-width: 479px)').matches;
+  const isMobile =
+    typeof window === 'undefined'
+      ? false
+      : window.matchMedia('(max-width: 479px)').matches;
 
   const mobileStyles = {
     position: 'fixed',


### PR DESCRIPTION
## Purpose

`window` is undefined on SSR, this would cause importing Popover to fail since part of the code would still be evaluated on the server even when using `use client` file annotation.

P.S: I have looked for other [usages of the window](https://github.com/search?q=repo:sumup-oss/circuit-ui+path:/%5Epackages%5C/circuit-ui%5C//+window&type=code) outside of React client APIs and this is the only component that uses the `window`.


## Approach and changes

This adds a window check for the `isMobile` check.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
