### PR TITLE
Disable dark mode snapshots for non-visual stories

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,2 +1,9 @@
 <meta name="description" content="SumUp's React UI component library" />
 <link rel="icon" type="image/png" href="/images/logo-icon.png" />
+
+<style>
+  [data-color-scheme='dark'] .sidebar-item[data-selected='true'],
+  [data-color-scheme='dark'] .sidebar-item[data-selected='true'] svg {
+    color: #0f131a; /* var(--cui-fg-on-strong) */
+  }
+</style>

--- a/.storybook/themes.ts
+++ b/.storybook/themes.ts
@@ -47,9 +47,13 @@ export const dark = create({
   base: 'dark',
   ...brand,
   brandImage: '/images/logo-name-dark.png',
-  colorPrimary: '#ffffff',
-  colorSecondary: '#ffffff',
-  appBg: '#0f131a',
+  colorPrimary: '#ffffff', // var(--cui-fg-accent)
+  colorSecondary: '#ffffff', // var(--cui-fg-normal)
+
+  // UI
+  appBg: '#0f131a', // var(--cui-bg-normal)
+  appContentBg: '#0f131a', // var(--cui-bg-normal)
+  appPreviewBg: '#0f131a', // var(--cui-bg-normal)
 });
 
 export const components = {

--- a/packages/circuit-ui/components/legacy/InlineElements/InlineElements.stories.tsx
+++ b/packages/circuit-ui/components/legacy/InlineElements/InlineElements.stories.tsx
@@ -17,7 +17,9 @@
 
 import { css } from '@emotion/react';
 
+import { Stack } from '../../../../../.storybook/components/index.js';
 import styled from '../../../styles/styled.js';
+import { modes } from '../../../../../.storybook/modes.js';
 
 import { InlineElements } from './InlineElements.js';
 
@@ -26,6 +28,12 @@ export default {
   component: InlineElements,
   parameters: {
     controls: { hideNoControlsWarning: true },
+    chromatic: {
+      modes: {
+        mobile: modes.smallMobile,
+        desktop: modes.desktop,
+      },
+    },
   },
 };
 
@@ -53,39 +61,38 @@ const inlineElementsStyles = css`
   border: 1px solid magenta;
 `;
 
-export const TwoInlineElements = () => (
-  <InlineElements css={inlineElementsStyles}>
-    <Box />
-    <Box />
-  </InlineElements>
+export const Base = () => (
+  <Stack vertical>
+    <InlineElements css={inlineElementsStyles}>
+      <Box />
+      <Box />
+    </InlineElements>
+    <InlineElements css={inlineElementsStyles}>
+      <Box />
+      <Box />
+      <Box />
+    </InlineElements>
+    <InlineElements css={inlineElementsStyles} ratios={[2, 1]}>
+      <Box>2x</Box>
+      <Box>1x</Box>
+    </InlineElements>
+  </Stack>
 );
 
-export const ThreeInlineElements = () => (
-  <InlineElements css={inlineElementsStyles}>
-    <Box />
-    <Box />
-    <Box />
-  </InlineElements>
-);
-
-export const ThreeInlineElementsInlineOnMobile = () => (
-  <InlineElements css={inlineElementsStyles} inlineMobile>
-    <Box />
-    <Box />
-    <Box />
-  </InlineElements>
-);
-
-export const TwoInlineElementsWithRatios = () => (
-  <InlineElements css={inlineElementsStyles} ratios={[2, 1]}>
-    <Box>2x</Box>
-    <Box>1x</Box>
-  </InlineElements>
-);
-
-export const TwoInlineElementsWithRatiosInlineOnMobile = () => (
-  <InlineElements css={inlineElementsStyles} ratios={[2, 1]} inlineMobile>
-    <Box>2x</Box>
-    <Box>1x</Box>
-  </InlineElements>
+export const InlineOnMobile = () => (
+  <Stack vertical>
+    <InlineElements css={inlineElementsStyles} inlineMobile>
+      <Box />
+      <Box />
+    </InlineElements>
+    <InlineElements css={inlineElementsStyles} inlineMobile>
+      <Box />
+      <Box />
+      <Box />
+    </InlineElements>
+    <InlineElements css={inlineElementsStyles} inlineMobile ratios={[2, 1]}>
+      <Box>2x</Box>
+      <Box>1x</Box>
+    </InlineElements>
+  </Stack>
 );

--- a/packages/circuit-ui/hooks/useFocusList/useFocusList.stories.tsx
+++ b/packages/circuit-ui/hooks/useFocusList/useFocusList.stories.tsx
@@ -15,6 +15,7 @@
 
 /* eslint-disable jsx-a11y/no-redundant-roles */
 import { action } from '@storybook/addon-actions';
+import { userEvent } from '@storybook/testing-library';
 
 import sharedClasses from '../../styles/shared.js';
 
@@ -44,4 +45,8 @@ export const Example = () => {
       ))}
     </ul>
   );
+};
+
+Example.play = async () => {
+  await userEvent.tab();
 };

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -108,11 +108,11 @@ const Box = styled.div`
   background-color: var(--cui-bg-normal);
 `;
 
-export const Shadow = () => <Box css={shadow} />;
-
-Shadow.parameters = {
-  layout: 'padded',
-};
+export const Shadow = () => (
+  <Stack>
+    <Box css={shadow} />
+  </Stack>
+);
 
 const Parent = styled.div`
   width: 100%;

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -15,6 +15,8 @@
 
 /** @jsxImportSource @emotion/react */
 
+import { userEvent } from '@storybook/testing-library';
+
 import { Stack } from '../../../.storybook/components/index.js';
 import Button from '../components/Button/index.js';
 
@@ -57,7 +59,7 @@ const spaceOptions = {
 
 const Background = styled.div`
   display: inline-block;
-  background-color: #f8cb9c;
+  background-color: var(--cui-bg-promo);
 `;
 
 type SpacingArgs = {
@@ -103,10 +105,14 @@ const Box = styled.div`
   width: 15rem;
   max-width: 100%;
   margin: 1rem;
-  background-color: white;
+  background-color: var(--cui-bg-normal);
 `;
 
 export const Shadow = () => <Box css={shadow} />;
+
+Shadow.parameters = {
+  layout: 'padded',
+};
 
 const Parent = styled.div`
   width: 100%;
@@ -118,7 +124,7 @@ const Floated = styled.div`
   float: right;
   height: 120px;
   width: 240px;
-  background-color: #ccc;
+  background-color: var(--cui-bg-highlight);
 `;
 
 export const Clearfix = () => (
@@ -136,6 +142,10 @@ export const FocusVisible = () => (
     <Box css={focusVisible('inset')} tabIndex={0} />
   </Stack>
 );
+
+FocusVisible.play = async () => {
+  await userEvent.tab();
+};
 
 export const InputOutline = () => (
   <Stack>


### PR DESCRIPTION
## Purpose

#2424 added dark mode snapshots for _all_ stories, doubling our Chromatic usage. In some stories, the color scheme doesn't matter, so this pull request ~disables dark mode for them to reduce our usage~ improves their appearance in dark mode.

## Approach and changes

- ~Disable dark mode snapshots for layout and hook stories~ Apparently, it's only possible to add modes, not remove them from individual stories 😢   
- Improve style mixin stories for dark mode

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
