### PR TITLE
Add support for rendering Tag as link

### DIFF
--- a/.changeset/three-students-crash.md
+++ b/.changeset/three-students-crash.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added support for rendering the Tag component as an anchor (`a`) element when passed the `href` prop.

--- a/packages/circuit-ui/components/Tag/Tag.module.css
+++ b/packages/circuit-ui/components/Tag/Tag.module.css
@@ -35,30 +35,35 @@
 
 /* Interactive */
 
+a.content,
 button.content {
   text-align: left;
   cursor: pointer;
   outline: 0;
 }
 
+a.content:hover,
 button.content:hover {
   color: var(--cui-fg-normal-hovered);
   background-color: var(--cui-bg-normal-hovered);
   border-color: var(--cui-border-normal-hovered);
 }
 
+a.content:active,
 button.content:active {
   color: var(--cui-fg-normal-pressed);
   background-color: var(--cui-bg-normal-pressed);
   border-color: var(--cui-border-normal-pressed);
 }
 
+.selected a.content:hover,
 .selected button.content:hover {
   color: var(--cui-fg-on-strong-hovered);
   background-color: var(--cui-bg-accent-strong-hovered);
   border-color: var(--cui-border-accent-hovered);
 }
 
+.selected a.content:active,
 .selected button.content:active {
   color: var(--cui-fg-on-strong-pressed);
   background-color: var(--cui-bg-accent-strong-pressed);

--- a/packages/circuit-ui/components/Tag/Tag.spec.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.spec.tsx
@@ -67,9 +67,19 @@ describe('Tag', () => {
   });
 
   describe('when interactive', () => {
+    it('should render an anchor', () => {
+      const onClick = vi.fn();
+      render(
+        <Tag href="/" onClick={onClick}>
+          Link
+        </Tag>,
+      );
+      expect(screen.getByRole('link')).toBeVisible();
+    });
+
     it('should render a button', () => {
       const onClick = vi.fn();
-      render(<Tag onClick={onClick}>SomeTest</Tag>);
+      render(<Tag onClick={onClick}>Button</Tag>);
       expect(screen.getByRole('button')).toBeVisible();
     });
 

--- a/packages/circuit-ui/components/Tag/Tag.spec.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.spec.tsx
@@ -82,7 +82,7 @@ describe('Tag', () => {
     it('should render a button', () => {
       const onClick = vi.fn();
       render(<Tag onClick={onClick}>Button</Tag>);
-      const buttonEl = screen.getByRole('button', { name: 'Button' });
+      const buttonEl = screen.getByRole('button');
       expect(buttonEl).toBeVisible();
       expect(buttonEl).toHaveAttribute('type', 'button');
     });

--- a/packages/circuit-ui/components/Tag/Tag.spec.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.spec.tsx
@@ -74,13 +74,17 @@ describe('Tag', () => {
           Link
         </Tag>,
       );
-      expect(screen.getByRole('link')).toBeVisible();
+      const linkEl = screen.getByRole('link');
+      expect(linkEl).toBeVisible();
+      expect(linkEl).not.toHaveAttribute('type');
     });
 
     it('should render a button', () => {
       const onClick = vi.fn();
       render(<Tag onClick={onClick}>Button</Tag>);
-      expect(screen.getByRole('button')).toBeVisible();
+      const buttonEl = screen.getByRole('button', { name: 'Button' });
+      expect(buttonEl).toBeVisible();
+      expect(buttonEl).toHaveAttribute('type', 'button');
     });
 
     it('should call onClick when clicked', async () => {

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -135,7 +135,7 @@ export const Tag = forwardRef<HTMLDivElement & HTMLButtonElement, TagProps>(
             classes.content,
             onClick && utilityClasses.focusVisible,
           )}
-          type={onClick && 'button'}
+          {...(onClick && !props.href && { type: 'button' })}
           onClick={onClick}
           ref={ref}
           {...props}

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -13,10 +13,16 @@
  * limitations under the License.
  */
 
-import { forwardRef, HTMLAttributes, ButtonHTMLAttributes } from 'react';
+import {
+  forwardRef,
+  type HTMLAttributes,
+  type ButtonHTMLAttributes,
+  type AnchorHTMLAttributes,
+} from 'react';
 import type { IconComponentType } from '@sumup/icons';
 
 import type { ClickEvent } from '../../types/events.js';
+import type { AsPropType } from '../../types/prop-types.js';
 import {
   AccessibilityError,
   isSufficientlyLabelled,
@@ -24,6 +30,7 @@ import {
 import { clsx } from '../../styles/clsx.js';
 import utilityClasses from '../../styles/utility.js';
 import CloseButton from '../CloseButton/index.js';
+import { useComponents } from '../ComponentsContext/index.js';
 
 import classes from './Tag.module.css';
 
@@ -62,12 +69,17 @@ type RemoveProps =
   | { onRemove?: never; removeButtonLabel?: never };
 
 type DivElProps = Omit<HTMLAttributes<HTMLDivElement>, 'onClick' | 'prefix'>;
+type LinkElProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'>;
 type ButtonElProps = Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
   'onClick' | 'prefix'
 >;
 
-export type TagProps = BaseProps & RemoveProps & DivElProps & ButtonElProps;
+export type TagProps = BaseProps &
+  RemoveProps &
+  DivElProps &
+  LinkElProps &
+  ButtonElProps;
 
 export const Tag = forwardRef<HTMLDivElement & HTMLButtonElement, TagProps>(
   (
@@ -85,6 +97,8 @@ export const Tag = forwardRef<HTMLDivElement & HTMLButtonElement, TagProps>(
     },
     ref,
   ) => {
+    const { Link } = useComponents();
+
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
@@ -96,7 +110,13 @@ export const Tag = forwardRef<HTMLDivElement & HTMLButtonElement, TagProps>(
         'The `removeButtonLabel` prop is missing or invalid. Omit the `onRemove` prop if you intend to disable the tag removing functionality.',
       );
     }
-    const Element = onClick ? 'button' : 'div';
+    let Element: AsPropType = 'div';
+
+    if (props.href) {
+      Element = Link;
+    } else if (onClick) {
+      Element = 'button';
+    }
 
     const isRemovable = onRemove && removeButtonLabel;
 

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -110,8 +110,8 @@ export const Tag = forwardRef<HTMLDivElement & HTMLButtonElement, TagProps>(
         'The `removeButtonLabel` prop is missing or invalid. Omit the `onRemove` prop if you intend to disable the tag removing functionality.',
       );
     }
-    let Element: AsPropType = 'div';
 
+    let Element: AsPropType = 'div';
     if (props.href) {
       Element = Link;
     } else if (onClick) {


### PR DESCRIPTION
## Purpose

Currently, the Tag component is rendered as an interactive `button` when passed the `onClick` prop. Therefore it makes sense to also support rendering it as an anchor (`a`) when passed the `href` prop to support use cases like a category tag on a blog.

## Approach and changes

- Render the Tag component as an `a` element when passed the `href` prop

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
