### PR TITLE
Replace IconButton label with children

### DIFF
--- a/.changeset/hot-eggs-agree.md
+++ b/.changeset/hot-eggs-agree.md
@@ -2,4 +2,4 @@
 '@sumup/eslint-plugin-circuit-ui': minor
 ---
 
-Added a migration for the IconButton's `icon` prop to the `circuit-ui/no-renamed-props` rule.
+Added a migration for the IconButton's `icon` and `label` props to the `circuit-ui/no-renamed-props` rule.

--- a/.changeset/silly-sheep-tease.md
+++ b/.changeset/silly-sheep-tease.md
@@ -2,4 +2,4 @@
 '@sumup/eslint-plugin-circuit-ui': minor
 ---
 
-Added migrations for the Avatar, Button, Hamburger, IconButton, ProgressBar, Selector and Spinner size values to the `circuit-ui/no-renamed-props` rule.
+Added migrations for the Avatar, Button, CloseButton, Hamburger, IconButton, ProgressBar, Selector and Spinner size values to the `circuit-ui/no-renamed-props` rule.

--- a/.changeset/yellow-books-doubt.md
+++ b/.changeset/yellow-books-doubt.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Replaced the IconButton's `label` prop with its `children`.
+Replaced the IconButton's and CloseButton's `label` prop with `children`.

--- a/.changeset/yellow-books-doubt.md
+++ b/.changeset/yellow-books-doubt.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Replaced the IconButton's `label` prop with its `children`.

--- a/packages/circuit-ui/components/Card/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Card/components/Header/Header.tsx
@@ -64,11 +64,9 @@ export const CardHeader = forwardRef<HTMLElement, CardHeaderProps>(
       >
         {children}
         {onClose && closeButtonLabel && (
-          <CloseButton
-            className={classes.close}
-            onClick={onClose}
-            label={closeButtonLabel}
-          />
+          <CloseButton className={classes.close} onClick={onClose}>
+            {closeButtonLabel}
+          </CloseButton>
         )}
       </header>
     );

--- a/packages/circuit-ui/components/Carousel/Carousel.tsx
+++ b/packages/circuit-ui/components/Carousel/Carousel.tsx
@@ -199,11 +199,12 @@ export function Carousel({
               <ButtonList className={classes.buttons}>
                 <PlayButton
                   paused={state.paused}
-                  label={state.paused ? playButtonLabel : pauseButtonLabel}
                   {...(state.paused
                     ? getPlayControlProps()
                     : getPauseControlProps())}
-                />
+                >
+                  {state.paused ? playButtonLabel : pauseButtonLabel}
+                </PlayButton>
                 <PrevButton
                   label={prevButtonLabel}
                   {...getPreviousControlProps()}

--- a/packages/circuit-ui/components/Carousel/components/Buttons/Buttons.spec.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Buttons/Buttons.spec.tsx
@@ -23,10 +23,10 @@ describe('Buttons', () => {
   it('should have no accessibility violations', async () => {
     const { container } = render(
       <ButtonList>
-        <PlayButton label="Pause" />
-        <PlayButton label="Play" paused />
-        <PrevButton label="Previous" />
-        <NextButton label="Next" />
+        <PlayButton>Pause</PlayButton>
+        <PlayButton paused>Play</PlayButton>
+        <PrevButton>Previous</PrevButton>
+        <NextButton>Next</NextButton>
       </ButtonList>,
     );
     const actual = await axe(container);

--- a/packages/circuit-ui/components/Carousel/components/Buttons/Buttons.stories.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Buttons/Buttons.stories.tsx
@@ -26,9 +26,11 @@ export default {
 
 export const AllButtons = () => (
   <ButtonList>
-    <PlayButton label="Pause" onClick={action('on play click')} />
-    <PlayButton label="Play" paused onClick={action('on pause click')} />
-    <PrevButton label="Previous" onClick={action('on previous click')} />
-    <NextButton label="Next" onClick={action('on next click')} />
+    <PlayButton onClick={action('on play click')}>Pause</PlayButton>
+    <PlayButton paused onClick={action('on pause click')}>
+      Play
+    </PlayButton>
+    <PrevButton onClick={action('on previous click')}>Previous</PrevButton>
+    <NextButton onClick={action('on next click')}>Next</NextButton>
   </ButtonList>
 );

--- a/packages/circuit-ui/components/Carousel/components/Buttons/Buttons.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Buttons/Buttons.tsx
@@ -27,7 +27,7 @@ export const ButtonList = ({ className, ...props }: ButtonListProps) => (
   <div className={clsx(classes['button-list'], className)} {...props} />
 );
 
-type ButtonProps = Omit<IconButtonProps, 'children'>;
+type ButtonProps = Omit<IconButtonProps, 'icon'>;
 
 export const NextButton = (props: ButtonProps) => (
   <IconButton

--- a/packages/circuit-ui/components/CloseButton/CloseButton.stories.tsx
+++ b/packages/circuit-ui/components/CloseButton/CloseButton.stories.tsx
@@ -25,5 +25,5 @@ export default {
 export const Base = (args: CloseButtonProps) => <CloseButton {...args} />;
 
 Base.args = {
-  label: 'Close',
+  children: 'Close',
 };

--- a/packages/circuit-ui/components/CloseButton/CloseButton.tsx
+++ b/packages/circuit-ui/components/CloseButton/CloseButton.tsx
@@ -21,21 +21,22 @@ import { IconButton, IconButtonProps } from '../IconButton/IconButton.js';
 
 import classes from './CloseButton.module.css';
 
-export type CloseButtonProps = Omit<IconButtonProps, 'children'>;
+export type CloseButtonProps = Omit<IconButtonProps, 'icon'>;
 
 /**
  * A generic close button.
  */
 export const CloseButton = forwardRef<any, CloseButtonProps>(
-  ({ label = 'Close', className, ...props }, ref) => (
+  ({ children = 'Close', className, ...props }, ref) => (
     <IconButton
       type="button"
       className={clsx(classes.base, className)}
-      label={label}
       {...props}
       icon={Close}
       ref={ref}
-    />
+    >
+      {children}
+    </IconButton>
   ),
 );
 

--- a/packages/circuit-ui/components/CloseButton/CloseButton.tsx
+++ b/packages/circuit-ui/components/CloseButton/CloseButton.tsx
@@ -27,7 +27,7 @@ export type CloseButtonProps = Omit<IconButtonProps, 'icon'>;
  * A generic close button.
  */
 export const CloseButton = forwardRef<any, CloseButtonProps>(
-  ({ children = 'Close', className, ...props }, ref) => (
+  ({ label = 'Close', children = label, className, ...props }, ref) => (
     <IconButton
       type="button"
       className={clsx(classes.base, className)}

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -93,16 +93,26 @@ export const Hamburger = forwardRef<any, HamburgerProps>(
     return (
       <IconButton
         {...props}
+        icon={({ size: _size, ...iconProps }) => (
+          // @ts-expect-error This doesn't have to be an SVG.
+          <Skeleton
+            {...iconProps}
+            className={clsx(
+              iconProps.className,
+              classes.skeleton,
+              classes[size],
+            )}
+          >
+            <span className={clsx(classes.base, classes[size])} />
+          </Skeleton>
+        )}
         className={clsx(classes.button, className)}
         size={size}
-        label={isActive ? activeLabel : inactiveLabel}
         type="button"
         aria-pressed={isActive}
         ref={ref}
       >
-        <Skeleton className={clsx(classes.skeleton, classes[size])}>
-          <span className={clsx(classes.base, classes[size])} />
-        </Skeleton>
+        {isActive ? activeLabel : inactiveLabel}
       </IconButton>
     );
   },

--- a/packages/circuit-ui/components/IconButton/IconButton.spec.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.spec.tsx
@@ -25,7 +25,9 @@ describe('IconButton', () => {
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
     const { container } = render(
-      <IconButton label="Close" icon={Close} className={className} />,
+      <IconButton icon={Close} className={className}>
+        Close
+      </IconButton>,
     );
     const button = container.querySelector('button');
     expect(button?.className).toContain(className);
@@ -34,14 +36,16 @@ describe('IconButton', () => {
   it('should forward a ref', () => {
     const ref = createRef<HTMLHRElement>();
     const { container } = render(
-      <IconButton label="Close" icon={Close} ref={ref} />,
+      <IconButton icon={Close} ref={ref}>
+        Close
+      </IconButton>,
     );
     const button = container.querySelector('button');
     expect(ref.current).toBe(button);
   });
 
   it('should meet accessibility guidelines', async () => {
-    const { container } = render(<IconButton label="Close" icon={Close} />);
+    const { container } = render(<IconButton icon={Close}>Close</IconButton>);
     const actual = await axe(container);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/IconButton/IconButton.stories.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.stories.tsx
@@ -25,6 +25,6 @@ export default {
 export const Base = (args: IconButtonProps) => <IconButton {...args} />;
 
 Base.args = {
-  label: 'Add',
+  children: 'Add',
   icon: Plus,
 };

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -264,12 +264,13 @@ export const ImageInput = ({
             size="s"
             variant="primary"
             destructive
-            label={clearButtonLabel}
             onClick={handleClear}
             disabled={isLoading || disabled}
             className={classes.button}
             icon={Delete}
-          />
+          >
+            {clearButtonLabel}
+          </IconButton>
         ) : (
           <IconButton
             type="button"
@@ -277,11 +278,13 @@ export const ImageInput = ({
             variant="primary"
             aria-hidden="true"
             tabIndex={-1}
-            label="-" // We need to pass a label here to prevent IconButton from throwing
             disabled={isLoading || disabled}
             className={clsx(classes.button, classes.add)}
             icon={Plus}
-          />
+          >
+            {/* We need to pass a label here to prevent IconButton from throwing */}
+            -
+          </IconButton>
         )}
         <Spinner
           className={clsx(classes.spinner, isLoading && classes.loading)}

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -134,11 +134,9 @@ export const Modal: ModalComponent<ModalProps> = ({
       <ReactModal {...reactModalProps}>
         <div className={clsx(classes.content, className)} style={style}>
           {!preventClose && closeButtonLabel && (
-            <CloseButton
-              onClick={onClose}
-              label={closeButtonLabel}
-              className={classes.close}
-            />
+            <CloseButton onClick={onClose} className={classes.close}>
+              {closeButtonLabel}
+            </CloseButton>
           )}
 
           {isFunction(children) ? children({ onClose }) : children}

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -197,12 +197,9 @@ export const NotificationBanner = forwardRef<
         </div>
         {image && image.src && <NotificationImage {...image} />}
         {onClose && closeButtonLabel && (
-          <CloseButton
-            className={classes.close}
-            label={closeButtonLabel}
-            size="s"
-            onClick={onClose}
-          />
+          <CloseButton className={classes.close} size="s" onClick={onClose}>
+            {closeButtonLabel}
+          </CloseButton>
         )}
       </div>
     );

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -180,12 +180,9 @@ export const NotificationInline = forwardRef<
           </div>
 
           {onClose && closeButtonLabel && (
-            <CloseButton
-              className={classes.close}
-              label={closeButtonLabel}
-              size="s"
-              onClick={onClose}
-            />
+            <CloseButton className={classes.close} size="s" onClick={onClose}>
+              {closeButtonLabel}
+            </CloseButton>
           )}
         </div>
       </div>

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
@@ -143,11 +143,9 @@ export const NotificationModal: ModalComponent<NotificationModalProps> = ({
   return (
     <ReactModal {...reactModalProps}>
       {!preventClose && closeButtonLabel && (
-        <CloseButton
-          onClick={onClose}
-          label={closeButtonLabel}
-          className={classes.close}
-        />
+        <CloseButton onClick={onClose} className={classes.close}>
+          {closeButtonLabel}
+        </CloseButton>
       )}
       <NotificationImage image={image} />
       <Headline as="h2" size="three" className={classes.headline}>

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -124,12 +124,14 @@ export function NotificationToast({
 
         <CloseButton
           className={classes.close}
-          label="-" // We need to pass a label here to prevent CloseButton from throwing an error
           aria-hidden="true"
           size="s"
           onClick={onClose}
           tabIndex={-1}
-        />
+        >
+          {/* We need to pass a label here to prevent CloseButton from throwing an error */}
+          -
+        </CloseButton>
       </div>
     </div>
   );

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -120,14 +120,15 @@ export const Pagination = ({
       {...props}
     >
       <IconButton
-        label={previousLabel}
         size="s"
         variant="tertiary"
         disabled={currentPage <= 1}
         onClick={() => onChange(currentPage - 1)}
         className={classes.prev}
         icon={ChevronLeft}
-      />
+      >
+        {previousLabel}
+      </IconButton>
 
       {showList ? (
         <PageList
@@ -148,14 +149,15 @@ export const Pagination = ({
       )}
 
       <IconButton
-        label={nextLabel}
         size="s"
         variant="tertiary"
         disabled={currentPage >= totalPages}
         onClick={() => onChange(currentPage + 1)}
         className={classes.next}
         icon={ChevronRight}
-      />
+      >
+        {nextLabel}
+      </IconButton>
     </nav>
   );
 };

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -81,12 +81,13 @@ export const SearchInput = forwardRef<InputElement, SearchInputProps>(
                   {...renderProps}
                   size="s"
                   onClick={onClick}
-                  label={clearLabel}
                   className={clsx(
                     renderProps.className,
                     classes['clear-button'],
                   )}
-                />
+                >
+                  {clearLabel}
+                </CloseButton>
               ),
             }
           : {})}

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
@@ -160,11 +160,9 @@ export const MobileNavigation: ModalComponent<MobileNavigationProps> = ({
         <ReactModal {...reactModalProps}>
           <div className={classes.content}>
             <div className={classes.header}>
-              <CloseButton
-                onClick={onClose}
-                label={closeButtonLabel}
-                className={classes.close}
-              />
+              <CloseButton onClick={onClose} className={classes.close}>
+                {closeButtonLabel}
+              </CloseButton>
             </div>
 
             <nav aria-label={primaryNavigationLabel}>

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.tsx
@@ -57,11 +57,9 @@ export const Header = ({
       {headline}
     </Headline>
     {closeButtonLabel && (
-      <CloseButton
-        className={classes.button}
-        label={closeButtonLabel}
-        onClick={onClose}
-      />
+      <CloseButton className={classes.button} onClick={onClose}>
+        {closeButtonLabel}
+      </CloseButton>
     )}
   </div>
 );

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.tsx
@@ -47,10 +47,11 @@ export const Header = ({
       <IconButton
         className={classes.button}
         type="button"
-        label={backButtonLabel}
         onClick={onBack}
         icon={ArrowLeft}
-      />
+      >
+        {backButtonLabel}
+      </IconButton>
     )}
     <Headline id={id} size="four" as="h2" className={classes.headline}>
       {headline}

--- a/packages/circuit-ui/components/Sidebar/Sidebar.tsx
+++ b/packages/circuit-ui/components/Sidebar/Sidebar.tsx
@@ -56,10 +56,10 @@ const baseStyles = ({ theme }: StyleProps) => css`
   height: 100%;
   min-width: ${SIDEBAR_WIDTH}px;
   background-color: ${theme.colors.n900};
-  transition: transform ${theme.transitions.default};
+  transition: transform var(--cui-transitions-default);
   position: absolute;
   transform: translateX(-100%);
-  z-index: ${theme.zIndex.navigation};
+  z-index: var(--cui-z-index-navigation);
   ${theme.mq.giga} {
     transform: translateX(0);
     position: relative;
@@ -99,10 +99,11 @@ export function Sidebar({
       />
       <CloseButton
         visible={open}
-        label={closeButtonLabel}
         onClick={onClose}
         data-testid="sidebar-close-button"
-      />
+      >
+        {closeButtonLabel}
+      </CloseButton>
     </Fragment>
   );
 }

--- a/packages/circuit-ui/components/Sidebar/__snapshots__/Sidebar.spec.tsx.snap
+++ b/packages/circuit-ui/components/Sidebar/__snapshots__/Sidebar.spec.tsx.snap
@@ -12,14 +12,14 @@ exports[`Sidebar > should render and match snapshot when open 1`] = `
   height: 100%;
   min-width: 256px;
   background-color: #1A1A1A;
-  -webkit-transition: -webkit-transform 120ms ease-in-out;
-  transition: transform 120ms ease-in-out;
+  -webkit-transition: -webkit-transform var(--cui-transitions-default);
+  transition: transform var(--cui-transitions-default);
   position: absolute;
   -webkit-transform: translateX(-100%);
   -moz-transform: translateX(-100%);
   -ms-transform: translateX(-100%);
   transform: translateX(-100%);
-  z-index: 800;
+  z-index: var(--cui-z-index-navigation);
   -webkit-transform: translateX(0);
   -moz-transform: translateX(0);
   -ms-transform: translateX(0);
@@ -146,14 +146,14 @@ exports[`Sidebar > should render and match the snapshot when closed 1`] = `
   height: 100%;
   min-width: 256px;
   background-color: #1A1A1A;
-  -webkit-transition: -webkit-transform 120ms ease-in-out;
-  transition: transform 120ms ease-in-out;
+  -webkit-transition: -webkit-transform var(--cui-transitions-default);
+  transition: transform var(--cui-transitions-default);
   position: absolute;
   -webkit-transform: translateX(-100%);
   -moz-transform: translateX(-100%);
   -ms-transform: translateX(-100%);
   transform: translateX(-100%);
-  z-index: 800;
+  z-index: var(--cui-z-index-navigation);
 }
 
 @media (min-width: 960px) {

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -131,11 +131,12 @@ export const Tag = forwardRef<HTMLDivElement & HTMLButtonElement, TagProps>(
           <CloseButton
             type="button"
             variant={selected ? 'primary' : 'secondary'}
-            label={removeButtonLabel}
             className={classes['remove-button']}
             size="s"
             onClick={onRemove}
-          />
+          >
+            {removeButtonLabel}
+          </CloseButton>
         )}
       </div>
     );

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/README.md
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/README.md
@@ -26,6 +26,9 @@ function Component() {
       <SelectorGroup size="kilo" />
       <Spinner size="byte" />
       <Button size="kilo" />
+      <IconButton size="kilo" label="Add to card">
+        <Add />
+      </IconButton>
     </div>
   );
 }
@@ -60,6 +63,9 @@ function Component() {
       <SelectorGroup size="s" />
       <Spinner size="s" />
       <Button size="s" />
+      <IconButton size="s" icon={Add}>
+        Add to card
+      </IconButton>
     </div>
   );
 }

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.spec.ts
@@ -57,6 +57,14 @@ ruleTester.run('no-renamed-props', noRenamedProps, {
         }
       `,
     },
+    {
+      name: 'matched IconButton component with the correct icon prop and label as children',
+      code: `
+        function Component() {
+          return <IconButton icon={Close}>Close</IconButton>
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -72,166 +80,6 @@ ruleTester.run('no-renamed-props', noRenamedProps, {
         }
       `,
       errors: [{ messageId: 'propName' }],
-    },
-    {
-      name: 'matched component with the old children prop',
-      code: `
-        function ComponentA() {
-          return <Button>Add</Button>
-        }
-
-        function ComponentB() {
-          return (
-            <Button>
-              Add
-            </Button>
-          )
-        }
-
-        function ComponentC() {
-          return (
-            <Button>
-              {t('add')}
-            </Button>
-          )
-        }
-
-        function ComponentD() {
-          return (
-            <Button>
-              <span>Add</span>
-            </Button>
-          )
-        }
-
-        function ComponentE() {
-          return (
-            <Button>
-              <Plus /> Add
-            </Button>
-          )
-        }
-      `,
-      output: `
-        function ComponentA() {
-          return <Button label="Add" />
-        }
-
-        function ComponentB() {
-          return (
-            <Button label="Add" />
-          )
-        }
-
-        function ComponentC() {
-          return (
-            <Button label={t('add')} />
-          )
-        }
-
-        function ComponentD() {
-          return (
-            <Button label={<span>Add</span>} />
-          )
-        }
-
-        function ComponentE() {
-          return (
-            <Button>
-              <Plus /> Add
-            </Button>
-          )
-        }
-      `,
-      errors: [
-        { messageId: 'propName' },
-        { messageId: 'propName' },
-        { messageId: 'propName' },
-        { messageId: 'propName' },
-        { messageId: 'propName' },
-      ],
-    },
-    {
-      name: 'matched IconButton component with the old children prop',
-      code: `
-        function ComponentA() {
-          return <IconButton><Close /></IconButton>
-        }
-
-        function ComponentB() {
-          return (
-            <IconButton>
-              <Close size="16" />
-            </IconButton>
-          )
-        }
-
-        function ComponentC() {
-          return (
-            <IconButton>
-              Close <Close size="16" />
-            </IconButton>
-          )
-        }
-
-        function ComponentD() {
-          return (
-            <IconButton>
-              <Close size="16" className="icon" />
-            </IconButton>
-          )
-        }
-
-        function ComponentE() {
-          return (
-            <IconButton>
-              <span>x</span>
-            </IconButton>
-          )
-        }
-      `,
-      output: `
-        function ComponentA() {
-          return <IconButton icon={Close} />
-        }
-
-        function ComponentB() {
-          return (
-            <IconButton icon={Close} />
-          )
-        }
-
-        function ComponentC() {
-          return (
-            <IconButton>
-              Close <Close size="16" />
-            </IconButton>
-          )
-        }
-
-        function ComponentD() {
-          return (
-            <IconButton>
-              <Close size="16" className="icon" />
-            </IconButton>
-          )
-        }
-
-        function ComponentE() {
-          return (
-            <IconButton>
-              <span>x</span>
-            </IconButton>
-          )
-        }
-      `,
-      errors: [
-        { messageId: 'propName' },
-        { messageId: 'propName' },
-        { messageId: 'propName' },
-        { messageId: 'propName' },
-        { messageId: 'propName' },
-      ],
     },
     {
       name: 'matched component with the old prop value',
@@ -276,6 +124,181 @@ ruleTester.run('no-renamed-props', noRenamedProps, {
         });
       `,
       errors: [{ messageId: 'propValue' }],
+    },
+    {
+      name: 'matched IconButton component with the old children prop',
+      code: `
+        // icon component as child
+        function ComponentA() {
+          return <IconButton label="Close"><Close /></IconButton>
+        }
+
+        // icon component with size prop as child
+        function ComponentB() {
+          return (
+            <IconButton label="Close">
+              <Close size="16" />
+            </IconButton>
+          )
+        }
+
+        // icon component with size prop and text as children
+        function ComponentC() {
+          return (
+            <IconButton label="Close">
+              Close <Close size="16" />
+            </IconButton>
+          )
+        }
+
+        // icon component with size and className props as child
+        function ComponentD() {
+          return (
+            <IconButton label="Close">
+              <Close size="16" className="icon" />
+            </IconButton>
+          )
+        }
+
+        // span element as child
+        function ComponentE() {
+          return (
+            <IconButton label="Close">
+              <span>x</span>
+            </IconButton>
+          )
+        }
+        `,
+      output: `
+        // icon component as child
+        function ComponentA() {
+          return <IconButton label="Close" icon={Close} />
+        }
+
+        // icon component with size prop as child
+        function ComponentB() {
+          return (
+            <IconButton label="Close" icon={Close} />
+          )
+        }
+
+        // icon component with size prop and text as children
+        function ComponentC() {
+          return (
+            <IconButton label="Close">
+              Close <Close size="16" />
+            </IconButton>
+          )
+        }
+
+        // icon component with size and className props as child
+        function ComponentD() {
+          return (
+            <IconButton label="Close">
+              <Close size="16" className="icon" />
+            </IconButton>
+          )
+        }
+
+        // span element as child
+        function ComponentE() {
+          return (
+            <IconButton label="Close">
+              <span>x</span>
+            </IconButton>
+          )
+        }
+        `,
+      errors: [
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+      ],
+    },
+    {
+      name: 'matched IconButton component with the old label prop',
+      code: `
+        // label prop as string
+        function ComponentA() {
+          return <IconButton icon={Close} label="Close" />
+        }
+
+        // label prop as expression
+        function ComponentB() {
+          return (
+            <IconButton icon={Close} label={t('close')} />
+          )
+        }
+
+        // label prop as elements
+        function ComponentC() {
+          return (
+            <IconButton icon={Close} label={<span>Close</span>} />
+          )
+        }
+
+        // label prop as conditional
+        function ComponentD() {
+          return (
+            <IconButton icon={Close} label={open ? 'Close' : 'Open'} />
+          )
+        }
+
+        // label prop as variable
+        function ComponentE() {
+          return (
+            <IconButton icon={Close} label={close} />
+          )
+        }
+        `,
+      output: `
+        // label prop as string
+        function ComponentA() {
+          return <IconButton icon={Close}  >Close</IconButton>
+        }
+
+        // label prop as expression
+        function ComponentB() {
+          return (
+            <IconButton icon={Close}  >{t('close')}</IconButton>
+          )
+        }
+
+        // label prop as elements
+        function ComponentC() {
+          return (
+            <IconButton icon={Close}  ><span>Close</span></IconButton>
+          )
+        }
+
+        // label prop as conditional
+        function ComponentD() {
+          return (
+            <IconButton icon={Close}  >{open ? 'Close' : 'Open'}</IconButton>
+          )
+        }
+
+        // label prop as variable
+        function ComponentE() {
+          return (
+            <IconButton icon={Close}  >{close}</IconButton>
+          )
+        }
+        `,
+      errors: [
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+        { messageId: 'propName' },
+      ],
     },
   ],
 });

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
@@ -107,6 +107,15 @@ const configs: Config[] = [
   },
   {
     type: 'values',
+    component: 'CloseButton',
+    prop: 'size',
+    values: {
+      kilo: 's',
+      giga: 'm',
+    },
+  },
+  {
+    type: 'values',
     component: 'IconButton',
     prop: 'size',
     values: {

--- a/packages/eslint-plugin-circuit-ui/utils/jsx.ts
+++ b/packages/eslint-plugin-circuit-ui/utils/jsx.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2023, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TSESTree, TSESLint } from '@typescript-eslint/utils';
+
+/* eslint-disable */
+
+export function findAttribute(
+  node: TSESTree.JSXElement,
+  attributeName: string,
+) {
+  return node.openingElement.attributes.find(
+    (attribute) =>
+      attribute.type === 'JSXAttribute' &&
+      attribute.name.type === 'JSXIdentifier' &&
+      attribute.name.name === attributeName,
+  ) as TSESTree.JSXAttribute | undefined;
+}
+
+export function getAttributeValue(
+  attribute: TSESTree.JSXAttribute,
+): string | null {
+  if (
+    attribute.value?.type === 'Literal' &&
+    typeof attribute.value.value === 'string'
+  ) {
+    return attribute.value.value;
+  }
+  if (
+    attribute.value?.type === 'JSXExpressionContainer' &&
+    attribute.value.expression.type === 'Literal'
+  ) {
+    return attribute.value.expression.value as string;
+  }
+  return null;
+}
+
+export function filterWhitespaceChildren(
+  children: TSESTree.JSXChild[],
+): TSESTree.JSXChild[] {
+  return children.filter((child) => {
+    if (child.type !== 'JSXText') {
+      return true;
+    }
+    const nonWhiteSpaceText = child.value.trim();
+    return Boolean(nonWhiteSpaceText);
+  });
+}
+
+export function transformAttributeValueToChildren(
+  sourceCode: TSESLint.SourceCode,
+  attribute: TSESTree.JSXAttribute,
+): string | null {
+  if (!attribute.value) {
+    return null;
+  }
+  switch (attribute.value.type) {
+    case 'Literal':
+      return sourceCode
+        .getText(attribute.value)
+        .replace(/^"/, '')
+        .replace(/"$/, '');
+    case 'JSXExpressionContainer':
+      switch (attribute.value.expression.type) {
+        case 'JSXElement':
+          return sourceCode.getText(attribute.value.expression);
+        default:
+          return sourceCode.getText(attribute.value);
+      }
+    default:
+      return null;
+  }
+}

--- a/packages/eslint-plugin-circuit-ui/utils/object.ts
+++ b/packages/eslint-plugin-circuit-ui/utils/object.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2023, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TSESTree } from '@typescript-eslint/utils';
+
+/* eslint-disable */
+
+export function getPropertyValue(property: TSESTree.Property): string | null {
+  if (
+    property.value.type === 'Literal' &&
+    typeof property.value.value === 'string'
+  ) {
+    return property.value.value;
+  }
+  return null;
+}


### PR DESCRIPTION
## Purpose

Since #2307, the IconButton's icon should be passed as a prop instead of as its children. This means the children can be used for the label instead, to align it with the Button component. 

## Approach and changes

- Deprecate the IconButton's and CloseButton's `label` prop in favor of their children
- Extend the ESLint `no-renamed-props` rule to flag and automatically transform the children to the `icon` prop and replace them with the value of the `label` prop instead.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
