### PR TITLE
Fix display and transition of Carousel slides (v7)

### DIFF
--- a/.changeset/sour-terms-tap.md
+++ b/.changeset/sour-terms-tap.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fix the display and transition of Carousel slides.

--- a/packages/circuit-ui/components/Carousel/components/Slide/Slide.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Slide/Slide.tsx
@@ -85,7 +85,7 @@ export function Slide({
       style={{
         '--slide-width': dynamicWidth,
         '--slide-stack-order': stackOrder,
-        '--slide-transform-x': `${index * 100}%`,
+        '--slide-transform-x': `${-index * 100}%`,
         '--slide-animation-duration': `${animationDuration}ms`,
       }}
       className={classes.base}
@@ -98,11 +98,11 @@ export function Slide({
             slideDirection === SLIDE_DIRECTIONS.FORWARD &&
             classes['animate-in'],
           isAnimating &&
-            slideDirection === SLIDE_DIRECTIONS.FORWARD &&
+            slideDirection === SLIDE_DIRECTIONS.BACK &&
             classes['animate-out'],
         )}
       >
-        <div>{children}</div>
+        <div className={classes.content}>{children}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Purpose

The display and transition of Carousel slides have been broken since v7 😳  

The first slide is displayed permanently due to not 1, not 2, but 3 bugs introduced in the migration to CSS Modules (#2163) 😬  

## Approach and changes

- Fix display and transition of Carousel slides

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
