### PR TITLE
Fix slide display for the composed Carousel

### DIFF
--- a/.changeset/wicked-bears-sneeze.md
+++ b/.changeset/wicked-bears-sneeze.md
@@ -1,5 +1,5 @@
 ---
-"@sumup/circuit-ui": minor
+"@sumup/circuit-ui": patch
 ---
 
-Fix the behaviour of the slide when used in the composed variation
+Fixed the display of the slides in the composed Carousel component.

--- a/.changeset/wicked-bears-sneeze.md
+++ b/.changeset/wicked-bears-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": minor
+---
+
+Fix the behaviour of the slide when used in the composed variation

--- a/packages/circuit-ui/components/Carousel/components/Slide/Slide.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Slide/Slide.tsx
@@ -63,6 +63,7 @@ export function Slide({
   slideDirection,
   animationDuration = ANIMATION_DURATION,
   children,
+  style = {},
   ...props
 }: SlideProps) {
   const stackOrder = SlideService.getStackOrder(
@@ -87,6 +88,7 @@ export function Slide({
         '--slide-stack-order': stackOrder,
         '--slide-transform-x': `${-index * 100}%`,
         '--slide-animation-duration': `${animationDuration}ms`,
+        ...style,
       }}
       className={classes.base}
       {...props}


### PR DESCRIPTION
Addresses [EXPN-1045](https://sumupteam.atlassian.net/browse/EXPN-1045)

## Purpose

The composed carousel displays only first slide and then a blank screen when changing to the next slides

## Approach and changes

- merge `style` prop for the `Slide` component

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
