### PR TITLE
Fix the size of icons in IconButtons

### DIFF
--- a/.changeset/shaggy-rules-explain.md
+++ b/.changeset/shaggy-rules-explain.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the size of icons inside IconButtons when the available icon size doesn't match the IconButton size.

--- a/packages/circuit-ui/components/IconButton/IconButton.tsx
+++ b/packages/circuit-ui/components/IconButton/IconButton.tsx
@@ -71,12 +71,21 @@ export const IconButton = forwardRef<any, IconButtonProps>(
     const labelString = isString(children) ? children : label;
 
     if (Icon) {
-      icon = <Icon size={iconSize} aria-hidden="true" />;
+      icon = (
+        <Icon
+          size={iconSize}
+          aria-hidden="true"
+          width={iconSize}
+          height={iconSize}
+        />
+      );
     } else if (!isString(children)) {
       const child = Children.only(children);
       icon = cloneElement(child!, {
         'aria-hidden': 'true',
         'size': (child!.props.size as string) || iconSize,
+        'width': iconSize,
+        'height': iconSize,
       });
     } else {
       throw new CircuitError('IconButton', 'The `icon` prop is missing.');


### PR DESCRIPTION
## Purpose

Before #2307, developers would pass icons as a child React Element to the IconButton component, which meant they could manually specify the icon size. Now, the icon component is passed directly as a prop, and the icon size is configured internally based on the IconButton's size: A small IconButton uses a 16px icon, and a medium IconButton uses a 24px icon.

Often, an icon is only available in one size that might not match the size the Button expects. The icon is up or downscaled as a workaround, and a warning is logged. Or at least it _should_ be scaled — this is currently broken. 

## Approach and changes

- Explicitly set the width and height of the icons inside IconButtons according to the IconButton size

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
