### PR TITLE
Revert using the experimental Tooltip component in stable components

### DIFF
--- a/.changeset/lemon-pens-shop.md
+++ b/.changeset/lemon-pens-shop.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Reverted usage of the experimental Tooltip component in the IconButton, Pagination, and Table components. Testing the change in applications surfaced too many edge cases and conflicts. The changes will be re-applied in the next major release.

--- a/packages/circuit-ui/components/Button/IconButton.module.css
+++ b/packages/circuit-ui/components/Button/IconButton.module.css
@@ -1,3 +1,17 @@
+/* Visually hide the label */
+.base > span:last-child > span:last-child {
+  /* .hide-visually */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Sizes */
 .s {
   padding: calc(var(--cui-spacings-bit) - var(--cui-border-width-kilo));

--- a/packages/circuit-ui/components/Button/IconButton.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.tsx
@@ -13,13 +13,9 @@
  * limitations under the License.
  */
 
-'use client';
-
 import {
   Children,
   cloneElement,
-  forwardRef,
-  memo,
   type ForwardRefExoticComponent,
   type PropsWithoutRef,
   type ReactElement,
@@ -31,11 +27,9 @@ import { clsx } from '../../styles/clsx.js';
 import { CircuitError } from '../../util/errors.js';
 import { deprecate } from '../../util/logger.js';
 import { isString } from '../../util/type-check.js';
-import Tooltip from '../Tooltip/index.js';
 
 import {
   createButtonComponent,
-  CreateButtonComponentProps,
   legacyButtonSizeMap,
   type SharedButtonProps,
 } from './base.js';
@@ -62,83 +56,75 @@ export type IconButtonProps = SharedButtonProps & {
   icon?: IconComponentType;
 };
 
-// TODO: This factory function doesn't make much sense for the IconButton anymore. Refactor?
-const InnerIconButton = createButtonComponent<CreateButtonComponentProps>(
-  'IconButton',
-  (props) => props,
-);
-
 /**
  * The IconButton component enables the user to perform an action or navigate
  * to a different screen.
  */
 export const IconButton: ForwardRefExoticComponent<
   PropsWithoutRef<IconButtonProps> & RefAttributes<any>
-> = memo(
-  forwardRef<HTMLButtonElement, IconButtonProps>(
-    (
-      {
-        className,
-        icon: Icon,
-        size: legacySize = 'm',
-        label,
-        children,
-        ...props
-      },
-      ref,
-    ) => {
-      const size = legacyButtonSizeMap[legacySize] || legacySize;
+> = createButtonComponent<IconButtonProps>(
+  'IconButton',
+  ({
+    className,
+    icon: Icon,
+    label,
+    children,
+    size: legacySize = 'm',
+    ...props
+  }) => {
+    const size = legacyButtonSizeMap[legacySize] || legacySize;
 
-      if (
-        process.env.NODE_ENV !== 'production' &&
-        !Icon &&
-        Children.count(children) !== 1
-      ) {
-        throw new CircuitError('IconButton', 'The `icon` prop is missing.');
-      }
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      !Icon &&
+      Children.count(children) !== 1
+    ) {
+      throw new CircuitError('IconButton', 'The `icon` prop is missing.');
+    }
 
-      if (process.env.NODE_ENV !== 'production' && !isString(children)) {
-        deprecate(
-          'IconButton',
-          'The `children` prop has been deprecated for passing the icon. Use the `icon` prop instead.',
-        );
-      }
-
-      if (process.env.NODE_ENV !== 'production' && label) {
-        deprecate(
-          'IconButton',
-          'The `label` prop has been deprecated. Use the `children` prop instead.',
-        );
-      }
-
-      return (
-        <Tooltip
-          type="label"
-          label={isString(children) ? children : (label as string)}
-          component={(tooltipProps) => (
-            <InnerIconButton
-              {...props}
-              {...tooltipProps}
-              size={size}
-              className={clsx(classes[size], tooltipProps.className, className)}
-              icon={(iconProps) => {
-                if (Icon) {
-                  return <Icon {...iconProps} />;
-                }
-                const child = Children.only(children)!;
-                // TODO: Remove with the next major
-                if (isString(child)) {
-                  return null;
-                }
-                return cloneElement(child, iconProps);
-              }}
-              ref={ref}
-            />
-          )}
-        />
+    if (process.env.NODE_ENV !== 'production' && !isString(children)) {
+      deprecate(
+        'IconButton',
+        'The `children` prop has been deprecated for passing the icon. Use the `icon` prop instead.',
       );
-    },
-  ),
+    }
+
+    if (process.env.NODE_ENV !== 'production' && label) {
+      deprecate(
+        'IconButton',
+        'The `label` prop has been deprecated. Use the `children` prop instead.',
+      );
+    }
+
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      legacyButtonSizeMap[legacySize]
+    ) {
+      deprecate(
+        'IconButton',
+        `The \`${legacySize}\` size has been deprecated. Use the \`${legacyButtonSizeMap[legacySize]}\` size instead.`,
+      );
+    }
+
+    return {
+      className: clsx(classes.base, classes[size], className),
+      icon: (iconProps) => {
+        if (Icon) {
+          return <Icon {...iconProps} />;
+        }
+        const child = Children.only(children)!;
+        // TODO: Remove with the next major
+        if (isString(child)) {
+          return null;
+        }
+        return cloneElement(child, iconProps);
+      },
+      size,
+      children: isString(children) ? children : label,
+      title: isString(children) ? children : label,
+      ...props,
+    };
+  },
 );
 
 IconButton.displayName = 'IconButton';

--- a/packages/circuit-ui/components/Button/base.tsx
+++ b/packages/circuit-ui/components/Button/base.tsx
@@ -97,7 +97,7 @@ export type CreateButtonComponentProps = SharedButtonProps & {
    * with the button. Use one strong, clear imperative verb and follow with a
    * one-word object if needed to clarify.
    */
-  children?: ReactNode;
+  children: ReactNode;
   /**
    * Choose from 2 sizes. Default: 'm'.
    */
@@ -124,7 +124,7 @@ export const legacyButtonSizeMap: Record<string, 's' | 'm'> = {
 
 export function createButtonComponent<Props>(
   componentName: string,
-  // TODO: Refactor to `mapClassName` once the deprecations have been removed?
+  // TODO: Refactor to `mapClassName` once the deprecations have been removed.
   mapProps: (props: Props) => CreateButtonComponentProps,
 ) {
   const Button = forwardRef<any, Props>((props, ref) => {
@@ -222,7 +222,7 @@ export function createButtonComponent<Props>(
               height={leadingIconSize}
             />
           )}
-          {children && <span className={classes.label}>{children}</span>}
+          <span className={classes.label}>{children}</span>
           {TrailingIcon && (
             <TrailingIcon
               aria-hidden="true"

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -283,9 +283,7 @@ export const ImageInput = ({
             disabled={isLoading || disabled}
             className={clsx(classes.button, classes.add)}
             icon={Plus}
-          >
-            +
-          </IconButton>
+          />
         )}
         <Spinner
           className={clsx(classes.spinner, isLoading && classes.loading)}

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
@@ -93,7 +93,7 @@ describe('NotificationToast', () => {
       expect(screen.getByText('This is a toast message')).toBeVisible();
     });
 
-    const closeButton = screen.getByLabelText('Close');
+    const closeButton = screen.getByText('Close');
 
     await userEvent.click(closeButton);
 

--- a/packages/circuit-ui/components/Pagination/Pagination.spec.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.spec.tsx
@@ -32,14 +32,14 @@ describe('Pagination', () => {
 
   it('should disable the previous button on the first page', () => {
     render(<Pagination {...baseProps} currentPage={1} />);
-    const prevButtonEl = screen.getByLabelText('Previous');
+    const prevButtonEl = screen.getByText('Previous').closest('button');
 
     expect(prevButtonEl).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('should disable the next button on the last page', () => {
     render(<Pagination {...baseProps} currentPage={baseProps.totalPages} />);
-    const nextButtonEl = screen.getByLabelText('Next');
+    const nextButtonEl = screen.getByText('Next').closest('button');
 
     expect(nextButtonEl).toHaveAttribute('aria-disabled', 'true');
   });
@@ -48,7 +48,7 @@ describe('Pagination', () => {
     const onChange = vi.fn();
     render(<Pagination {...baseProps} onChange={onChange} currentPage={3} />);
 
-    const prevButtonEl = screen.getByLabelText('Previous');
+    const prevButtonEl = screen.getByText('Previous');
 
     await userEvent.click(prevButtonEl);
 
@@ -60,7 +60,7 @@ describe('Pagination', () => {
     const onChange = vi.fn();
     render(<Pagination {...baseProps} onChange={onChange} />);
 
-    const nextButtonEl = screen.getByLabelText('Next');
+    const nextButtonEl = screen.getByText('Next');
 
     await userEvent.click(nextButtonEl);
 

--- a/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
@@ -17,9 +17,8 @@
 
 import type { FC, OlHTMLAttributes } from 'react';
 
-import { clsx } from '../../../../styles/clsx.js';
 import Button from '../../../Button/index.js';
-import Tooltip from '../../../Tooltip/index.js';
+import { clsx } from '../../../../styles/clsx.js';
 
 import classes from './PageList.module.css';
 
@@ -36,31 +35,27 @@ export const PageList: FC<PageListProps> = ({
   pageLabel,
   pages,
   currentPage,
+  className,
   ...props
 }: PageListProps): JSX.Element => (
   // eslint-disable-next-line jsx-a11y/no-redundant-roles
-  <ol role="list" className={classes.base} {...props}>
+  <ol role="list" className={clsx(classes.base, className)} {...props}>
     {pages.map((page) => {
       const isCurrent = currentPage === page;
       const label = pageLabel(page);
       return (
         <li key={page}>
-          <Tooltip
-            type="description"
-            label={label}
-            component={(tooltipProps) => (
-              <Button
-                {...tooltipProps}
-                size="s"
-                onClick={() => onChange(page)}
-                variant={isCurrent ? 'primary' : 'tertiary'}
-                aria-current={isCurrent}
-                className={clsx(tooltipProps.className, classes.button)}
-              >
-                {page}
-              </Button>
-            )}
-          />
+          <Button
+            size="s"
+            onClick={() => onChange(page)}
+            variant={isCurrent ? 'primary' : 'tertiary'}
+            title={label}
+            aria-label={label}
+            aria-current={isCurrent}
+            className={classes.button}
+          >
+            {page}
+          </Button>
         </li>
       );
     })}

--- a/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
@@ -73,7 +73,7 @@ describe('SidePanel', () => {
     const onClose = vi.fn();
     renderComponent({ onClose });
 
-    await userEvent.click(screen.getByLabelText(baseProps.closeButtonLabel));
+    await userEvent.click(screen.getByTitle(baseProps.closeButtonLabel));
 
     expect(onClose).toHaveBeenCalled();
   });
@@ -123,7 +123,7 @@ describe('SidePanel', () => {
       renderComponent({ isStacked: true, onBack });
 
       expect(
-        screen.getByLabelText(baseProps.backButtonLabel as string),
+        screen.getByTitle(baseProps.backButtonLabel as string),
       ).toBeVisible();
     });
 
@@ -132,7 +132,7 @@ describe('SidePanel', () => {
       renderComponent({ isStacked: true, onBack });
 
       await userEvent.click(
-        screen.getByLabelText(baseProps.backButtonLabel as string),
+        screen.getByTitle(baseProps.backButtonLabel as string),
       );
 
       expect(onBack).toHaveBeenCalled();

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.spec.tsx
@@ -42,7 +42,7 @@ describe('Header', () => {
     const onClose = vi.fn();
     renderComponent({ onClose });
 
-    await userEvent.click(screen.getByLabelText(baseProps.closeButtonLabel));
+    await userEvent.click(screen.getByTitle(baseProps.closeButtonLabel));
 
     expect(onClose).toHaveBeenCalled();
   });
@@ -53,7 +53,7 @@ describe('Header', () => {
       onBack,
     });
 
-    expect(screen.getByLabelText(baseProps.backButtonLabel)).toBeVisible();
+    expect(screen.getByTitle(baseProps.backButtonLabel)).toBeVisible();
   });
 
   it('should call the onBack callback from the back button', async () => {
@@ -62,7 +62,7 @@ describe('Header', () => {
       onBack,
     });
 
-    await userEvent.click(screen.getByLabelText(baseProps.backButtonLabel));
+    await userEvent.click(screen.getByTitle(baseProps.backButtonLabel));
 
     expect(onBack).toHaveBeenCalled();
   });

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.spec.tsx
@@ -41,8 +41,8 @@ describe('SortArrow', () => {
 
   it('should call the onClick callback', async () => {
     const onClick = vi.fn();
-    render(<SortArrow label="Sort" onClick={onClick} />);
-    await userEvent.click(screen.getByRole('button'));
+    render(<SortArrow label="Sort" onClick={onClick} data-testid="sort" />);
+    await userEvent.click(screen.getByTestId('sort'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
@@ -20,7 +20,7 @@ import { ChevronUp, ChevronDown } from '@sumup/icons';
 
 import type { Direction } from '../../types.js';
 import { clsx } from '../../../../styles/clsx.js';
-import Tooltip from '../../../Tooltip/index.js';
+import utilityClasses from '../../../../styles/utility.js';
 
 import classes from './SortArrow.module.css';
 
@@ -32,29 +32,21 @@ interface SortArrowProps extends HTMLAttributes<HTMLButtonElement> {
 /**
  * SortArrow for the Table component. The Table handles rendering it.
  */
-export function SortArrow({ label, direction, onClick }: SortArrowProps) {
+export function SortArrow({
+  label,
+  direction,
+  className,
+  ...props
+}: SortArrowProps) {
   return (
-    <Tooltip
-      type="label"
-      label={label}
-      component={(props) => (
-        <button
-          {...props}
-          className={clsx(classes.base, props.className)}
-          onClick={onClick}
-        >
-          {direction !== 'ascending' && (
-            <ChevronUp size="16" aria-hidden="true" className={classes.icon} />
-          )}
-          {direction !== 'descending' && (
-            <ChevronDown
-              size="16"
-              aria-hidden="true"
-              className={classes.icon}
-            />
-          )}
-        </button>
+    <button title={label} className={clsx(classes.base, className)} {...props}>
+      {direction !== 'ascending' && (
+        <ChevronUp size="16" aria-hidden="true" className={classes.icon} />
       )}
-    />
+      {direction !== 'descending' && (
+        <ChevronDown size="16" aria-hidden="true" className={classes.icon} />
+      )}
+      <span className={utilityClasses.hideVisually}>{label}</span>
+    </button>
   );
 }

--- a/packages/circuit-ui/components/Tag/Tag.spec.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.spec.tsx
@@ -51,7 +51,7 @@ describe('Tag', () => {
       </Tag>,
     );
 
-    await userEvent.click(screen.getByLabelText('Remove'));
+    await userEvent.click(screen.getByText('Remove'));
 
     expect(onRemove).toHaveBeenCalledTimes(1);
   });

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -71,10 +71,7 @@ type RemoveProps =
   | { onRemove?: never; removeButtonLabel?: never };
 
 type DivElProps = Omit<HTMLAttributes<HTMLDivElement>, 'onClick' | 'prefix'>;
-type LinkElProps = Omit<
-  AnchorHTMLAttributes<HTMLAnchorElement>,
-  'onClick' | 'prefix'
->;
+type LinkElProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'>;
 type ButtonElProps = Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
   'onClick' | 'prefix'

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -65,13 +65,29 @@ Base.play = showTooltip;
 
 export const Types = (args: TooltipProps) => (
   <Stack>
-    {/* The IconButton uses the Tooltip component under the hood */}
-    <IconButton icon={TransferOut}>Transfer out</IconButton>
-    <Tooltip {...args} />
+    <Tooltip
+      {...args}
+      type="label"
+      label="Transfer out"
+      component={(props) => (
+        <IconButton {...props} icon={TransferOut} title={undefined}>
+          Transfer out
+        </IconButton>
+      )}
+    />
+    <Tooltip
+      {...args}
+      type="description"
+      label="This may take a few minutes"
+      component={(props) => (
+        <Button {...props} icon={UploadCloud}>
+          Upload
+        </Button>
+      )}
+    />
   </Stack>
 );
 
-Types.args = descriptionProps;
 Types.play = showTooltip;
 
 export const Placements = (args: TooltipProps) => (


### PR DESCRIPTION
This reverts some commits from #2393.

## Purpose

Using the experimental Tooltip component in stable components has turned out to be a mistake. Especially the widely-used IconButton has surfaced many edge cases and clashes with existing custom tooltips.

## Approach and changes

- Revert usage of the experimental Tooltip component in the IconButton, Pagination, and Table components

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
