### PR TITLE
Fix clipped Button content

### DIFF
--- a/.changeset/nervous-jokes-invite.md
+++ b/.changeset/nervous-jokes-invite.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed Buttons not taking up the available space, causing the label to be hidden.

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -125,8 +125,7 @@
 
 /* Content */
 .content {
-  display: grid;
-  grid-auto-flow: column;
+  display: flex;
   gap: var(--content-gap);
   place-content: center;
   align-items: center;


### PR DESCRIPTION
## Purpose

I switched from Flexbox to CSS Grid for laying out the Button content to be able to use the `gap` property ([`gap` for Flexbox isn't supported in all browsers we support](https://caniuse.com/flexbox-gap)). This introduced a bug where the Button shrinks to its minimum width when the parent element doesn't have a defined width, thus clipping the Button content.

## Approach and changes

- Switch back to Flexbox. This means the Button content won't be properly spaced on browsers that don't support `gap` for Flexbox yet, which is a trade-off I'm willing to make.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
