### PR TITLE
Fix the size of icons in Buttons

### DIFF
--- a/.changeset/rare-cycles-vanish.md
+++ b/.changeset/rare-cycles-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the size of icons inside Buttons when the available icon size doesn't match the Button size.

--- a/packages/circuit-ui/components/Button/Button.module.css
+++ b/packages/circuit-ui/components/Button/Button.module.css
@@ -200,6 +200,18 @@
   margin-left: var(--cui-spacings-byte);
 }
 
+.s .leading-icon,
+.s .trailing-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.m .leading-icon,
+.m .trailing-icon {
+  width: 24px;
+  height: 24px;
+}
+
 .base .spinner {
   position: absolute;
   visibility: hidden;


### PR DESCRIPTION
## Purpose

Before #2307, developers would pass icons as a child React Element to the IconButton component, which meant they could manually specify the icon size. Now, the icon component is passed directly as a prop, and the icon size is configured internally based on the Button's size: A small Button uses a 16px icon, and a medium Button uses a 24px icon.

Often, an icon is only available in one size that might not match the size the Button expects. The icon is up or downscaled as a workaround, and a warning is logged. Or at least it _should_ be scaled — this is currently broken. 

## Approach and changes

- Explicitly set the width and height of the icons inside Buttons according to the Button size

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
