### PR TITLE
Backport PercentageInput component to v7

### DIFF
--- a/.changeset/lovely-pillows-build.md
+++ b/.changeset/lovely-pillows-build.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a PercentageInput component for fractional numeric values.

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.mdx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.mdx
@@ -16,13 +16,12 @@ The CurrencyInput component indicates to the user that a number should be entere
 
 ### Currency
 
-You can use `currency` to specify which currency the input should use.
+Use the `currency` prop to specify which currency the input should use.
 
 <Story of={Stories.Currencies} />
 
 ### Locale
 
-You can use `locale` to change the currency formatting locale.
-For example, Euros could be formatted differently based on locale:
+Use the `locale` prop to format the currency value according to that locale's formatting style. For example, euros could be formatted differently based on locale:
 
 <Story of={Stories.Locales} />

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -115,7 +115,7 @@ describe('CurrencyInput', () => {
         </>,
       );
       expect(getByRole('textbox')).toHaveAccessibleDescription(
-        `${customDescription} ${EUR_CURRENCY_SYMBOL}`,
+        `${EUR_CURRENCY_SYMBOL} ${customDescription}`,
       );
     });
   });

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.stories.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.stories.tsx
@@ -28,10 +28,11 @@ const baseArgs = {
   validationHint: 'Excluding VAT',
   currency: 'EUR',
   locale: 'de-DE',
-  style: { maxWidth: '250px' },
 };
 
-export const Base = (args: CurrencyInputProps) => <CurrencyInput {...args} />;
+export const Base = (args: CurrencyInputProps) => (
+  <CurrencyInput {...args} style={{ maxWidth: '250px' }} />
+);
 
 Base.args = baseArgs;
 
@@ -39,12 +40,14 @@ export const Currencies = (args: CurrencyInputProps) => (
   <Stack>
     <CurrencyInput
       {...args}
+      style={{ maxWidth: '250px' }}
       label="Amount (pt-BR, BRL)"
       currency="BRL"
       locale="pt-BR"
     />
     <CurrencyInput
       {...args}
+      style={{ maxWidth: '250px' }}
       label="Amount (pt-BR, EUR)"
       currency="EUR"
       locale="pt-BR"
@@ -58,12 +61,14 @@ export const Locales = (args: CurrencyInputProps) => (
   <Stack>
     <CurrencyInput
       {...args}
+      style={{ maxWidth: '250px' }}
       label="Amount (de-DE, EUR)"
       currency="EUR"
       locale="de-DE"
     />
     <CurrencyInput
       {...args}
+      style={{ maxWidth: '250px' }}
       label="Amount (en-IE, EUR)"
       currency="EUR"
       locale="en-IE"

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -28,7 +28,7 @@ export interface CurrencyInputProps
       InputProps,
       'placeholder' | 'ref' | 'value' | 'defaultValue' | 'type'
     >,
-    Pick<NumericFormatProps, 'onValueChange'> {
+    Pick<NumericFormatProps, 'onValueChange' | 'allowNegative'> {
   /**
    * A ISO 4217 currency code, such as 'USD' for the US dollar,
    * 'EUR' for the Euro, or 'CNY' for the Chinese RMB.
@@ -83,9 +83,7 @@ export const CurrencyInput = forwardRef<InputElement, CurrencyInputProps>(
     ref,
   ) => {
     const currencySymbolId = useId();
-    const descriptionIds = `${
-      descriptionId ? `${descriptionId} ` : ''
-    }${currencySymbolId}`;
+    const descriptionIds = clsx(currencySymbolId, descriptionId);
 
     const currencyFormat =
       resolveCurrencyFormat(locale, currency) || DEFAULT_FORMAT;

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.mdx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.mdx
@@ -1,0 +1,27 @@
+import { Meta, Status, Props, Story } from '../../../../.storybook/components';
+import * as Stories from './PercentageInput.stories';
+
+<Meta of={Stories} />
+
+# PercentageInput
+
+<Status variant="stable" />
+
+The PercentageInput component indicates to the user that a fractional number should be entered.
+
+<Story of={Stories.Base} />
+<Props />
+
+## Component Variations
+
+### Locale
+
+Use the `locale` prop to format the number according to that locale's formatting style.
+
+<Story of={Stories.Locales} />
+
+### Decimals
+
+Use the `decimalScale` prop to allow users to enter numbers with decimals. The default is `0`.
+
+<Story of={Stories.Decimals} />

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.module.css
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.module.css
@@ -1,0 +1,6 @@
+.symbol {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: var(--cui-spacings-mega);
+}

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.spec.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.spec.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.spec.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.spec.tsx
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ChangeEvent, createRef, useState } from 'react';
+
+import { render, userEvent, axe } from '../../util/test-utils.js';
+import type { InputElement } from '../Input/index.js';
+
+import { PercentageInput, PercentageInputProps } from './PercentageInput.js';
+
+const defaultProps = {
+  locale: 'de-DE',
+  label: 'Discount',
+};
+
+describe('PercentageInput', () => {
+  it('should forward a ref', () => {
+    const ref = createRef<InputElement>();
+    const { getByRole } = render(
+      <PercentageInput {...defaultProps} ref={ref} />,
+    );
+    const input = getByRole('textbox');
+    expect(ref.current).toBe(input);
+  });
+
+  it('should format an en-GB amount', async () => {
+    const { getByRole } = render(
+      <PercentageInput {...defaultProps} locale="en-GB" />,
+    );
+
+    const input = getByRole('textbox') as HTMLInputElement;
+
+    await userEvent.type(input, '1234');
+
+    expect(input.value).toBe('1,234');
+  });
+
+  it('should format an de-DE amount', async () => {
+    const { getByRole } = render(
+      <PercentageInput {...defaultProps} locale="de-DE" />,
+    );
+
+    const input = getByRole('textbox') as HTMLInputElement;
+
+    await userEvent.type(input, '1234');
+
+    expect(input.value).toBe('1.234');
+  });
+
+  it('should format an amount with decimals', async () => {
+    const { getByRole } = render(
+      <PercentageInput {...defaultProps} decimalScale={2} />,
+    );
+
+    const input = getByRole('textbox') as HTMLInputElement;
+
+    await userEvent.type(input, '1234,56');
+
+    expect(input.value).toBe('1.234,56');
+  });
+
+  it('should format an amount in a controlled input with an initial numeric value', async () => {
+    const ControlledPercentageInput = () => {
+      const [value, setValue] = useState<PercentageInputProps['value']>(1234);
+      return (
+        <PercentageInput
+          {...defaultProps}
+          value={value}
+          onChange={(e: ChangeEvent<HTMLInputElement & HTMLTextAreaElement>) =>
+            setValue(e.target.value)
+          }
+        />
+      );
+    };
+    const { getByRole } = render(<ControlledPercentageInput />);
+
+    const input = getByRole('textbox') as HTMLInputElement;
+    expect(input.value).toBe('1.234');
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '1234');
+
+    expect(input.value).toBe('1.234');
+  });
+
+  it('should have no accessibility violations', async () => {
+    const { container } = render(<PercentageInput {...defaultProps} />);
+    const actual = await axe(container);
+    expect(actual).toHaveNoViolations();
+  });
+
+  describe('Labeling', () => {
+    const PERCENT_SYMBOL = '%';
+    /**
+     * Note: further labeling logic is covered by the underlying `Input` component.
+     */
+    it('should have the currency symbol as part of its accessible description', () => {
+      const { getByRole } = render(<PercentageInput {...defaultProps} />);
+      expect(getByRole('textbox')).toHaveAccessibleDescription(PERCENT_SYMBOL);
+    });
+
+    it('should accept a custom description via aria-describedby', () => {
+      const customDescription = 'Custom description';
+      const customDescriptionId = 'customDescriptionId';
+      const { getByRole } = render(
+        <>
+          <span id={customDescriptionId}>{customDescription}</span>
+          <PercentageInput
+            {...defaultProps}
+            aria-describedby={customDescriptionId}
+          />
+        </>,
+      );
+      expect(getByRole('textbox')).toHaveAccessibleDescription(
+        `${PERCENT_SYMBOL} ${customDescription}`,
+      );
+    });
+  });
+});

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.stories.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.stories.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.stories.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.stories.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Stack } from '../../../../.storybook/components/index.js';
+
+import { PercentageInput, PercentageInputProps } from './PercentageInput.js';
+
+export default {
+  title: 'Forms/Input/PercentageInput',
+  component: PercentageInput,
+};
+
+const baseArgs = {
+  label: 'Discount',
+  placeholder: 0,
+  locale: 'de-DE',
+};
+
+export const Base = (args: PercentageInputProps) => (
+  <PercentageInput {...args} style={{ maxWidth: '250px' }} />
+);
+
+Base.args = baseArgs;
+
+export const Locales = (args: PercentageInputProps) => (
+  <Stack>
+    <PercentageInput
+      {...args}
+      style={{ maxWidth: '250px' }}
+      label="Percentage (de-DE)"
+      locale="de-DE"
+    />
+    <PercentageInput
+      {...args}
+      style={{ maxWidth: '250px' }}
+      label="Percentage (en-IE)"
+      locale="en-IE"
+    />
+  </Stack>
+);
+
+Locales.args = {
+  ...baseArgs,
+  decimalScale: 1,
+};
+
+export const Decimals = (args: PercentageInputProps) => (
+  <PercentageInput {...args} style={{ maxWidth: '250px' }} />
+);
+
+Decimals.args = {
+  ...baseArgs,
+  decimalScale: 2,
+};

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { forwardRef, useId } from 'react';
+import { resolveNumberFormat } from '@sumup/intl';
+import { NumericFormat, NumericFormatProps } from 'react-number-format';
+
+import { clsx } from '../../styles/clsx.js';
+import Input, { InputElement, InputProps } from '../Input/index.js';
+
+import { formatPlaceholder } from './PercentageInputService.js';
+import classes from './PercentageInput.module.css';
+
+export interface PercentageInputProps
+  extends Omit<
+      InputProps,
+      'placeholder' | 'ref' | 'value' | 'defaultValue' | 'type'
+    >,
+    Pick<
+      NumericFormatProps,
+      'onValueChange' | 'decimalScale' | 'fixedDecimalScale' | 'allowNegative'
+    > {
+  /**
+   * One or more Unicode BCP 47 locale identifiers, such as `'de-DE'` or
+   * `['GB', 'en-US']` (the first supported locale is used).
+   */
+  locale?: string | string[];
+  /**
+   * A short string that is shown inside the empty input.
+   * If the placeholder is a number, it is formatted in the local format.
+   */
+  placeholder?: string | number;
+  /**
+   * The value of the input element.
+   */
+  value?: string | number;
+  /**
+   * The default value of the input element.
+   */
+  defaultValue?: string | number;
+}
+
+const DEFAULT_FORMAT = {
+  decimalDelimiter: '.',
+  groupDelimiter: ',',
+};
+
+/**
+ * PercentageInput component for fractional values
+ */
+export const PercentageInput = forwardRef<InputElement, PercentageInputProps>(
+  (
+    {
+      locale,
+      placeholder = '0',
+      decimalScale = 0,
+      'aria-describedby': descriptionId,
+      ...props
+    },
+    ref,
+  ) => {
+    const percentageSymbolId = useId();
+    const descriptionIds = clsx(percentageSymbolId, descriptionId);
+
+    const { groupDelimiter, decimalDelimiter } =
+      resolveNumberFormat(locale, {
+        style: 'percent',
+        // There must be at least 1 decimal for the decimalDelimiter to be resolved
+        minimumFractionDigits: 1,
+        maximumFractionDigits: 1,
+      }) || DEFAULT_FORMAT;
+
+    const placeholderString = formatPlaceholder(placeholder, locale, {
+      minimumFractionDigits: decimalScale,
+      maximumFractionDigits: decimalScale,
+    });
+
+    // Allow common decimal signs as well as the one from resolveNumberFormat()
+    const allowedDecimalSeparators = [
+      '.',
+      ',',
+      ...(decimalDelimiter ? [decimalDelimiter] : []),
+    ];
+
+    const renderSuffix = (suffixProps: { className?: string }) => (
+      <span
+        {...suffixProps}
+        className={clsx(suffixProps.className, classes.symbol)}
+        id={percentageSymbolId}
+      >
+        %
+      </span>
+    );
+
+    return (
+      <NumericFormat
+        // react-number-format props
+        thousandSeparator={groupDelimiter}
+        decimalSeparator={decimalDelimiter}
+        decimalScale={decimalScale}
+        customInput={Input}
+        getInputRef={ref}
+        allowedDecimalSeparators={allowedDecimalSeparators}
+        // Circuit input props
+        renderSuffix={renderSuffix}
+        placeholder={placeholderString}
+        textAlign="right"
+        type="text"
+        inputMode="decimal"
+        aria-describedby={descriptionIds}
+        {...props}
+      />
+    );
+  },
+);
+
+PercentageInput.displayName = 'PercentageInput';

--- a/packages/circuit-ui/components/PercentageInput/PercentageInputService.spec.ts
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInputService.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/circuit-ui/components/PercentageInput/PercentageInputService.spec.ts
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInputService.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { formatPlaceholder } from './PercentageInputService.js';
+
+describe('PercentageInputService', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('formatPlaceholder', () => {
+    it('should format a numeric placeholder', () => {
+      const placeholder = 1234.56;
+      const actual = formatPlaceholder(placeholder, 'en-US');
+      const expected = '1,234.56';
+      expect(actual).toBe(expected);
+    });
+
+    it('should return a string placeholder', () => {
+      const placeholder = '1234.56';
+      const actual = formatPlaceholder(placeholder, 'de-DE');
+      const expected = placeholder;
+      expect(actual).toBe(expected);
+    });
+  });
+});

--- a/packages/circuit-ui/components/PercentageInput/PercentageInputService.ts
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInputService.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/circuit-ui/components/PercentageInput/PercentageInputService.ts
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInputService.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatNumber } from '@sumup/intl';
+
+export function formatPlaceholder(
+  placeholder?: string | number,
+  locale?: string | string[],
+  options?: Intl.NumberFormatOptions,
+): string | undefined {
+  return typeof placeholder === 'number'
+    ? formatNumber(placeholder, locale, options)
+    : placeholder;
+}

--- a/packages/circuit-ui/components/PercentageInput/index.ts
+++ b/packages/circuit-ui/components/PercentageInput/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/circuit-ui/components/PercentageInput/index.ts
+++ b/packages/circuit-ui/components/PercentageInput/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PercentageInput } from './PercentageInput.js';
+
+export type { PercentageInputProps } from './PercentageInput.js';
+
+export default PercentageInput;

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -54,6 +54,8 @@ export { default as TextArea } from './components/TextArea/index.js';
 export type { TextAreaProps } from './components/TextArea/index.js';
 export { default as CurrencyInput } from './components/CurrencyInput/index.js';
 export type { CurrencyInputProps } from './components/CurrencyInput/index.js';
+export { default as PercentageInput } from './components/PercentageInput/index.js';
+export type { PercentageInputProps } from './components/PercentageInput/index.js';
 export { default as ImageInput } from './components/ImageInput/index.js';
 export type { ImageInputProps } from './components/ImageInput/index.js';
 


### PR DESCRIPTION
Relates to https://github.com/sumup-oss/circuit-ui/pull/2394

## Purpose

We often ask users to enter fractional values such as fees or taxes. The percent symbol shouldn't be part of the input value but should be displayed inside the input as a suffix.

## Approach and changes

- Backported the new PercentageInput component to v7

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
