### PR TITLE
Replace Tabs shadow with bottom border

### DIFF
--- a/.changeset/grumpy-lies-promise.md
+++ b/.changeset/grumpy-lies-promise.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Replaced the Tabs' and TabList's outer shadow with a border at the bottom.

--- a/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
@@ -39,6 +39,7 @@ export const Base = (args: TabsProps) => <Tabs {...args} />;
 
 Base.args = {
   items: tabs,
+  stretched: false,
 };
 
 export const Links = () => (

--- a/packages/circuit-ui/components/Tabs/Tabs.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.tsx
@@ -21,11 +21,11 @@ import {
   isArrowDown,
 } from '../../util/key-codes.js';
 
-import { TabList } from './components/TabList/index.js';
+import { TabList, TabListProps } from './components/TabList/index.js';
 import { Tab } from './components/Tab/index.js';
 import { TabPanel } from './components/TabPanel/index.js';
 
-export interface TabsProps {
+export interface TabsProps extends TabListProps {
   /**
    * The index of the initially selected tab.
    */

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.module.css
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.module.css
@@ -48,6 +48,7 @@
   right: 0;
   bottom: 0;
   left: 0;
+  z-index: var(--cui-z-index-absolute);
   width: 100%;
   height: var(--cui-spacings-bit);
   content: " ";

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.module.css
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.module.css
@@ -1,11 +1,23 @@
 .wrapper {
   --tab-list-height: 48px;
 
+  position: relative;
   display: flex;
   height: var(--tab-list-height);
   overflow-x: auto;
   background: var(--cui-bg-normal);
-  box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);
+}
+
+.wrapper::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: block;
+  width: 100%;
+  height: var(--cui-spacings-bit);
+  content: "";
+  background-color: var(--cui-border-divider);
 }
 
 .base {
@@ -17,10 +29,11 @@
   width: 100%;
 }
 
-.stretched [role='tab'] {
+.stretched [role="tab"] {
   flex: 1 1 auto;
   width: var(--tab-list-width);
-  padding: 0 var(--cui-spacings-kilo);
+  padding-right: var(--cui-spacings-kilo);
+  padding-left: var(--cui-spacings-kilo);
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -30,10 +43,11 @@
     width: 100%;
   }
 
-  .stretched-mobile [role='tab'] {
+  .stretched-mobile [role="tab"] {
     flex: 1 1 auto;
     width: var(--tab-list-width);
-    padding: 0 var(--cui-spacings-kilo);
+    padding-right: var(--cui-spacings-kilo);
+    padding-left: var(--cui-spacings-kilo);
     overflow: hidden;
     text-overflow: ellipsis;
   }


### PR DESCRIPTION
## Purpose

The shadow outline around the Tabs/TabList doesn't fit our design language anymore. Already, more often than not, it is removed by developers using custom styles. 

A different approach is needed to group the tabs together visually. This is a short-term solution since the tab component is due to be redesigned from scratch soon.

## Approach and changes

- Replaced the Tabs' and TabList's outer shadow with a light-gray border at the bottom.

_Before_

<img width="802" alt="Screenshot 2024-01-15 at 11 10 28" src="https://github.com/sumup-oss/circuit-ui/assets/11017722/c3b83dcc-03f9-426b-b3c2-f19efc4519bb">

_After_

<img width="793" alt="Screenshot 2024-01-15 at 11 10 56" src="https://github.com/sumup-oss/circuit-ui/assets/11017722/29b2e500-c583-4786-adc3-8d6ab2689a0b">

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
