### PR TITLE
Fix Button and IconButton types when used with experimental React

### DIFF
--- a/.changeset/large-suns-provide.md
+++ b/.changeset/large-suns-provide.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the prop types of the Button and IconButton components when used with experimental versions of React.

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -13,7 +13,12 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import type {
+  ForwardRefExoticComponent,
+  PropsWithoutRef,
+  ReactNode,
+  RefAttributes,
+} from 'react';
 import type { IconComponentType } from '@sumup/icons';
 
 import { CircuitError } from '../../util/errors.js';
@@ -57,7 +62,9 @@ export type ButtonProps = SharedButtonProps & {
  * The Button component enables the user to perform an action or navigate
  * to a different screen.
  */
-export const Button = createButtonComponent<ButtonProps>(
+export const Button: ForwardRefExoticComponent<
+  PropsWithoutRef<ButtonProps> & RefAttributes<any>
+> = createButtonComponent<ButtonProps>(
   'Button',
   ({ className, size: legacySize = 'm', stretch, ...props }) => {
     const size = legacyButtonSizeMap[legacySize] || legacySize;

--- a/packages/circuit-ui/components/Button/IconButton.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.tsx
@@ -13,7 +13,14 @@
  * limitations under the License.
  */
 
-import { Children, cloneElement, type ReactElement } from 'react';
+import {
+  Children,
+  cloneElement,
+  type ForwardRefExoticComponent,
+  type PropsWithoutRef,
+  type ReactElement,
+  type RefAttributes,
+} from 'react';
 import type { IconComponentType, IconProps } from '@sumup/icons';
 
 import { clsx } from '../../styles/clsx.js';
@@ -53,7 +60,9 @@ export type IconButtonProps = SharedButtonProps & {
  * The IconButton component enables the user to perform an action or navigate
  * to a different screen.
  */
-export const IconButton = createButtonComponent<IconButtonProps>(
+export const IconButton: ForwardRefExoticComponent<
+  PropsWithoutRef<IconButtonProps> & RefAttributes<any>
+> = createButtonComponent<IconButtonProps>(
   'IconButton',
   ({
     className,

--- a/packages/circuit-ui/components/Button/shared.tsx
+++ b/packages/circuit-ui/components/Button/shared.tsx
@@ -15,9 +15,9 @@
 
 import {
   forwardRef,
-  ButtonHTMLAttributes,
-  AnchorHTMLAttributes,
-  ReactNode,
+  type ButtonHTMLAttributes,
+  type AnchorHTMLAttributes,
+  type ReactNode,
 } from 'react';
 import type { IconComponentType } from '@sumup/icons';
 


### PR DESCRIPTION
## Purpose

In #2299, I refactored the Button and IconButton components to be based on a shared factory function. For reasons unknown to me, this caused TypeScript to expand and statically inline the prop types for the components. This caused a clash with Next.js' types which extend the `formAction` type to allow function values.

## Approach and changes

- Explicitly type the Button and IconButton components. The explicit types are kept as-is by TypeScript and can be augmented by the environment.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
