### PR TITLE
Improve accessibility of Popover icons

### DIFF
--- a/.changeset/shiny-dryers-try.md
+++ b/.changeset/shiny-dryers-try.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Removed presentational icons in the Popover component from the accessibility tree.

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -102,7 +102,7 @@ export const PopoverItem = ({
       )}
       {...props}
     >
-      {Icon && <Icon className={classes.icon} size="24" />}
+      {Icon && <Icon className={classes.icon} size="24" aria-hidden="true" />}
       {children}
     </Element>
   );


### PR DESCRIPTION
## Purpose

The optional icons next to Popover items are purely presentational.

## Approach and changes

- Removed icons inside the Popover component from the accessibility tree

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
