### PR TITLE
Add scoped versions of the dark and light themes

### DIFF
--- a/.changeset/lazy-dingos-look.md
+++ b/.changeset/lazy-dingos-look.md
@@ -2,4 +2,4 @@
 '@sumup/design-tokens': minor
 ---
 
-Added an experimental dark theme. Import `@sumup/design-tokens/dark.css` for the standalone dark theme. Import `@sumup/design-tokens/dynamic.css` to switch between the light and dark themes automatically based on the system settings or explicitly using the `data-color-mode` attribute.
+Added an experimental dark theme. Import `@sumup/design-tokens/dark.css` for the standalone dark theme. Import `@sumup/design-tokens/dynamic.css` to switch between the light and dark themes automatically based on the system settings or explicitly using the `data-color-scheme` attribute.

--- a/.changeset/nasty-owls-collect.md
+++ b/.changeset/nasty-owls-collect.md
@@ -1,0 +1,5 @@
+---
+'@sumup/design-tokens': minor
+---
+
+Added experimental scoped light and dark themes. Import `@sumup/design-tokens/light-scoped.css` or `@sumup/design-tokens/dark-scoped.css` to theme a subset of an application marked up with the `data-color-scheme` attribute.

--- a/packages/design-tokens/scripts/build.spec.ts
+++ b/packages/design-tokens/scripts/build.spec.ts
@@ -24,13 +24,13 @@ import {
 } from './build.js';
 
 describe('build', () => {
-  it('should throw an error no tokens are globally defined', () => {
+  it('should throw not throw an error when tokens are  missing in a scoped theme', () => {
     const theme = {
       name: 'test',
       groups: [
         {
           colorScheme: 'light' as const,
-          selectors: ['body'],
+          selectors: ['[data-color-scheme="light"]'],
           tokens: [
             {
               name: '--cui-bg-normal',
@@ -46,9 +46,7 @@ describe('build', () => {
 
     const actual = () => validateTheme(theme);
 
-    expect(actual).toThrow(
-      'The "test" theme does not define any global tokens. Add them to the ":root" selector.',
-    );
+    expect(actual).not.toThrow();
   });
 
   describe('validateTheme', () => {

--- a/packages/design-tokens/scripts/build.ts
+++ b/packages/design-tokens/scripts/build.ts
@@ -62,6 +62,26 @@ function main(): void {
       ],
     },
     {
+      name: 'light-scoped',
+      groups: [
+        {
+          tokens: light,
+          selectors: ['[data-color-scheme="light"]'],
+          colorScheme: 'light',
+        },
+      ],
+    },
+    {
+      name: 'dark-scoped',
+      groups: [
+        {
+          tokens: dark,
+          selectors: ['[data-color-scheme="dark"]'],
+          colorScheme: 'dark',
+        },
+      ],
+    },
+    {
       name: 'dynamic',
       groups: [
         {
@@ -132,15 +152,13 @@ export function validateTheme(theme: Theme): void {
     });
   });
 
-  // Validate that all tokens have a default value defined at the root
+  // Validate that the tokens at the root are complete
   const rootGroup = theme.groups.find(
     (group) => group.selectors.length === 1 && group.selectors[0] === ':root',
   );
 
   if (!rootGroup) {
-    throw new Error(
-      `The "${theme.name}" theme does not define any global tokens. Add them to the ":root" selector.`,
-    );
+    return;
   }
 
   if (rootGroup.tokens.length !== schema.length) {


### PR DESCRIPTION
## Purpose

We've found an additional use case for dark mode: some sections on SumUp's website use a black background to stand out more. This has worked ok with blue buttons but breaks with the switch to black&white (#2356). Applying the dark mode locally is an elegant way to solve this dilemma without designing additional button variants.

## Approach and changes

- Add experimental scoped light and dark themes (`@sumup/design-tokens/light-scoped.css` and `@sumup/design-tokens/dark-scoped.css`). They don't declare all tokens and must be used alongside the `@sumup/design-tokens/light.css` or `@sumup/design-tokens/dark.css` themes.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
