### PR TITLE
Fix passing custom styles to SelectorGroup options (v7)

### DIFF
--- a/.changeset/seven-peaches-float.md
+++ b/.changeset/seven-peaches-float.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed passing custom styles to the SelectorGroup options.

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -192,7 +192,7 @@ export const SelectorGroup = forwardRef<
               <Selector
                 {...option}
                 key={option.label}
-                className={classes.option}
+                className={clsx(classes.option, option.className)}
                 name={name}
                 onChange={onChange}
                 onBlur={onBlur}


### PR DESCRIPTION
## Purpose

It should be possible to style the SelectorGroup options.

## Approach and changes

- Fixed passing custom styles to the SelectorGroup options

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
