### PR TITLE
Add support for custom components in TopNavigation links

### DIFF
--- a/.changeset/tidy-buses-sleep.md
+++ b/.changeset/tidy-buses-sleep.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": minor
+---
+
+Added support for passing custom components to the `links` prop of the TopNavigation component and deprecated the `user` and `profileMenu` props.

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -36,7 +36,12 @@ import sharedClasses from '../../../../styles/shared.js';
 
 import classes from './SecondaryLinks.module.css';
 
-function SecondaryLink({ label, badge, ...props }: SecondaryLinkProps) {
+function SecondaryLink({
+  label,
+  badge,
+  isActive,
+  ...props
+}: SecondaryLinkProps) {
   const { Link } = useComponents();
 
   const Element = props.href ? (Link as AsPropType) : 'button';
@@ -50,13 +55,13 @@ function SecondaryLink({ label, badge, ...props }: SecondaryLinkProps) {
           sharedClasses.navigationItem,
           utilityClasses.focusVisibleInset,
         )}
-        aria-current={props.isActive ? 'page' : undefined}
+        aria-current={isActive ? 'page' : undefined}
       >
         <Skeleton className={classes.label}>
           <Body
             as="span"
             size="one"
-            variant={props.isActive ? 'highlight' : undefined}
+            variant={isActive ? 'highlight' : undefined}
           >
             {label}
           </Body>

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
@@ -21,6 +21,7 @@ import { modes } from '../../../../.storybook/modes.js';
 import { SideNavigation } from '../SideNavigation/index.js';
 import { baseArgs as sideNavigationProps } from '../SideNavigation/SideNavigation.stories.js';
 import { ModalProvider } from '../ModalContext/index.js';
+import Body from '../Body/index.js';
 
 import { TopNavigation, TopNavigationProps } from './TopNavigation.js';
 
@@ -41,18 +42,20 @@ export default {
   excludeStories: /.*Args$/,
 };
 
-function Announcement() {
+function CustomComponent() {
   return (
-    <div
+    <Body
+      size="two"
       style={{
         display: 'flex',
         alignItems: 'center',
         height: '100%',
         padding: '0 var(--cui-spacings-mega)',
+        textAlign: 'center',
       }}
     >
-      Test mode active
-    </div>
+      Test account
+    </Body>
   );
 }
 
@@ -96,8 +99,8 @@ export const baseArgs: TopNavigationProps = {
   },
   links: [
     {
-      key: 'announcement',
-      children: <Announcement />,
+      key: 'custom',
+      children: <CustomComponent />,
     },
     {
       icon: Shop,

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
@@ -41,6 +41,21 @@ export default {
   excludeStories: /.*Args$/,
 };
 
+function Announcement() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        height: '100%',
+        padding: '0 var(--cui-spacings-mega)',
+      }}
+    >
+      Test mode active
+    </div>
+  );
+}
+
 export const baseArgs: TopNavigationProps = {
   isLoading: false,
   logo: (
@@ -78,6 +93,10 @@ export const baseArgs: TopNavigationProps = {
     className: 'custom-class-name',
   },
   links: [
+    {
+      key: 'announcement',
+      children: <Announcement />,
+    },
     {
       icon: Shop,
       label: 'Shop',

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
@@ -43,8 +43,14 @@ export interface TopNavigationProps
     HTMLAttributes<HTMLElement> {
   logo: ReactNode;
   hamburger?: HamburgerProps;
-  user: UserProps;
-  profileMenu: Omit<ProfileMenuProps, 'user'>;
+  /**
+   * @deprecated Use a custom component in the `links` prop instead.
+   */
+  profileMenu?: Omit<ProfileMenuProps, 'user'>;
+  /**
+   * @deprecated Use a custom component in the `links` prop instead.
+   */
+  user?: UserProps;
   isLoading?: boolean;
 }
 
@@ -89,7 +95,7 @@ export function TopNavigation({
         isLoading={Boolean(isLoading)}
       >
         {links && <UtilityLinks links={links} />}
-        <ProfileMenu {...profileMenu} user={user} />
+        {profileMenu && user && <ProfileMenu {...profileMenu} user={user} />}
       </SkeletonContainer>
     </header>
   );

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.module.css
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.module.css
@@ -6,13 +6,13 @@
 
 .item {
   height: 100%;
+  border-left: var(--cui-border-width-kilo) solid var(--cui-border-divider);
 }
 
 .anchor {
   height: 100%;
   padding: 0 var(--cui-spacings-mega);
   text-decoration: none;
-  border-left: var(--cui-border-width-kilo) solid var(--cui-border-divider);
 }
 
 .icon {
@@ -41,6 +41,6 @@
   }
 }
 
-[aria-current='page'] .label {
+[aria-current="page"] .label {
   font-weight: var(--cui-font-weight-bold);
 }

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.spec.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.spec.tsx
@@ -13,13 +13,13 @@
  * limitations under the License.
  */
 
+import type { KeyboardEvent, MouseEvent, FC } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { IconProps, More } from '@sumup/icons';
-import { KeyboardEvent, MouseEvent, FC } from 'react';
+import { More, type IconProps } from '@sumup/icons';
 
 import { axe, render, userEvent, screen } from '../../../../util/test-utils.js';
 
-import { UtilityLinks } from './UtilityLinks.js';
+import { UtilityLinks, type UtilityLinkProps } from './UtilityLinks.js';
 
 describe('UtilityLinks', () => {
   const baseProps = {
@@ -32,17 +32,27 @@ describe('UtilityLinks', () => {
           event.preventDefault();
         }),
       },
+      {
+        key: 'custom',
+        children: <More data-testid="custom-component" />,
+      },
     ],
   };
 
   it('should call the onClick handler of a link', async () => {
     render(<UtilityLinks {...baseProps} />);
 
-    const link = baseProps.links[0];
+    const link = baseProps.links[0] as UtilityLinkProps;
 
     await userEvent.click(screen.getByText(link.label));
 
     expect(link.onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render a custom component', () => {
+    render(<UtilityLinks {...baseProps} />);
+
+    expect(screen.getByTestId('custom-component')).toBeVisible();
   });
 
   it('should have no accessibility violations', async () => {

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -15,7 +15,12 @@
 
 'use client';
 
-import type { MouseEvent, KeyboardEvent, AnchorHTMLAttributes } from 'react';
+import type {
+  MouseEvent,
+  KeyboardEvent,
+  AnchorHTMLAttributes,
+  ReactNode,
+} from 'react';
 import type { IconComponentType } from '@sumup/icons';
 
 import type { AsPropType } from '../../../../types/prop-types.js';
@@ -90,18 +95,32 @@ function UtilityLink({
   );
 }
 
+type CustomLinkProps = { key: string; children: ReactNode };
+
 export interface UtilityLinksProps {
-  links: UtilityLinkProps[];
+  links: (UtilityLinkProps | CustomLinkProps)[];
 }
 
 export function UtilityLinks({ links }: UtilityLinksProps): JSX.Element {
   return (
     <ul className={classes.list}>
-      {links.map((link) => (
-        <li key={link.label} className={classes.item}>
-          <UtilityLink {...link} />
-        </li>
-      ))}
+      {links.map((link) =>
+        isUtilityLink(link) ? (
+          <li key={link.label} className={classes.item}>
+            <UtilityLink {...link} />
+          </li>
+        ) : (
+          <li key={link.key} className={classes.item}>
+            {link.children}
+          </li>
+        ),
+      )}
     </ul>
   );
+}
+
+function isUtilityLink(
+  link: UtilityLinkProps | CustomLinkProps,
+): link is UtilityLinkProps {
+  return 'label' in link;
 }

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -95,7 +95,20 @@ function UtilityLink({
   );
 }
 
-type CustomLinkProps = { key: string; children: ReactNode };
+type CustomLinkProps = {
+  /**
+   * A string or a number that uniquely identifies the link among other links.
+   *
+   * See https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key
+   */
+  key: string | number;
+  /**
+   * A custom component. Ensure that the element's styles fit in with the rest
+   * of the TopNavigation. If the element is interactive, it should match the
+   * hover, focus, and active styles of the regular links.
+   */
+  children: ReactNode;
+};
 
 export interface UtilityLinksProps {
   links: (UtilityLinkProps | CustomLinkProps)[];


### PR DESCRIPTION
## Purpose

The TopNavigation currently assumes a very specific layout for the profile menu. The `profileMenu` and `user` props are oddly specific for a design system component.

Additionally, the profile menu is implemented using the Popover component, whose `menu` role is semantically incorrect for this context (fixed in #2483).

## Approach and changes

- Deprecated the `profileMenu` and `user` props
- Added support for passing custom components to the TopNavigation's `links` prop

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
