### PR TITLE
Revert Button API changes

### DIFF
--- a/.changeset/good-tigers-swim.md
+++ b/.changeset/good-tigers-swim.md
@@ -1,5 +1,0 @@
----
-'@sumup/eslint-plugin-circuit-ui': minor
----
-
-Added migrations for the Button's `leadingIcon` props to the `circuit-ui/no-renamed-props` rule.

--- a/.changeset/good-tigers-swim.md
+++ b/.changeset/good-tigers-swim.md
@@ -2,4 +2,4 @@
 '@sumup/eslint-plugin-circuit-ui': minor
 ---
 
-Added migrations for the Button's `label` and `leadingIcon` props to the `circuit-ui/no-renamed-props` rule.
+Added migrations for the Button's `leadingIcon` props to the `circuit-ui/no-renamed-props` rule.

--- a/.changeset/moody-berries-move.md
+++ b/.changeset/moody-berries-move.md
@@ -1,5 +1,0 @@
----
-'@sumup/circuit-ui': minor
----
-
-Replaced the Button's `children` with a new `label` prop. The label must be a string; use the `leadingIcon` and `trailingIcon` props for icons.

--- a/.changeset/nervous-queens-return.md
+++ b/.changeset/nervous-queens-return.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Added a new `trailingIcon` prop to the Button component. Trailing icons hint that the button will perform an unexpected action, such as opening a dropdown or navigating the user to a new tab.
+Added a new `navigationIcon` prop to the Button component. Navigation icons hint that the button will perform an unexpected action, such as opening a dropdown or navigating the user to a new tab.

--- a/.changeset/old-dots-judge.md
+++ b/.changeset/old-dots-judge.md
@@ -1,5 +1,0 @@
----
-'@sumup/circuit-ui': minor
----
-
-Renamed the Button's `icon` prop to `leadingIcon`. The legacy name is deprecated and will be removed in the next major version.

--- a/packages/circuit-ui/components/Button/Button.mdx
+++ b/packages/circuit-ui/components/Button/Button.mdx
@@ -62,8 +62,8 @@ The button component supports 2 different sizes:
 
 ### With Icons
 
-- A **leading icon** provides additional context for the button, such as a “search” icon next to the label for a search field submission.
-- A **trailing icon** hints that the button will perform an unexpected action, such as opening a dropdown or navigating the user to a new tab, so make sure you use them only when necessary. Trailing icons are not an alternative to leading icons and **should not** be used to provide additional context for the button!
+- An **icon** provides additional context for the button, such as a “search” icon next to the label for a search field submission. It is rendered on the leading side of the label.
+- A **navigation icon** hints that the button will perform an unexpected action, such as opening a dropdown or navigating the user to a new tab, so make sure you use them only when necessary. Navigation icons are not an alternative to leading icons and **should not** be used to provide additional context for the button!
 
 <Story of={Stories.WithIcons} />
 

--- a/packages/circuit-ui/components/Button/Button.stories.tsx
+++ b/packages/circuit-ui/components/Button/Button.stories.tsx
@@ -81,14 +81,14 @@ export const Sizes = (args: ButtonProps) => (
 
 export const WithIcons = (args: ButtonProps) => (
   <Stack>
-    <Button {...args} leadingIcon={Plus}>
+    <Button {...args} icon={Plus}>
       Add to cart
     </Button>
     <Button
       {...args}
       href="https://sumup.com/terms"
       target="_blank"
-      trailingIcon={ArrowSlanted}
+      navigationIcon={ArrowSlanted}
     >
       Terms & Conditions
     </Button>

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -37,15 +37,11 @@ import classes from './Button.module.css';
 
 export interface BaseProps {
   /**
-   * @deprecated Use the `label` prop instead.
-   */
-  'children'?: ReactNode;
-  /**
    * Communicates the action that will be performed when the user interacts
    * with the button. Use one strong, clear imperative verb and follow with a
    * one-word object if needed to clarify.
    */
-  'label'?: string;
+  'children': ReactNode;
   /**
    * Choose from 3 style variants. Default: 'secondary'.
    */
@@ -143,7 +139,6 @@ export const Button = forwardRef<any, ButtonProps>(
       leadingIcon: LeadingIcon = icon,
       trailingIcon: TrailingIcon,
       as,
-      label = children,
       ...props
     },
     ref,
@@ -165,13 +160,6 @@ export const Button = forwardRef<any, ButtonProps>(
       throw new AccessibilityError(
         'Button',
         "The `loadingLabel` prop is missing or invalid. Remove the `isLoading` prop if you don't intend to use the Button's loading state.",
-      );
-    }
-
-    if (process.env.NODE_ENV !== 'production' && children) {
-      deprecate(
-        'Button',
-        'The `children` prop has been deprecated. Use the `label` prop instead.',
       );
     }
 
@@ -225,7 +213,7 @@ export const Button = forwardRef<any, ButtonProps>(
               aria-hidden="true"
             />
           )}
-          {label}
+          {children}
           {TrailingIcon && (
             <TrailingIcon
               className={classes['trailing-icon']}

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -74,17 +74,18 @@ export interface BaseProps {
    */
   'stretch'?: boolean;
   /**
-   * A leading icon provides additional context for the button, such as a “search” icon next to the label for a search field submission.
-   */
-  'leadingIcon'?: IconComponentType;
-  /**
-   * A trailing icon hints that the button will perform an unexpected action, such as opening a dropdown or navigating the user to a new tab, so make sure you use them only when necessary. Trailing icons are not an alternative to leading icons and should not be used to provide additional context for the button.
-   */
-  'trailingIcon'?: IconComponentType;
-  /**
-   * @deprecated Use the `leadingIcon` prop instead.
+   * An icon provides additional context for the button, such as a “search”
+   * icon next to the label for a search field submission.
    */
   'icon'?: IconComponentType;
+  /**
+   * A navigation icon hints that the button will perform an unexpected action,
+   * such as opening a dropdown or navigating the user to a new tab, so make
+   * sure you use them only when necessary. Navigation icons are not an
+   * alternative to leading icons and should not be used to provide additional
+   * context for the button.
+   */
+  'navigationIcon'?: IconComponentType;
   /**
    * The HTML button type
    */
@@ -135,9 +136,8 @@ export const Button = forwardRef<any, ButtonProps>(
       isLoading,
       loadingLabel,
       className,
-      icon,
-      leadingIcon: LeadingIcon = icon,
-      trailingIcon: TrailingIcon,
+      icon: LeadingIcon,
+      navigationIcon: TrailingIcon,
       as,
       ...props
     },
@@ -160,13 +160,6 @@ export const Button = forwardRef<any, ButtonProps>(
       throw new AccessibilityError(
         'Button',
         "The `loadingLabel` prop is missing or invalid. Remove the `isLoading` prop if you don't intend to use the Button's loading state.",
-      );
-    }
-
-    if (process.env.NODE_ENV !== 'production' && icon) {
-      deprecate(
-        'Button',
-        'The `icon` prop has been deprecated. Use the `leadingIcon` prop instead.',
       );
     }
 

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -14,7 +14,7 @@
  */
 
 import { Children, cloneElement, ReactElement, forwardRef } from 'react';
-import type { IconComponentType, IconProps } from '@sumup/icons';
+import type { IconProps } from '@sumup/icons';
 
 import utilityClasses from '../../styles/utility.js';
 import { clsx } from '../../styles/clsx.js';
@@ -29,17 +29,13 @@ import { deprecate } from '../../util/logger.js';
 import classes from './IconButton.module.css';
 
 export interface IconButtonProps
-  extends Omit<
-    ButtonProps,
-    'icon' | 'leadingIcon' | 'trailingIcon' | 'stretch'
-  > {
+  extends Omit<ButtonProps, 'navigationIcon' | 'stretch' | 'children'> {
   /**
    * @deprecated
    *
    * Use the `icon` prop instead.
    */
   children?: ReactElement<IconProps>;
-  icon?: IconComponentType;
   /**
    * Communicates the action that will be performed when the user interacts
    * with the button. Use one strong, clear imperative verb and follow with a

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/README.md
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/README.md
@@ -26,8 +26,6 @@ function Component() {
       <SelectorGroup size="kilo" />
       <Spinner size="byte" />
       <Button size="kilo" />
-      <Button>Submit</Button>
-      <Button icon={Plus} />
     </div>
   );
 }
@@ -62,8 +60,6 @@ function Component() {
       <SelectorGroup size="s" />
       <Spinner size="s" />
       <Button size="s" />
-      <Button label="Submit" />
-      <Button leadingIcon={Plus} />
     </div>
   );
 }

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
@@ -159,13 +159,6 @@ const configs: (PropNameConfig | PropValuesConfig | CustomConfig)[] = [
     },
   },
   {
-    type: 'name',
-    component: 'Button',
-    props: {
-      children: 'label',
-    },
-  },
-  {
     type: 'custom',
     component: 'IconButton',
     transform: (node, context) => {

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
@@ -152,13 +152,6 @@ const configs: (PropNameConfig | PropValuesConfig | CustomConfig)[] = [
     },
   },
   {
-    type: 'name',
-    component: 'Button',
-    props: {
-      icon: 'leadingIcon',
-    },
-  },
-  {
     type: 'custom',
     component: 'IconButton',
     transform: (node, context) => {


### PR DESCRIPTION
## Purpose

Reduce the number of breaking changes with little benefit.

## Approach and changes

- Revert the renaming of the Button's `children` prop to `label`. The original intention behind the change was consistency with other components. I realized that it would create new inconsistency with the typography components (e.g. Anchor). This convinced me that the migration effort wasn't worth it.
- Rever the renaming of the Button's `icon` prop to `leadingIcon`. While `leadingIcon` and `trailingIcon` highlight the icon's position, `icon` and `navigationIcon` better communicate their purpose. This keeps the Button and IconButton APIs aligned and reduces the migration effort.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
