### PR TITLE
Fix semantics of the TopNavigation's profile menu

### DIFF
--- a/.changeset/slow-shrimps-smoke.md
+++ b/.changeset/slow-shrimps-smoke.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": patch
+---
+
+Fixed the semantics of the TopNavigation's profile menu.

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
+import type { FC } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { FC } from 'react';
-import { Delete, Add, Download, IconProps } from '@sumup/icons';
+import { Delete, Add, Download, type IconProps } from '@sumup/icons';
 
 import {
   act,
@@ -25,13 +25,13 @@ import {
   userEvent,
   screen,
 } from '../../util/test-utils.js';
-import { ClickEvent } from '../../types/events.js';
+import type { ClickEvent } from '../../types/events.js';
 
 import {
   PopoverItem,
-  PopoverItemProps,
+  type PopoverItemProps,
   Popover,
-  PopoverProps,
+  type PopoverProps,
 } from './Popover.js';
 
 describe('PopoverItem', () => {
@@ -261,12 +261,32 @@ describe('Popover', () => {
     });
   });
 
-  it('should render items as role=menuitem and dividers as aria-hidden', async () => {
+  it('should render the popover with menu semantics by default ', async () => {
+    renderPopover(baseProps);
+
+    const menu = screen.getByRole('menu');
+    expect(menu).toBeVisible();
+    const menuitems = screen.getAllByRole('menuitem');
+    expect(menuitems.length).toBe(2);
+
+    await flushMicrotasks();
+  });
+
+  it('should render the popover without menu semantics ', async () => {
+    renderPopover({ ...baseProps, role: null });
+
+    const menu = screen.queryByRole('menu');
+    expect(menu).toBeNull();
+    const menuitems = screen.queryAllByRole('menuitem');
+    expect(menuitems.length).toBe(0);
+
+    await flushMicrotasks();
+  });
+
+  it('should hide dividers from the accessibility tree', async () => {
     const { baseElement } = renderPopover(baseProps);
 
-    const items = screen.getAllByRole('menuitem');
     const dividers = baseElement.querySelectorAll('hr[aria-hidden="true"');
-    expect(items.length).toBe(2);
     expect(dividers.length).toBe(1);
 
     await flushMicrotasks();

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -95,7 +95,6 @@ export const PopoverItem = ({
 
   return (
     <Element
-      role="menuitem"
       className={clsx(
         classes.item,
         sharedClasses.listItem,
@@ -165,6 +164,14 @@ export interface PopoverProps {
     'aria-controls': string;
     'aria-expanded': boolean;
   }) => JSX.Element;
+  /**
+   * Remove the [`menu` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/roles/menu_role)
+   * when its semantics aren't appropriate for the use case, for example when
+   * the Popover is used as part of a navigation. Default: 'menu'.
+   *
+   * Learn more: https://inclusive-components.design/menus-menu-buttons/
+   */
+  role?: 'menu' | null;
 }
 
 type TriggerKey = 'ArrowUp' | 'ArrowDown';
@@ -187,6 +194,7 @@ export const Popover = ({
   component: Component,
   offset,
   className,
+  role = 'menu',
   ...props
 }: PopoverProps): JSX.Element | null => {
   const zIndex = useStackContext();
@@ -305,6 +313,8 @@ export const Popover = ({
     };
   }, [isOpen, prevOpen, refs.reference, update]);
 
+  const isMenu = role === 'menu';
+
   return (
     <Fragment>
       <div className={classes.trigger} ref={refs.setReference}>
@@ -342,8 +352,8 @@ export const Popover = ({
           <div
             id={menuId}
             ref={menuEl}
-            aria-labelledby={triggerId}
-            role="menu"
+            aria-labelledby={isMenu ? triggerId : undefined}
+            role={isMenu ? 'menu' : undefined}
             className={clsx(classes.menu, isOpen && classes.open)}
           >
             {actions.map((action, index) =>
@@ -354,6 +364,7 @@ export const Popover = ({
                   key={index}
                   {...action}
                   {...focusProps}
+                  role={isMenu ? 'menuitem' : undefined}
                   onClick={(event) =>
                     handlePopoverItemClick(event, action.onClick)
                   }

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
@@ -61,10 +61,12 @@ export const baseArgs: TopNavigationProps = {
     label: 'Open profile menu',
     actions: [
       {
+        href: '/profile',
         onClick: action('View profile'),
         children: 'View profile',
       },
       {
+        href: '/settings',
         onClick: action('Settings'),
         children: 'Settings',
       },

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.spec.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.spec.tsx
@@ -64,7 +64,7 @@ describe('ProfileMenu', () => {
 
     render(<ProfileMenu {...baseProps} onToggle={onToggle} />);
 
-    const profileEl = screen.getByRole('button');
+    const profileEl = screen.getByRole('button', { name: /Jane Doe/i });
 
     await userEvent.click(profileEl);
 

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -132,6 +132,9 @@ export function ProfileMenu({
       fallbackPlacements={[]}
       offset={offset}
       className={className}
+      // This removes the default `menu` role of the Popover.
+      // eslint-disable-next-line jsx-a11y/aria-role
+      role={null}
     />
   );
 }


### PR DESCRIPTION
Addresses [DSYS-453](https://sumupteam.atlassian.net/browse/DSYS-453).

## Purpose

The TopNavigation's profile menu uses the Popover component under the hood. Its default [`menu`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/roles/menu_role) semantics aren't appropriate when used in the navigation.

## Approach and changes

- Add option to the Popover component to disable its menu semantics
- Disable the menu semantics for the profile menu

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
