### PR TITLE
Remove invalid styles on disabled Input

### DIFF
--- a/.changeset/dirty-rice-jump.md
+++ b/.changeset/dirty-rice-jump.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed invalid styles from disabled Inputs.

--- a/packages/circuit-ui/components/Input/Input.module.css
+++ b/packages/circuit-ui/components/Input/Input.module.css
@@ -39,35 +39,25 @@
   text-overflow: ellipsis;
 }
 
-.base:disabled,
-.base[disabled] {
-  background-color: var(--cui-bg-normal-disabled);
-  box-shadow: 0 0 0 1px var(--cui-border-normal-disabled);
-}
-
-.base[readonly] {
-  background-color: var(--cui-bg-subtle-disabled);
-}
-
 /* Validations */
 
-.base[aria-invalid='true'] {
+.base[aria-invalid="true"] {
   box-shadow: 0 0 0 1px var(--cui-border-danger);
 }
 
-.base[aria-invalid='true']:hover {
+.base[aria-invalid="true"]:hover {
   box-shadow: 0 0 0 1px var(--cui-border-danger-hovered);
 }
 
-.base[aria-invalid='true']:focus {
+.base[aria-invalid="true"]:focus {
   box-shadow: 0 0 0 2px var(--cui-border-danger);
 }
 
-.base[aria-invalid='true']:active {
+.base[aria-invalid="true"]:active {
   box-shadow: 0 0 0 1px var(--cui-border-danger-pressed);
 }
 
-.base[aria-invalid='true']:not(:focus):not([disabled])::placeholder {
+.base[aria-invalid="true"]:not(:focus):not([disabled])::placeholder {
   color: var(--cui-fg-danger);
 }
 
@@ -89,6 +79,18 @@
 
 .warning:not(:focus):not([disabled])::placeholder {
   color: var(--cui-fg-warning);
+}
+
+/* Disabled */
+
+.base:disabled,
+.base[disabled] {
+  background-color: var(--cui-bg-normal-disabled);
+  box-shadow: 0 0 0 1px var(--cui-border-normal-disabled);
+}
+
+.base[readonly] {
+  background-color: var(--cui-bg-subtle-disabled);
 }
 
 /* Alignment */


### PR DESCRIPTION
## Purpose

When disabled, an Input should not be highlighted as invalid since there's nothing a user can do about it.

## Approach and changes

- Removed invalid styles from disabled Inputs.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
