### PR TITLE
Reduce footprint of the button components

### DIFF
--- a/.changeset/purple-islands-explain.md
+++ b/.changeset/purple-islands-explain.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed the `aria-disabled` attribute from the button components when it isn't needed.

--- a/packages/circuit-ui/components/Button/shared.tsx
+++ b/packages/circuit-ui/components/Button/shared.tsx
@@ -189,8 +189,10 @@ export function createButtonComponent<Props>(
           'aria-live': 'polite',
           'aria-busy': Boolean(isLoading),
         })}
+        {...(isDisabled && {
+          'aria-disabled': true,
+        })}
         onClick={isDisabled ? onDisabledClick : onClick}
-        aria-disabled={isDisabled}
         className={clsx(
           classes.base,
           classes[variant],

--- a/packages/circuit-ui/components/Sidebar/__snapshots__/Sidebar.spec.tsx.snap
+++ b/packages/circuit-ui/components/Sidebar/__snapshots__/Sidebar.spec.tsx.snap
@@ -95,7 +95,6 @@ exports[`Sidebar > should render and match snapshot when open 1`] = `
     data-testid="sidebar-backdrop"
   />
   <button
-    aria-disabled="false"
     class="_base_60a0b0 _secondary_60a0b0 _m_60a0b0 _focus-visible_73b4bb _base_037c7e _m_037c7e _base_9bf092 circuit-2"
     data-testid="sidebar-close-button"
     title="Close sidebar"
@@ -223,7 +222,6 @@ exports[`Sidebar > should render and match the snapshot when closed 1`] = `
     data-testid="sidebar-backdrop"
   />
   <button
-    aria-disabled="false"
     class="_base_60a0b0 _secondary_60a0b0 _m_60a0b0 _focus-visible_73b4bb _base_037c7e _m_037c7e _base_9bf092 circuit-2"
     data-testid="sidebar-close-button"
     title="Close sidebar"

--- a/packages/circuit-ui/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
+++ b/packages/circuit-ui/components/Sidebar/components/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
@@ -19,7 +19,6 @@ exports[`CloseButton > styles > should render and match snapshot when not visibl
 }
 
 <button
-  aria-disabled="false"
   class="_base_60a0b0 _secondary_60a0b0 _m_60a0b0 _focus-visible_73b4bb _base_037c7e _m_037c7e _base_9bf092 circuit-0"
   title="Close"
   type="button"
@@ -88,7 +87,6 @@ exports[`CloseButton > styles > should render and match snapshot when visible 1`
 }
 
 <button
-  aria-disabled="false"
   class="_base_60a0b0 _secondary_60a0b0 _m_60a0b0 _focus-visible_73b4bb _base_037c7e _m_037c7e _base_9bf092 circuit-0"
   title="Close"
   type="button"


### PR DESCRIPTION
Addresses #ticket-number.

## Purpose

Only adding attributes when necessary minimizes the size of server-rendered HTML and reduces the noise in the DOM inspector.

## Approach and changes

- Only add the `aria-disabled` attribute when necessary

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
