### PR TITLE
Replace no-bundle plugin with Rollup option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36260,32 +36260,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/vite-plugin-no-bundle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-no-bundle/-/vite-plugin-no-bundle-3.0.0.tgz",
-      "integrity": "sha512-B8O4ZmWHbA8MWhsCqjcxwCLW5Kk2Q1Ax7JhZBBB/ort+DNONkBA2HND0d9lQ5d0Q+JSOMYAQDDQ1qAS1nmThyA==",
-      "dev": true,
-      "dependencies": {
-        "fast-glob": "^3.2.12",
-        "micromatch": "^4.0.5"
-      }
-    },
-    "node_modules/vite-plugin-no-bundle/node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
     "node_modules/vite-plugin-turbosnap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/vite-plugin-turbosnap/-/vite-plugin-turbosnap-1.0.2.tgz",
@@ -37511,8 +37485,7 @@
         "react-swipeable": "^7.0.1",
         "typescript": "^5.3.3",
         "typescript-plugin-css-modules": "^5.0.2",
-        "vite": "^4.5.2",
-        "vite-plugin-no-bundle": "^3.0.0"
+        "vite": "^4.5.2"
       },
       "engines": {
         "node": ">=18"
@@ -45885,8 +45858,7 @@
         "react-swipeable": "^7.0.1",
         "typescript": "^5.3.3",
         "typescript-plugin-css-modules": "^5.0.2",
-        "vite": "^4.5.2",
-        "vite-plugin-no-bundle": "^3.0.0"
+        "vite": "^4.5.2"
       },
       "dependencies": {
         "@sumup/design-tokens": {
@@ -65308,31 +65280,6 @@
         "pathe": "^1.1.1",
         "picocolors": "^1.0.0",
         "vite": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
-      }
-    },
-    "vite-plugin-no-bundle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-no-bundle/-/vite-plugin-no-bundle-3.0.0.tgz",
-      "integrity": "sha512-B8O4ZmWHbA8MWhsCqjcxwCLW5Kk2Q1Ax7JhZBBB/ort+DNONkBA2HND0d9lQ5d0Q+JSOMYAQDDQ1qAS1nmThyA==",
-      "dev": true,
-      "requires": {
-        "fast-glob": "^3.2.12",
-        "micromatch": "^4.0.5"
-      },
-      "dependencies": {
-        "fast-glob": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-          "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
-          "dev": true,
-          "requires": {
-            "@nodelib/fs.stat": "^2.0.2",
-            "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.2",
-            "merge2": "^1.3.0",
-            "micromatch": "^4.0.4"
-          }
-        }
       }
     },
     "vite-plugin-turbosnap": {

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -76,8 +76,7 @@
     "react-swipeable": "^7.0.1",
     "typescript": "^5.3.3",
     "typescript-plugin-css-modules": "^5.0.2",
-    "vite": "^4.5.2",
-    "vite-plugin-no-bundle": "^3.0.0"
+    "vite": "^4.5.2"
   },
   "peerDependencies": {
     "@emotion/is-prop-valid": "^1.2.1",

--- a/packages/circuit-ui/vite.config.ts
+++ b/packages/circuit-ui/vite.config.ts
@@ -17,7 +17,6 @@ import crypto from 'node:crypto';
 import path from 'node:path';
 
 import { UserConfig, defineConfig } from 'vite';
-import noBundlePlugin from 'vite-plugin-no-bundle';
 
 import {
   dependencies,
@@ -84,6 +83,9 @@ export default defineConfig({
     },
     minify: false,
     rollupOptions: {
+      output: {
+        preserveModules: true,
+      },
       external: [
         ...Object.keys(dependencies),
         ...Object.keys(peerDependencies),
@@ -95,11 +97,6 @@ export default defineConfig({
       ],
     },
   },
-  plugins: [
-    // @ts-expect-error vite-plugin-no-bundle is bundled in a non-standard way.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    (noBundlePlugin.default || noBundlePlugin)({ root: './' }),
-  ],
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Purpose

Vite uses Rollup under the hood, which combines all files into a single bundle by default. This breaks tree-shaking, so we've used the `vite-plugin-no-bundle` plugin in the past to retain the file structure.

This has led to issues with the CSS import order, requiring changes to the selector specificity to make style overrides work reliably.

## Approach and changes

- Switch to Rollup's built-in `output.preserveModules` option

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
