### PR TITLE
Prefer web safe fonts over system fonts (v7)

### DIFF
--- a/.changeset/real-suits-relate.md
+++ b/.changeset/real-suits-relate.md
@@ -1,0 +1,5 @@
+---
+'@sumup/design-tokens': minor
+---
+
+Changed the order of the default font stack to prefer web safe fonts over system fonts. This provides a more consistent user experience across platforms, reduces layout shift when switching to SumUp's brand font, Aktiv Grotesk, and works around a (supposedly fixed) [Chrome bug](https://www.bram.us/2020/04/24/chrome-vs-blinkmacsystemfont-a-workaround/).

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -31,9 +31,9 @@
   }
 
   html {
-    font-family: 'aktiv-grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI',
-      Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji',
-      'Segoe UI Emoji', 'Segoe UI Symbol';
+    font-family: 'aktiv-grotesk', Helvetica, Arial, system-ui, sans-serif,
+      'Segoe UI', Roboto, 'Apple Color Emoji', 'Segoe UI Emoji',
+      'Segoe UI Symbol';
   }
 
   .sbdocs.sbdocs-content {

--- a/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
@@ -91,7 +91,7 @@ exports[`Themes > light > should match the snapshot 1`] = `
     "y900": "#725514",
   },
   "fontStack": {
-    "default": "aktiv-grotesk, -apple-system, BlinkMacSystemFont, \\"Segoe UI\\", Roboto, Helvetica, Arial, sans-serif, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\"",
+    "default": "aktiv-grotesk, Helvetica, Arial, system-ui, sans-serif, \\"Segoe UI\\", Roboto, \\"Apple Color Emoji\\", \\"Segoe UI Emoji\\", \\"Segoe UI Symbol\\"",
     "mono": "Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
   },
   "fontWeight": {

--- a/packages/design-tokens/themes/legacy/shared.ts
+++ b/packages/design-tokens/themes/legacy/shared.ts
@@ -118,7 +118,7 @@ export const typography = {
 
 export const fontStack: FontStack = {
   default:
-    'aktiv-grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+    'aktiv-grotesk, Helvetica, Arial, system-ui, sans-serif, "Segoe UI", Roboto, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
   mono: 'Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace',
 };
 

--- a/packages/design-tokens/themes/light.ts
+++ b/packages/design-tokens/themes/light.ts
@@ -756,7 +756,7 @@ export const light = [
   {
     name: '--cui-font-stack-default',
     value:
-      'aktiv-grotesk, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+      'aktiv-grotesk, Helvetica, Arial, system-ui, sans-serif, "Segoe UI", Roboto, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
     type: 'fontFamily',
   },
   {


### PR DESCRIPTION
## Purpose

A [bug in Chrome](https://www.bram.us/2020/04/24/chrome-vs-blinkmacsystemfont-a-workaround/) causes bold text rendered using the system font on macOS to be extra thick. The bug has supposedly been fixed, but can still be reproduced with bold & italic text.

The bug is present when any of the `-apple-system`, `BlinkMacSystemFont`, or `system-ui` fonts are used. Removing these causes Chrome on macOS to fallback to Helvetica. This prompted the idea to move Helvetica and Arial before the system fonts as this provides a more consistent user experience across platforms and reduces layout shift when switching to SumUp's brand font, Aktiv Grotesk.

The system fonts are kept in the font stack in case certain characters aren't available in any of the previous fonts. The same reasoning applies to the emoji and symbol fonts.

## Approach and changes

- Re-arrange the fonts in the default font stack to prefer web safe fonts over system fonts

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
