### PR TITLE
Add missing client directives

### DIFF
--- a/.changeset/stupid-cups-sell.md
+++ b/.changeset/stupid-cups-sell.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Added the `use client` directive to a few more components that require it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "chromatic": "^10.3.1",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-prettier": "^4.2.1",
-        "eslint-plugin-react-server-components": "^1.1.1",
+        "eslint-plugin-react-server-components": "^1.1.2",
         "eslint-plugin-storybook": "^0.6.15",
         "jsdom": "^23.2.0",
         "lerna": "^8.0.2",
@@ -18551,9 +18551,9 @@
       }
     },
     "node_modules/eslint-plugin-react-server-components": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-server-components/-/eslint-plugin-react-server-components-1.1.1.tgz",
-      "integrity": "sha512-oL8d1mzvUgm6ezwKie0hQvXAgjx5II8e2vzt9vcp6Ygn+LXyg3KXdVTpQu6bsJomblbRBVLJCIFDSKr420+wmA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-server-components/-/eslint-plugin-react-server-components-1.1.2.tgz",
+      "integrity": "sha512-t3hEE7V7YxeWBkC2hL/GUBBCZ9xa6leo4SzAudlt6ZUSBQkK8UeSziLKnhyuK+GI7KSTp6j+CaGJ/RggJQNrYg==",
       "dev": true,
       "dependencies": {
         "eslint-plugin-react": "^7.32.2",
@@ -37641,7 +37641,7 @@
     },
     "packages/icons": {
       "name": "@sumup/icons",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.23.9",
@@ -51975,9 +51975,9 @@
       "requires": {}
     },
     "eslint-plugin-react-server-components": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-server-components/-/eslint-plugin-react-server-components-1.1.1.tgz",
-      "integrity": "sha512-oL8d1mzvUgm6ezwKie0hQvXAgjx5II8e2vzt9vcp6Ygn+LXyg3KXdVTpQu6bsJomblbRBVLJCIFDSKr420+wmA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-server-components/-/eslint-plugin-react-server-components-1.1.2.tgz",
+      "integrity": "sha512-t3hEE7V7YxeWBkC2hL/GUBBCZ9xa6leo4SzAudlt6ZUSBQkK8UeSziLKnhyuK+GI7KSTp6j+CaGJ/RggJQNrYg==",
       "dev": true,
       "requires": {
         "eslint-plugin-react": "^7.32.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "chromatic": "^10.3.1",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-react-server-components": "^1.1.1",
+    "eslint-plugin-react-server-components": "^1.1.2",
     "eslint-plugin-storybook": "^0.6.15",
     "jsdom": "^23.2.0",
     "lerna": "^8.0.2",

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -117,8 +117,6 @@ export function ProgressBar({
   className,
   ...props
 }: ProgressBarProps): ReturnType {
-  // useId is allowed in Server Components
-  // eslint-disable-next-line react-server-components/use-client
   const ariaId = useId();
 
   if (

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   FieldsetHTMLAttributes,
   InputHTMLAttributes,
@@ -132,8 +134,6 @@ export const RadioButtonGroup = forwardRef(
     }: RadioButtonGroupProps,
     ref: RadioButtonGroupProps['ref'],
   ) => {
-    // useId is allowed in Server Components
-    // eslint-disable-next-line react-server-components/use-client
     const randomName = useId();
     const name = customName || randomName;
     const validationHintId = useId();

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -139,8 +139,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
         'The `label` prop is missing or invalid. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
-    // useId is allowed in Server Components
-    // eslint-disable-next-line react-server-components/use-client
+
     const id = useId();
     const selectId = customId || id;
     const validationHintId = useId();

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   ComponentType,
   Fragment,
@@ -128,8 +130,6 @@ export const Selector = forwardRef<HTMLInputElement, SelectorProps>(
     },
     ref,
   ) => {
-    // useId is allowed in Server Components
-    // eslint-disable-next-line react-server-components/use-client
     const randomId = useId();
     const inputId = customId || randomId;
     const descriptionId = useId();

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { forwardRef, FieldsetHTMLAttributes, useId } from 'react';
 
 import {
@@ -146,8 +148,6 @@ export const SelectorGroup = forwardRef<
     },
     ref,
   ) => {
-    // useId is allowed in Server Components
-    // eslint-disable-next-line react-server-components/use-client
     const randomName = useId();
     const name = customName || randomName;
     const validationHintId = useId();

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { ButtonHTMLAttributes, forwardRef, useId } from 'react';
 
 import {
@@ -92,8 +94,6 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
       }
     }
 
-    // useId is allowed in Server Components
-    // eslint-disable-next-line react-server-components/use-client
     const switchId = useId();
     const labelId = useId();
     const descriptionId = useId();


### PR DESCRIPTION
## Purpose

#2430 added eslint-plugin-react-server-components to automatically add the `use client` directive to any components that require it. The plugin had a bug where it didn't account for the `useId` hook being supported on the client _and_ server. Unfortunately, disabling the rule for affected lines caused false negatives.

## Approach and changes

- Upgrade eslint-plugin-react-server-components to v1.1.2
- Add missing client directives to components that require it

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
