### PR TITLE
Transpile ES modules for Jest in Next.js template

### DIFF
--- a/.changeset/fair-beds-hammer.md
+++ b/.changeset/fair-beds-hammer.md
@@ -1,0 +1,5 @@
+---
+"next-app": patch
+---
+
+Transpile optional Circuit UI dependencies in ESM format for Jest.

--- a/packages/cna-template/template/jest.config.js
+++ b/packages/cna-template/template/jest.config.js
@@ -1,6 +1,11 @@
 const nextJest = require('next/jest');
 
-const esModules = ['@sumup/circuit-ui', '@sumup/icons'].join('|');
+const esModules = [
+  '@sumup/circuit-ui',
+  '@sumup/icons',
+  '@nanostores/react',
+  'nanostores',
+].join('|');
 
 const createJestConfig = nextJest({ dir: './' });
 


### PR DESCRIPTION
## Purpose

Circuit UI v8.6 adds [nanostores](https://github.com/nanostores/nanostores) as a dependency for the experimental Tooltip component. The packages are pure ESM and need to be transpiled for Jest.

## Approach and changes

- Add `@nanostores/react` and `nanostores` to the list of ES modules to transpile for Jest

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
