### PR TITLE
Revert "Revert the Button's disabled state (#2340)"

### DIFF
--- a/.changeset/cold-buses-fail.md
+++ b/.changeset/cold-buses-fail.md
@@ -1,5 +1,5 @@
 ---
-'@sumup/circuit-ui': minor
+'@sumup/circuit-ui': major
 ---
 
 Changed the NotificationInline's action from the Button to the Anchor component. Update the action props if necessary.

--- a/.changeset/old-schools-walk.md
+++ b/.changeset/old-schools-walk.md
@@ -1,5 +1,5 @@
 ---
-'@sumup/circuit-ui': minor
+'@sumup/circuit-ui': major
 ---
 
 Changed the default size of the CloseButton from 40px to 48px to match the Button component.

--- a/.changeset/orange-squids-hammer.md
+++ b/.changeset/orange-squids-hammer.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Improved the accessibility of disabled Buttons. The `disabled` attribute has been replaced with the `aria-disabled` attribute which enables the disabled element to receive focus and be perceived by screenreader users. Interactions with the disabled element are blocked by a dummy click handler.

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -204,9 +204,6 @@
 .base[disabled],
 .base[aria-disabled="true"] {
   color: var(--cui-fg-normal-disabled);
-
-  /* TODO: Remove in the next major version */
-  pointer-events: none;
   cursor: not-allowed;
   background-color: var(--cui-bg-highlight-disabled);
   border-color: transparent;

--- a/packages/circuit-ui/components/Button/base.spec.tsx
+++ b/packages/circuit-ui/components/Button/base.spec.tsx
@@ -72,7 +72,6 @@ describe('Button', () => {
 
       const button = screen.getByRole('button');
 
-      expect(button).toBeDisabled();
       expect(button).toHaveAttribute('aria-disabled', 'true');
     });
 
@@ -81,7 +80,6 @@ describe('Button', () => {
 
       const button = screen.getByRole('button');
 
-      expect(button).toBeDisabled();
       expect(button).toHaveAttribute('aria-disabled', 'true');
     });
 

--- a/packages/circuit-ui/components/Button/base.tsx
+++ b/packages/circuit-ui/components/Button/base.tsx
@@ -190,10 +190,6 @@ export function createButtonComponent<Props>(
           'aria-live': 'polite',
           'aria-busy': Boolean(isLoading),
         })}
-        // TODO: Remove in the next major version
-        {...(!isLink && {
-          disabled: isDisabled,
-        })}
         {...(isDisabled && {
           'aria-disabled': true,
         })}


### PR DESCRIPTION
This reverts #2340.

## Purpose

After further testing, I've concluded that there are too many subtle breaking changes related to the button redesign. The only safe way to roll them out is to release a major version with a detailed migration guide.

This means we can re-include the changes to the button's disabled state.

## Approach and changes

- Revert commit 3361c45afadf9148d35f4ffd95705491ecd56c54

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
