### PR TITLE
Truncate long Button labels

### DIFF
--- a/.changeset/wild-chicken-call.md
+++ b/.changeset/wild-chicken-call.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Changed the overflow behaviour of long Button labels. Text that would previously wrap is now truncated to a single line with a trailing ellipsis.

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -24,6 +24,144 @@
   overflow: hidden;
 }
 
+/* Loader */
+.loader {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: grid;
+  grid-auto-flow: column;
+  gap: var(--loader-gap);
+  place-content: center;
+  width: 100%;
+  height: 100%;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity var(--cui-transitions-default),
+    visibility var(--cui-transitions-default);
+}
+
+/* The animation of the dots consists of five phases: an 80ms pause
+   and four 160ms transitions between each dot being highlighted */
+
+.dot {
+  --loader-opacity: 0.25;
+
+  display: block;
+  width: var(--loader-diameter);
+  height: var(--loader-diameter);
+  background-color: var(--cui-fg-normal);
+  border-radius: var(--cui-border-radius-circle);
+  animation-duration: 720ms; /* 80ms + 4 * 160ms */
+  animation-play-state: paused;
+  animation-timing-function: cubic-bezier(0.75, 0, 1, 1);
+  animation-iteration-count: infinite;
+}
+
+@keyframes pulse1 {
+  0%,
+  11%,
+  55%,
+  100% {
+    opacity: var(--loader-opacity);
+    transform: scale(100%);
+  }
+
+  33% {
+    opacity: 1;
+    transform: var(--loader-transform);
+  }
+}
+
+.dot:nth-child(1) {
+  animation-name: pulse1;
+}
+
+@keyframes pulse2 {
+  0%,
+  33%,
+  77%,
+  100% {
+    opacity: var(--loader-opacity);
+    transform: scale(100%);
+  }
+
+  55% {
+    opacity: 1;
+    transform: var(--loader-transform);
+  }
+}
+
+.dot:nth-child(2) {
+  animation-name: pulse2;
+}
+
+@keyframes pulse3 {
+  0%,
+  55%,
+  100% {
+    opacity: var(--loader-opacity);
+    transform: scale(100%);
+  }
+
+  77% {
+    opacity: 1;
+    transform: var(--loader-transform);
+  }
+}
+
+.dot:nth-child(3) {
+  animation-name: pulse3;
+}
+
+.base[aria-busy="true"] .loader {
+  visibility: inherit;
+  opacity: 1;
+}
+
+.base[aria-busy="true"] .dot {
+  animation-play-state: running;
+}
+
+/* Content */
+.content {
+  display: grid;
+  grid-auto-flow: column;
+  gap: var(--content-gap);
+  place-content: center;
+  align-items: center;
+  min-width: 24px;
+  min-height: 24px;
+  opacity: 1;
+  transition: opacity var(--cui-transitions-default);
+}
+
+.base:active .content,
+.base[aria-expanded="true"] .content,
+.base[aria-pressed="true"] .content {
+  transform: translate(0, 1px);
+}
+
+.base[aria-busy="true"] .content {
+  opacity: 0;
+}
+
+.label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.leading-icon {
+  width: var(--leading-icon-size);
+  height: var(--leading-icon-size);
+}
+
+.trailing-icon {
+  width: var(--cui-icon-sizes-kilo);
+  height: var(--cui-icon-sizes-kilo);
+}
+
 /* Sizes */
 .s {
   --content-gap: var(--cui-spacings-bit);
@@ -207,138 +345,6 @@
   cursor: not-allowed;
   background-color: var(--cui-bg-highlight-disabled);
   border-color: transparent;
-}
-
-/* Loader */
-.loader {
-  position: absolute;
-  top: 0;
-  left: 0;
-  display: grid;
-  grid-auto-flow: column;
-  gap: var(--loader-gap);
-  place-content: center;
-  width: 100%;
-  height: 100%;
-  visibility: hidden;
-  opacity: 0;
-  transition: opacity var(--cui-transitions-default),
-    visibility var(--cui-transitions-default);
-}
-
-/* The animation of the dots consists of five phases: an 80ms pause
-   and four 160ms transitions between each dot being highlighted */
-
-.dot {
-  --loader-opacity: 0.25;
-
-  display: block;
-  width: var(--loader-diameter);
-  height: var(--loader-diameter);
-  background-color: var(--cui-fg-normal);
-  border-radius: var(--cui-border-radius-circle);
-  animation-duration: 720ms; /* 80ms + 4 * 160ms */
-  animation-play-state: paused;
-  animation-timing-function: cubic-bezier(0.75, 0, 1, 1);
-  animation-iteration-count: infinite;
-}
-
-@keyframes pulse1 {
-  0%,
-  11%,
-  55%,
-  100% {
-    opacity: var(--loader-opacity);
-    transform: scale(100%);
-  }
-
-  33% {
-    opacity: 1;
-    transform: var(--loader-transform);
-  }
-}
-
-.dot:nth-child(1) {
-  animation-name: pulse1;
-}
-
-@keyframes pulse2 {
-  0%,
-  33%,
-  77%,
-  100% {
-    opacity: var(--loader-opacity);
-    transform: scale(100%);
-  }
-
-  55% {
-    opacity: 1;
-    transform: var(--loader-transform);
-  }
-}
-
-.dot:nth-child(2) {
-  animation-name: pulse2;
-}
-
-@keyframes pulse3 {
-  0%,
-  55%,
-  100% {
-    opacity: var(--loader-opacity);
-    transform: scale(100%);
-  }
-
-  77% {
-    opacity: 1;
-    transform: var(--loader-transform);
-  }
-}
-
-.dot:nth-child(3) {
-  animation-name: pulse3;
-}
-
-.base[aria-busy="true"] .loader {
-  visibility: inherit;
-  opacity: 1;
-}
-
-.base[aria-busy="true"] .dot {
-  animation-play-state: running;
-}
-
-/* Content */
-.content {
-  display: grid;
-  grid-auto-flow: column;
-  gap: var(--content-gap);
-  place-content: center;
-  align-items: center;
-  min-width: 24px;
-  min-height: 24px;
-  opacity: 1;
-  transition: opacity var(--cui-transitions-default);
-}
-
-.base:active .content,
-.base[aria-expanded="true"] .content,
-.base[aria-pressed="true"] .content {
-  transform: translate(0, 1px);
-}
-
-.base[aria-busy="true"] .content {
-  opacity: 0;
-}
-
-.leading-icon {
-  width: var(--leading-icon-size);
-  height: var(--leading-icon-size);
-}
-
-.trailing-icon {
-  width: var(--cui-icon-sizes-kilo);
-  height: var(--cui-icon-sizes-kilo);
 }
 
 /* ButtonGroup */


### PR DESCRIPTION
## Purpose

The design team insists that truncating long Button labels when they overflow their container is better than letting the text wrap 🤷🏻 

_Before_

<img width="200" alt="Screenshot 2023-12-21 at 11 25 42" src="https://github.com/sumup-oss/circuit-ui/assets/11017722/d8e0da83-b3db-4ed3-b6aa-4a657b734257">

_After_

<img width="200" alt="Screenshot 2023-12-21 at 11 25 26" src="https://github.com/sumup-oss/circuit-ui/assets/11017722/1347569c-7b7c-4f33-9027-62be3f149db0">

## Approach and changes

- Changed the overflow behaviour of long Button labels. Text that would previously wrap is now truncated to a single line with a trailing ellipsis.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
