### PR TITLE
Deprecate the ProgressBar's variant prop

### DIFF
--- a/.changeset/late-wolves-cross.md
+++ b/.changeset/late-wolves-cross.md
@@ -1,0 +1,6 @@
+---
+'@sumup/circuit-ui': minor
+'@sumup/eslint-plugin-circuit-ui': minor
+---
+
+Deprecated the ProgressBar's `variant` prop. The ProgressBar will always be black in the future.

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -28,6 +28,8 @@ import classes from './ProgressBar.module.css';
 
 interface BaseProps extends HTMLAttributes<HTMLDivElement> {
   /**
+   * @deprecated
+   *
    * Choose from 2 style variants. Default: 'primary'.
    */
   variant?: 'primary' | 'secondary';
@@ -113,7 +115,7 @@ export function ProgressBar({
   max,
   value,
   size: legacySize = 'm',
-  variant = 'primary',
+  variant: deprecatedVariant,
   duration = 3000,
   loop = false,
   paused = false,
@@ -142,7 +144,15 @@ export function ProgressBar({
     );
   }
 
+  if (process.env.NODE_ENV !== 'production' && deprecatedVariant) {
+    deprecate(
+      'ProgressBar',
+      `The \`${legacySize}\` size has been deprecated. Use the \`${legacySizeMap[legacySize]}\` size instead.`,
+    );
+  }
+
   const size = legacySizeMap[legacySize] || legacySize;
+  const variant = deprecatedVariant || 'primary';
 
   return (
     <div className={clsx(classes.wrapper, className)} {...props}>

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/README.md
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/README.md
@@ -16,6 +16,11 @@ Note that the rule can only lint direct uses of a component. Wrapped instances s
 Examples of **incorrect** code for this rule:
 
 ```tsx
+// Since Circuit UI v7.7
+function Component() {
+  return <ProgressBar variant="secondary" />;
+}
+
 // Since Circuit UI v6.4
 function Component() {
   return (
@@ -31,6 +36,11 @@ function Component() {
 Examples of **correct** code for this rule:
 
 ```tsx
+// Since Circuit UI v7.7
+function Component() {
+  return <ProgressBar />;
+}
+
 // Since Circuit UI v6.4
 function Component() {
   return (

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.ts
@@ -56,6 +56,11 @@ const mappings: Config[] = [
     alternative:
       'Use an `onClick` handler to dispatch user interaction events instead.',
   },
+  {
+    components: ['ProgressBar'],
+    props: ['variant'],
+    alternative: '',
+  },
 ];
 
 export const noDeprecatedProps = createRule({


### PR DESCRIPTION
## Purpose

With the upcoming switch to black&white, the ProgressBar's "primary" variant will change from blue to black, matching the "secondary" variant.

## Approach and changes

- Deprecate the ProgressBar's obsolete `variant` prop.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
