### PR TITLE
Enable table of contents for doc pages

### DIFF
--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -33,6 +33,7 @@ import {
   clsx,
   utilClasses,
 } from '../../packages/circuit-ui/index.js';
+import { slugify } from '../slugify.js';
 import classes from './Icons.module.css';
 
 function groupBy(
@@ -145,7 +146,7 @@ const Icons = () => {
           groupBy(activeIcons, 'category'),
         ).map(([category, items]) => (
           <section key={category} className={classes.category}>
-            <Headline as="h3" size="three">
+            <Headline as="h2" size="two" id={slugify(category)}>
               {category}
             </Headline>
             <div className={classes.list}>

--- a/.storybook/components/Teaser.tsx
+++ b/.storybook/components/Teaser.tsx
@@ -14,8 +14,12 @@
  */
 
 import type { ReactNode } from 'react';
+import GithubSlugger from 'github-slugger';
+
 import { Headline, Card } from '../../packages/circuit-ui/index.js';
 import classes from './Teaser.module.css';
+
+const slugger = new GithubSlugger();
 
 interface TeaserProps {
   title: string;
@@ -24,7 +28,7 @@ interface TeaserProps {
 
 const Teaser = ({ title, children }: TeaserProps) => (
   <Card className={classes.base}>
-    <Headline as="h2" size="three">
+    <Headline as="h2" size="three" id={slugger.slug(title)}>
       {title}
     </Headline>
 

--- a/.storybook/components/Teaser.tsx
+++ b/.storybook/components/Teaser.tsx
@@ -14,12 +14,10 @@
  */
 
 import type { ReactNode } from 'react';
-import GithubSlugger from 'github-slugger';
 
 import { Headline, Card } from '../../packages/circuit-ui/index.js';
+import { slugify } from '../slugify.js';
 import classes from './Teaser.module.css';
-
-const slugger = new GithubSlugger();
 
 interface TeaserProps {
   title: string;
@@ -28,7 +26,7 @@ interface TeaserProps {
 
 const Teaser = ({ title, children }: TeaserProps) => (
   <Card className={classes.base}>
-    <Headline as="h2" size="three" id={slugger.slug(title)}>
+    <Headline as="h2" size="three" id={slugify(title)}>
       {title}
     </Headline>
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -45,7 +45,12 @@ export const parameters = {
       includeName: true,
     },
   },
-  docs: { theme: light, components, container: DocsContainer },
+  docs: {
+    theme: light,
+    components,
+    container: DocsContainer,
+    toc: { title: 'On this page', headingSelector: 'h2, h3' },
+  },
 };
 
 // TODO: Re-enable once a dark theme exists

--- a/.storybook/slugify.ts
+++ b/.storybook/slugify.ts
@@ -1,0 +1,7 @@
+import GithubSlugger from 'github-slugger';
+
+const slugger = new GithubSlugger();
+
+export function slugify(value: string): string {
+  return slugger.slug(value);
+}

--- a/docs/contributing/3-testing.mdx
+++ b/docs/contributing/3-testing.mdx
@@ -6,7 +6,7 @@ import { Meta } from '../../.storybook/components';
 
 ## Unit tests
 
-We use [Vitest](https://vitest.dev/) and [@testing-library/react](https://github.com/testing-library/react-testing-library) to unit test our components. Since most components are purely visual, we rely a lot on snapshot tests. Business logic should be tested with more specific assertions. To start unit tests in watch mode, run:
+We use [Vitest](https://vitest.dev/) and [@testing-library/react](https://github.com/testing-library/react-testing-library) to unit test the business logic and accessibility of our components. To start unit tests in watch mode, run:
 
 ```bash
 npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react-server-components": "^1.1.2",
         "eslint-plugin-storybook": "^0.6.15",
+        "github-slugger": "^2.0.0",
         "jsdom": "^23.2.0",
         "lerna": "^8.0.2",
         "license-checker": "^25.0.1",
@@ -196,11 +197,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@astrojs/markdown-remark/node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "node_modules/@astrojs/markdown-remark/node_modules/is-plain-obj": {
       "version": "4.1.0",
@@ -13816,11 +13812,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/astro/node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
-    },
     "node_modules/astro/node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -20070,10 +20061,9 @@
       }
     },
     "node_modules/github-slugger": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
-      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -32050,6 +32040,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-slug/node_modules/github-slugger": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
+      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
+      "dev": true
+    },
     "node_modules/remark-slug/node_modules/mdast-util-to-string": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",
@@ -37492,7 +37488,7 @@
     },
     "packages/circuit-ui": {
       "name": "@sumup/circuit-ui",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.5",
@@ -38631,11 +38627,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
           "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-        },
-        "github-slugger": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-          "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
         },
         "is-plain-obj": {
           "version": "4.1.0",
@@ -48431,11 +48422,6 @@
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
           "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="
         },
-        "github-slugger": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-          "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
-        },
         "html-escaper": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -53042,10 +53028,9 @@
       }
     },
     "github-slugger": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
-      "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
     },
     "glob": {
       "version": "7.2.3",
@@ -61962,6 +61947,12 @@
         "unist-util-visit": "^2.0.0"
       },
       "dependencies": {
+        "github-slugger": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
+          "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==",
+          "dev": true
+        },
         "mdast-util-to-string": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react-server-components": "^1.1.2",
     "eslint-plugin-storybook": "^0.6.15",
+    "github-slugger": "^2.0.0",
     "jsdom": "^23.2.0",
     "lerna": "^8.0.2",
     "license-checker": "^25.0.1",

--- a/packages/circuit-ui/components/Headline/Headline.mdx
+++ b/packages/circuit-ui/components/Headline/Headline.mdx
@@ -9,7 +9,7 @@ import * as Stories from './Headline.stories';
 
 The Headline component is used for describing the contents of a page or page section. It is an essential part of a page's structure, helping organize information for users.
 
-<Story of={Stories.Base} />
+<Story of={Stories.Base} inline={false} />
 <Props />
 
 ## Component variations
@@ -20,7 +20,7 @@ The Headline component comes in four sizes.
 
 Use the `four` size for card headers and `three` for page titles in web applications. For specific use cases such as landing pages, consider using the [Title](Typography/Title) component.
 
-<Story of={Stories.Sizes} />
+<Story of={Stories.Sizes} inline={false} />
 
 ---
 

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.mdx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.mdx
@@ -9,7 +9,7 @@ import * as Stories from './NotificationBanner.stories';
 
 The notification banner component prominently communicates and promotes high-level, site-wide information to the user.
 
-<Story of={Stories.Base} />
+<Story of={Stories.Base} inline={false} />
 <Props />
 
 ## When to use it
@@ -28,4 +28,4 @@ The notification banner should be used to display the global system messages or 
 - **Do** use the coloured illustration style for the promotional notification use cases.
 - **Do** provide an action to allow users to directly follow up on the communicated content. Depending on the context action can be either tertirary, or a primary button.
 
-<Story id="notification-notificationbanner--dismissable" />
+<Story of={Stories.Dismissable} inline={false} />

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.mdx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.mdx
@@ -9,7 +9,7 @@ import * as Stories from './NotificationFullscreen.stories';
 
 The NotificationFullscreen component provides important information or feedback as part of a process flow.
 
-<Story of={Stories.Base} />
+<Story of={Stories.Base} inline={false} />
 <Props />
 
 ## When to use it

--- a/packages/circuit-ui/components/Step/Step.mdx
+++ b/packages/circuit-ui/components/Step/Step.mdx
@@ -23,4 +23,4 @@ import * as Stories from './Step.stories';
 
 ### Multi Step Form
 
-<Story of={Stories.Form} />
+<Story of={Stories.Form} inline={false} />

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.mdx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.mdx
@@ -9,7 +9,7 @@ import * as Stories from './SubHeadline.stories';
 
 The SubHeadline component helps break up larger related chunks of content in the same section. It is typically used to separate subsections within a card.
 
-<Story of={Stories.Base} />
+<Story of={Stories.Base} inline={false} />
 <Props />
 
 ---

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.mdx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.mdx
@@ -14,6 +14,6 @@ The top navigation is part of the [application shell](https://developers.google.
 
 ## Usage with the side navigation
 
-<Story of={Stories.WithSideNavigation} />
+<Story of={Stories.WithSideNavigation} inline={false} />
 
 When used alongside the [SideNavigation](Navigation/SideNavigation) component, the top navigation displays a hamburger button on narrow viewports which can be used to toggle the side navigation.


### PR DESCRIPTION
## Purpose

Some of the documentation pages, such as the [Theme](https://circuit.sumup.com/?path=/docs/features-theme--docs) and [Icons](https://circuit.sumup.com/?path=/docs/features-icons--docs) pages, are very long which makes it difficult to gain an overview of their content.

## Approach and changes

- Configure Storybook's `toc` option to generate a table of contents for docs pages

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
