### PR TITLE
Make components compatible with React Server Components

### DIFF
--- a/.changeset/four-garlics-sleep.md
+++ b/.changeset/four-garlics-sleep.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Made all components compatible with [React Server Components](https://github.com/reactjs/rfcs/blob/main/text/0188-server-components.md) out of the box by adding the [`use client`](https://react.dev/reference/react/use-client) directive to client components.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = require('@sumup/foundry/eslint')({
-  extends: ['plugin:storybook/recommended'],
+  extends: [
+    'plugin:storybook/recommended',
+    'plugin:react-server-components/recommended',
+  ],
   plugins: ['@sumup/circuit-ui'],
   settings: {
     'import/parsers': {
@@ -26,6 +29,19 @@ module.exports = require('@sumup/foundry/eslint')({
       files: ['**/*.stories.*'],
       rules: {
         'import/no-relative-packages': 'off',
+        'react-server-components/use-client': 'off',
+      },
+    },
+    {
+      files: ['**/*.spec.*'],
+      rules: {
+        'react-server-components/use-client': 'off',
+      },
+    },
+    {
+      files: ['packages/circuit-ui/components/legacy/**/*'],
+      rules: {
+        '@sumup/circuit-ui/prefer-custom-properties': 'off',
       },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32595,6 +32595,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-preserve-directives": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-preserve-directives/-/rollup-plugin-preserve-directives-0.3.1.tgz",
+      "integrity": "sha512-Jn1gWU7G55A1sU6eFpXmwknfBasF0XbBzRqsE6nqrb/gun+mGV7nx++CwOSGPJQpFzFqvKm5U4XNKo3LTLi4Hg==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.5"
+      },
+      "peerDependencies": {
+        "rollup": "2.x || 3.x || 4.x"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
@@ -37483,6 +37495,7 @@
         "react-dates": "^21.8.0",
         "react-dom": "^18.2.0",
         "react-swipeable": "^7.0.1",
+        "rollup-plugin-preserve-directives": "^0.3.1",
         "typescript": "^5.3.3",
         "typescript-plugin-css-modules": "^5.0.2",
         "vite": "^4.5.2"
@@ -45856,6 +45869,7 @@
         "react-modal": "^3.16.1",
         "react-number-format": "5.3.0",
         "react-swipeable": "^7.0.1",
+        "rollup-plugin-preserve-directives": "^0.3.1",
         "typescript": "^5.3.3",
         "typescript-plugin-css-modules": "^5.0.2",
         "vite": "^4.5.2"
@@ -62388,6 +62402,15 @@
       "integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
       "requires": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-preserve-directives": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-preserve-directives/-/rollup-plugin-preserve-directives-0.3.1.tgz",
+      "integrity": "sha512-Jn1gWU7G55A1sU6eFpXmwknfBasF0XbBzRqsE6nqrb/gun+mGV7nx++CwOSGPJQpFzFqvKm5U4XNKo3LTLi4Hg==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.30.5"
       }
     },
     "rrweb-cssom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "chromatic": "^10.3.1",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-react-server-components": "^1.1.1",
         "eslint-plugin-storybook": "^0.6.15",
         "jsdom": "^23.2.0",
         "lerna": "^8.0.2",
@@ -18547,6 +18548,43 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react-server-components": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-server-components/-/eslint-plugin-react-server-components-1.1.1.tgz",
+      "integrity": "sha512-oL8d1mzvUgm6ezwKie0hQvXAgjx5II8e2vzt9vcp6Ygn+LXyg3KXdVTpQu6bsJomblbRBVLJCIFDSKr420+wmA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-plugin-react": "^7.32.2",
+        "globals": "^13.20.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-server-components/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-react-server-components/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -52047,6 +52085,33 @@
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "dev": true,
       "requires": {}
+    },
+    "eslint-plugin-react-server-components": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-server-components/-/eslint-plugin-react-server-components-1.1.1.tgz",
+      "integrity": "sha512-oL8d1mzvUgm6ezwKie0hQvXAgjx5II8e2vzt9vcp6Ygn+LXyg3KXdVTpQu6bsJomblbRBVLJCIFDSKr420+wmA==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-react": "^7.32.2",
+        "globals": "^13.20.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "13.24.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+          "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
     },
     "eslint-plugin-storybook": {
       "version": "0.6.15",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "chromatic": "^10.3.1",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react-server-components": "^1.1.1",
     "eslint-plugin-storybook": "^0.6.15",
     "jsdom": "^23.2.0",
     "lerna": "^8.0.2",

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   forwardRef,
   AnchorHTMLAttributes,

--- a/packages/circuit-ui/components/Button/base.tsx
+++ b/packages/circuit-ui/components/Button/base.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   forwardRef,
   type ButtonHTMLAttributes,

--- a/packages/circuit-ui/components/Card/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Card/components/Header/Header.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { ReactNode, HTMLAttributes, forwardRef } from 'react';
 
 import type { ClickEvent } from '../../../../types/events.js';

--- a/packages/circuit-ui/components/Carousel/Carousel.tsx
+++ b/packages/circuit-ui/components/Carousel/Carousel.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { ReactNode, useRef, useState } from 'react';
 
 import ProgressBar from '../ProgressBar/index.js';

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   InputHTMLAttributes,
   forwardRef,

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   FieldsetHTMLAttributes,
   InputHTMLAttributes,

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { forwardRef, useId } from 'react';
 import { resolveCurrencyFormat } from '@sumup/intl';
 import { NumericFormat, NumericFormatProps } from 'react-number-format';

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { forwardRef, useState, useEffect } from 'react';
 import { PatternFormat } from 'react-number-format';
 

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { forwardRef } from 'react';
 
 import { legacyButtonSizeMap } from '../Button/index.js';

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   useState,
   useRef,

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   ComponentType,
   forwardRef,

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   ReactNode,
   forwardRef,

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { forwardRef, HTMLAttributes, ReactNode, useState } from 'react';
 
 import { AccessibilityError } from '../../util/errors.js';

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { HTMLAttributes, ReactNode } from 'react';
 import ReactModal from 'react-modal';
 

--- a/packages/circuit-ui/components/ModalContext/ModalContext.tsx
+++ b/packages/circuit-ui/components/ModalContext/ModalContext.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   createContext,
   useEffect,

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   MouseEvent,
   KeyboardEvent,

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   ForwardRefExoticComponent,
   HTMLAttributes,

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { FC, ReactNode, SVGProps } from 'react';
 import ReactModal from 'react-modal';
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { HTMLAttributes, RefObject, useEffect, useRef, useState } from 'react';
 
 import { useAnimation } from '../../hooks/useAnimation/index.js';

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { HTMLAttributes, ReactElement } from 'react';
 import { ChevronLeft, ChevronRight } from '@sumup/icons';
 

--- a/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { FC, OlHTMLAttributes } from 'react';
 
 import Button from '../../../Button/index.js';

--- a/packages/circuit-ui/components/Pagination/components/PageSelect/PageSelect.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageSelect/PageSelect.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { useCallback, FunctionComponent, ChangeEvent, Fragment } from 'react';
 
 import Select, { SelectProps } from '../../../Select/index.js';

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { forwardRef, useId } from 'react';
 import { resolveNumberFormat } from '@sumup/intl';
 import { NumericFormat, NumericFormatProps } from 'react-number-format';

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   Fragment,
   useEffect,

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -117,6 +117,8 @@ export function ProgressBar({
   className,
   ...props
 }: ProgressBarProps): ReturnType {
+  // useId is allowed in Server Components
+  // eslint-disable-next-line react-server-components/use-client
   const ariaId = useId();
 
   if (

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   createContext,
   InputHTMLAttributes,

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -132,6 +132,8 @@ export const RadioButtonGroup = forwardRef(
     }: RadioButtonGroupProps,
     ref: RadioButtonGroupProps['ref'],
   ) => {
+    // useId is allowed in Server Components
+    // eslint-disable-next-line react-server-components/use-client
     const randomName = useId();
     const name = customName || randomName;
     const validationHintId = useId();

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { forwardRef, useRef } from 'react';
 import { Search } from '@sumup/icons';
 

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -139,6 +139,8 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         'The `label` prop is missing or invalid. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
+    // useId is allowed in Server Components
+    // eslint-disable-next-line react-server-components/use-client
     const id = useId();
     const selectId = customId || id;
     const validationHintId = useId();

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -128,6 +128,8 @@ export const Selector = forwardRef<HTMLInputElement, SelectorProps>(
     },
     ref,
   ) => {
+    // useId is allowed in Server Components
+    // eslint-disable-next-line react-server-components/use-client
     const randomId = useId();
     const inputId = customId || randomId;
     const descriptionId = useId();

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -146,6 +146,8 @@ export const SelectorGroup = forwardRef<
     },
     ref,
   ) => {
+    // useId is allowed in Server Components
+    // eslint-disable-next-line react-server-components/use-client
     const randomName = useId();
     const name = customName || randomName;
     const validationHintId = useId();

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { useEffect } from 'react';
 
 import { useMedia } from '../../hooks/useMedia/index.js';

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -15,6 +15,8 @@
 
 /* eslint-disable jsx-a11y/no-redundant-roles */
 
+'use client';
+
 import utilityClasses from '../../../../styles/utility.js';
 import { clsx } from '../../../../styles/clsx.js';
 import { useFocusList } from '../../../../hooks/useFocusList/index.js';

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { Fragment } from 'react';
 import ReactModal from 'react-modal';
 import { ChevronDown } from '@sumup/icons';

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { ArrowRight } from '@sumup/icons';
 import { ComponentType } from 'react';
 

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -15,6 +15,8 @@
 
 /* eslint-disable jsx-a11y/no-redundant-roles */
 
+'use client';
+
 import { forwardRef } from 'react';
 
 import type { AsPropType } from '../../../../types/prop-types.js';

--- a/packages/circuit-ui/components/SidePanel/SidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { UIEventHandler, useEffect, useId, useState } from 'react';
 import type { Props as ReactModalProps } from 'react-modal';
 

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   createContext,
   useCallback,

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import type { HTMLAttributes } from 'react';
 import { ArrowLeft } from '@sumup/icons';
 

--- a/packages/circuit-ui/components/Skeleton/Skeleton.tsx
+++ b/packages/circuit-ui/components/Skeleton/Skeleton.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   createContext,
   useContext,

--- a/packages/circuit-ui/components/Step/examples/MultiStepForm.tsx
+++ b/packages/circuit-ui/components/Step/examples/MultiStepForm.tsx
@@ -15,6 +15,8 @@
 
 /* istanbul ignore file */
 
+'use client';
+
 import Headline from '../../Headline/index.js';
 import Button from '../../Button/index.js';
 import ButtonGroup from '../../ButtonGroup/index.js';

--- a/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
+++ b/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
@@ -16,6 +16,8 @@
 /* istanbul ignore file */
 /* eslint-disable import/no-extraneous-dependencies */
 
+'use client';
+
 import { ReactNode, useState } from 'react';
 import {
   SwipeableProps,

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { Component, createRef, HTMLAttributes, UIEvent } from 'react';
 
 import { isNil } from '../../util/type-check.js';

--- a/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
+++ b/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { mapRowProps, mapCellProps } from '../../utils.js';
 import { Row } from '../../types.js';
 import TableRow from '../TableRow/index.js';

--- a/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { Fragment } from 'react';
 
 import TableRow from '../TableRow/index.js';

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import type { ThHTMLAttributes } from 'react';
 
 import SortArrow from '../SortArrow/index.js';

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import type { HTMLAttributes } from 'react';
 
 import type { ClickEvent } from '../../../../types/events.js';

--- a/packages/circuit-ui/components/Tabs/Tabs.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { Component, Fragment, ReactElement, ReactNode, createRef } from 'react';
 
 import {

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { AnchorHTMLAttributes, ButtonHTMLAttributes, forwardRef } from 'react';
 
 import { useComponents } from '../../../ComponentsContext/index.js';

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   forwardRef,
   type HTMLAttributes,

--- a/packages/circuit-ui/components/TextArea/TextArea.tsx
+++ b/packages/circuit-ui/components/TextArea/TextArea.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { forwardRef, useRef } from 'react';
 
 import Input from '../Input/index.js';

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   createContext,
   ReactNode,

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -92,6 +92,8 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
       }
     }
 
+    // useId is allowed in Server Components
+    // eslint-disable-next-line react-server-components/use-client
     const switchId = useId();
     const labelId = useId();
     const descriptionId = useId();

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { HTMLAttributes, ReactNode, useEffect } from 'react';
 
 import Hamburger, { HamburgerProps } from '../Hamburger/index.js';

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { useState, ButtonHTMLAttributes, useEffect } from 'react';
 import { ChevronDown, Profile as ProfileIcon } from '@sumup/icons';
 

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import type { MouseEvent, KeyboardEvent, AnchorHTMLAttributes } from 'react';
 import type { IconComponentType } from '@sumup/icons';
 

--- a/packages/circuit-ui/components/legacy/CalendarTag/CalendarTag.tsx
+++ b/packages/circuit-ui/components/legacy/CalendarTag/CalendarTag.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { Component, createRef } from 'react';
 import type { Moment } from 'moment';
 

--- a/packages/circuit-ui/components/legacy/CalendarTagTwoStep/CalendarTagTwoStep.tsx
+++ b/packages/circuit-ui/components/legacy/CalendarTagTwoStep/CalendarTagTwoStep.tsx
@@ -15,6 +15,8 @@
 
 /** @jsxImportSource @emotion/react */
 
+'use client';
+
 import { Component, createRef } from 'react';
 import { css } from '@emotion/react';
 import type { Moment } from 'moment';

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -74,6 +74,7 @@
     "react-dates": "^21.8.0",
     "react-dom": "^18.2.0",
     "react-swipeable": "^7.0.1",
+    "rollup-plugin-preserve-directives": "^0.3.1",
     "typescript": "^5.3.3",
     "typescript-plugin-css-modules": "^5.0.2",
     "vite": "^4.5.2"

--- a/packages/circuit-ui/vite.config.ts
+++ b/packages/circuit-ui/vite.config.ts
@@ -15,6 +15,7 @@
 
 import crypto from 'node:crypto';
 import path from 'node:path';
+import preserveDirectives from 'rollup-plugin-preserve-directives';
 
 import { UserConfig, defineConfig } from 'vite';
 
@@ -83,6 +84,11 @@ export default defineConfig({
     },
     minify: false,
     rollupOptions: {
+      plugins: [
+        // @ts-expect-error rollup-plugin-preserve-directives is bundled in a non-standard way.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        (preserveDirectives.default || preserveDirectives)(),
+      ],
       output: {
         preserveModules: true,
       },


### PR DESCRIPTION
Relates to https://github.com/rollup/rollup/issues/4699.

## Purpose

Components must adhere to certain constraints to be usable as [React Server Components (RCS)](https://github.com/reactjs/rfcs/blob/main/text/0188-server-components.md):

> ### Limitations of Server Components
> 
> - Server Components cannot support interaction as event handlers must be registered and triggered by a client.
>   - For example, event handlers like `onClick` can only be defined in Client Components.
> - Server Components cannot use most Hooks.
>   - When Server Components are rendered, their output is essentially a list of components for the client to render. Server Components do not persist in memory after render and cannot have their own state.

Pages and components in Next.js' App directory are treated as RCS by default. Components that don't meet the above constraints must be explicitly marked as client components using the `use client` directive. 

## Approach and changes

- Install [`rollup-plugin-preserve-directives`](https://github.com/Ephem/rollup-plugin-preserve-directives) to allow directives
- Install [`eslint-plugin-react-server-components`](https://github.com/roginfarrer/eslint-plugin-react-server-components) to mark up client components with the [`use client`](https://react.dev/reference/react/use-client#using-third-party-libraries) directive

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
