### PR TITLE
Improve modal and toast stories

### DIFF
--- a/.storybook/components/FullViewport.module.css
+++ b/.storybook/components/FullViewport.module.css
@@ -1,0 +1,9 @@
+.base {
+  width: 100vw;
+  height: 100vh;
+}
+
+:global(.docs-story) .base {
+  width: auto;
+  height: auto;
+}

--- a/.storybook/components/FullViewport.tsx
+++ b/.storybook/components/FullViewport.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ReactNode } from 'react';
+
+import classes from './FullViewport.module.css';
+
+interface FullViewportProps {
+  children: ReactNode;
+}
+
+export default function FullViewport({ children }: FullViewportProps) {
+  return <div className={classes.base}>{children}</div>;
+}

--- a/.storybook/components/index.ts
+++ b/.storybook/components/index.ts
@@ -21,16 +21,17 @@ export { Props };
 
 export { Meta, IconGallery, IconItem, Typeset } from '@storybook/addon-docs';
 
-export { default as DocsContainer } from './DocsContainer';
-export { default as Status } from './Statuses';
-export { default as Preview } from './Preview';
-export { default as Story } from './Story';
-export { default as Icons } from './Icons';
-export { default as Intro } from './Intro';
-export { default as Teaser } from './Teaser';
-export { default as Link } from './Link';
-export { default as Image } from './Image';
-export { default as Stack } from './Stack';
+export { default as DocsContainer } from './DocsContainer.js';
+export { default as Status } from './Statuses.js';
+export { default as Preview } from './Preview.js';
+export { default as Story } from './Story.js';
+export { default as Icons } from './Icons.js';
+export { default as Intro } from './Intro.js';
+export { default as Teaser } from './Teaser.js';
+export { default as Link } from './Link.js';
+export { default as Image } from './Image.js';
+export { default as Stack } from './Stack.js';
+export { default as FullViewport } from './FullViewport.js';
 
 export {
   CustomPropertiesTable,
@@ -43,4 +44,4 @@ export {
   FontWeight,
   Transition,
   MediaQueriesTable,
-} from './Theme';
+} from './Theme.js';

--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -1,0 +1,18 @@
+const viewports = {
+  smallMobile: {
+    viewport: 'smallMobile',
+  },
+  largeMobile: {
+    viewport: 'largeMobile',
+  },
+  tablet: {
+    viewport: 'tablet',
+  },
+  desktop: {
+    viewport: 'desktop',
+  },
+};
+
+export const modes = {
+  ...viewports,
+};

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -16,6 +16,26 @@ export const parameters = {
       { name: 'v5', url: 'https://circuit-v5.sumup-vercel.app' },
     ],
   },
+  viewport: {
+    viewports: {
+      smallMobile: {
+        name: 'Small mobile',
+        styles: { width: '320px', height: '568px' },
+      },
+      largeMobile: {
+        name: 'Large mobile',
+        styles: { width: '414px', height: '896px' },
+      },
+      tablet: {
+        name: 'Tablet',
+        styles: { width: '834px', height: '1112px' },
+      },
+      desktop: {
+        name: 'Desktop',
+        styles: { width: '1280px', height: '1000px' },
+      },
+    },
+  },
   previewTabs: { 'storybook/docs/panel': { index: -1 } },
   actions: { argTypesRegex: '^on.*' },
   controls: { expanded: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@vitest/coverage-c8": "^0.30.1",
         "@vitest/coverage-v8": "^0.34.6",
         "audit-ci": "^6.6.1",
+        "chromatic": "^10.3.1",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-storybook": "^0.6.15",
@@ -14326,9 +14327,9 @@
       }
     },
     "node_modules/astro/node_modules/vite": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dependencies": {
         "esbuild": "^0.19.3",
         "postcss": "^8.4.32",
@@ -15594,6 +15595,17 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chromatic": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-10.3.1.tgz",
+      "integrity": "sha512-IHczKH3K3vVeZGE3XyCy/T8EQH2mGUEyQ9QUuULrWlYCfo760cnzehdTjrpuIUetkHtv7noA5Hmn6joQlz3Ufw==",
+      "dev": true,
+      "bin": {
+        "chroma": "dist/bin.js",
+        "chromatic": "dist/bin.js",
+        "chromatic-cli": "dist/bin.js"
       }
     },
     "node_modules/ci-info": {
@@ -38367,9 +38379,9 @@
       }
     },
     "packages/remix-template/node_modules/vite": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-      "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
       "dev": true,
       "optional": true,
       "peer": true,
@@ -46389,9 +46401,9 @@
           }
         },
         "vite": {
-          "version": "5.0.11",
-          "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-          "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+          "version": "5.0.12",
+          "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+          "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
           "dev": true,
           "optional": true,
           "peer": true,
@@ -48703,9 +48715,9 @@
           }
         },
         "vite": {
-          "version": "5.0.11",
-          "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-          "integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+          "version": "5.0.12",
+          "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+          "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
           "requires": {
             "esbuild": "^0.19.3",
             "fsevents": "~2.3.3",
@@ -49594,6 +49606,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4= sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true
+    },
+    "chromatic": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-10.3.1.tgz",
+      "integrity": "sha512-IHczKH3K3vVeZGE3XyCy/T8EQH2mGUEyQ9QUuULrWlYCfo760cnzehdTjrpuIUetkHtv7noA5Hmn6joQlz3Ufw==",
       "dev": true
     },
     "ci-info": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@vitest/coverage-c8": "^0.30.1",
     "@vitest/coverage-v8": "^0.34.6",
     "audit-ci": "^6.6.1",
+    "chromatic": "^10.3.1",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-storybook": "^0.6.15",

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -16,6 +16,7 @@
 import { action } from '@storybook/addon-actions';
 
 import { Stack } from '../../../../.storybook/components/index.js';
+import { modes } from '../../../../.storybook/modes.js';
 
 import { ButtonGroup, ButtonGroupProps } from './ButtonGroup.js';
 
@@ -25,7 +26,12 @@ export default {
   parameters: {
     // we don't want to center this story to be able to see the effects of the `align` prop
     layout: 'padded',
-    chromatic: { viewports: [320, 1280] },
+    chromatic: {
+      modes: {
+        mobile: modes.smallMobile,
+        desktop: modes.desktop,
+      },
+    },
   },
 };
 

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -211,7 +211,8 @@ CustomStyles.args = {
         Custom styles
       </Headline>
       <Body style={{ margin: '1rem' }}>
-        Custom styles can be applied using the <code>css</code> prop.
+        Custom styles can be applied using the <code>className</code> or{' '}
+        <code>style</code> props.
       </Body>
     </Fragment>
   ),

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -14,9 +14,10 @@
  */
 
 import { Fragment } from 'react';
-import { userEvent, within } from '@storybook/testing-library';
+import { screen, userEvent, within } from '@storybook/testing-library';
 
 import { Stack } from '../../../../.storybook/components/index.js';
+import { modes } from '../../../../.storybook/modes.js';
 import Button from '../Button/index.js';
 import Headline from '../Headline/index.js';
 import Body from '../Body/index.js';
@@ -30,7 +31,12 @@ export default {
   component: Modal,
   subcomponents: { ModalProvider },
   parameters: {
-    chromatic: { viewports: [320, 1280] },
+    chromatic: {
+      modes: {
+        mobile: modes.smallMobile,
+        desktop: modes.desktop,
+      },
+    },
   },
 };
 
@@ -49,11 +55,12 @@ const openModal = async ({
   canvasElement: HTMLCanvasElement;
 }) => {
   const canvas = within(canvasElement);
-  const thirdItem = canvas.getByRole('button', {
+  const button = canvas.getByRole('button', {
     name: 'Open modal',
   });
 
-  await userEvent.click(thirdItem);
+  await userEvent.click(button);
+  await screen.findByRole('dialog');
 };
 
 export const Base = (modal: ModalProps): JSX.Element => {

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -14,6 +14,7 @@
  */
 
 import { Fragment } from 'react';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 import Button from '../Button/index.js';
@@ -39,6 +40,19 @@ const defaultModalChildren = () => (
   </Fragment>
 );
 
+const openModal = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLCanvasElement;
+}) => {
+  const canvas = within(canvasElement);
+  const thirdItem = canvas.getByRole('button', {
+    name: 'Open modal',
+  });
+
+  await userEvent.click(thirdItem);
+};
+
 export const Base = (modal: ModalProps): JSX.Element => {
   const ComponentWithModal = () => {
     const { setModal } = useModal();
@@ -61,6 +75,7 @@ Base.args = {
   variant: 'contextual',
   closeButtonLabel: 'Close modal',
 };
+Base.play = openModal;
 
 export const Variants = (modal: ModalProps): JSX.Element => {
   const ComponentWithModal = ({ variant }: Pick<ModalProps, 'variant'>) => {
@@ -123,6 +138,7 @@ PreventClose.args = {
   variant: 'immersive',
   preventClose: true,
 };
+PreventClose.play = openModal;
 
 export const InitiallyOpen = (modal: ModalProps): JSX.Element => {
   const initialModal = { id: 'initial', component: Modal, ...modal };
@@ -179,3 +195,4 @@ CustomStyles.args = {
   variant: 'contextual',
   closeButtonLabel: 'Close modal',
 };
+CustomStyles.play = openModal;

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -31,6 +31,7 @@ export default {
   component: Modal,
   subcomponents: { ModalProvider },
   parameters: {
+    layout: 'padded',
     chromatic: {
       modes: {
         mobile: modes.smallMobile,

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -122,6 +122,9 @@ Variants.args = {
   children: defaultModalChildren,
   closeButtonLabel: 'Close modal',
 };
+Variants.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const PreventClose = (modal: ModalProps): JSX.Element => {
   const ComponentWithModal = () => {

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -29,6 +29,9 @@ export default {
   title: 'Components/Modal',
   component: Modal,
   subcomponents: { ModalProvider },
+  parameters: {
+    chromatic: { viewports: [320, 1280] },
+  },
 };
 
 const defaultModalChildren = () => (

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -13,10 +13,14 @@
  * limitations under the License.
  */
 
+import type { Decorator } from '@storybook/react';
 import { Fragment } from 'react';
 import { screen, userEvent, within } from '@storybook/testing-library';
 
-import { Stack } from '../../../../.storybook/components/index.js';
+import {
+  FullViewport,
+  Stack,
+} from '../../../../.storybook/components/index.js';
 import { modes } from '../../../../.storybook/modes.js';
 import Button from '../Button/index.js';
 import Headline from '../Headline/index.js';
@@ -31,7 +35,6 @@ export default {
   component: Modal,
   subcomponents: { ModalProvider },
   parameters: {
-    layout: 'padded',
     chromatic: {
       modes: {
         mobile: modes.smallMobile,
@@ -39,6 +42,13 @@ export default {
       },
     },
   },
+  decorators: [
+    (Story) => (
+      <FullViewport>
+        <Story />
+      </FullViewport>
+    ),
+  ] as Decorator[],
 };
 
 const defaultModalChildren = () => (

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
@@ -13,9 +13,11 @@
  * limitations under the License.
  */
 
+import type { Decorator } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { screen, userEvent, within } from '@storybook/testing-library';
 
+import { FullViewport } from '../../../../.storybook/components/index.js';
 import { ModalProvider } from '../ModalContext/index.js';
 import Button from '../Button/index.js';
 
@@ -31,6 +33,13 @@ export default {
   parameters: {
     layout: 'padded',
   },
+  decorators: [
+    (Story) => (
+      <FullViewport>
+        <Story />
+      </FullViewport>
+    ),
+  ] as Decorator[],
 };
 
 export const Base = (modal: NotificationModalProps): JSX.Element => {

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
@@ -14,6 +14,7 @@
  */
 
 import { action } from '@storybook/addon-actions';
+import { userEvent, within } from '@storybook/testing-library';
 
 import { ModalProvider } from '../ModalContext/index.js';
 import Button from '../Button/index.js';
@@ -60,4 +61,12 @@ Base.args = {
     },
   },
   closeButtonLabel: 'Close',
+};
+Base.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
+  const canvas = within(canvasElement);
+  const thirdItem = canvas.getByRole('button', {
+    name: 'Open modal',
+  });
+
+  await userEvent.click(thirdItem);
 };

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
@@ -28,6 +28,9 @@ import { useNotificationModal } from './useNotificationModal.js';
 export default {
   title: 'Notification/NotificationModal',
   component: NotificationModal,
+  parameters: {
+    layout: 'padded',
+  },
 };
 
 export const Base = (modal: NotificationModalProps): JSX.Element => {

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
@@ -14,7 +14,7 @@
  */
 
 import { action } from '@storybook/addon-actions';
-import { userEvent, within } from '@storybook/testing-library';
+import { screen, userEvent, within } from '@storybook/testing-library';
 
 import { ModalProvider } from '../ModalContext/index.js';
 import Button from '../Button/index.js';
@@ -64,9 +64,10 @@ Base.args = {
 };
 Base.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
   const canvas = within(canvasElement);
-  const thirdItem = canvas.getByRole('button', {
+  const button = canvas.getByRole('button', {
     name: 'Open modal',
   });
 
-  await userEvent.click(thirdItem);
+  await userEvent.click(button);
+  await screen.findByRole('dialog');
 };

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { userEvent, within } from '@storybook/testing-library';
+
 import { Stack } from '../../../../.storybook/components/index.js';
 import Button from '../Button/index.js';
 import { ToastProvider } from '../ToastContext/index.js';
@@ -74,6 +76,15 @@ export const Base = (toast: NotificationToastProps): JSX.Element => {
       <App />
     </ToastProvider>
   );
+};
+
+Base.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
+  const canvas = within(canvasElement);
+  const thirdItem = canvas.getByRole('button', {
+    name: 'Open toast',
+  });
+
+  await userEvent.click(thirdItem);
 };
 
 const variants = ['info', 'success', 'warning', 'danger'] as const;

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { userEvent, within } from '@storybook/testing-library';
+import { screen, userEvent, within } from '@storybook/testing-library';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 import Button from '../Button/index.js';
@@ -80,11 +80,12 @@ export const Base = (toast: NotificationToastProps): JSX.Element => {
 
 Base.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
   const canvas = within(canvasElement);
-  const thirdItem = canvas.getByRole('button', {
+  const button = canvas.getByRole('button', {
     name: 'Open toast',
   });
 
-  await userEvent.click(thirdItem);
+  await userEvent.click(button);
+  await screen.findByRole('status');
 };
 
 const variants = ['info', 'success', 'warning', 'danger'] as const;

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -15,6 +15,7 @@
  */
 
 import { screen, userEvent, within } from '@storybook/testing-library';
+import isChromatic from 'chromatic/isChromatic';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 import Button from '../Button/index.js';
@@ -29,9 +30,6 @@ import {
 export default {
   title: 'Notification/NotificationToast',
   component: NotificationToast,
-  parameters: {
-    layout: 'padded',
-  },
 };
 
 const TOASTS = [
@@ -60,15 +58,13 @@ const TOASTS = [
 export const Base = (toast: NotificationToastProps): JSX.Element => {
   const App = () => {
     const { setToast } = useNotificationToast();
+    const randomIndex = isChromatic()
+      ? 1
+      : Math.floor(Math.random() * TOASTS.length);
     return (
       <Button
         type="button"
-        onClick={() =>
-          setToast({
-            ...toast,
-            ...TOASTS[Math.floor(Math.random() * TOASTS.length)],
-          })
-        }
+        onClick={() => setToast({ ...toast, ...TOASTS[randomIndex] })}
       >
         Open toast
       </Button>

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -29,6 +29,9 @@ import {
 export default {
   title: 'Notification/NotificationToast',
   component: NotificationToast,
+  parameters: {
+    layout: 'padded',
+  },
 };
 
 const TOASTS = [

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
@@ -16,6 +16,7 @@
 import { action } from '@storybook/addon-actions';
 import { Like, Home, LiveChat, Package, Shop } from '@sumup/icons';
 
+import { modes } from '../../../../.storybook/modes.js';
 import { ModalProvider } from '../ModalContext/index.js';
 
 import { SideNavigation, SideNavigationProps } from './SideNavigation.js';
@@ -25,7 +26,13 @@ export default {
   component: SideNavigation,
   parameters: {
     layout: 'fullscreen',
-    chromatic: { viewports: [320, 960, 1280] },
+    chromatic: {
+      modes: {
+        mobile: modes.smallMobile,
+        tablet: modes.tablet,
+        desktop: modes.desktop,
+      },
+    },
   },
   excludeStories: /.*Args$/,
 };

--- a/packages/circuit-ui/components/SidePanel/SidePanel.stories.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.stories.tsx
@@ -16,6 +16,7 @@
 import { useState } from 'react';
 import { within, userEvent } from '@storybook/testing-library';
 
+import { modes } from '../../../../.storybook/modes.js';
 import Body from '../Body/index.js';
 import Button from '../Button/index.js';
 import ListItemGroup from '../ListItemGroup/index.js';
@@ -36,7 +37,12 @@ export default {
   title: 'Navigation/SidePanel',
   parameters: {
     layout: 'fullscreen',
-    chromatic: { viewports: [320, 960] },
+    chromatic: {
+      modes: {
+        mobile: modes.smallMobile,
+        desktop: modes.desktop,
+      },
+    },
   },
   argTypes: {
     backButtonLabel: { control: 'text' },
@@ -232,7 +238,13 @@ WithTopNavigation.storyName = 'With TopNavigation';
 WithTopNavigation.args = baseArgs;
 WithTopNavigation.play = basePlay;
 WithTopNavigation.parameters = {
-  chromatic: { viewports: [320, 960, 1280] },
+  chromatic: {
+    modes: {
+      mobile: modes.smallMobile,
+      tablet: modes.tablet,
+      desktop: modes.desktop,
+    },
+  },
 };
 
 const SIDEPANEL_UPDATE_DURATION = 1000;

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
@@ -17,6 +17,7 @@ import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { Shop, SumUpLogo } from '@sumup/icons';
 
+import { modes } from '../../../../.storybook/modes.js';
 import { SideNavigation } from '../SideNavigation/index.js';
 import { baseArgs as sideNavigationProps } from '../SideNavigation/SideNavigation.stories.js';
 import { ModalProvider } from '../ModalContext/index.js';
@@ -28,7 +29,14 @@ export default {
   component: TopNavigation,
   parameters: {
     layout: 'fullscreen',
-    chromatic: { viewports: [320, 480, 960] },
+    chromatic: {
+      modes: {
+        smallMobile: modes.smallMobile,
+        largeMobile: modes.largeMobile,
+        tablet: modes.tablet,
+        desktop: modes.desktop,
+      },
+    },
   },
   excludeStories: /.*Args$/,
 };
@@ -120,7 +128,4 @@ WithSideNavigation.args = {
     activeLabel: 'Close side navigation',
     inactiveLabel: 'Open side navigation',
   },
-};
-WithSideNavigation.parameters = {
-  chromatic: { viewports: [320, 480, 960, 1280] },
 };


### PR DESCRIPTION
## Purpose

The Chromatic snapshots for the modal and toast components are unhelpful because they only capture the trigger button, not the components themselves.

## Approach and changes

- Use Storybook's `play` feature to open modals and toasts automatically
- Migrate to [Chromatic modes](https://www.chromatic.com/docs/modes/) to test modals on mobile viewports

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
