### PR TITLE
Remove ProgressBar's variant prop

### DIFF
--- a/.changeset/stupid-crabs-switch.md
+++ b/.changeset/stupid-crabs-switch.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Removed the deprecated `variant` prop from the ProgressBar component.

--- a/packages/circuit-ui/components/Carousel/Carousel.tsx
+++ b/packages/circuit-ui/components/Carousel/Carousel.tsx
@@ -185,7 +185,6 @@ export function Carousel({
                 aria-hidden
                 key={state.step}
                 size="s"
-                variant="secondary"
                 loop
                 paused={state.paused}
                 duration={Math.round(

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.mdx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.mdx
@@ -31,12 +31,6 @@ When you specify the label for the progress bar, it should only be shown as eith
 
 <Story of={Stories.Labelled} />
 
-### Variants
-
-You can use the progress bar in two variants: `primary` or `secondary`.
-
-<Story of={Stories.Variants} />
-
 ### Sizes
 
 You can use the progress bar in one of three sizes: `s`, `m`, or `l`.

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.module.css
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.module.css
@@ -87,16 +87,6 @@
   height: var(--cui-spacings-mega);
 }
 
-/* Variants */
-
-.primary::after {
-  background-color: var(--cui-bg-accent-strong);
-}
-
-.secondary::after {
-  background-color: var(--cui-bg-strong);
-}
-
 .label {
   flex-shrink: 0;
   margin-left: var(--cui-spacings-byte);

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.stories.tsx
@@ -22,7 +22,6 @@ export default {
   component: ProgressBar,
 };
 
-const variants = ['primary', 'secondary'] as const;
 const sizes = ['s', 'm', 'l'] as const;
 
 const progressBarStyles = {
@@ -68,22 +67,6 @@ export const Labelled = (args: ProgressBarProps) => {
 };
 
 Labelled.args = {
-  value: 3,
-  max: 10,
-};
-
-export const Variants = (args: ProgressBarProps) =>
-  variants.map((variant) => (
-    <ProgressBar
-      key={variant}
-      {...args}
-      variant={variant}
-      label={`A ${variant} progressbar`}
-      style={progressBarStyles}
-    />
-  ));
-
-Variants.args = {
   value: 3,
   max: 10,
 };

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -28,12 +28,6 @@ import classes from './ProgressBar.module.css';
 
 interface BaseProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * @deprecated
-   *
-   * Choose from 2 style variants. Default: 'primary'.
-   */
-  variant?: 'primary' | 'secondary';
-  /**
    * Choose from 3 sizes. Default: 'm'.
    */
   size?:
@@ -115,7 +109,6 @@ export function ProgressBar({
   max,
   value,
   size: legacySize = 'm',
-  variant: deprecatedVariant,
   duration = 3000,
   loop = false,
   paused = false,
@@ -144,12 +137,7 @@ export function ProgressBar({
     );
   }
 
-  if (process.env.NODE_ENV !== 'production' && deprecatedVariant) {
-    deprecate('ProgressBar', 'The `variant` prop has been deprecated.');
-  }
-
   const size = legacySizeMap[legacySize] || legacySize;
-  const variant = deprecatedVariant || 'primary';
 
   return (
     <div className={clsx(classes.wrapper, className)} {...props}>
@@ -160,14 +148,14 @@ export function ProgressBar({
           aria-valuemin={0}
           aria-valuemax={max}
           aria-labelledby={ariaId}
-          className={clsx(classes.base, classes[variant], classes[size])}
+          className={clsx(classes.base, classes[size])}
           style={{ '--pagination-width': getWidth(value, max) }}
         />
       ) : (
         <span
           role="progressbar"
           aria-labelledby={ariaId}
-          className={clsx(classes.base, classes[variant], classes[size])}
+          className={clsx(classes.base, classes[size])}
           data-loop={loop}
           style={{
             '--pagination-animation-duration': `${duration}ms`,


### PR DESCRIPTION
Follow up to #2358.

## Purpose

With the switch to black&white, the ProgressBar's "primary" variant has changed from blue to black, matching the "secondary" variant. This makes the `variant` prop obsolete.

## Approach and changes

- Removed the ProgressBar's `variant` prop which has been deprecated since v7.7

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
