### PR TITLE
Decrease viewport width at which the ButtonGroup wraps

### DIFF
--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -343,7 +343,7 @@
   }
 }
 
-@container cui-button-group (width > 420px) {
+@container cui-button-group (width > 370px) {
   /* Keep in sync with the .secondary class above */
   .tertiary {
     color: var(--cui-fg-normal);

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.module.css
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.module.css
@@ -13,7 +13,7 @@
   margin-top: var(--cui-spacings-kilo);
 }
 
-@container cui-button-group (width > 420px) {
+@container cui-button-group (width > 370px) {
   .base {
     flex-direction: row-reverse;
   }


### PR DESCRIPTION
Fixes https://github.com/sumup-oss/circuit-ui/pull/2349.

## Purpose

With the new container-based responsive styles, the ButtonGroup now uses a vertical layout inside the Modal component on wide viewports. This is not the intended behavior.

## Approach and changes

- Reduced the container width at which the ButtonGroup component switches to a horizontal layout to improve compatibility with the Modal component.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
