### PR TITLE
Fix missing focus outline on the Anchor component

### DIFF
--- a/.changeset/lovely-zebras-attack.md
+++ b/.changeset/lovely-zebras-attack.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": patch
+---
+
+Fixed the missing focus outline of the Anchor component when it renders as the `a` element.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -70,7 +70,7 @@ export const Anchor = forwardRef(
       return (
         <Body
           {...props}
-          className={clsx(classes.base, className)}
+          className={clsx(classes.base, utilityClasses.focusVisible, className)}
           as={Link}
           ref={ref}
         />


### PR DESCRIPTION
## Purpose

Interactive elements must always show a focus ring when focused using a keyboard.

## Approach and changes

- Add the missing `focusVisible` utility class to the Anchor component when rendered as the `a` element

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
