### PR TITLE
Add experimental Toggletip component

### DIFF
--- a/.changeset/beige-bottles-act.md
+++ b/.changeset/beige-bottles-act.md
@@ -1,5 +1,5 @@
 ---
-"@sumup/circuit-ui": minor
+'@sumup/circuit-ui': minor
 ---
 
-Added an experimental Tooltip component.
+Added experimental Tooltip and Toggletip components to display additional information that is contextual, helpful, and nonessential to clarify the purpose of otherwise ambiguous elements.

--- a/.changeset/giant-seals-vanish.md
+++ b/.changeset/giant-seals-vanish.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": minor
+---
+
+Extended the function signature of the `useClickOutside` hook to accept an array of refs as its first argument.

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -18,7 +18,6 @@ import {
   type SetStateAction,
   useState,
   ChangeEvent,
-  forwardRef,
 } from 'react';
 import { Unstyled } from '@storybook/addon-docs';
 import * as iconComponents from '@sumup/icons';
@@ -187,17 +186,16 @@ const Icons = () => {
                       <Tooltip
                         type="description"
                         label={icon.deprecation}
-                        component={forwardRef((props, ref) => (
+                        component={(props) => (
                           <Badge
                             {...props}
-                            ref={ref}
                             tabIndex={0}
                             variant="danger"
                             className={classes.badge}
                           >
                             Deprecated
                           </Badge>
-                        ))}
+                        )}
                       />
                     )}
                   </div>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,12 +2,21 @@
   name="viewport"
   content="width=device-width, initial-scale=1, viewport-fit=cover"
 />
+<link
+  rel="preload"
+  href="https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff2"
+/>
+<link
+  rel="preload"
+  href="https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff2"
+/>
 <style>
   @font-face {
     font-family: 'aktiv-grotesk';
     font-weight: 400;
     font-display: swap;
-    src: url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff2')
+    src:
+      url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff2')
         format('woff2'),
       url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff')
         format('woff'),
@@ -18,7 +27,8 @@
     font-family: 'aktiv-grotesk';
     font-weight: 700;
     font-display: swap;
-    src: url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff2')
+    src:
+      url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff2')
         format('woff2'),
       url('https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff')
         format('woff'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -15745,6 +15745,11 @@
         "wrappy": "1"
       }
     },
+    "node_modules/dialog-polyfill": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz",
+      "integrity": "sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w=="
+    },
     "node_modules/diff": {
       "version": "5.1.0",
       "resolved": "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz",
@@ -40070,6 +40075,7 @@
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.5",
         "@nanostores/react": "^0.7.2",
+        "dialog-polyfill": "^0.5.6",
         "nanostores": "^0.10.0",
         "react-modal": "^3.16.1",
         "react-number-format": "5.3.0"
@@ -47172,6 +47178,7 @@
         "@types/react-dates": "^21.8.6",
         "@types/react-dom": "^18.2.18",
         "@types/react-modal": "^3.16.3",
+        "dialog-polyfill": "^0.5.6",
         "jest-axe": "^8.0.0",
         "moment": "^2.29.4",
         "nanostores": "^0.10.0",
@@ -52308,6 +52315,11 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "dialog-polyfill": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz",
+      "integrity": "sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w=="
     },
     "diff": {
       "version": "5.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "circuit-ui-web",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -47,6 +48,7 @@
         "jsdom": "^24.0.0",
         "lerna": "^8.1.2",
         "license-checker": "^25.0.1",
+        "patch-package": "^8.0.0",
         "prettier-plugin-astro": "^0.13.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -13126,6 +13128,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/audit-ci": {
       "version": "6.6.1",
       "resolved": "https://registry.yarnpkg.com/audit-ci/-/audit-ci-6.6.1.tgz",
@@ -18085,6 +18096,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/find-yarn-workspace-root2": {
       "version": "1.2.16",
       "resolved": "https://registry.yarnpkg.com/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz",
@@ -22057,11 +22077,35 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.5",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "license": "MIT"
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -22097,6 +22141,15 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonparse": {
@@ -22156,6 +22209,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -32062,6 +32124,100 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/yaml": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
+      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/path-exists": {
@@ -50377,6 +50533,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "audit-ci": {
       "version": "6.6.1",
       "resolved": "https://registry.yarnpkg.com/audit-ci/-/audit-ci-6.6.1.tgz",
@@ -54098,6 +54260,15 @@
         "semver-regex": "^3.1.2"
       }
     },
+    "find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "find-yarn-workspace-root2": {
       "version": "1.2.16",
       "resolved": "https://registry.yarnpkg.com/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz",
@@ -57026,6 +57197,26 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.5",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -57057,6 +57248,12 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -57098,6 +57295,15 @@
       "version": "6.0.3",
       "resolved": "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0= sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
     },
     "kleur": {
       "version": "4.1.5",
@@ -63632,6 +63838,74 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "patch-package": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "open": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+          "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+          "dev": true,
+          "requires": {
+            "is-docker": "^2.0.0",
+            "is-wsl": "^2.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "yaml": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
+          "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+          "dev": true
+        }
+      }
     },
     "path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "check:svg-sizes": "./scripts/check-svg-sizes.sh",
     "copy-docs": "./scripts/copy-docs.sh",
     "bootstrap": "npm run build && npm run copy-docs && cd packages/cna-template/template && npm ci",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
@@ -75,6 +76,7 @@
     "jsdom": "^24.0.0",
     "lerna": "^8.1.2",
     "license-checker": "^25.0.1",
+    "patch-package": "^8.0.0",
     "prettier-plugin-astro": "^0.13.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/circuit-ui/components/Anchor/Anchor.module.css
+++ b/packages/circuit-ui/components/Anchor/Anchor.module.css
@@ -9,7 +9,7 @@
   text-decoration: underline;
   background: none;
   border: 0;
-  border-radius: var(--cui-border-radius-byte);
+  border-radius: var(--cui-border-radius-bit);
   outline: none;
   transition: opacity var(--cui-transitions-default),
     color var(--cui-transitions-default),

--- a/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
@@ -15,7 +15,7 @@
 
 'use client';
 
-import { FC, OlHTMLAttributes, forwardRef } from 'react';
+import type { FC, OlHTMLAttributes } from 'react';
 
 import { clsx } from '../../../../styles/clsx.js';
 import Button from '../../../Button/index.js';
@@ -48,10 +48,9 @@ export const PageList: FC<PageListProps> = ({
           <Tooltip
             type="description"
             label={label}
-            component={forwardRef((tooltipProps, ref) => (
+            component={(tooltipProps) => (
               <Button
                 {...tooltipProps}
-                ref={ref}
                 size="s"
                 onClick={() => onChange(page)}
                 variant={isCurrent ? 'primary' : 'tertiary'}
@@ -60,7 +59,7 @@ export const PageList: FC<PageListProps> = ({
               >
                 {page}
               </Button>
-            ))}
+            )}
           />
         </li>
       );

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -196,6 +196,7 @@ export const Popover = ({
   const menuId = useId();
 
   const { x, y, strategy, refs, update } = useFloating<HTMLElement>({
+    open: isOpen,
     placement,
     strategy: 'fixed',
     middleware: offset
@@ -247,15 +248,11 @@ export const Popover = ({
     }
   };
 
-  const handlePopoverItemClick = (
-    event: ClickEvent,
-    onClick: BaseProps['onClick'],
-  ) => {
-    if (onClick) {
-      onClick(event);
-    }
-    handleToggle(false);
-  };
+  const handlePopoverItemClick =
+    (onClick: BaseProps['onClick']) => (event: ClickEvent) => {
+      onClick?.(event);
+      handleToggle(false);
+    };
 
   useEscapeKey(() => handleToggle(false), isOpen);
   useClickOutside(floatingRef, () => handleToggle(false), isOpen);
@@ -359,9 +356,7 @@ export const Popover = ({
                   key={index}
                   {...action}
                   {...focusProps}
-                  onClick={(event) =>
-                    handlePopoverItemClick(event, action.onClick)
-                  }
+                  onClick={handlePopoverItemClick(action.onClick)}
                 />
               ),
             )}

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
@@ -15,10 +15,10 @@
 
 'use client';
 
-import { HTMLAttributes, forwardRef } from 'react';
+import { type HTMLAttributes } from 'react';
 import { ChevronUp, ChevronDown } from '@sumup/icons';
 
-import { Direction } from '../../types.js';
+import type { Direction } from '../../types.js';
 import { clsx } from '../../../../styles/clsx.js';
 import Tooltip from '../../../Tooltip/index.js';
 
@@ -37,10 +37,9 @@ export function SortArrow({ label, direction, onClick }: SortArrowProps) {
     <Tooltip
       type="label"
       label={label}
-      component={forwardRef((props, ref) => (
+      component={(props) => (
         <button
           {...props}
-          ref={ref}
           className={clsx(classes.base, props.className)}
           onClick={onClick}
         >
@@ -55,7 +54,7 @@ export function SortArrow({ label, direction, onClick }: SortArrowProps) {
             />
           )}
         </button>
-      ))}
+      )}
     />
   );
 }

--- a/packages/circuit-ui/components/Toggletip/Toggletip.mdx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.mdx
@@ -1,0 +1,54 @@
+import { Meta, Status, Props, Story } from '../../../../.storybook/components';
+import * as Stories from './Toggletip.stories';
+
+<Meta of={Stories} />
+
+# Toggletip
+
+<Status variant="experimental" />
+
+Toggletips display additional information that is contextual, helpful, and nonessential to the user upon pressing a UI trigger element and can contain interactive elements.
+
+<Story of={Stories.Base} />
+<Props />
+
+## Usage
+
+Toggletips hide information by default and require user interaction to be shown. They should be used as a last resort when space truly is limited and the information cannot be shown inline.
+
+The wrapped component must be a `<button>` element.
+
+The optional headline is always accompanied by body text, so use it only whenever necessary. Keep it short and under 120 characters.
+
+When defining the body text make sure it does not contain essential task instructions since a toggletip is not present at all times. Use it to provide additional help or to define a term.
+
+Use the action button to point the user to additional information or enable a contextual action via the toggletip. Try to use one strong, clear imperative verb and follow with a one-word object if needed to clarify.
+
+## Variations
+
+### Placement
+
+By default, the toggletip is positioned above the wrapped component and center-aligned. Use the `placement` prop to specify a different initial position and alignment.
+
+The toggletip automatically flips to the opposite side to stay within the viewport when there isn't enough space available.
+
+<Story of={Stories.Placements} />
+
+## Related components
+
+- [Tooltip](Components/Tooltip/Docs): Tooltips display additional information upon hover or focus that is contextual, helpful, and nonessential to clarify the purpose of otherwise ambiguous interactive elements
+
+---
+
+## Accessibility
+
+### Best practices
+
+- Only use `<button>` elements as the trigger element
+- Do not put essential information in toggletips
+- Provide a means to dismiss the toggletip with both keyboard and pointer
+- Move focus to the main interactive element upon opening the toggletip and revert focus to the trigger element after closing it
+
+### Resources
+
+- [Inclusive Components: Tooltips & Toggletips](https://inclusive-components.design/tooltips-toggletips/) by Heydon Pickering

--- a/packages/circuit-ui/components/Toggletip/Toggletip.module.css
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.module.css
@@ -1,0 +1,80 @@
+.base {
+  /* The arrow should be 8px tall. A square element is rotated to achieve a triangular shape. Using Pythagoras' theorem, we can calculate the ratio between the triangle height and the square sides: √(8^2 + 8^2) / 8 ≈ 1.414 */
+  --tooltip-arrow-size: calc(var(--cui-spacings-byte) * 1.414);
+
+  position: absolute;
+  z-index: var(--cui-z-index-popover);
+  width: max-content;
+  max-width: 360px;
+  max-width: min(360px, 100vw);
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.base[data-state="open"] {
+  pointer-events: auto;
+  visibility: visible;
+}
+
+.content {
+  padding: var(--cui-spacings-mega);
+  color: var(--cui-fg-normal);
+  background-color: var(--cui-bg-elevated);
+  border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
+  border-radius: var(--cui-border-radius-byte);
+  outline: 0;
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
+}
+
+.headline {
+  padding-right: var(--cui-spacings-peta);
+  margin-bottom: var(--cui-spacings-bit);
+}
+
+.body {
+  padding-right: var(--cui-spacings-peta);
+}
+
+.action {
+  margin-top: var(--cui-spacings-kilo);
+}
+
+.close {
+  position: absolute;
+  top: var(--cui-spacings-mega);
+  right: var(--cui-spacings-mega);
+}
+
+.arrow {
+  position: absolute;
+  width: var(--tooltip-arrow-size);
+  height: var(--tooltip-arrow-size);
+  background-color: var(--cui-bg-elevated);
+  border-right: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
+  border-bottom: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
+  border-bottom-right-radius: 2px;
+}
+
+.base[data-side="top"] .arrow {
+  top: calc(100% - (var(--tooltip-arrow-size) / 2));
+  left: calc(50% - (var(--tooltip-arrow-size) / 2));
+  transform: rotate(45deg);
+}
+
+.base[data-side="right"] .arrow {
+  right: calc(100% - (var(--tooltip-arrow-size) / 2));
+  bottom: calc(50% - (var(--tooltip-arrow-size) / 2));
+  transform: rotate(135deg);
+}
+
+.base[data-side="bottom"] .arrow {
+  bottom: calc(100% - (var(--tooltip-arrow-size) / 2));
+  left: calc(50% - (var(--tooltip-arrow-size) / 2));
+  transform: rotate(225deg);
+}
+
+.base[data-side="left"] .arrow {
+  bottom: calc(50% - (var(--tooltip-arrow-size) / 2));
+  left: calc(100% - (var(--tooltip-arrow-size) / 2));
+  transform: rotate(315deg);
+}

--- a/packages/circuit-ui/components/Toggletip/Toggletip.module.css
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.module.css
@@ -60,6 +60,13 @@
   box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
 }
 
+@media (max-width: 479px) {
+  .content {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+}
+
 .headline {
   padding-right: var(--cui-spacings-peta);
   margin-bottom: var(--cui-spacings-bit);

--- a/packages/circuit-ui/components/Toggletip/Toggletip.module.css
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.module.css
@@ -7,13 +7,47 @@
   width: max-content;
   max-width: 360px;
   max-width: min(360px, 100vw);
+  padding: 0;
+  margin: 0;
+  pointer-events: none;
+  visibility: hidden;
+  background: none;
+  border: none;
+}
+
+.base[open] {
+  pointer-events: auto;
+  visibility: visible;
+}
+
+@media (max-width: 479px) {
+  .base {
+    width: 100%;
+    max-width: 100%;
+  }
+}
+
+.backdrop {
   pointer-events: none;
   visibility: hidden;
 }
 
-.base[data-state="open"] {
-  pointer-events: auto;
-  visibility: visible;
+@media (max-width: 479px) {
+  .backdrop {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: var(--cui-bg-overlay);
+  }
+
+  .base[open] + .backdrop {
+    pointer-events: auto;
+    visibility: visible;
+  }
 }
 
 .content {
@@ -77,4 +111,10 @@
   bottom: calc(50% - (var(--tooltip-arrow-size) / 2));
   left: calc(100% - (var(--tooltip-arrow-size) / 2));
   transform: rotate(315deg);
+}
+
+@media (max-width: 479px) {
+  .arrow {
+    display: none;
+  }
 }

--- a/packages/circuit-ui/components/Toggletip/Toggletip.spec.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.spec.tsx
@@ -1,0 +1,152 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { createRef } from 'react';
+
+import { render, axe, screen, userEvent } from '../../util/test-utils.js';
+
+import { Toggletip, ToggletipReferenceProps } from './Toggletip.js';
+
+const baseProps = {
+  headline: 'What is a chargeback?',
+  body: 'A chargeback is a return of money to a payer of a transaction, especially a credit card transaction.',
+  action: {
+    children: 'Learn more',
+    onClick: vi.fn(),
+    target: '_blank',
+  },
+  closeButtonLabel: 'Close',
+  component: (props: ToggletipReferenceProps) => (
+    <button {...props}>Open toggletip</button>
+  ),
+} as const;
+
+describe('Toggletip', () => {
+  it('should merge a custom class name with the default ones', () => {
+    const className = 'foo';
+    render(<Toggletip {...baseProps} className={className} defaultOpen />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog?.className).toContain(className);
+  });
+
+  it('should forward a ref to the dialog', () => {
+    const ref = createRef<HTMLDialogElement>();
+    render(<Toggletip {...baseProps} ref={ref} defaultOpen />);
+    const dialog = screen.getByRole('dialog');
+    expect(ref.current).toBe(dialog);
+  });
+
+  it('should use the headline and body as the label and description for the dialog element', () => {
+    render(<Toggletip {...baseProps} defaultOpen />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAccessibleName(baseProps.headline);
+    expect(dialog).toHaveAccessibleDescription(baseProps.body);
+  });
+
+  it('should use the body as the label for the dialog element with no headline', () => {
+    const { headline, ...props } = baseProps;
+    render(<Toggletip {...props} defaultOpen />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAccessibleName(props.body);
+  });
+
+  it('should be initially closed', () => {
+    render(<Toggletip {...baseProps} />);
+    const dialog = screen.queryByRole('dialog');
+    expect(dialog).toBeNull();
+  });
+
+  it('should open when the reference element is clicked', async () => {
+    render(<Toggletip {...baseProps} />);
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('open');
+  });
+
+  it('should stay open when the reference element is clicked multiple times', async () => {
+    render(<Toggletip {...baseProps} />);
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    await userEvent.click(button);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('open');
+  });
+
+  it('should focus the action button when the dialog is opened', async () => {
+    render(<Toggletip {...baseProps} />);
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    const actionButton = screen.getByRole('button', { name: /learn more/i });
+    expect(document.activeElement).toBe(actionButton);
+  });
+
+  it('should focus the close button when the dialog is opened with no action button', async () => {
+    const { action, ...props } = baseProps;
+    render(<Toggletip {...props} />);
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    expect(document.activeElement).toBe(closeButton);
+  });
+
+  it('should close when the escape key is pressed', async () => {
+    render(<Toggletip {...baseProps} />);
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('open');
+    await userEvent.keyboard('{Escape}');
+    expect(dialog).not.toHaveAttribute('open');
+  });
+
+  it('should close when clicking outside the dialog', async () => {
+    render(<Toggletip {...baseProps} />);
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    const dialog = screen.getByRole('dialog');
+    await userEvent.click(document.body);
+    expect(dialog).not.toHaveAttribute('open');
+  });
+
+  it('should close when the close button is pressed', async () => {
+    render(<Toggletip {...baseProps} />);
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    const dialog = screen.getByRole('dialog');
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    await userEvent.click(closeButton);
+    expect(dialog).not.toHaveAttribute('open');
+  });
+
+  it('should close when the action button is pressed', async () => {
+    render(<Toggletip {...baseProps} />);
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    const dialog = screen.getByRole('dialog');
+    const actionButton = screen.getByRole('button', { name: /learn more/i });
+    await userEvent.click(actionButton);
+    expect(dialog).not.toHaveAttribute('open');
+    expect(baseProps.action.onClick).toHaveBeenCalledOnce();
+    expect(baseProps.action.onClick).toHaveBeenCalledWith(expect.any(Object));
+  });
+
+  it('should have no accessibility violations', async () => {
+    const { container } = render(<Toggletip {...baseProps} />);
+    const actual = await axe(container);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/packages/circuit-ui/components/Toggletip/Toggletip.stories.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.stories.tsx
@@ -13,12 +13,11 @@
  * limitations under the License.
  */
 
-import { forwardRef, useState } from 'react';
-import { action } from '@storybook/addon-actions';
 import { userEvent, within } from '@storybook/test';
-import { Info } from '@sumup/icons';
+import { ArrowSlanted, Info } from '@sumup/icons';
 
-import Button from '../Button/index.js';
+import { Stack } from '../../../../.storybook/components/index.js';
+import { IconButton } from '../Button/index.js';
 
 import {
   Toggletip,
@@ -31,44 +30,78 @@ export default {
   component: Toggletip,
 };
 
-const Reference = forwardRef<HTMLButtonElement, ToggletipReferenceProps>(
-  (props, ref) => (
-    <Button {...props} ref={ref} icon={Info}>
-      Info
-    </Button>
-  ),
+const wrapperStyle = { display: 'flex', gap: '4px', alignItems: 'center' };
+
+export const Base = (args: ToggletipProps) => (
+  <div style={wrapperStyle}>
+    Chargeback
+    <Toggletip
+      {...args}
+      component={(props) => (
+        <IconButton {...props} icon={Info} variant="tertiary" size="s">
+          View details
+        </IconButton>
+      )}
+    />
+  </div>
 );
 
-const showToggletip = async ({
-  canvasElement,
-}: {
-  canvasElement: HTMLCanvasElement;
-}) => {
+Base.args = {
+  headline: 'What is a chargeback?',
+  body: 'A chargeback is a return of money to a payer of a transaction, especially a credit card transaction.',
+  action: {
+    children: 'Learn more',
+    navigationIcon: ArrowSlanted,
+    href: 'https://help.sumup.com/en-US/articles/3ztthQLEXab3K0vUaQqgwx-chargeback-faq',
+    target: '_blank',
+  },
+  offset: 8,
+};
+
+Base.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
   const canvas = within(canvasElement);
   const referenceEl = canvas.getByRole('button');
 
   await userEvent.click(referenceEl);
 };
 
-export const Base = (args: ToggletipProps) => {
-  const [isOpen, setOpen] = useState(false);
-  return (
-    <Toggletip
-      {...args}
-      isOpen={isOpen}
-      onToggle={setOpen}
-      component={Reference}
-    />
+const ReferenceButton = (props: ToggletipReferenceProps) => (
+  <IconButton {...props} icon={Info} variant="tertiary" size="s">
+    View details
+  </IconButton>
+);
+
+export const Placements = (args: ToggletipProps) => (
+  <Stack>
+    <Toggletip {...args} component={ReferenceButton} placement="left" />
+    <Toggletip {...args} component={ReferenceButton} placement="bottom-start" />
+    <Toggletip {...args} component={ReferenceButton} placement="right-end" />
+  </Stack>
+);
+
+Placements.args = {
+  headline: 'What is a chargeback?',
+  body: 'A chargeback is a return of money to a payer of a transaction, especially a credit card transaction.',
+  action: {
+    children: 'Learn more',
+    navigationIcon: ArrowSlanted,
+    href: 'https://help.sumup.com/en-US/articles/3ztthQLEXab3K0vUaQqgwx-chargeback-faq',
+    target: '_blank',
+  },
+  offset: 8,
+};
+
+Placements.play = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLCanvasElement;
+}) => {
+  const canvas = within(canvasElement);
+  const referenceEls = canvas.getAllByRole('button');
+
+  await Promise.all(
+    referenceEls.map(async (referenceEl) => {
+      await userEvent.click(referenceEl);
+    }),
   );
 };
-
-Base.args = {
-  headline: 'Tutorial',
-  body: "We'll show you how to use this exiting new feature.",
-  action: {
-    children: 'Start tour',
-    onClick: action('Start tour'),
-  },
-};
-
-Base.play = showToggletip;

--- a/packages/circuit-ui/components/Toggletip/Toggletip.stories.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.stories.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { forwardRef, useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import { userEvent, within } from '@storybook/test';
+import { Info } from '@sumup/icons';
+
+import Button from '../Button/index.js';
+
+import {
+  Toggletip,
+  type ToggletipProps,
+  type ToggletipReferenceProps,
+} from './Toggletip.js';
+
+export default {
+  title: 'Components/Toggletip',
+  component: Toggletip,
+};
+
+const Reference = forwardRef<HTMLButtonElement, ToggletipReferenceProps>(
+  (props, ref) => (
+    <Button {...props} ref={ref} icon={Info}>
+      Info
+    </Button>
+  ),
+);
+
+const showToggletip = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLCanvasElement;
+}) => {
+  const canvas = within(canvasElement);
+  const referenceEl = canvas.getByRole('button');
+
+  await userEvent.click(referenceEl);
+};
+
+export const Base = (args: ToggletipProps) => {
+  const [isOpen, setOpen] = useState(false);
+  return (
+    <Toggletip
+      {...args}
+      isOpen={isOpen}
+      onToggle={setOpen}
+      component={Reference}
+    />
+  );
+};
+
+Base.args = {
+  headline: 'Tutorial',
+  body: "We'll show you how to use this exiting new feature.",
+  action: {
+    children: 'Start tour',
+    onClick: action('Start tour'),
+  },
+};
+
+Base.play = showToggletip;

--- a/packages/circuit-ui/components/Toggletip/Toggletip.stories.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.stories.tsx
@@ -30,6 +30,17 @@ export default {
   component: Toggletip,
 };
 
+const showToggletip = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLCanvasElement;
+}) => {
+  const canvas = within(canvasElement);
+  const referenceEl = canvas.getAllByRole('button');
+
+  await userEvent.click(referenceEl[0]);
+};
+
 const wrapperStyle = { display: 'flex', gap: '4px', alignItems: 'center' };
 
 export const Base = (args: ToggletipProps) => (
@@ -58,12 +69,7 @@ Base.args = {
   offset: 8,
 };
 
-Base.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
-  const canvas = within(canvasElement);
-  const referenceEl = canvas.getByRole('button');
-
-  await userEvent.click(referenceEl);
-};
+Base.play = showToggletip;
 
 const ReferenceButton = (props: ToggletipReferenceProps) => (
   <IconButton {...props} icon={Info} variant="tertiary" size="s">
@@ -91,17 +97,4 @@ Placements.args = {
   offset: 8,
 };
 
-Placements.play = async ({
-  canvasElement,
-}: {
-  canvasElement: HTMLCanvasElement;
-}) => {
-  const canvas = within(canvasElement);
-  const referenceEls = canvas.getAllByRole('button');
-
-  await Promise.all(
-    referenceEls.map(async (referenceEl) => {
-      await userEvent.click(referenceEl);
-    }),
-  );
-};
+Placements.play = showToggletip;

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -145,6 +145,8 @@ export const Toggletip = forwardRef<HTMLDialogElement, ToggletipProps>(
         return undefined;
       }
 
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore The package is bundled incorrectly
       dialogPolyfill.registerDialog(dialogElement);
 
       const handleClose = () => {

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -237,10 +237,11 @@ export const Toggletip = forwardRef<HTMLDialogElement, ToggletipProps>(
         {/* @ts-expect-error "Expression produces a union type that is too complex to represent" */}
         <dialog
           {...props}
+          open={defaultOpen}
           ref={applyMultipleRefs(ref, dialogRef, refs.setFloating)}
           data-side={side}
-          aria-labelledby={headlineId}
-          aria-describedby={bodyId}
+          aria-labelledby={headline ? headlineId : bodyId}
+          aria-describedby={headline ? bodyId : undefined}
           className={clsx(classes.base, className)}
           // @ts-expect-error z-index can be a string
           style={{

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -51,13 +51,6 @@ import Button, { type ButtonProps } from '../Button/index.js';
 
 import classes from './Toggletip.module.css';
 
-// TODO: mobile: focus trap
-// TODO: check rerenders
-
-// inert with polyfill
-// render modal outside root with portal?
-// add inert on root
-
 export interface ToggletipReferenceProps {
   'id': string;
   'onClick': (event: ClickEvent) => void;
@@ -70,19 +63,25 @@ export interface ToggletipProps extends HTMLAttributes<HTMLDialogElement> {
    */
   component: ComponentType<ToggletipReferenceProps>;
   /**
-   * TODO:
+   * The optional headline acts as the toggletip's [accessible name](https://w3c.github.io/accname/#dfn-accessible-name).
+   * Keep it short and under 120 characters.
    */
   headline?: string;
   /**
-   * TODO:
+   * Use the body text to provide additional help or to define a term.
+   * The body acts as the toggletip's [accessible description](https://w3c.github.io/accname/#dfn-accessible-description)
+   * or as its [accessible name](https://w3c.github.io/accname/#dfn-accessible-name)
+   * when no headline is present.
    */
   body: string;
   /**
-   * TODO:
+   * Use the optional action button to point the user to additional information
+   * or enable a contextual action. Use one strong, clear imperative verb and
+   * follow with a one-word object if needed to clarify.
    */
   action?: Omit<ButtonProps, 'variant' | 'size'>;
   /**
-   * TODO:
+   * Label for the toggletip's close button.
    */
   closeButtonLabel: string;
   /**
@@ -90,7 +89,9 @@ export interface ToggletipProps extends HTMLAttributes<HTMLDialogElement> {
    */
   defaultOpen?: boolean;
   /**
-   * TODO:
+   * Where to display the toggletip relative to the trigger component. The
+   * toggletip will automatically move if there isn't enough space available.
+   * Default: 'top'.
    */
   placement?: Placement;
   /**

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use client';
+
+import {
+  forwardRef,
+  useEffect,
+  useId,
+  useRef,
+  type ComponentType,
+  type HTMLAttributes,
+  type Ref,
+} from 'react';
+import {
+  arrow,
+  flip,
+  offset,
+  shift,
+  useFloating,
+  type Placement,
+  type Side,
+} from '@floating-ui/react-dom';
+
+import type { ClickEvent } from '../../types/events.js';
+import { clsx } from '../../styles/clsx.js';
+import { applyMultipleRefs } from '../../util/refs.js';
+import { isHTMLElement } from '../../util/type-check.js';
+import { useEscapeKey } from '../../hooks/useEscapeKey/index.js';
+import { useClickOutside } from '../../hooks/useClickOutside/index.js';
+import { useLatest } from '../../hooks/useLatest/index.js';
+import { usePrevious } from '../../hooks/usePrevious/index.js';
+import CloseButton from '../CloseButton/index.js';
+import Headline from '../Headline/index.js';
+import Body from '../Body/index.js';
+import Button, { type ButtonProps } from '../Button/index.js';
+
+import classes from './Toggletip.module.css';
+
+// TODO: mobile:  position, focus trap
+// TODO: what should the a11y semantics be?
+// FIXME: IconButton with Toggletip
+// FIXME: ghost tooltip on close button
+
+// mobile modal
+// inert with polyfill
+// render modal outside root with portal
+// add inert on root
+
+export interface ToggletipReferenceProps {
+  onClick: (event: ClickEvent) => void;
+  ref: Ref<any>;
+}
+
+type OnToggle = (open: boolean | ((prevOpen: boolean) => boolean)) => void;
+
+export interface ToggletipProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * The button element that triggers the toggletip.
+   */
+  component: ComponentType<ToggletipReferenceProps>;
+  /**
+   * Determines whether the toggletip is open or closed.
+   */
+  isOpen: boolean;
+  /**
+   * Function that is called when opening and closing the toggletip.
+   */
+  onToggle: OnToggle;
+  /**
+   * TODO:
+   */
+  headline?: string;
+  /**
+   * TODO:
+   */
+  body: string;
+  /**
+   * TODO:
+   */
+  action?: Omit<ButtonProps, 'variant' | 'size'>;
+  /**
+   * TODO:
+   */
+  closeButtonLabel: string;
+  /**
+   * TODO:
+   */
+  placement?: Placement;
+}
+
+export const Toggletip = forwardRef<HTMLDivElement, ToggletipProps>(
+  (
+    {
+      isOpen = false,
+      onToggle,
+      placement: defaultPlacement = 'top',
+      headline,
+      body,
+      action,
+      component: Component,
+      closeButtonLabel,
+      className,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
+    const arrowRef = useRef<HTMLDivElement>(null);
+    const toggletipId = useId();
+    const prevOpen = usePrevious(isOpen);
+
+    const { refs, floatingStyles, middlewareData, update, placement } =
+      useFloating({
+        open: isOpen,
+        placement: defaultPlacement,
+        middleware: [
+          offset(12),
+          flip(),
+          shift(),
+          arrow({ element: arrowRef, padding: 12 }),
+        ],
+      });
+
+    const side = placement.split('-')[0] as Side;
+
+    // This is a performance optimization to prevent event listeners from being
+    // re-attached on every render.
+    const floatingRef = useLatest(refs.floating.current);
+
+    useEscapeKey(() => onToggle(false), isOpen);
+    useClickOutside(floatingRef, () => onToggle(false), isOpen);
+
+    useEffect(() => {
+      /**
+       * When we support `ResizeObserver` (https://caniuse.com/resizeobserver),
+       * we can look into using Floating UI's `autoUpdate` (but we can't use
+       * `whileElementInMounted` because our implementation hides the floating
+       * element using CSS instead of using conditional rendering.
+       * See https://floating-ui.com/docs/react-dom#updating
+       */
+      if (isOpen) {
+        update();
+        window.addEventListener('resize', update);
+        window.addEventListener('scroll', update);
+      } else {
+        window.removeEventListener('resize', update);
+        window.removeEventListener('scroll', update);
+      }
+      return () => {
+        window.removeEventListener('resize', update);
+        window.removeEventListener('scroll', update);
+      };
+    }, [isOpen, update]);
+
+    useEffect(() => {
+      // Focus the toggletip content after opening
+      if (!prevOpen && isOpen) {
+        const contentElement = refs.floating.current?.firstElementChild;
+
+        if (isHTMLElement(contentElement)) {
+          contentElement.setAttribute('tabindex', '0');
+          contentElement.focus();
+          contentElement.setAttribute('tabindex', '-1');
+        }
+      }
+
+      // Focus the reference element after closing
+      const referenceElement = refs.reference.current;
+
+      if (prevOpen && !isOpen && isHTMLElement(referenceElement)) {
+        referenceElement.focus();
+      }
+    }, [isOpen, prevOpen, refs.reference, refs.floating]);
+
+    const handleReferenceClick = (event: ClickEvent) => {
+      // This prevents the event from bubbling which would trigger the
+      // useClickOutside above and would prevent the popover from closing.
+      event.stopPropagation();
+      onToggle(true);
+    };
+
+    const handleActionClick = (event: ClickEvent) => {
+      action?.onClick?.(event);
+      onToggle(false);
+    };
+
+    return (
+      <>
+        <Component onClick={handleReferenceClick} ref={refs.setReference} />
+        <div
+          {...props}
+          ref={applyMultipleRefs(ref, refs.setFloating)}
+          id={toggletipId}
+          data-state={isOpen ? 'open' : 'closed'}
+          data-side={side}
+          className={clsx(classes.base, className)}
+          style={{ ...style, ...floatingStyles }}
+        >
+          <div className={classes.content}>
+            {headline && (
+              <Headline as="h2" size="four" className={classes.headline}>
+                {headline}
+              </Headline>
+            )}
+            <Body size="two" className={classes.body}>
+              {body}
+            </Body>
+            {action && (
+              <Button
+                {...action}
+                onClick={handleActionClick}
+                variant="secondary"
+                size="s"
+                className={classes.action}
+              />
+            )}
+            <CloseButton
+              size="s"
+              variant="tertiary"
+              className={classes.close}
+              onClick={() => onToggle(false)}
+            >
+              {closeButtonLabel}
+            </CloseButton>
+          </div>
+          <div
+            ref={arrowRef}
+            className={classes.arrow}
+            style={{
+              top: middlewareData.arrow?.y,
+              left: middlewareData.arrow?.x,
+            }}
+          />
+        </div>
+      </>
+    );
+  },
+);

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -25,6 +25,7 @@ import {
   useState,
   type ComponentType,
   type HTMLAttributes,
+  type RefObject,
 } from 'react';
 import {
   arrow,
@@ -132,13 +133,6 @@ export const Toggletip = forwardRef<HTMLDialogElement, ToggletipProps>(
     const bodyId = useId();
     const [open, setOpen] = useState(defaultOpen);
 
-    const closeDialog = useCallback(() => {
-      dialogRef.current?.close();
-    }, []);
-
-    useEscapeKey(closeDialog, open);
-    useClickOutside(dialogRef, closeDialog, open);
-
     useEffect(() => {
       const dialogElement = dialogRef.current;
 
@@ -201,10 +195,18 @@ export const Toggletip = forwardRef<HTMLDialogElement, ToggletipProps>(
       };
     }, [open, update]);
 
-    const handleReferenceClick = useCallback((event: ClickEvent) => {
-      // This prevents the event from bubbling which would trigger the
-      // useClickOutside above and would prevent the dialog from closing.
-      event.stopPropagation();
+    const closeDialog = useCallback(() => {
+      dialogRef.current?.close();
+    }, []);
+
+    useClickOutside(
+      [refs.floating, refs.reference as RefObject<HTMLButtonElement>],
+      closeDialog,
+      open,
+    );
+    useEscapeKey(closeDialog, open);
+
+    const handleReferenceClick = useCallback(() => {
       if (dialogRef.current) {
         dialogRef.current.show();
         setOpen(true);

--- a/packages/circuit-ui/components/Toggletip/index.ts
+++ b/packages/circuit-ui/components/Toggletip/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,12 +13,8 @@
  * limitations under the License.
  */
 
-export {
-  default as Tooltip,
-  type TooltipProps,
-  type TooltipReferenceProps,
-} from './components/Tooltip/index.js';
-export {
-  default as Toggletip,
-  type ToggletipProps,
-} from './components/Toggletip/index.js';
+import { Toggletip } from './Toggletip.js';
+
+export type { ToggletipProps } from './Toggletip.js';
+
+export default Toggletip;

--- a/packages/circuit-ui/components/Tooltip/Tooltip.mdx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.mdx
@@ -16,7 +16,7 @@ Tooltips display additional information upon hover or focus that is contextual, 
 
 Tooltips hide information by default and require user interaction to be shown. They should be used as a last resort when space truly is limited and the information cannot be shown inline.
 
-A Tooltip must be used with an interactive, focusable element such as a button, link or input. When wrapping a custom component or an inline function, ensure that the [`ref` is forwarded](https://react.dev/reference/react/forwardRef).
+The wrapped component must be a focusable element such as `<a>`, `<button>`, `<input>`, or an element with `tabindex="0"`.
 
 The label must be a single unformatted string. Use a [Toggletip](Components/Toggletip/Docs) instead if the content should be structured or interactive.
 
@@ -44,12 +44,15 @@ The tooltip automatically flips to the opposite side to stay within the viewport
 
 <Story of={Stories.Placements} />
 
+## Related components
+
+- [Toggletip](Components/Toggletip/Docs): Toggletips display additional information that is contextual, helpful, and nonessential to the user upon pressing a UI trigger element and can contain interactive elements
+
 ---
 
 ## Accessibility
 
 ### Best practices
-
 
 - Only interactive elements should trigger tooltips
 - Tooltips should directly describe the UI control that triggers them (i.e. do not create a control purely to trigger a tooltip)
@@ -60,7 +63,6 @@ The tooltip automatically flips to the opposite side to stay within the viewport
 - Allow the mouse to easily move over the tooltip without dismissing it
 - Do not use a timeout to hide the tooltip
 
-
 ### Resources
 
 - [Tooltips in the time of WCAG 2.1](https://sarahmhigley.com/writing/tooltips-in-wcag-21/) by Sarah Highley
@@ -69,4 +71,3 @@ The tooltip automatically flips to the opposite side to stay within the viewport
 #### Related WCAG success criteria
 
 - 1.4.13: [Content on Hover or Focus](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
-

--- a/packages/circuit-ui/components/Tooltip/Tooltip.module.css
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.module.css
@@ -7,7 +7,7 @@
   z-index: var(--cui-z-index-tooltip);
   width: max-content;
   max-width: 360px;
-  max-width: min(360px, 100vw);
+  max-width: min(360px, calc(100vw - 8px));
   pointer-events: none;
   opacity: 0;
   transition: opacity var(--cui-transitions-default);
@@ -40,7 +40,7 @@
 .base[data-state="open"],
 .base:hover,
 .component:hover + .base,
-.component:focus + .base {
+.component:focus-visible + .base {
   pointer-events: auto;
   opacity: 1;
   transition-delay: 1s;
@@ -49,7 +49,7 @@
 .base,
 .base[data-state="closed"]:hover,
 .component:hover + .base[data-state="closed"],
-.component:focus + .base[data-state="closed"] {
+.component:focus-visible + .base[data-state="closed"] {
   transition-delay: 0s;
 }
 

--- a/packages/circuit-ui/components/Tooltip/Tooltip.module.css
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.module.css
@@ -5,6 +5,9 @@
 
   position: absolute;
   z-index: var(--cui-z-index-tooltip);
+  width: max-content;
+  max-width: 360px;
+  max-width: min(360px, 100vw);
   pointer-events: none;
   opacity: 0;
   transition: opacity var(--cui-transitions-default);
@@ -68,6 +71,18 @@
   padding-right: var(--tooltip-offset);
 }
 
+.content {
+  padding: var(--cui-spacings-byte) var(--cui-spacings-kilo);
+  font-size: var(--cui-typography-body-two-font-size);
+  font-weight: var(--cui-font-weight-regular);
+  line-height: var(--cui-typography-body-two-line-height);
+  color: var(--cui-fg-normal);
+  background-color: var(--cui-bg-elevated);
+  border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
+  border-radius: var(--cui-border-radius-byte);
+  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
+}
+
 .arrow {
   position: absolute;
   width: var(--tooltip-arrow-size);
@@ -100,18 +115,4 @@
   bottom: calc(50% - (var(--tooltip-arrow-size) / 2));
   left: calc(100% - var(--tooltip-offset) - (var(--tooltip-arrow-size) / 2));
   transform: rotate(315deg);
-}
-
-.content {
-  width: max-content;
-  max-width: 360px;
-  padding: var(--cui-spacings-byte) var(--cui-spacings-kilo);
-  font-size: var(--cui-typography-body-two-font-size);
-  font-weight: var(--cui-font-weight-regular);
-  line-height: var(--cui-typography-body-two-line-height);
-  color: var(--cui-fg-normal);
-  background-color: var(--cui-bg-elevated);
-  border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
-  border-radius: var(--cui-border-radius-byte);
-  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
 }

--- a/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
@@ -14,7 +14,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { createRef, forwardRef } from 'react';
+import { createRef } from 'react';
 
 import { render, axe, screen, userEvent } from '../../util/test-utils.js';
 
@@ -23,7 +23,7 @@ import { Tooltip, TooltipProps } from './Tooltip.js';
 const baseProps: TooltipProps = {
   label: 'Label',
   type: 'label',
-  component: forwardRef((props, ref) => <button {...props} ref={ref} />),
+  component: (props) => <button {...props} />,
 };
 
 describe('Tooltip', () => {
@@ -42,15 +42,13 @@ describe('Tooltip', () => {
   });
 
   it('should act as a label for the reference element', () => {
-    const ref = createRef<HTMLDivElement>();
-    render(<Tooltip {...baseProps} ref={ref} />);
+    render(<Tooltip {...baseProps} />);
     const button = screen.getByRole('button');
     expect(button).toHaveAccessibleName(baseProps.label);
   });
 
   it('should act as a description for the reference element', () => {
-    const ref = createRef<HTMLDivElement>();
-    render(<Tooltip {...baseProps} type="description" ref={ref} />);
+    render(<Tooltip {...baseProps} type="description" />);
     const button = screen.getByRole('button');
     expect(button).toHaveAccessibleDescription(baseProps.label);
   });

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import { forwardRef } from 'react';
 import { userEvent } from '@storybook/test';
 import { TransferOut, UploadCloud } from '@sumup/icons';
 
@@ -34,12 +33,10 @@ export default {
 const descriptionProps = {
   label: 'This may take a few minutes',
   type: 'description',
-  component: forwardRef<HTMLButtonElement, TooltipReferenceProps>(
-    (props, ref) => (
-      <Button {...props} icon={UploadCloud} ref={ref}>
-        Upload
-      </Button>
-    ),
+  component: (props: TooltipReferenceProps) => (
+    <Button {...props} icon={UploadCloud}>
+      Upload
+    </Button>
   ),
 } as const;
 
@@ -49,29 +46,41 @@ const showTooltip = async () => {
 
 export const Base = (args: TooltipProps) => (
   <Stack>
-    <Tooltip {...args} />
+    <Tooltip
+      {...args}
+      component={(props) => (
+        <Button {...props} icon={UploadCloud}>
+          Upload
+        </Button>
+      )}
+    />
   </Stack>
 );
 
-Base.args = descriptionProps;
+Base.args = {
+  label: 'This may take a few minutes',
+  type: 'description',
+};
 Base.play = showTooltip;
 
 export const Types = (args: TooltipProps) => (
   <Stack>
     {/* The IconButton uses the Tooltip component under the hood */}
     <IconButton icon={TransferOut}>Transfer out</IconButton>
-    <Tooltip {...args} {...descriptionProps} />
+    <Tooltip {...args} />
   </Stack>
 );
 
+Types.args = descriptionProps;
 Types.play = showTooltip;
 
 export const Placements = (args: TooltipProps) => (
   <Stack>
-    <Tooltip {...args} {...descriptionProps} placement="left" />
-    <Tooltip {...args} {...descriptionProps} placement="bottom-start" />
-    <Tooltip {...args} {...descriptionProps} placement="right-end" />
+    <Tooltip {...args} placement="left" />
+    <Tooltip {...args} placement="bottom-start" />
+    <Tooltip {...args} placement="right-end" />
   </Stack>
 );
 
+Placements.args = descriptionProps;
 Placements.play = showTooltip;

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -71,8 +71,9 @@ export interface TooltipProps extends HTMLAttributes<HTMLDivElement> {
    */
   component: ComponentType<TooltipReferenceProps>;
   /**
-   * Whether the tooltip is the main label or a supplemental description of
-   * the reference component.
+   * Whether the tooltip is the [main label](https://w3c.github.io/accname/#dfn-accessible-name)
+   * or a [supplemental description](https://w3c.github.io/accname/#dfn-accessible-description)
+   * of the reference component.
    */
   type: 'label' | 'description';
   /**

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.5",
     "@nanostores/react": "^0.7.2",
+    "dialog-polyfill": "^0.5.6",
     "nanostores": "^0.10.0",
     "react-modal": "^3.16.1",
     "react-number-format": "5.3.0"

--- a/packages/circuit-ui/util/type-check.spec.ts
+++ b/packages/circuit-ui/util/type-check.spec.ts
@@ -18,6 +18,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   isArray,
   isFunction,
+  isHTMLElement,
   isNil,
   isNumber,
   isObject,
@@ -132,6 +133,12 @@ describe('type check', () => {
       expect(actual).toBeFalsy();
     });
 
+    it('should return false for a node list', () => {
+      const nodeList = document.querySelectorAll('div');
+      const actual = isArray(nodeList);
+      expect(actual).toBeFalsy();
+    });
+
     it('should return false for a function', () => {
       const actual = isArray(vi.fn());
       expect(actual).toBeFalsy();
@@ -203,6 +210,31 @@ describe('type check', () => {
 
     it('should return false for NaN', () => {
       const actual = isNil(NaN);
+      expect(actual).toBeFalsy();
+    });
+  });
+
+  describe('isHTMLElement', () => {
+    it('should return true for an HTML element', () => {
+      const element = document.createElement('div');
+      const actual = isHTMLElement(element);
+      expect(actual).toBeTruthy();
+    });
+
+    it('should return false for an array of HTML elements', () => {
+      const elements = [document.createElement('div')];
+      const actual = isHTMLElement(elements);
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for a node list', () => {
+      const nodeList = document.querySelectorAll('div');
+      const actual = isHTMLElement(nodeList);
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for a function', () => {
+      const actual = isHTMLElement(vi.fn());
       expect(actual).toBeFalsy();
     });
   });

--- a/packages/circuit-ui/util/type-check.ts
+++ b/packages/circuit-ui/util/type-check.ts
@@ -39,3 +39,7 @@ export function isObject<T extends Record<string, unknown>>(
 export function isNil(value?: unknown): value is null | undefined {
   return value === undefined || value === null;
 }
+
+export function isHTMLElement(element: unknown): element is HTMLElement {
+  return element instanceof HTMLElement;
+}

--- a/patches/nwsapi+2.2.7.patch
+++ b/patches/nwsapi+2.2.7.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/nwsapi/src/nwsapi.js b/node_modules/nwsapi/src/nwsapi.js
+index 03cac4e..b02227a 100644
+--- a/node_modules/nwsapi/src/nwsapi.js
++++ b/node_modules/nwsapi/src/nwsapi.js
+@@ -82,7 +82,7 @@
+     treestruct: '(nth(?:-last)?(?:-child|-of-type))(?:\\x28\\s?(even|odd|(?:[-+]?\\d*)(?:n\\s?[-+]?\\s?\\d*)?)\\s?\\x29)',
+     // pseudo-classes not requiring parameters
+     locationpc: '(any-link|link|visited|target)\\b',
+-    useraction: '(hover|active|focus-within|focus)\\b',
++    useraction: '(hover|active|focus-within|focus-visible|focus)\\b',
+     structural: '(root|empty|(?:(?:first|last|only)(?:-child|-of-type)))\\b',
+     inputstate: '(enabled|disabled|read-only|read-write|placeholder-shown|default)\\b',
+     inputvalue: '(checked|indeterminate|required|optional|valid|invalid|in-range|out-of-range)\\b',
+@@ -1076,6 +1076,7 @@
+                     'if((e===s.doc.activeElement)){' + source + '}' : source;
+                   break;
+                 case 'focus':
++                case 'focus-visible':
+                   source = 'hasFocus' in doc ?
+                     'if(e.parentElement&&e.parentElement.style.display!="none"&&' +
+                     'e===s.doc.activeElement&&s.doc.hasFocus()&&(e.type||e.href||typeof e.tabIndex=="number")){' + source + '}' : source;


### PR DESCRIPTION
Closes #1676. Relates to #2393.

## Purpose

The legacy Tooltip component has critical accessibility issues that cannot be addressed with its current API (see #1676). This pull request adds an experimental Toggletip component, which displays additional information that is contextual, helpful, and nonessential to the user upon pressing a UI trigger element and can contain interactive elements.

The Toggletip complements the experimental Tooltip component (#2393).

## Approach and changes

- Implemented an experimental Toggletip component
	- The toggletip uses a non-modal [`dialog` element](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement) and includes a [polyfill](https://github.com/GoogleChrome/dialog-polyfill) for older browsers that don't support it yet.
	- The tooltip is dynamically positioned using [Floating UI](https://floating-ui.com/)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
