### PR TITLE
Improve compatibility of the ButtonGroup with the Modal component

### DIFF
--- a/.changeset/tame-camels-argue.md
+++ b/.changeset/tame-camels-argue.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': patch
 ---
 
-Reduced the container width at which the ButtonGroup component switches to a vertical layout to improve compatibility with the Modal component.
+Reduced the container width at which the ButtonGroup component switches to a horizontal layout to improve compatibility with the Modal component.

--- a/.changeset/tame-camels-argue.md
+++ b/.changeset/tame-camels-argue.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Reduced the container width at which the ButtonGroup component switches to a vertical layout to improve compatibility with the Modal component.

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -351,7 +351,7 @@
   }
 }
 
-@container cui-button-group (width > 480px) {
+@container cui-button-group (width > 420px) {
   /* Keep in sync with the .secondary class above */
   .tertiary {
     color: var(--cui-fg-normal);

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.module.css
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.module.css
@@ -9,11 +9,11 @@
   align-items: center;
 }
 
-.secondary {
+.base .secondary {
   margin-top: var(--cui-spacings-kilo);
 }
 
-@container cui-button-group (width > 480px) {
+@container cui-button-group (width > 420px) {
   .base {
     flex-direction: row-reverse;
   }
@@ -30,7 +30,7 @@
     justify-content: flex-start;
   }
 
-  .secondary {
+  .base .secondary {
     margin-top: 0;
     margin-right: var(--cui-spacings-mega);
   }


### PR DESCRIPTION
## Purpose

With the new container-based responsive styles, the ButtonGroup now uses a vertical layout inside the Modal component on wide viewports. This is not the intended behavior.

## Approach and changes

- Reduced the container width at which the ButtonGroup component switches to a horizontal layout to improve compatibility with the Modal component.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
