### PR TITLE
Use value as React key in form field group components

### DIFF
--- a/.changeset/grumpy-items-trade.md
+++ b/.changeset/grumpy-items-trade.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Switched to using an option's `value` instead of its `label` as the [React key](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key) in the CheckboxGroup, RadioButtonGroup and SelectorGroup components.

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
@@ -183,7 +183,7 @@ export const CheckboxGroup = forwardRef(
         </FieldLegend>
         <ul className={classes.base}>
           {options.map((option) => (
-            <li key={option.label}>
+            <li key={option.value || option.label}>
               <Checkbox
                 {...option}
                 name={name}

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -180,7 +180,7 @@ export const RadioButtonGroup = forwardRef(
           {options.map((option) => (
             <RadioButton
               {...option}
-              key={option.label}
+              key={option.value?.toString() || option.label}
               name={name}
               onChange={onChange}
               onBlur={onBlur}

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -193,7 +193,7 @@ export const SelectorGroup = forwardRef<
             {options.map((option) => (
               <Selector
                 {...option}
-                key={option.label}
+                key={option.value || option.label}
                 className={clsx(classes.option, option.className)}
                 name={name}
                 onChange={onChange}


### PR DESCRIPTION
## Purpose

In rare cases, the label or a CheckboxGroup, RadioButtonGroup and SelectorGroup's option might be a ReactNode, which can't be properly stringified. Thanks, @davilima6, for the bug report!

## Approach and changes

- Prefer using `option.value` over `option.label` as the [React key](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
