### PR TITLE
Upgrade to Foundry v7.1

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,4 @@
 module.exports = require('@sumup/foundry/stylelint')({
-  plugins: ['@sumup/stylelint-plugin-circuit-ui'],
   rules: {
     'selector-class-pattern': [
       '^([a-z][a-z0-9]*)(-[a-z0-9]+)*$',
@@ -8,6 +7,5 @@ module.exports = require('@sumup/foundry/stylelint')({
           `Expected class selector "${selector}" to be kebab-case`,
       },
     ],
-    'circuit-ui/no-invalid-custom-properties': true,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@storybook/test": "^8.0.0",
         "@storybook/theming": "^8.0.0",
         "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-        "@sumup/foundry": "^7.0.0",
+        "@sumup/foundry": "^7.1.1",
         "@sumup/stylelint-plugin-circuit-ui": "^1.0.0",
         "@types/node": "^18.16.19",
         "@vitest/coverage-v8": "^1.3.1",
@@ -9184,9 +9184,9 @@
       "link": true
     },
     "node_modules/@sumup/foundry": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sumup/foundry/-/foundry-7.0.0.tgz",
-      "integrity": "sha512-fVT2vPn5BI0qWYbyvQFbdaO9aljWUs+37C/6Er/sqKOviCq2lULRrR3lfHEXPNwq6RBpPSCadabtPJb/KwXcwQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sumup/foundry/-/foundry-7.1.1.tgz",
+      "integrity": "sha512-etcrtk7C3XqvZh2Gx29XcV5wEtdkGFwgpu0GYx8ZiD9ZcU4U+Lc4paQeqS2pFdBxIRR+2a9UoGFGoZPUBVbylg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.0",
@@ -40103,7 +40103,7 @@
       },
       "devDependencies": {
         "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-        "@sumup/foundry": "^7.0.0",
+        "@sumup/foundry": "^7.1.1",
         "@sumup/stylelint-plugin-circuit-ui": "^2.0.0",
         "prettier-plugin-astro": "^0.13.0"
       }
@@ -40238,7 +40238,7 @@
       },
       "devDependencies": {
         "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-        "@sumup/foundry": "^7.0.0",
+        "@sumup/foundry": "^7.1.1",
         "@sumup/stylelint-plugin-circuit-ui": "^2.0.0",
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^14.1.2",
@@ -40345,7 +40345,7 @@
         "@remix-run/dev": "^2.4.1",
         "@remix-run/eslint-config": "^2.4.1",
         "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-        "@sumup/foundry": "^7.0.0",
+        "@sumup/foundry": "^7.1.1",
         "@sumup/stylelint-plugin-circuit-ui": "^2.0.0",
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.2.18",
@@ -47257,7 +47257,7 @@
         "@sumup/circuit-ui": "^8.0.0",
         "@sumup/design-tokens": "^7.0.0",
         "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-        "@sumup/foundry": "^7.0.0",
+        "@sumup/foundry": "^7.1.1",
         "@sumup/icons": "^3.3.0",
         "@sumup/intl": "^1.6.0",
         "@sumup/stylelint-plugin-circuit-ui": "^2.0.0",
@@ -47358,9 +47358,9 @@
       }
     },
     "@sumup/foundry": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sumup/foundry/-/foundry-7.0.0.tgz",
-      "integrity": "sha512-fVT2vPn5BI0qWYbyvQFbdaO9aljWUs+37C/6Er/sqKOviCq2lULRrR3lfHEXPNwq6RBpPSCadabtPJb/KwXcwQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@sumup/foundry/-/foundry-7.1.1.tgz",
+      "integrity": "sha512-etcrtk7C3XqvZh2Gx29XcV5wEtdkGFwgpu0GYx8ZiD9ZcU4U+Lc4paQeqS2pFdBxIRR+2a9UoGFGoZPUBVbylg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.24.0",
@@ -47576,7 +47576,7 @@
         "@sumup/circuit-ui": "^8.0.0",
         "@sumup/design-tokens": "^7.0.0",
         "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-        "@sumup/foundry": "^7.0.0",
+        "@sumup/foundry": "^7.1.1",
         "@sumup/icons": "^3.3.0",
         "@sumup/intl": "^1.6.0",
         "@sumup/stylelint-plugin-circuit-ui": "^2.0.0",
@@ -62183,7 +62183,7 @@
         "@sumup/circuit-ui": "^8.0.0",
         "@sumup/design-tokens": "^7.0.0",
         "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-        "@sumup/foundry": "^7.0.0",
+        "@sumup/foundry": "^7.1.1",
         "@sumup/icons": "^3.0.0",
         "@sumup/intl": "^1.5.0",
         "@sumup/stylelint-plugin-circuit-ui": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@storybook/test": "^8.0.0",
     "@storybook/theming": "^8.0.0",
     "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-    "@sumup/foundry": "^7.0.0",
+    "@sumup/foundry": "^7.1.1",
     "@sumup/stylelint-plugin-circuit-ui": "^1.0.0",
     "@types/node": "^18.16.19",
     "@vitest/coverage-v8": "^1.3.1",

--- a/packages/astro-template/.stylelintrc.cjs
+++ b/packages/astro-template/.stylelintrc.cjs
@@ -1,6 +1,1 @@
-module.exports = require('@sumup/foundry/stylelint')({
-  plugins: ['@sumup/stylelint-plugin-circuit-ui'],
-  rules: {
-    'circuit-ui/no-invalid-custom-properties': true,
-  },
-});
+module.exports = require('@sumup/foundry/stylelint')();

--- a/packages/astro-template/package.json
+++ b/packages/astro-template/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-    "@sumup/foundry": "^7.0.0",
+    "@sumup/foundry": "^7.1.1",
     "@sumup/stylelint-plugin-circuit-ui": "^2.0.0",
     "prettier-plugin-astro": "^0.13.0"
   }

--- a/packages/cna-template/template/.stylelintrc.js
+++ b/packages/cna-template/template/.stylelintrc.js
@@ -1,6 +1,1 @@
-module.exports = require('@sumup/foundry/stylelint')({
-  plugins: ['@sumup/stylelint-plugin-circuit-ui'],
-  rules: {
-    'circuit-ui/no-invalid-custom-properties': true,
-  },
-});
+module.exports = require('@sumup/foundry/stylelint')();

--- a/packages/cna-template/template/package.json
+++ b/packages/cna-template/template/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-    "@sumup/foundry": "^7.0.0",
+    "@sumup/foundry": "^7.1.1",
     "@sumup/stylelint-plugin-circuit-ui": "^2.0.0",
     "@testing-library/jest-dom": "^6.2.0",
     "@testing-library/react": "^14.1.2",

--- a/packages/remix-template/.stylelintrc.cjs
+++ b/packages/remix-template/.stylelintrc.cjs
@@ -1,6 +1,1 @@
-module.exports = require('@sumup/foundry/stylelint')({
-  plugins: ['@sumup/stylelint-plugin-circuit-ui'],
-  rules: {
-    'circuit-ui/no-invalid-custom-properties': true,
-  },
-});
+module.exports = require('@sumup/foundry/stylelint')();

--- a/packages/remix-template/package.json
+++ b/packages/remix-template/package.json
@@ -30,7 +30,7 @@
     "@remix-run/dev": "^2.4.1",
     "@remix-run/eslint-config": "^2.4.1",
     "@sumup/eslint-plugin-circuit-ui": "^4.0.0",
-    "@sumup/foundry": "^7.0.0",
+    "@sumup/foundry": "^7.1.1",
     "@sumup/stylelint-plugin-circuit-ui": "^2.0.0",
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.18",


### PR DESCRIPTION
## Purpose

Foundry v7.1 adds support for Circuit UI's Stylelint plugin.

## Approach and changes

- Upgrade to Foundry v7.1.1
- Remove the obsolete manual config for Circuit UI's Storybook plugin

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
