### PR TITLE
Fix border color token names in the dark theme

### DIFF
--- a/.changeset/wise-mice-design.md
+++ b/.changeset/wise-mice-design.md
@@ -1,0 +1,5 @@
+---
+'@sumup/design-tokens': patch
+---
+
+Fixed the names of the dark border color tokens.

--- a/packages/design-tokens/themes/dark.ts
+++ b/packages/design-tokens/themes/dark.ts
@@ -17,52 +17,52 @@ import type { Token } from '../types/index.js';
 
 export const dark = [
   {
-    name: '--cui-┅-border-accent',
+    name: '--cui-border-accent',
     value: '#ffffff',
     type: 'color',
   },
   {
-    name: '--cui-┅-border-danger',
+    name: '--cui-border-danger',
     value: '#de331d',
     type: 'color',
   },
   {
-    name: '--cui-┅-border-divider',
+    name: '--cui-border-divider',
     value: '#454954',
     type: 'color',
   },
   {
-    name: '--cui-┅-border-focus',
+    name: '--cui-border-focus',
     value: '#ffffff',
     type: 'color',
   },
   {
-    name: '--cui-┅-border-normal',
+    name: '--cui-border-normal',
     value: '#454954',
     type: 'color',
   },
   {
-    name: '--cui-┅-border-promo',
+    name: '--cui-border-promo',
     value: '#ae49de',
     type: 'color',
   },
   {
-    name: '--cui-┅-border-strong',
+    name: '--cui-border-strong',
     value: '#4e5155',
     type: 'color',
   },
   {
-    name: '--cui-┅-border-subtle',
+    name: '--cui-border-subtle',
     value: '#2c3038',
     type: 'color',
   },
   {
-    name: '--cui-┅-border-success',
+    name: '--cui-border-success',
     value: '#39c57a',
     type: 'color',
   },
   {
-    name: '--cui-┅-border-warning',
+    name: '--cui-border-warning',
     value: '#e87c00',
     type: 'color',
   },

--- a/packages/design-tokens/types/index.ts
+++ b/packages/design-tokens/types/index.ts
@@ -185,8 +185,36 @@ interface BaseToken {
   value: unknown;
 }
 
+type ColorUsage = 'fg' | 'bg' | 'border';
+type ColorSentiment =
+  | 'normal'
+  | 'subtle'
+  | 'highlight'
+  | 'accent'
+  | 'placeholder'
+  | 'promo'
+  | 'divider'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'strong'
+  | 'on-strong';
+type ColorVariant = 'strong' | 'on-strong';
+type ColorInteraction = 'hovered' | 'pressed' | 'disabled';
+
 interface ColorToken extends BaseToken {
   type: 'color';
+  name: // usage - sentiment - variant - interaction, with variant and interaction being optional
+  | `--cui-${ColorUsage}-${ColorSentiment}`
+    | `--cui-${ColorUsage}-${ColorSentiment}-${ColorVariant | ColorInteraction}`
+    | `--cui-${ColorUsage}-${ColorSentiment}-${ColorVariant}-${ColorInteraction}`
+    // Special colors
+    | '--cui-bg-elevated'
+    | '--cui-bg-overlay'
+    | '--cui-border-focus'
+    // FIXME: The '--cui-fg-on-strong-subtle' tokens don't follow the naming scheme.
+    | `--cui-${ColorUsage}-${ColorVariant}-${ColorSentiment | ColorInteraction}`
+    | `--cui-${ColorUsage}-${ColorVariant}-${ColorSentiment}-${ColorInteraction}`;
   value: Color;
 }
 


### PR DESCRIPTION
## Purpose

When transforming the Figma export of the dark theme, I messed up the names for the border color tokens.

## Approach and changes

- Fix border color token names in the dark theme
- Add better color name validation

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
