### PR TITLE
Add minimum height to SidePanelProvider

### DIFF
--- a/.changeset/clever-ducks-play.md
+++ b/.changeset/clever-ducks-play.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a minimum height to the SidePanelProvider to allow its children to be vertically centered.

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.module.css
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.module.css
@@ -1,5 +1,6 @@
 .base {
   width: 100%;
+  min-height: calc(100vh - var(--top-navigation-height));
   transition: width var(--cui-transitions-slow);
 }
 

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.spec.tsx
@@ -135,6 +135,17 @@ describe('SidePanelContext', () => {
       <button onClick={() => hookFn({ group, ...props })}>Update panel</button>
     );
 
+    it('should merge a custom class name with the default ones', () => {
+      const className = 'foo';
+      const { container } = render(
+        <SidePanelProvider className={className}>
+          <span />
+        </SidePanelProvider>,
+      );
+      const button = container.querySelector('div');
+      expect(button?.className).toContain(className);
+    });
+
     describe('setSidePanel', () => {
       it('should open a side panel', async () => {
         const Trigger = () => {

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
@@ -16,11 +16,12 @@
 import {
   createContext,
   useCallback,
-  ReactNode,
   useMemo,
   useState,
+  type ReactNode,
+  type HTMLAttributes,
 } from 'react';
-import ReactModal, { Props as ReactModalProps } from 'react-modal';
+import ReactModal, { type Props as ReactModalProps } from 'react-modal';
 
 import { useMedia } from '../../hooks/useMedia/index.js';
 import { useStack, StackItem } from '../../hooks/useStack/index.js';
@@ -29,7 +30,7 @@ import { warn } from '../../util/logger.js';
 import { clsx } from '../../styles/clsx.js';
 import { useLatest } from '../../hooks/useLatest/useLatest.js';
 
-import { SidePanel, SidePanelProps } from './SidePanel.js';
+import { SidePanel, type SidePanelProps } from './SidePanel.js';
 import { TRANSITION_DURATION } from './constants.js';
 import type { SidePanelHookProps } from './useSidePanel.js';
 import classes from './SidePanelContext.module.css';
@@ -102,7 +103,7 @@ export const SidePanelContext = createContext<SidePanelContextValue>({
   transitionDuration: TRANSITION_DURATION,
 });
 
-export interface SidePanelProviderProps {
+export interface SidePanelProviderProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * The SidePanelProvider should wrap your entire primary content,
    * which will be resized when the side panel is opened.
@@ -110,7 +111,10 @@ export interface SidePanelProviderProps {
   children: ReactNode;
 }
 
-export function SidePanelProvider({ children }: SidePanelProviderProps) {
+export function SidePanelProvider({
+  children,
+  ...props
+}: SidePanelProviderProps) {
   const isMobile = useMedia('(max-width: 767px)');
   const [sidePanels, dispatch] = useStack<SidePanelContextItem>();
   const [isPrimaryContentResized, setIsPrimaryContentResized] = useState(false);
@@ -235,9 +239,11 @@ export function SidePanelProvider({ children }: SidePanelProviderProps) {
   return (
     <SidePanelContext.Provider value={context}>
       <div
+        {...props}
         className={clsx(
           classes.base,
           !isMobile && isPrimaryContentResized && classes.resized,
+          props.className,
         )}
       >
         {children}


### PR DESCRIPTION
## Purpose

The SidePanelProvider must wrap the page content so it can be resized when a side panel is open. It's a common use case to show a spinner while the page content is loading. Currently, it's difficult to vertically center this spinner since the SidePanelProvider does not fill the viewport height and cannot be styled.

## Approach and changes

- Add a minimum height to the SidePanelProvider to allow its children to be vertically centered
- Accept custom attributes on the SidePanelProvider

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
