### PR TITLE
Fix disabled ButtonGroup action

### DIFF
--- a/.changeset/dull-pets-hope.md
+++ b/.changeset/dull-pets-hope.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the disabled styles of the secondary action inside a ButtonGroup.

--- a/packages/circuit-ui/components/Button/Button.stories.tsx
+++ b/packages/circuit-ui/components/Button/Button.stories.tsx
@@ -29,6 +29,7 @@ export default {
   subcomponents: { IconButton, CloseButton, ButtonGroup },
   argTypes: {
     children: { control: 'text' },
+    disabled: { control: 'boolean' },
   },
 };
 

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -337,16 +337,6 @@
   transform: translateY(2px);
 }
 
-/* Disabled */
-.base:disabled,
-.base[disabled],
-.base[aria-disabled="true"] {
-  color: var(--cui-fg-normal-disabled);
-  cursor: not-allowed;
-  background-color: var(--cui-bg-highlight-disabled);
-  border-color: transparent;
-}
-
 /* ButtonGroup */
 @container cui-button-group (width < 360px) {
   .base {
@@ -397,4 +387,20 @@
   .tertiary .label::after {
     display: none;
   }
+}
+
+/* Disabled */
+.base:disabled,
+.base[disabled],
+.base[aria-disabled="true"] {
+  color: var(--cui-fg-normal-disabled);
+  cursor: not-allowed;
+  background-color: var(--cui-bg-highlight-disabled);
+  border-color: transparent;
+}
+
+.base:disabled .content,
+.base[disabled] .content,
+.base[aria-disabled="true"] .content {
+  transform: translate(0);
 }


### PR DESCRIPTION
## Purpose

The ButtonGroup's secondary action is rendered as a tertiary Button inside wide containers. The style override also mistakenly overrides the disabled styles.

## Approach and changes

- Move disabled styles below ButtonGroup style overrides

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
