### PR TITLE
Improve icon search

### DIFF
--- a/.storybook/components/Icons.module.css
+++ b/.storybook/components/Icons.module.css
@@ -1,9 +1,41 @@
 .filters {
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
-  gap: var(--cui-spacings-kilo);
-  margin-top: var(--cui-spacings-tera);
-  margin-bottom: var(--cui-spacings-peta);
+  grid-template-columns: 1fr;
+  gap: var(--cui-spacings-giga);
+  padding-top: var(--cui-spacings-kilo);
+  padding-bottom: var(--cui-spacings-kilo);
+  margin-top: var(--cui-spacings-giga);
+  margin-bottom: var(--cui-spacings-tera);
+  background-color: var(--cui-bg-normal);
+}
+
+@media (min-width: 500px) {
+  .filters {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (min-width: 750px) {
+  .filters {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    grid-template-columns: 2fr 1fr 1fr 1fr;
+  }
+
+  .filters::after {
+    position: absolute;
+    top: 100%;
+    display: block;
+    width: 100%;
+    height: var(--cui-spacings-kilo);
+    content: "";
+    background: linear-gradient(
+      rgb(255 255 255 / 100%),
+      rgb(255 255 255 / 66%),
+      rgb(255 255 255 / 0%)
+    );
+  }
 }
 
 .category {
@@ -33,12 +65,23 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 64px; /* 2 * 32px icon */
+  height: 48px; /* max icon height */
+}
+
+.one-x {
+  height: 48px; /* 1 × 48px (max icon height) */
+}
+
+.two-x {
+  height: 96px; /* 2 × 48px (max icon height) */
+}
+
+.two-x .icon {
+  transform: scale(2);
 }
 
 .icon {
   max-width: 3rem;
-  transform: scale(2);
 }
 
 .label {

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -13,7 +13,12 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import {
+  type Dispatch,
+  type SetStateAction,
+  useState,
+  ChangeEvent,
+} from 'react';
 import { Unstyled } from '@storybook/addon-docs';
 import * as iconComponents from '@sumup/icons';
 import type { IconsManifest } from '@sumup/icons';
@@ -24,6 +29,9 @@ import {
   SearchInput,
   Select,
   Badge,
+  SelectorGroup,
+  clsx,
+  utilClasses,
 } from '../../packages/circuit-ui/index.js';
 import classes from './Icons.module.css';
 
@@ -60,24 +68,20 @@ const Icons = () => {
   const [search, setSearch] = useState('');
   const [size, setSize] = useState('all');
   const [color, setColor] = useState('var(--cui-fg-normal)');
+  const [scale, setScale] = useState('one-x');
 
-  const handleSearch = (event) => {
-    setSearch(event.target.value);
-  };
-
-  const handleSizeChange = (event) => {
-    setSize(event.target.value);
-  };
-
-  const handleColorChange = (event) => {
-    setColor(event.target.value);
-  };
+  const handleChange =
+    (setState: Dispatch<SetStateAction<string>>) =>
+    (event: ChangeEvent<any>) => {
+      setState(event.target.value);
+    };
 
   const sizeOptions = [
     { label: 'All sizes', value: 'all' },
     { label: '16', value: '16' },
     { label: '24', value: '24' },
     { label: '32', value: '32' },
+    { label: '48', value: '48' },
   ];
 
   const colorOptions = [
@@ -90,9 +94,14 @@ const Icons = () => {
     { label: 'On Strong', value: 'var(--cui-fg-on-strong)' },
   ];
 
+  const scaleOptions = [
+    { label: '1x', value: 'one-x' },
+    { label: '2x', value: 'two-x' },
+  ];
+
   const activeIcons = iconsManifest.icons.filter((icon) => {
     const matchesKeyword = [icon.name, ...(icon.keywords || [])].some(
-      (keyword) => keyword.includes(search),
+      (keyword) => keyword.toLowerCase().includes(search.toLowerCase()),
     );
     const matchesSize = size === 'all' || size === icon.size;
     return matchesKeyword && matchesSize;
@@ -100,28 +109,35 @@ const Icons = () => {
 
   return (
     <Unstyled>
-      <div className={classes.filters}>
+      <fieldset className={classes.filters}>
+        <legend className={utilClasses.hideVisually}>Icon filters</legend>
         <SearchInput
-          label="Filter icons by name"
+          label="Search by name or keyword"
           placeholder="Search..."
           value={search}
-          onChange={handleSearch}
+          onChange={handleChange(setSearch)}
           onClear={() => setSearch('')}
           clearLabel="Clear"
         />
         <Select
-          label="Select icon size"
+          label="Size"
           options={sizeOptions}
           value={size}
-          onChange={handleSizeChange}
+          onChange={handleChange(setSize)}
         />
         <Select
-          label="Select icon color"
+          label="Color"
           options={colorOptions}
           value={color}
-          onChange={handleColorChange}
+          onChange={handleChange(setColor)}
         />
-      </div>
+        <SelectorGroup
+          label="Scale"
+          options={scaleOptions}
+          value={scale}
+          onChange={handleChange(setScale)}
+        />
+      </fieldset>
 
       {activeIcons.length <= 0 ? (
         <Body>No icons found</Body>
@@ -140,7 +156,9 @@ const Icons = () => {
                 const Icon = iconComponents[componentName];
                 return (
                   <div key={id} className={classes.wrapper}>
-                    <div className={classes['icon-wrapper']}>
+                    <div
+                      className={clsx(classes['icon-wrapper'], classes[scale])}
+                    >
                       <Icon
                         aria-labelledby={id}
                         size={icon.size}

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -29,7 +29,7 @@ import classes from './Icons.module.css';
 
 function groupBy(
   icons: IconsManifest['icons'],
-  key: keyof IconsManifest['icons'][0],
+  key: 'name' | 'category' | 'size',
 ) {
   return icons.reduce((groups, icon) => {
     (groups[icon[key]] = groups[icon[key]] || []).push(icon);
@@ -39,7 +39,7 @@ function groupBy(
 
 function sortBy(
   icons: IconsManifest['icons'],
-  key: keyof IconsManifest['icons'][0],
+  key: 'name' | 'category' | 'size',
 ) {
   return icons.sort((iconA, iconB) => {
     return iconA[key].localeCompare(iconB[key]);
@@ -90,10 +90,13 @@ const Icons = () => {
     { label: 'On Strong', value: 'var(--cui-fg-on-strong)' },
   ];
 
-  const activeIcons = iconsManifest.icons.filter(
-    (icon) =>
-      icon.name.includes(search) && (size === 'all' || size === icon.size),
-  );
+  const activeIcons = iconsManifest.icons.filter((icon) => {
+    const matchesKeyword = [icon.name, ...(icon.keywords || [])].some(
+      (keyword) => keyword.includes(search),
+    );
+    const matchesSize = size === 'all' || size === icon.size;
+    return matchesKeyword && matchesSize;
+  }) as IconsManifest['icons'];
 
   return (
     <Unstyled>

--- a/packages/icons/scripts/web.ts
+++ b/packages/icons/scripts/web.ts
@@ -33,6 +33,7 @@ const DIST_DIR = path.join(BASE_DIR, 'dist');
 type Icon = {
   name: string;
   category: string;
+  keywords?: string[];
   size: '16' | '24' | '32';
   deprecation?: string;
 };
@@ -148,6 +149,7 @@ function buildDeclarationFile(components: Component[]): string {
       icons: {
         name: string;
         category: string;
+        keywords?: string[];
         size: '16' | '24' | '32';
         deprecation?: string;
       }[];


### PR DESCRIPTION
## Purpose

Finding an icon on the existing docs page can be difficult when the exact icon name isn't known.

## Approach and changes

- Add keywords to icons (synonyms or alternative words to describe an icon)
- Display icons at their true size and add a control to view them at 2x scale
- Pin the search filters at the top on large viewports when scrolling 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
