### PR TITLE
Fix scroll-lock caused by ModalProvider

### DIFF
--- a/.changeset/clean-teachers-float.md
+++ b/.changeset/clean-teachers-float.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed a bug where users were unable to scroll after the ModalProvider was mounted and immediately unmounted.

--- a/packages/circuit-ui/components/ModalContext/ModalContext.tsx
+++ b/packages/circuit-ui/components/ModalContext/ModalContext.tsx
@@ -129,14 +129,14 @@ export function ModalProvider<TProps extends BaseModalProps>({
 
   const activeModal = modals[modals.length - 1];
 
-  const cleanUp = useCallback(() => {
+  useEffect(() => {
     // // Clean up after react-modal in case it fails to do so itself
     // // https://github.com/reactjs/react-modal/issues/888#issuecomment-1158061329
-    document.documentElement.classList.remove(HTML_OPEN_CLASS_NAME);
-    getAppElement()?.removeAttribute('aria-hidden');
-  }, []);
+    const cleanUp = () => {
+      document.documentElement.classList.remove(HTML_OPEN_CLASS_NAME);
+      getAppElement()?.removeAttribute('aria-hidden');
+    };
 
-  useEffect(() => {
     if (!activeModal) {
       cleanUp();
       return undefined;

--- a/packages/circuit-ui/components/ModalContext/ModalContext.tsx
+++ b/packages/circuit-ui/components/ModalContext/ModalContext.tsx
@@ -129,12 +129,16 @@ export function ModalProvider<TProps extends BaseModalProps>({
 
   const activeModal = modals[modals.length - 1];
 
+  const cleanUp = useCallback(() => {
+    // // Clean up after react-modal in case it fails to do so itself
+    // // https://github.com/reactjs/react-modal/issues/888#issuecomment-1158061329
+    document.documentElement.classList.remove(HTML_OPEN_CLASS_NAME);
+    getAppElement()?.removeAttribute('aria-hidden');
+  }, []);
+
   useEffect(() => {
     if (!activeModal) {
-      // Clean up after react-modal in case it fails to do so itself
-      // https://github.com/reactjs/react-modal/issues/888#issuecomment-1158061329
-      document.documentElement.classList.remove(HTML_OPEN_CLASS_NAME);
-      getAppElement()?.removeAttribute('aria-hidden');
+      cleanUp();
       return undefined;
     }
 
@@ -145,6 +149,7 @@ export function ModalProvider<TProps extends BaseModalProps>({
     window.addEventListener('popstate', popModal);
 
     return () => {
+      cleanUp();
       window.removeEventListener('popstate', popModal);
     };
   }, [activeModal, removeModal]);


### PR DESCRIPTION
## Purpose

Due to potential conditional re-rendering in ze-dashboard, the `cui-modal-open` class might still be present.
It might cause the issue with react-modal, [described here](https://github.com/reactjs/react-modal/issues/888#issuecomment-1158061329).

## Approach and changes

- Clean up the `react-modal` attributes when the all modals are closed or the ModalProvider component is unmounted

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
