### PR TITLE
Fix scroll-lock caused by modal

### DIFF
--- a/.changeset/loud-penguins-type.md
+++ b/.changeset/loud-penguins-type.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed a bug where users were unable to scroll after a modal was mounted and immediately unmounted.


### PR DESCRIPTION
Relates to https://github.com/reactjs/react-modal/issues/888.

## Purpose

> If React Modal is mounted and almost immediately unmounted, the [html]'s class is not removed when the modal disappears. If this class is used to prevent scrolling, the [page] will remain unscrollable forever.

## Approach and changes

- Manually clean up after `react-modal` once all modals have been closed ([as suggested in this comment](https://github.com/reactjs/react-modal/issues/888#issuecomment-1158061329))

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
