### PR TITLE
Address deprecations in the Carousel component

### DIFF
--- a/.changeset/pretty-buttons-fold.md
+++ b/.changeset/pretty-buttons-fold.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Resolved deprecation warnings in the Carousel component.

--- a/packages/circuit-ui/components/Carousel/Carousel.tsx
+++ b/packages/circuit-ui/components/Carousel/Carousel.tsx
@@ -204,14 +204,12 @@ export function Carousel({
                 >
                   {state.paused ? playButtonLabel : pauseButtonLabel}
                 </PlayButton>
-                <PrevButton
-                  label={prevButtonLabel}
-                  {...getPreviousControlProps()}
-                />
-                <NextButton
-                  label={nextButtonLabel}
-                  {...getNextControlProps()}
-                />
+                <PrevButton {...getPreviousControlProps()}>
+                  {prevButtonLabel}
+                </PrevButton>
+                <NextButton {...getNextControlProps()}>
+                  {nextButtonLabel}
+                </NextButton>
               </ButtonList>
             </Controls>
           )}


### PR DESCRIPTION
## Purpose

The IconButton expects the label as `children` instead of the `label` prop.

## Approach and changes

- Move label to `children` for the PrevButton and NextButton components inside the Carousel

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
