### PR TITLE
Revert the Button's disabled state

### DIFF
--- a/.changeset/cold-buses-fail.md
+++ b/.changeset/cold-buses-fail.md
@@ -1,5 +1,5 @@
 ---
-'@sumup/circuit-ui': major
+'@sumup/circuit-ui': minor
 ---
 
 Changed the NotificationInline's action from the Button to the Anchor component. Update the action props if necessary.

--- a/.changeset/old-schools-walk.md
+++ b/.changeset/old-schools-walk.md
@@ -1,5 +1,5 @@
 ---
-'@sumup/circuit-ui': major
+'@sumup/circuit-ui': minor
 ---
 
 Changed the default size of the CloseButton from 40px to 48px to match the Button component.

--- a/.changeset/orange-squids-hammer.md
+++ b/.changeset/orange-squids-hammer.md
@@ -1,5 +1,0 @@
----
-'@sumup/circuit-ui': major
----
-
-Improved the accessibility of disabled Buttons. The `disabled` attribute has been replaced with the `aria-disabled` attribute which enables the disabled element to receive focus and be perceived by screenreader users. Interactions with the disabled element are blocked by a dummy click handler.

--- a/packages/circuit-ui/components/Button/shared.module.css
+++ b/packages/circuit-ui/components/Button/shared.module.css
@@ -200,6 +200,9 @@
 .base[disabled],
 .base[aria-disabled="true"] {
   color: var(--cui-fg-normal-disabled);
+
+  /* TODO: Remove in the next major version */
+  pointer-events: none;
   cursor: not-allowed;
   background-color: var(--cui-bg-highlight-disabled);
   border-color: transparent;

--- a/packages/circuit-ui/components/Button/shared.spec.tsx
+++ b/packages/circuit-ui/components/Button/shared.spec.tsx
@@ -72,6 +72,7 @@ describe('Button', () => {
 
       const button = screen.getByRole('button');
 
+      expect(button).toBeDisabled();
       expect(button).toHaveAttribute('aria-disabled', 'true');
     });
 
@@ -80,6 +81,7 @@ describe('Button', () => {
 
       const button = screen.getByRole('button');
 
+      expect(button).toBeDisabled();
       expect(button).toHaveAttribute('aria-disabled', 'true');
     });
 

--- a/packages/circuit-ui/components/Button/shared.tsx
+++ b/packages/circuit-ui/components/Button/shared.tsx
@@ -189,6 +189,10 @@ export function createButtonComponent<Props>(
           'aria-live': 'polite',
           'aria-busy': Boolean(isLoading),
         })}
+        // TODO: Remove in the next major version
+        {...(!isLink && {
+          disabled: isDisabled,
+        })}
         {...(isDisabled && {
           'aria-disabled': true,
         })}


### PR DESCRIPTION
## Purpose

#2299 improved the behavior of disabled Buttons. The `disabled` attribute was replaced with the `aria-disabled` attribute, which enabled the disabled element to receive focus and be perceived by screenreader users.

This is a breaking change since it requires developers to update unit tests that were validating the Button's disabled state using Testing Library's `.toBeDisabled()` matcher. 

We'd like to roll out the new button design in a minor version, so we've decided to postpone this functional change until the next major.

The other potentially major changes were found to be non-breaking, so we're able to include them in a minor release.

## Approach and changes

- Re-add the `disabled` attribute and `pointer-events: none` style to Buttons
- Downgrade non-breaking major changesets to minor

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
