### PR TITLE
Add Tooltip component

### DIFF
--- a/.changeset/beige-bottles-act.md
+++ b/.changeset/beige-bottles-act.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": minor
+---
+
+Added an experimental Tooltip component.

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -18,6 +18,7 @@ import {
   type SetStateAction,
   useState,
   ChangeEvent,
+  forwardRef,
 } from 'react';
 import { Unstyled } from '@storybook/addon-docs';
 import * as iconComponents from '@sumup/icons';
@@ -29,6 +30,7 @@ import {
   SearchInput,
   Select,
   Badge,
+  Tooltip,
   SelectorGroup,
   clsx,
   utilClasses,
@@ -40,10 +42,13 @@ function groupBy(
   icons: IconsManifest['icons'],
   key: 'name' | 'category' | 'size',
 ) {
-  return icons.reduce((groups, icon) => {
-    (groups[icon[key]] = groups[icon[key]] || []).push(icon);
-    return groups;
-  }, {});
+  return icons.reduce(
+    (groups, icon) => {
+      (groups[icon[key]] = groups[icon[key]] || []).push(icon);
+      return groups;
+    },
+    {} as Record<string, IconsManifest['icons']>,
+  );
 }
 
 function sortBy(
@@ -172,20 +177,28 @@ const Icons = () => {
                         }}
                       />
                     </div>
-                    <span id={id} className={classes.label} title={icon.name}>
-                      {icon.name}
+                    <span id={id} className={classes.label}>
+                      {componentName}
                       {size === 'all' && (
                         <span className={classes.size}>{icon.size}</span>
                       )}
                     </span>
                     {icon.deprecation && (
-                      <Badge
-                        title={icon.deprecation}
-                        variant="warning"
-                        className={classes.badge}
-                      >
-                        Deprecated
-                      </Badge>
+                      <Tooltip
+                        type="description"
+                        label={icon.deprecation}
+                        component={forwardRef((props, ref) => (
+                          <Badge
+                            {...props}
+                            ref={ref}
+                            tabIndex={0}
+                            variant="danger"
+                            className={classes.badge}
+                          >
+                            Deprecated
+                          </Badge>
+                        ))}
+                      />
                     )}
                   </div>
                 );

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -30,11 +30,11 @@ import {
   SearchInput,
   Select,
   Badge,
-  Tooltip,
   SelectorGroup,
   clsx,
   utilClasses,
 } from '../../packages/circuit-ui/index.js';
+import { Tooltip } from '../../packages/circuit-ui/experimental.js';
 import { slugify } from '../slugify.js';
 import classes from './Icons.module.css';
 

--- a/.storybook/components/Stack.module.css
+++ b/.storybook/components/Stack.module.css
@@ -1,4 +1,5 @@
 .base {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 2rem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6306,6 +6306,24 @@
         "react": ">=16"
       }
     },
+    "node_modules/@nanostores/react": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@nanostores/react/-/react-0.7.2.tgz",
+      "integrity": "sha512-e3OhHJFv3NMSFYDgREdlAQqkyBTHJM91s31kOZ4OvZwJKdFk5BLk0MLbh51EOGUz9QGX2aCHfy1RvweSi7fgwA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "nanostores": "^0.9.0 || ^0.10.0",
+        "react": ">=18.0.0"
+      }
+    },
     "node_modules/@ndelangen/get-tarball": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@ndelangen/get-tarball/-/get-tarball-3.0.9.tgz",
@@ -29854,6 +29872,20 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nanostores": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.10.0.tgz",
+      "integrity": "sha512-Poy5+9wFXOD0jAstn4kv9n686U2BFw48z/W8lms8cS8lcbRz7BU20JxZ3e/kkKQVfRrkm4yLWCUA6GQINdvJCQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -40037,6 +40069,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.5",
+        "@nanostores/react": "^0.7.2",
+        "nanostores": "^0.10.0",
         "react-modal": "^3.16.1",
         "react-number-format": "5.3.0"
       },
@@ -45194,6 +45228,12 @@
         "@types/mdx": "^2.0.0"
       }
     },
+    "@nanostores/react": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@nanostores/react/-/react-0.7.2.tgz",
+      "integrity": "sha512-e3OhHJFv3NMSFYDgREdlAQqkyBTHJM91s31kOZ4OvZwJKdFk5BLk0MLbh51EOGUz9QGX2aCHfy1RvweSi7fgwA==",
+      "requires": {}
+    },
     "@ndelangen/get-tarball": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@ndelangen/get-tarball/-/get-tarball-3.0.9.tgz",
@@ -47118,6 +47158,7 @@
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
         "@floating-ui/react-dom": "^2.0.5",
+        "@nanostores/react": "^0.7.2",
         "@sumup/design-tokens": "^7.0.0",
         "@sumup/icons": "^3.0.0",
         "@sumup/intl": "^1.5.0",
@@ -47133,6 +47174,7 @@
         "@types/react-modal": "^3.16.3",
         "jest-axe": "^8.0.0",
         "moment": "^2.29.4",
+        "nanostores": "^0.10.0",
         "react": "^18.2.0",
         "react-dates": "^21.8.0",
         "react-dom": "^18.2.0",
@@ -61954,6 +61996,11 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+    },
+    "nanostores": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.10.0.tgz",
+      "integrity": "sha512-Poy5+9wFXOD0jAstn4kv9n686U2BFw48z/W8lms8cS8lcbRz7BU20JxZ3e/kkKQVfRrkm4yLWCUA6GQINdvJCQ=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/packages/circuit-ui/components/Button/IconButton.module.css
+++ b/packages/circuit-ui/components/Button/IconButton.module.css
@@ -1,17 +1,3 @@
-/* Visually hide the label */
-.base > span:last-child > span:last-child {
-  /* .hide-visually */
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 /* Sizes */
 .s {
   padding: calc(var(--cui-spacings-bit) - var(--cui-border-width-kilo));

--- a/packages/circuit-ui/components/Button/base.tsx
+++ b/packages/circuit-ui/components/Button/base.tsx
@@ -97,7 +97,7 @@ export type CreateButtonComponentProps = SharedButtonProps & {
    * with the button. Use one strong, clear imperative verb and follow with a
    * one-word object if needed to clarify.
    */
-  children: ReactNode;
+  children?: ReactNode;
   /**
    * Choose from 2 sizes. Default: 'm'.
    */
@@ -124,7 +124,7 @@ export const legacyButtonSizeMap: Record<string, 's' | 'm'> = {
 
 export function createButtonComponent<Props>(
   componentName: string,
-  // TODO: Refactor to `mapClassName` once the deprecations have been removed.
+  // TODO: Refactor to `mapClassName` once the deprecations have been removed?
   mapProps: (props: Props) => CreateButtonComponentProps,
 ) {
   const Button = forwardRef<any, Props>((props, ref) => {
@@ -222,7 +222,7 @@ export function createButtonComponent<Props>(
               height={leadingIconSize}
             />
           )}
-          <span className={classes.label}>{children}</span>
+          {children && <span className={classes.label}>{children}</span>}
           {TrailingIcon && (
             <TrailingIcon
               aria-hidden="true"

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -283,7 +283,9 @@ export const ImageInput = ({
             disabled={isLoading || disabled}
             className={clsx(classes.button, classes.add)}
             icon={Plus}
-          />
+          >
+            +
+          </IconButton>
         )}
         <Spinner
           className={clsx(classes.spinner, isLoading && classes.loading)}

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
@@ -93,7 +93,7 @@ describe('NotificationToast', () => {
       expect(screen.getByText('This is a toast message')).toBeVisible();
     });
 
-    const closeButton = screen.getByText('Close');
+    const closeButton = screen.getByLabelText('Close');
 
     await userEvent.click(closeButton);
 

--- a/packages/circuit-ui/components/Pagination/Pagination.spec.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.spec.tsx
@@ -32,14 +32,14 @@ describe('Pagination', () => {
 
   it('should disable the previous button on the first page', () => {
     render(<Pagination {...baseProps} currentPage={1} />);
-    const prevButtonEl = screen.getByText('Previous').closest('button');
+    const prevButtonEl = screen.getByLabelText('Previous');
 
     expect(prevButtonEl).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('should disable the next button on the last page', () => {
     render(<Pagination {...baseProps} currentPage={baseProps.totalPages} />);
-    const nextButtonEl = screen.getByText('Next').closest('button');
+    const nextButtonEl = screen.getByLabelText('Next');
 
     expect(nextButtonEl).toHaveAttribute('aria-disabled', 'true');
   });
@@ -48,7 +48,7 @@ describe('Pagination', () => {
     const onChange = vi.fn();
     render(<Pagination {...baseProps} onChange={onChange} currentPage={3} />);
 
-    const prevButtonEl = screen.getByText('Previous');
+    const prevButtonEl = screen.getByLabelText('Previous');
 
     await userEvent.click(prevButtonEl);
 
@@ -60,7 +60,7 @@ describe('Pagination', () => {
     const onChange = vi.fn();
     render(<Pagination {...baseProps} onChange={onChange} />);
 
-    const nextButtonEl = screen.getByText('Next');
+    const nextButtonEl = screen.getByLabelText('Next');
 
     await userEvent.click(nextButtonEl);
 

--- a/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
@@ -46,6 +46,7 @@ export const PageList: FC<PageListProps> = ({
       return (
         <li key={page}>
           <Tooltip
+            type="description"
             label={label}
             component={forwardRef((tooltipProps, ref) => (
               <Button

--- a/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
@@ -15,9 +15,11 @@
 
 'use client';
 
-import { FC, OlHTMLAttributes } from 'react';
+import { FC, OlHTMLAttributes, forwardRef } from 'react';
 
+import { clsx } from '../../../../styles/clsx.js';
 import Button from '../../../Button/index.js';
+import Tooltip from '../../../Tooltip/index.js';
 
 import classes from './PageList.module.css';
 
@@ -43,17 +45,22 @@ export const PageList: FC<PageListProps> = ({
       const label = pageLabel(page);
       return (
         <li key={page}>
-          <Button
-            size="s"
-            onClick={() => onChange(page)}
-            variant={isCurrent ? 'primary' : 'tertiary'}
-            title={label}
-            aria-label={label}
-            aria-current={isCurrent}
-            className={classes.button}
-          >
-            {page}
-          </Button>
+          <Tooltip
+            label={label}
+            component={forwardRef((tooltipProps, ref) => (
+              <Button
+                {...tooltipProps}
+                ref={ref}
+                size="s"
+                onClick={() => onChange(page)}
+                variant={isCurrent ? 'primary' : 'tertiary'}
+                aria-current={isCurrent}
+                className={clsx(tooltipProps.className, classes.button)}
+              >
+                {page}
+              </Button>
+            ))}
+          />
         </li>
       );
     })}

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -277,7 +277,14 @@ export const Popover = ({
       window.removeEventListener('scroll', update);
     }
 
-    // Focus the first or last element after opening
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update);
+    };
+  }, [isOpen, refs.reference, update]);
+
+  useEffect(() => {
+    // Focus the first or last popover item after opening
     if (!prevOpen && isOpen) {
       const element = (
         triggerKey.current && triggerKey.current === 'ArrowUp'
@@ -289,7 +296,7 @@ export const Popover = ({
       }
     }
 
-    // Focus the trigger button after closing
+    // Focus the reference element after closing
     if (prevOpen && !isOpen) {
       const triggerButton = (refs.reference.current &&
         refs.reference.current.firstElementChild) as HTMLElement;
@@ -297,13 +304,7 @@ export const Popover = ({
     }
 
     triggerKey.current = null;
-
-    // Clean up the event listener when the component is unmounted
-    return () => {
-      window.removeEventListener('resize', update);
-      window.removeEventListener('scroll', update);
-    };
-  }, [isOpen, prevOpen, refs.reference, update]);
+  }, [isOpen, prevOpen, refs.reference]);
 
   return (
     <Fragment>

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -264,7 +264,7 @@ export const Popover = ({
     /**
      * When we support `ResizeObserver` (https://caniuse.com/resizeobserver),
      * we can look into using Floating UI's `autoUpdate` (but we can't use
-     * `whileElementInMounted` because our implementation hides the floating
+     * `whileElementIsMounted` because our implementation hides the floating
      * element using CSS instead of using conditional rendering.
      * See https://floating-ui.com/docs/react-dom#updating
      */

--- a/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
@@ -73,7 +73,7 @@ describe('SidePanel', () => {
     const onClose = vi.fn();
     renderComponent({ onClose });
 
-    await userEvent.click(screen.getByTitle(baseProps.closeButtonLabel));
+    await userEvent.click(screen.getByLabelText(baseProps.closeButtonLabel));
 
     expect(onClose).toHaveBeenCalled();
   });
@@ -123,7 +123,7 @@ describe('SidePanel', () => {
       renderComponent({ isStacked: true, onBack });
 
       expect(
-        screen.getByTitle(baseProps.backButtonLabel as string),
+        screen.getByLabelText(baseProps.backButtonLabel as string),
       ).toBeVisible();
     });
 
@@ -132,7 +132,7 @@ describe('SidePanel', () => {
       renderComponent({ isStacked: true, onBack });
 
       await userEvent.click(
-        screen.getByTitle(baseProps.backButtonLabel as string),
+        screen.getByLabelText(baseProps.backButtonLabel as string),
       );
 
       expect(onBack).toHaveBeenCalled();

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.spec.tsx
@@ -42,7 +42,7 @@ describe('Header', () => {
     const onClose = vi.fn();
     renderComponent({ onClose });
 
-    await userEvent.click(screen.getByTitle(baseProps.closeButtonLabel));
+    await userEvent.click(screen.getByLabelText(baseProps.closeButtonLabel));
 
     expect(onClose).toHaveBeenCalled();
   });
@@ -53,7 +53,7 @@ describe('Header', () => {
       onBack,
     });
 
-    expect(screen.getByTitle(baseProps.backButtonLabel)).toBeVisible();
+    expect(screen.getByLabelText(baseProps.backButtonLabel)).toBeVisible();
   });
 
   it('should call the onBack callback from the back button', async () => {
@@ -62,7 +62,7 @@ describe('Header', () => {
       onBack,
     });
 
-    await userEvent.click(screen.getByTitle(baseProps.backButtonLabel));
+    await userEvent.click(screen.getByLabelText(baseProps.backButtonLabel));
 
     expect(onBack).toHaveBeenCalled();
   });

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.spec.tsx
@@ -41,8 +41,8 @@ describe('SortArrow', () => {
 
   it('should call the onClick callback', async () => {
     const onClick = vi.fn();
-    render(<SortArrow label="Sort" onClick={onClick} data-testid="sort" />);
-    await userEvent.click(screen.getByTestId('sort'));
+    render(<SortArrow label="Sort" onClick={onClick} />);
+    await userEvent.click(screen.getByRole('button'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
@@ -35,6 +35,7 @@ interface SortArrowProps extends HTMLAttributes<HTMLButtonElement> {
 export function SortArrow({ label, direction, onClick }: SortArrowProps) {
   return (
     <Tooltip
+      type="label"
       label={label}
       component={forwardRef((props, ref) => (
         <button

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { HTMLAttributes, forwardRef } from 'react';
 import { ChevronUp, ChevronDown } from '@sumup/icons';
 

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
@@ -13,12 +13,12 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, forwardRef } from 'react';
 import { ChevronUp, ChevronDown } from '@sumup/icons';
 
 import { Direction } from '../../types.js';
 import { clsx } from '../../../../styles/clsx.js';
-import utilityClasses from '../../../../styles/utility.js';
+import Tooltip from '../../../Tooltip/index.js';
 
 import classes from './SortArrow.module.css';
 
@@ -30,21 +30,29 @@ interface SortArrowProps extends HTMLAttributes<HTMLButtonElement> {
 /**
  * SortArrow for the Table component. The Table handles rendering it.
  */
-export function SortArrow({
-  label,
-  direction,
-  className,
-  ...props
-}: SortArrowProps) {
+export function SortArrow({ label, direction, onClick }: SortArrowProps) {
   return (
-    <button title={label} className={clsx(classes.base, className)} {...props}>
-      {direction !== 'ascending' && (
-        <ChevronUp size="16" aria-hidden="true" className={classes.icon} />
-      )}
-      {direction !== 'descending' && (
-        <ChevronDown size="16" aria-hidden="true" className={classes.icon} />
-      )}
-      <span className={utilityClasses.hideVisually}>{label}</span>
-    </button>
+    <Tooltip
+      label={label}
+      component={forwardRef((props, ref) => (
+        <button
+          {...props}
+          ref={ref}
+          className={clsx(classes.base, props.className)}
+          onClick={onClick}
+        >
+          {direction !== 'ascending' && (
+            <ChevronUp size="16" aria-hidden="true" className={classes.icon} />
+          )}
+          {direction !== 'descending' && (
+            <ChevronDown
+              size="16"
+              aria-hidden="true"
+              className={classes.icon}
+            />
+          )}
+        </button>
+      ))}
+    />
   );
 }

--- a/packages/circuit-ui/components/Tag/Tag.spec.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.spec.tsx
@@ -51,7 +51,7 @@ describe('Tag', () => {
       </Tag>,
     );
 
-    await userEvent.click(screen.getByText('Remove'));
+    await userEvent.click(screen.getByLabelText('Remove'));
 
     expect(onRemove).toHaveBeenCalledTimes(1);
   });

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -71,7 +71,10 @@ type RemoveProps =
   | { onRemove?: never; removeButtonLabel?: never };
 
 type DivElProps = Omit<HTMLAttributes<HTMLDivElement>, 'onClick' | 'prefix'>;
-type LinkElProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'>;
+type LinkElProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  'onClick' | 'prefix'
+>;
 type ButtonElProps = Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
   'onClick' | 'prefix'

--- a/packages/circuit-ui/components/Tooltip/Tooltip.mdx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.mdx
@@ -1,0 +1,14 @@
+import { Meta, Status, Props, Story } from '../../../../.storybook/components';
+import * as Stories from './Tooltip.stories';
+
+<Meta of={Stories} />
+
+# Tooltip
+
+<Status variant="experimental" />
+
+A floating bubble of information that clarifies the purpose of otherwise ambiguous controls/tools.
+
+<Story of={Stories.Base} />
+
+<Props />

--- a/packages/circuit-ui/components/Tooltip/Tooltip.mdx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.mdx
@@ -7,8 +7,66 @@ import * as Stories from './Tooltip.stories';
 
 <Status variant="experimental" />
 
-A floating bubble of information that clarifies the purpose of otherwise ambiguous controls/tools.
+Tooltips display additional information upon hover or focus that is contextual, helpful, and nonessential to clarify the purpose of otherwise ambiguous interactive elements.
 
 <Story of={Stories.Base} />
-
 <Props />
+
+## Usage
+
+Tooltips hide information by default and require user interaction to be shown. They should be used as a last resort when space truly is limited and the information cannot be shown inline.
+
+A Tooltip must be used with an interactive, focusable element such as a button, link or input. When wrapping a custom component or an inline function, ensure that the [`ref` is forwarded](https://react.dev/reference/react/forwardRef).
+
+The label must be a single unformatted string. Use a [Toggletip](Components/Toggletip/Docs) instead if the content should be structured or interactive.
+
+The Tooltip works without JavaScript as long as the parent element is [positioned](https://developer.mozilla.org/en-US/docs/Web/CSS/position#types_of_positioning). When JavaScript is available, the Tooltip is progressively enhanced to place itself within the viewport.
+
+## Variations
+
+### Types
+
+<Story of={Stories.Types} />
+
+#### Label
+
+Use the `label` type when the tooltip acts as the wrapped component's label (aka [accessible name](https://w3c.github.io/accname/#dfn-accessible-name)). The label text should state the element's function or action in one or two words maximum.
+
+#### Description
+
+Use the `description` type when the tooltip provides supplemental information about the wrapped component ([accessible description](https://w3c.github.io/accname/#dfn-accessible-description)). The label text should not contain information that is critical for a user to understand the wrapped element. Use sentence-case for the label text and write complete sentences with punctuation unless space is limited. Avoid exceeding 160 characters.
+
+### Placement
+
+By default, the tooltip is positioned above the wrapped component and center-aligned. Use the `placement` prop to specify a different initial position and alignment.
+
+The tooltip automatically flips to the opposite side to stay within the viewport when there isn't enough space available.
+
+<Story of={Stories.Placements} />
+
+---
+
+## Accessibility
+
+### Best practices
+
+
+- Only interactive elements should trigger tooltips
+- Tooltips should directly describe the UI control that triggers them (i.e. do not create a control purely to trigger a tooltip)
+- Use `aria-describedby` or `aria-labelledby` to associate the UI control with the tooltip. Avoid `aria-haspopup` and `aria-live`
+- Do not use the `title` attribute to create a tooltip
+- Do not put essential information in tooltips
+- Provide a means to dismiss the tooltip with both keyboard and pointer
+- Allow the mouse to easily move over the tooltip without dismissing it
+- Do not use a timeout to hide the tooltip
+
+
+### Resources
+
+- [Tooltips in the time of WCAG 2.1](https://sarahmhigley.com/writing/tooltips-in-wcag-21/) by Sarah Highley
+- [Inclusive Components: Tooltip & Toggletips](https://inclusive-components.design/tooltips-toggletips/) by Heydon Pickering
+
+#### Related WCAG success criteria
+
+- 1.4.13: [Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
+

--- a/packages/circuit-ui/components/Tooltip/Tooltip.module.css
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.module.css
@@ -1,0 +1,31 @@
+.parent {
+  position: relative;
+  display: inline-block;
+}
+
+.base {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  z-index: var(--cui-z-index-tooltip);
+  width: max-content;
+  max-width: 280px;
+  padding: var(--cui-spacings-bit) var(--cui-spacings-byte);
+  font-size: var(--cui-typography-body-two-font-size);
+  line-height: var(--cui-typography-body-two-line-height);
+  color: var(--cui-fg-on-strong);
+  pointer-events: none;
+  background-color: var(--cui-bg-strong);
+  border-radius: var(--cui-border-radius-bit);
+  opacity: 0;
+  transition: opacity var(--transition-slow);
+  transform: translateX(-50%);
+}
+
+.base:hover,
+.component:hover + .base,
+.component:focus + .base {
+  pointer-events: auto;
+  opacity: 1;
+  transition-delay: 0.6s;
+}

--- a/packages/circuit-ui/components/Tooltip/Tooltip.module.css
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.module.css
@@ -5,11 +5,10 @@
 
 .base {
   position: absolute;
-  bottom: 100%;
+  bottom: calc(100% + 16px); /* 8px (arrow size) + 4px (offset) */
   left: 50%;
   z-index: var(--cui-z-index-tooltip);
-  padding: var(--cui-spacings-byte);
-  transition: opacity var(--transition-slow);
+  transition: opacity var(--cui-transitions-default);
   transform: translateX(-50%);
 }
 
@@ -19,7 +18,7 @@
 .component:focus + .base {
   pointer-events: auto;
   opacity: 1;
-  transition-delay: 0.6s;
+  transition-delay: 1s;
 }
 
 .base[data-state="open"] {
@@ -36,16 +35,30 @@
   transition-delay: 0s;
 }
 
+.arrow {
+  position: absolute;
+  width: var(--cui-spacings-kilo);
+  height: var(--cui-spacings-kilo);
+  background-color: var(--cui-bg-elevated);
+  border-right: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
+  border-bottom: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
+  border-bottom-right-radius: 2px;
+}
+
+[data-state="closed"] .arrow {
+  display: none;
+}
+
 .content {
   width: max-content;
-  max-width: 280px;
-  padding: var(--cui-spacings-bit) var(--cui-spacings-byte);
+  max-width: 360px;
+  padding: var(--cui-spacings-byte) var(--cui-spacings-kilo);
   font-size: var(--cui-typography-body-two-font-size);
   font-weight: var(--cui-font-weight-regular);
   line-height: var(--cui-typography-body-two-line-height);
   color: var(--cui-fg-normal);
-  background-color: var(--cui-bg-normal);
-  border: var(--cui-border-width-kilo) solid var(--cui-border-divider);
-  border-radius: var(--cui-border-radius-bit);
-  box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);
+  background-color: var(--cui-bg-elevated);
+  border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
+  border-radius: var(--cui-border-radius-byte);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
 }

--- a/packages/circuit-ui/components/Tooltip/Tooltip.module.css
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.module.css
@@ -41,6 +41,7 @@
   max-width: 280px;
   padding: var(--cui-spacings-bit) var(--cui-spacings-byte);
   font-size: var(--cui-typography-body-two-font-size);
+  font-weight: var(--cui-font-weight-regular);
   line-height: var(--cui-typography-body-two-line-height);
   color: var(--cui-fg-on-strong);
   background-color: var(--cui-bg-strong);

--- a/packages/circuit-ui/components/Tooltip/Tooltip.module.css
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.module.css
@@ -1,8 +1,3 @@
-.parent {
-  position: relative;
-  display: inline-block;
-}
-
 .base {
   position: absolute;
   bottom: calc(100% + 16px); /* 8px (arrow size) + 4px (offset) */

--- a/packages/circuit-ui/components/Tooltip/Tooltip.module.css
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.module.css
@@ -1,10 +1,37 @@
 .base {
+  /* The arrow should be 8px tall. A square element is rotated to achieve a triangular shape. Using Pythagoras' theorem, we can calculate the ratio between the triangle height and the square sides: √(8^2 + 8^2) / 8 ≈ 1.414 */
+  --tooltip-arrow-size: calc(var(--cui-spacings-byte) * 1.414);
+  --tooltip-offset: var(--cui-spacings-kilo);
+
   position: absolute;
-  bottom: calc(100% + 16px); /* 8px (arrow size) + 4px (offset) */
-  left: 50%;
   z-index: var(--cui-z-index-tooltip);
+  pointer-events: none;
+  opacity: 0;
   transition: opacity var(--cui-transitions-default);
+}
+
+.base[data-state="initial"][data-side="top"] {
+  bottom: calc(100% + var(--tooltip-offset));
+  left: 50%;
   transform: translateX(-50%);
+}
+
+.base[data-state="initial"][data-side="left"] {
+  top: 50%;
+  right: 100%;
+  transform: translateY(-50%);
+}
+
+.base[data-state="initial"][data-side="bottom"] {
+  top: calc(100% + var(--tooltip-offset));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.base[data-state="initial"][data-side="right"] {
+  top: 50%;
+  left: 100%;
+  transform: translateY(-50%);
 }
 
 .base[data-state="open"],
@@ -16,32 +43,63 @@
   transition-delay: 1s;
 }
 
-.base[data-state="open"] {
-  bottom: auto;
-  left: auto;
-}
-
 .base,
 .base[data-state="closed"]:hover,
 .component:hover + .base[data-state="closed"],
 .component:focus + .base[data-state="closed"] {
-  pointer-events: none;
-  opacity: 0;
   transition-delay: 0s;
+}
+
+/* We use padding instead of Floating UI's `offset` middleware to enable users
+   to hover over the tooltip without dismissing it. */
+.base[data-side="top"] {
+  padding-bottom: var(--tooltip-offset);
+}
+
+.base[data-side="right"] {
+  padding-left: var(--tooltip-offset);
+}
+
+.base[data-side="bottom"] {
+  padding-top: var(--tooltip-offset);
+}
+
+.base[data-side="left"] {
+  padding-right: var(--tooltip-offset);
 }
 
 .arrow {
   position: absolute;
-  width: var(--cui-spacings-kilo);
-  height: var(--cui-spacings-kilo);
+  width: var(--tooltip-arrow-size);
+  height: var(--tooltip-arrow-size);
   background-color: var(--cui-bg-elevated);
   border-right: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
   border-bottom: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
   border-bottom-right-radius: 2px;
 }
 
-[data-state="closed"] .arrow {
-  display: none;
+.base[data-side="top"] .arrow {
+  top: calc(100% - var(--tooltip-offset) - (var(--tooltip-arrow-size) / 2));
+  left: calc(50% - (var(--tooltip-arrow-size) / 2));
+  transform: rotate(45deg);
+}
+
+.base[data-side="right"] .arrow {
+  right: calc(100% - var(--tooltip-offset) - (var(--tooltip-arrow-size) / 2));
+  bottom: calc(50% - (var(--tooltip-arrow-size) / 2));
+  transform: rotate(135deg);
+}
+
+.base[data-side="bottom"] .arrow {
+  bottom: calc(100% - var(--tooltip-offset) - (var(--tooltip-arrow-size) / 2));
+  left: calc(50% - (var(--tooltip-arrow-size) / 2));
+  transform: rotate(225deg);
+}
+
+.base[data-side="left"] .arrow {
+  bottom: calc(50% - (var(--tooltip-arrow-size) / 2));
+  left: calc(100% - var(--tooltip-offset) - (var(--tooltip-arrow-size) / 2));
+  transform: rotate(315deg);
 }
 
 .content {

--- a/packages/circuit-ui/components/Tooltip/Tooltip.module.css
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.module.css
@@ -43,7 +43,9 @@
   font-size: var(--cui-typography-body-two-font-size);
   font-weight: var(--cui-font-weight-regular);
   line-height: var(--cui-typography-body-two-line-height);
-  color: var(--cui-fg-on-strong);
-  background-color: var(--cui-bg-strong);
+  color: var(--cui-fg-normal);
+  background-color: var(--cui-bg-normal);
+  border: var(--cui-border-width-kilo) solid var(--cui-border-divider);
   border-radius: var(--cui-border-radius-bit);
+  box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);
 }

--- a/packages/circuit-ui/components/Tooltip/Tooltip.module.css
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.module.css
@@ -8,24 +8,41 @@
   bottom: 100%;
   left: 50%;
   z-index: var(--cui-z-index-tooltip);
-  width: max-content;
-  max-width: 280px;
-  padding: var(--cui-spacings-bit) var(--cui-spacings-byte);
-  font-size: var(--cui-typography-body-two-font-size);
-  line-height: var(--cui-typography-body-two-line-height);
-  color: var(--cui-fg-on-strong);
-  pointer-events: none;
-  background-color: var(--cui-bg-strong);
-  border-radius: var(--cui-border-radius-bit);
-  opacity: 0;
+  padding: var(--cui-spacings-byte);
   transition: opacity var(--transition-slow);
   transform: translateX(-50%);
 }
 
+.base[data-state="open"],
 .base:hover,
 .component:hover + .base,
 .component:focus + .base {
   pointer-events: auto;
   opacity: 1;
   transition-delay: 0.6s;
+}
+
+.base[data-state="open"] {
+  bottom: auto;
+  left: auto;
+}
+
+.base,
+.base[data-state="closed"]:hover,
+.component:hover + .base[data-state="closed"],
+.component:focus + .base[data-state="closed"] {
+  pointer-events: none;
+  opacity: 0;
+  transition-delay: 0s;
+}
+
+.content {
+  width: max-content;
+  max-width: 280px;
+  padding: var(--cui-spacings-bit) var(--cui-spacings-byte);
+  font-size: var(--cui-typography-body-two-font-size);
+  line-height: var(--cui-typography-body-two-line-height);
+  color: var(--cui-fg-on-strong);
+  background-color: var(--cui-bg-strong);
+  border-radius: var(--cui-border-radius-bit);
 }

--- a/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
@@ -28,8 +28,10 @@ const baseProps: TooltipProps = {
 describe('Tooltip', () => {
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
-    render(<Tooltip {...baseProps} className={className} />);
-    const tooltip = screen.getByRole('tooltip');
+    const { container } = render(
+      <Tooltip {...baseProps} className={className} />,
+    );
+    const tooltip = container.querySelectorAll('div')[0];
     expect(tooltip?.className).toContain(className);
   });
 

--- a/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createRef } from 'react';
+
+import { render, axe, screen } from '../../util/test-utils.js';
+
+import { Tooltip, TooltipProps } from './Tooltip.js';
+
+const baseProps: TooltipProps = {
+  label: 'Label',
+  component: (props) => <button {...props} />,
+};
+
+describe('Tooltip', () => {
+  it('should merge a custom class name with the default ones', () => {
+    const className = 'foo';
+    render(<Tooltip {...baseProps} className={className} />);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip?.className).toContain(className);
+  });
+
+  it('should forward a ref to the tooltip', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Tooltip {...baseProps} ref={ref} />);
+    const tooltip = screen.getByRole('tooltip');
+    expect(ref.current).toBe(tooltip);
+  });
+
+  it('should act as a label for the reference element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<Tooltip {...baseProps} ref={ref} />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAccessibleName(baseProps.label);
+  });
+
+  it('should have no accessibility violations', async () => {
+    const { container } = render(<Tooltip {...baseProps} />);
+    const actual = await axe(container);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
@@ -16,7 +16,7 @@
 import { describe, expect, it } from 'vitest';
 import { createRef } from 'react';
 
-import { render, axe, screen } from '../../util/test-utils.js';
+import { render, axe, screen, userEvent } from '../../util/test-utils.js';
 
 import { Tooltip, TooltipProps } from './Tooltip.js';
 
@@ -45,6 +45,52 @@ describe('Tooltip', () => {
     render(<Tooltip {...baseProps} ref={ref} />);
     const button = screen.getByRole('button');
     expect(button).toHaveAccessibleName(baseProps.label);
+  });
+
+  it('should be initially closed', () => {
+    render(<Tooltip {...baseProps} />);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveAttribute('data-state', 'closed');
+  });
+
+  it('should be open when the reference element is focused', async () => {
+    render(<Tooltip {...baseProps} />);
+
+    await userEvent.tab();
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveAttribute('data-state', 'open');
+  });
+
+  it('should be open when the reference element is hovered', async () => {
+    render(<Tooltip {...baseProps} />);
+    const button = screen.getByRole('button');
+
+    await userEvent.hover(button);
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveAttribute('data-state', 'open');
+  });
+
+  it('should stay open when the tooltip element is hovered', async () => {
+    render(<Tooltip {...baseProps} />);
+    const button = screen.getByRole('button');
+    const tooltip = screen.getByRole('tooltip');
+
+    await userEvent.hover(button);
+    await userEvent.hover(tooltip);
+
+    expect(tooltip).toHaveAttribute('data-state', 'open');
+  });
+
+  it('should close when the escape key is pressed', async () => {
+    render(<Tooltip {...baseProps} />);
+
+    await userEvent.keyboard('{Escape}');
+
+    const tooltip = screen.getByRole('tooltip');
+
+    expect(tooltip).toHaveAttribute('data-state', 'closed');
   });
 
   it('should have no accessibility violations', async () => {

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -13,22 +13,41 @@
  * limitations under the License.
  */
 
-import { NotificationCenter } from '@sumup/icons';
+import { forwardRef } from 'react';
+import { within, userEvent } from '@storybook/testing-library';
 
-import { Tooltip, TooltipProps } from './Tooltip.js';
+import Button from '../Button/index.js';
+
+import { Tooltip, TooltipProps, TooltipReferenceProps } from './Tooltip.js';
 
 export default {
   title: 'Components/Tooltip',
   component: Tooltip,
+  parameters: {
+    // Account for the Tooltip's transition-delay
+    chromatic: { delay: 700 },
+  },
 };
 
+const Reference = forwardRef<HTMLButtonElement, TooltipReferenceProps>(
+  (props, ref) => (
+    <Button {...props} ref={ref} size="s" disabled>
+      Submit
+    </Button>
+  ),
+);
+
 export const Base = (args: TooltipProps) => (
-  <Tooltip
-    {...args}
-    component={(props) => <NotificationCenter {...props} tabIndex={0} />}
-  />
+  <Tooltip {...args} component={Reference} />
 );
 
 Base.args = {
-  label: 'Notifications',
+  label: 'Please fill out all fields',
+};
+
+Base.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
+  const canvas = within(canvasElement);
+  const reference = canvas.getByRole('button');
+
+  await userEvent.hover(reference);
 };

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -14,9 +14,11 @@
  */
 
 import { forwardRef } from 'react';
-import { within, userEvent } from '@storybook/testing-library';
+import { userEvent } from '@storybook/test';
+import { TransferOut, UploadCloud } from '@sumup/icons';
 
-import Button from '../Button/index.js';
+import { Stack } from '../../../../.storybook/components/index.js';
+import Button, { IconButton } from '../Button/index.js';
 
 import { Tooltip, TooltipProps, TooltipReferenceProps } from './Tooltip.js';
 
@@ -29,25 +31,47 @@ export default {
   },
 };
 
-const Reference = forwardRef<HTMLButtonElement, TooltipReferenceProps>(
-  (props, ref) => (
-    <Button {...props} ref={ref} size="s" disabled>
-      Submit
-    </Button>
+const descriptionProps = {
+  label: 'This may take a few minutes',
+  type: 'description',
+  component: forwardRef<HTMLButtonElement, TooltipReferenceProps>(
+    (props, ref) => (
+      <Button {...props} icon={UploadCloud} ref={ref}>
+        Upload
+      </Button>
+    ),
   ),
-);
+} as const;
+
+const showTooltip = async () => {
+  await userEvent.tab();
+};
 
 export const Base = (args: TooltipProps) => (
-  <Tooltip {...args} component={Reference} />
+  <Stack>
+    <Tooltip {...args} />
+  </Stack>
 );
 
-Base.args = {
-  label: 'Please fill out all fields',
-};
+Base.args = descriptionProps;
+Base.play = showTooltip;
 
-Base.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
-  const canvas = within(canvasElement);
-  const reference = canvas.getByRole('button');
+export const Types = (args: TooltipProps) => (
+  <Stack>
+    {/* The IconButton uses the Tooltip component under the hood */}
+    <IconButton icon={TransferOut}>Transfer out</IconButton>
+    <Tooltip {...args} {...descriptionProps} />
+  </Stack>
+);
 
-  await userEvent.hover(reference);
-};
+Types.play = showTooltip;
+
+export const Placements = (args: TooltipProps) => (
+  <Stack>
+    <Tooltip {...args} {...descriptionProps} placement="left" />
+    <Tooltip {...args} {...descriptionProps} placement="bottom-start" />
+    <Tooltip {...args} {...descriptionProps} placement="right-end" />
+  </Stack>
+);
+
+Placements.play = showTooltip;

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NotificationCenter } from '@sumup/icons';
+
+import { Tooltip, TooltipProps } from './Tooltip.js';
+
+export default {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+};
+
+export const Base = (args: TooltipProps) => (
+  <Tooltip
+    {...args}
+    component={(props) => <NotificationCenter {...props} tabIndex={0} />}
+  />
+);
+
+Base.args = {
+  label: 'Notifications',
+};

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -28,7 +28,8 @@ import { useFloating, flip, shift } from '@floating-ui/react-dom';
 
 import { clsx } from '../../styles/clsx.js';
 import { applyMultipleRefs } from '../../util/refs.js';
-import { useEscapeKey } from '../../index.js';
+import { useEscapeKey } from '../../hooks/useEscapeKey/index.js';
+import Portal from '../Portal/index.js';
 
 import classes from './Tooltip.module.css';
 
@@ -127,7 +128,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     };
 
     return (
-      <div className={classes.parent}>
+      <>
         <Component
           {...referenceProps}
           onFocus={handleOpen}
@@ -137,20 +138,22 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
           className={classes.component}
           ref={refs.setReference}
         />
-        <div
-          {...props}
-          ref={applyMultipleRefs(ref, refs.setFloating)}
-          id={tooltipId}
-          role="tooltip"
-          onMouseEnter={handleOpen}
-          onMouseLeave={handleClose}
-          data-state={state}
-          style={{ ...props.style, ...floatingStyles }}
-          className={clsx(classes.base, className)}
-        >
-          <div className={classes.content}>{label}</div>
-        </div>
-      </div>
+        <Portal>
+          <div
+            {...props}
+            ref={applyMultipleRefs(ref, refs.setFloating)}
+            id={tooltipId}
+            role="tooltip"
+            onMouseEnter={handleOpen}
+            onMouseLeave={handleClose}
+            data-state={state}
+            style={{ ...props.style, ...floatingStyles }}
+            className={clsx(classes.base, className)}
+          >
+            <div className={classes.content}>{label}</div>
+          </div>
+        </Portal>
+      </>
     );
   },
 );

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -99,6 +99,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       type,
       placement: defaultPlacement = 'top',
       className,
+      style,
       ...props
     },
     ref,
@@ -172,7 +173,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     };
 
     return (
-      <div className={clsx(classes.parent, className)}>
+      <>
         <Component
           {...referenceProps}
           onFocus={handleOpen}
@@ -191,8 +192,8 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
           onMouseEnter={handleOpen}
           onMouseLeave={handleClose}
           data-state={state}
-          className={classes.base}
-          style={{ ...props.style, ...floatingStyles }}
+          className={clsx(classes.base, className)}
+          style={{ ...style, ...floatingStyles }}
         >
           <div className={classes.content}>{label}</div>
           <div
@@ -207,7 +208,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
             }}
           />
         </div>
-      </div>
+      </>
     );
   },
 );

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   forwardRef,
   useEffect,

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -14,17 +14,22 @@
  */
 
 import {
-  ComponentType,
-  FocusEventHandler,
-  HTMLAttributes,
-  MouseEventHandler,
-  Ref,
   forwardRef,
   useEffect,
   useId,
   useState,
+  type ComponentType,
+  type FocusEventHandler,
+  type HTMLAttributes,
+  type MouseEventHandler,
+  type Ref,
 } from 'react';
-import { useFloating, flip, shift } from '@floating-ui/react-dom';
+import {
+  useFloating,
+  flip,
+  shift,
+  type Placement,
+} from '@floating-ui/react-dom';
 
 import { clsx } from '../../styles/clsx.js';
 import { applyMultipleRefs } from '../../util/refs.js';
@@ -60,6 +65,12 @@ export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
    * the reference component. Default: 'label'.
    */
   type?: 'label' | 'description';
+  /**
+   * Where to display the tooltip relative to the reference component. The
+   * tooltip will automatically move if there isn't enough space available.
+   * Default: 'top'.
+   */
+  placement?: Placement;
 }
 
 enum State {
@@ -70,7 +81,14 @@ enum State {
 
 export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
   (
-    { label, component: Component, type = 'label', className, ...props },
+    {
+      label,
+      component: Component,
+      type = 'label',
+      placement = 'top',
+      className,
+      ...props
+    },
     ref,
   ) => {
     const tooltipId = useId();
@@ -87,7 +105,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
 
     const { refs, floatingStyles, update } = useFloating({
       open: state === State.open,
-      placement: 'top',
+      placement,
       middleware: [flip(), shift()],
     });
 

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -67,9 +67,9 @@ export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
   component: ComponentType<TooltipReferenceProps>;
   /**
    * Whether the tooltip is the main label or a supplemental description of
-   * the reference component. Default: 'label'.
+   * the reference component.
    */
-  type?: 'label' | 'description';
+  type: 'label' | 'description';
   /**
    * Where to display the tooltip relative to the reference component. The
    * tooltip will automatically move if there isn't enough space available.
@@ -96,7 +96,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     {
       label,
       component: Component,
-      type = 'label',
+      type,
       placement: defaultPlacement = 'top',
       className,
       ...props
@@ -139,7 +139,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       /**
        * When we support `ResizeObserver` (https://caniuse.com/resizeobserver),
        * we can look into using Floating UI's `autoUpdate` (but we can't use
-       * `whileElementInMounted` because our implementation hides the floating
+       * `whileElementIsMounted` because our implementation hides the floating
        * element using CSS instead of using conditional rendering.
        * See https://floating-ui.com/docs/react-dom#updating
        */
@@ -186,6 +186,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
           {...props}
           ref={applyMultipleRefs(ref, refs.setFloating)}
           id={tooltipId}
+          // See https://github.com/w3c/aria/issues/979
           role="tooltip"
           onMouseEnter={handleOpen}
           onMouseLeave={handleClose}

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -131,6 +131,13 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       $activeTooltipId.set(null);
     };
 
+    // The tooltip works without JavaScript using only CSS (the "initial" state).
+    // When JS is available, the component is progressively enhanced and toggles
+    // between the "closed" and "open" states.
+    useEffect(() => {
+      $activeTooltipId.set(null);
+    }, []);
+
     useEscapeKey(handleClose, state === State.open);
 
     const { refs, floatingStyles, middlewareData, update, placement } =

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentType, HTMLAttributes, forwardRef, useId } from 'react';
+
+import { clsx } from '../../styles/clsx.js';
+
+import classes from './Tooltip.module.css';
+
+export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * A clear and concise label for the reference component.
+   * Interactive content such as buttons or links and rich content such as
+   * bold text or headings are not supported.
+   */
+  label: string;
+  /**
+   * The focusable element that is labelled by the tooltip.
+   */
+  component: ComponentType<{
+    'aria-describedby'?: string;
+    'aria-labelledby'?: string;
+    'className'?: string;
+  }>;
+  /**
+   * Whether the tooltip is the main label or a supplemental description of
+   * the reference component. Default: 'label'.
+   */
+  type?: 'label' | 'description';
+}
+
+export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
+  (
+    { label, component: Component, type = 'label', className, ...props },
+    ref,
+  ) => {
+    const tooltipId = useId();
+
+    const referenceProps = {
+      [type === 'label' ? 'aria-labelledby' : 'aria-describedby']: tooltipId,
+    };
+
+    return (
+      <div className={classes.parent}>
+        <Component {...referenceProps} className={classes.component} />
+        <div
+          {...props}
+          ref={ref}
+          id={tooltipId}
+          className={clsx(classes.base, className)}
+        >
+          {label}
+        </div>
+      </div>
+    );
+  },
+);

--- a/packages/circuit-ui/components/Tooltip/index.ts
+++ b/packages/circuit-ui/components/Tooltip/index.ts
@@ -15,6 +15,6 @@
 
 import { Tooltip } from './Tooltip.js';
 
-export type { TooltipProps } from './Tooltip.js';
+export type { TooltipProps, TooltipReferenceProps } from './Tooltip.js';
 
 export default Tooltip;

--- a/packages/circuit-ui/components/Tooltip/index.ts
+++ b/packages/circuit-ui/components/Tooltip/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Tooltip } from './Tooltip.js';
+
+export type { TooltipProps } from './Tooltip.js';
+
+export default Tooltip;

--- a/packages/circuit-ui/components/legacy/Tooltip/Tooltip.mdx
+++ b/packages/circuit-ui/components/legacy/Tooltip/Tooltip.mdx
@@ -5,12 +5,14 @@ import * as Stories from './Tooltip.stories';
 
 # Tooltip
 
-<Status variant="legacy">
-  Does not meet [accessibility requirements](https://inclusive-components.design/tooltips-toggletips/).
+<Status variant="deprecated">
+  Use the [stable Tooltip](Components/Tooltip/Docs) component instead.
 </Status>
 
-Tooltips display additional information on floating labels.
-They can be activated when users hover, focus, tap, or click.
+<Story of={Stories.Base} />
+
+<Props />
+
 
 ## Dependencies
 
@@ -38,27 +40,6 @@ export default function App() {
   );
 }
 ```
-
-<Story of={Stories.Base} />
-
-<Props />
-
-## When to use it
-
-You can use it as primary label, to associate one element with another (Icon→Action), or
-as an auxiliary description to provide a supplementary or clarifying description.
-
-## Usage guidelines
-
-- **Do** use delay before the tooltip is hidden on mouse leave.
-- **Do** provide useful, additional information or clarification.
-- **Do** use sentence case.
-- **Do** be brief.
-- **Do** use it to describe an action/icon.
-- **Do not** use delay when the tooltip is shown on mouse enter
-- **Do not** use it to communicate important information (form title attributes or notifications)
-- **Do not** put links or buttons inside of a tooltip
-- **Do not** use it too often. If you are building not self-explanatory software, try different approaches.
 
 ## Positions
 

--- a/packages/circuit-ui/components/legacy/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/legacy/Tooltip/Tooltip.stories.tsx
@@ -21,7 +21,7 @@ import styled from '../../../styles/styled.js';
 import { Tooltip, TooltipProps } from './Tooltip.js';
 
 export default {
-  title: 'Components/Tooltip',
+  title: 'Components/Tooltip/Legacy',
   component: Tooltip,
 };
 

--- a/packages/circuit-ui/components/legacy/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/legacy/Tooltip/Tooltip.tsx
@@ -19,29 +19,20 @@ import { css } from '@emotion/react';
 
 import styled from '../../../styles/styled.js';
 import type { StyleProps } from '../../../styles/styled.js';
-import { typography, shadow } from '../../../styles/style-mixins.js';
+import { typography } from '../../../styles/style-mixins.js';
 
 const baseStyles = ({ theme }: StyleProps) => css`
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: ${theme.borderRadius.bit};
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: ${theme.borderRadius.byte};
+  border: ${theme.borderWidth.kilo} solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: ${theme.spacings.byte} ${theme.spacings.kilo};
   position: absolute;
   z-index: ${theme.zIndex.tooltip};
   transition: opacity 0.3s;
-
-  &::after {
-    display: block;
-    content: '';
-    width: 0;
-    height: 0;
-    position: absolute;
-    border: ${theme.spacings.byte} solid transparent;
-  }
 `;
 
 const positionMap: Record<Position, Position> = {
@@ -56,18 +47,11 @@ export type Position = 'top' | 'right' | 'bottom' | 'left';
 const getPositionStyles = ({
   theme,
   position,
-}: StyleProps & { position: Position }) => {
+}: StyleProps & Required<TooltipProps>) => {
   const absolutePosition = positionMap[position];
 
-  // The first absolute position rule is a fallback.
   return `
-    ${absolutePosition}: 100%;
-    ${absolutePosition}: calc(100% + ${theme.spacings.kilo});
-
-    &::after {
-      ${position}: 100%;
-      border-${position}-color: var(--cui-bg-strong);
-    }
+    ${absolutePosition}: calc(100% + ${theme.spacings.bit});
   `;
 };
 
@@ -89,18 +73,13 @@ const getAlignmentStyles = ({
   theme,
   position,
   align,
-}: StyleProps & TooltipProps) => {
+}: StyleProps & Required<TooltipProps>) => {
   const isHorizontal = position === 'bottom' || position === 'top';
 
   if (isHorizontal && isVerticalAlignment(align)) {
     return `
       left: 50%;
       transform: translateX(-50%);
-
-      &::after {
-        left: 50%;
-        transform: translateX(-50%);
-      }
     `;
   }
 
@@ -108,11 +87,6 @@ const getAlignmentStyles = ({
     return `
       top: 50%;
       transform: translateY(-50%);
-
-      &::after {
-        top: 50%;
-        transform: translateY(-50%);
-      }
     `;
   }
 
@@ -124,10 +98,6 @@ const getAlignmentStyles = ({
   return `
     ${absolutePosition}: 50%;
     ${absolutePosition}: calc(50% - (${theme.spacings.mega} + ${theme.spacings.bit}));
-
-    &::after {
-      ${absolutePosition}: ${theme.spacings.kilo};
-    }
   `;
   /* eslint-enable max-len */
 };
@@ -138,7 +108,7 @@ const positionAndAlignStyles = ({
   align = 'center',
 }: StyleProps & TooltipProps) => css`
   ${getAlignmentStyles({ theme, position, align })};
-  ${getPositionStyles({ theme, position })};
+  ${getPositionStyles({ theme, position, align })};
 `;
 
 export interface TooltipProps {
@@ -147,11 +117,12 @@ export interface TooltipProps {
 }
 
 /**
- * @legacy
+ * @deprecated
+ *
+ * Use the [stable `Tooltip`](https://circuit.sumup.com/?path=/docs/components-tooltip--docs) component instead.
  */
 export const Tooltip = styled.div<TooltipProps>(
   typography('two'),
   baseStyles,
-  shadow,
   positionAndAlignStyles,
 );

--- a/packages/circuit-ui/components/legacy/Tooltip/__snapshots__/Tooltip.spec.tsx.snap
+++ b/packages/circuit-ui/components/legacy/Tooltip/__snapshots__/Tooltip.spec.tsx.snap
@@ -5,47 +5,25 @@ exports[`Tooltip > should override alignment styles with position styles 1`] = `
   font-size: 0.875rem;
   line-height: 1.25rem;
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 1px solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: 8px 12px;
   position: absolute;
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  right: 100%;
-  right: calc(100% + 12px);
-}
-
-.circuit-0::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-0::after {
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-}
-
-.circuit-0::after {
-  left: 100%;
-  border-left-color: var(--cui-bg-strong);
+  right: calc(100% + 4px);
 }
 
 <div>
@@ -62,40 +40,22 @@ exports[`Tooltip > should render with align bottom, when passed "bottom" for the
   font-size: 0.875rem;
   line-height: 1.25rem;
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 1px solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: 8px 12px;
   position: absolute;
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   top: calc(50% - (16px + 4px));
-  left: 100%;
-  left: calc(100% + 12px);
-}
-
-.circuit-0::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-0::after {
-  top: 12px;
-}
-
-.circuit-0::after {
-  right: 100%;
-  border-right-color: var(--cui-bg-strong);
+  left: calc(100% + 4px);
 }
 
 <div>
@@ -112,47 +72,25 @@ exports[`Tooltip > should render with align center, when passed "center" for the
   font-size: 0.875rem;
   line-height: 1.25rem;
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 1px solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: 8px 12px;
   position: absolute;
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  left: 100%;
-  left: calc(100% + 12px);
-}
-
-.circuit-0::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-0::after {
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-}
-
-.circuit-0::after {
-  right: 100%;
-  border-right-color: var(--cui-bg-strong);
+  left: calc(100% + 4px);
 }
 
 <div>
@@ -169,47 +107,25 @@ exports[`Tooltip > should render with align left, when passed "left" for the ali
   font-size: 0.875rem;
   line-height: 1.25rem;
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 1px solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: 8px 12px;
   position: absolute;
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  left: 100%;
-  left: calc(100% + 12px);
-}
-
-.circuit-0::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-0::after {
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-}
-
-.circuit-0::after {
-  right: 100%;
-  border-right-color: var(--cui-bg-strong);
+  left: calc(100% + 4px);
 }
 
 <div>
@@ -226,47 +142,25 @@ exports[`Tooltip > should render with align right, when passed "right" for the a
   font-size: 0.875rem;
   line-height: 1.25rem;
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 1px solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: 8px 12px;
   position: absolute;
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  left: 100%;
-  left: calc(100% + 12px);
-}
-
-.circuit-0::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-0::after {
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-}
-
-.circuit-0::after {
-  right: 100%;
-  border-right-color: var(--cui-bg-strong);
+  left: calc(100% + 4px);
 }
 
 <div>
@@ -283,40 +177,22 @@ exports[`Tooltip > should render with align top, when passed "top" for the align
   font-size: 0.875rem;
   line-height: 1.25rem;
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 1px solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: 8px 12px;
   position: absolute;
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   bottom: 50%;
   bottom: calc(50% - (16px + 4px));
-  left: 100%;
-  left: calc(100% + 12px);
-}
-
-.circuit-0::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-0::after {
-  bottom: 12px;
-}
-
-.circuit-0::after {
-  right: 100%;
-  border-right-color: var(--cui-bg-strong);
+  left: calc(100% + 4px);
 }
 
 <div>
@@ -333,47 +209,25 @@ exports[`Tooltip > should render with position bottom, when passed "bottom" for 
   font-size: 0.875rem;
   line-height: 1.25rem;
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 1px solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: 8px 12px;
   position: absolute;
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   left: 50%;
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
   transform: translateX(-50%);
-  top: 100%;
-  top: calc(100% + 12px);
-}
-
-.circuit-0::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-0::after {
-  left: 50%;
-  -webkit-transform: translateX(-50%);
-  -moz-transform: translateX(-50%);
-  -ms-transform: translateX(-50%);
-  transform: translateX(-50%);
-}
-
-.circuit-0::after {
-  bottom: 100%;
-  border-bottom-color: var(--cui-bg-strong);
+  top: calc(100% + 4px);
 }
 
 <div>
@@ -390,47 +244,25 @@ exports[`Tooltip > should render with position left, when passed "left" for the 
   font-size: 0.875rem;
   line-height: 1.25rem;
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 1px solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: 8px 12px;
   position: absolute;
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  right: 100%;
-  right: calc(100% + 12px);
-}
-
-.circuit-0::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-0::after {
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-}
-
-.circuit-0::after {
-  left: 100%;
-  border-left-color: var(--cui-bg-strong);
+  right: calc(100% + 4px);
 }
 
 <div>
@@ -447,47 +279,25 @@ exports[`Tooltip > should render with position right, when passed "right" for th
   font-size: 0.875rem;
   line-height: 1.25rem;
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 1px solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: 8px 12px;
   position: absolute;
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  left: 100%;
-  left: calc(100% + 12px);
-}
-
-.circuit-0::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-0::after {
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-}
-
-.circuit-0::after {
-  right: 100%;
-  border-right-color: var(--cui-bg-strong);
+  left: calc(100% + 4px);
 }
 
 <div>
@@ -504,47 +314,25 @@ exports[`Tooltip > should render with position top, when passed "top" for the po
   font-size: 0.875rem;
   line-height: 1.25rem;
   display: inline-block;
-  width: auto;
-  max-width: 280px;
-  min-width: 120px;
-  background-color: var(--cui-bg-strong);
-  color: var(--cui-fg-on-strong);
-  border-radius: 4px;
+  width: -webkit-max-content;
+  width: -moz-max-content;
+  width: max-content;
+  max-width: 360px;
+  background-color: var(--cui-bg-elevated);
+  border-radius: 8px;
+  border: 1px solid var(--cui-border-subtle);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
   padding: 8px 12px;
   position: absolute;
   z-index: 40;
   -webkit-transition: opacity 0.3s;
   transition: opacity 0.3s;
-  box-shadow: 0 3px 8px 0 rgba(0, 0, 0, 0.2);
   left: 50%;
   -webkit-transform: translateX(-50%);
   -moz-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
   transform: translateX(-50%);
-  bottom: 100%;
-  bottom: calc(100% + 12px);
-}
-
-.circuit-0::after {
-  display: block;
-  content: '';
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-}
-
-.circuit-0::after {
-  left: 50%;
-  -webkit-transform: translateX(-50%);
-  -moz-transform: translateX(-50%);
-  -ms-transform: translateX(-50%);
-  transform: translateX(-50%);
-}
-
-.circuit-0::after {
-  top: 100%;
-  border-top-color: var(--cui-bg-strong);
+  bottom: calc(100% + 4px);
 }
 
 <div>

--- a/packages/circuit-ui/experimental.ts
+++ b/packages/circuit-ui/experimental.ts
@@ -16,4 +16,5 @@
 export {
   default as Tooltip,
   type TooltipProps,
+  type TooltipReferenceProps,
 } from './components/Tooltip/index.js';

--- a/packages/circuit-ui/experimental.ts
+++ b/packages/circuit-ui/experimental.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2023, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  default as Tooltip,
+  type TooltipProps,
+} from './components/Tooltip/index.js';

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -49,6 +49,8 @@
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.5",
+    "@nanostores/react": "^0.7.2",
+    "nanostores": "^0.10.0",
     "react-modal": "^3.16.1",
     "react-number-format": "5.3.0"
   },

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -14,6 +14,10 @@
       "types": "./dist/legacy.d.ts",
       "default": "./dist/legacy.js"
     },
+    "./experimental": {
+      "types": "./dist/experimental.d.ts",
+      "default": "./dist/experimental.js"
+    },
     "./styles.css": "./dist/style.css"
   },
   "typesVersions": {

--- a/packages/circuit-ui/vite.config.ts
+++ b/packages/circuit-ui/vite.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
     lib: {
       entry: [
         path.resolve(__dirname, 'index.ts'),
+        path.resolve(__dirname, 'experimental.ts'),
         path.resolve(__dirname, 'legacy.ts'),
       ],
       formats: ['es'],


### PR DESCRIPTION
Closes #1676.

## Purpose

The legacy Tooltip component has critical accessibility issues that cannot be addressed with its current API (see #1676). This pull request adds an experimental Tooltip component which displays additional information upon hover or focus that is contextual, helpful, and nonessential to clarify the purpose of otherwise ambiguous interactive elements.

A follow-up pull request will add an experimental Toggletip component.

## Approach and changes

- Implemented an experimental Tooltip component
	- The tooltip can be used as an [accessible name](https://w3c.github.io/accname/#dfn-accessible-name) or [description](https://w3c.github.io/accname/#dfn-accessible-description) for the reference element 
	- The tooltip is dynamically positioned using [Floating UI](https://floating-ui.com/) when JavaScript is available
- Adopted the Tooltip component for the IconButton, Pagination and Table's SortArrow components

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
