### PR TITLE
Fix Anchor alignment

### DIFF
--- a/.changeset/loud-rules-study.md
+++ b/.changeset/loud-rules-study.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the alignment of the Anchor component when rendered as a `button` element.

--- a/packages/circuit-ui/components/Anchor/Anchor.module.css
+++ b/packages/circuit-ui/components/Anchor/Anchor.module.css
@@ -5,8 +5,8 @@
   margin-right: 0;
   margin-left: 0;
   color: var(--cui-fg-accent);
+  text-align: left;
   text-decoration: underline;
-  text-decoration-skip-ink: auto;
   background: none;
   border: 0;
   border-radius: var(--cui-border-radius-byte);
@@ -15,6 +15,7 @@
     color var(--cui-transitions-default),
     background-color var(--cui-transitions-default),
     border-color var(--cui-transitions-default);
+  text-decoration-skip-ink: auto;
 }
 
 .base:hover {


### PR DESCRIPTION
## Purpose

When the `Anchor` component renders as a `button` element, its text content is center-aligned due to the default browser styles.

## Approach and changes

- Explicitly align the text content to the left 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
