### PR TITLE
Improve tree-shaking using the verbatimModuleSyntax flag

### DIFF
--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -17,16 +17,16 @@
 
 import {
   forwardRef,
-  AnchorHTMLAttributes,
-  ButtonHTMLAttributes,
-  ReactNode,
-  Ref,
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+  type Ref,
 } from 'react';
 
 import type { ReturnType } from '../../types/return-type.js';
 import type { ClickEvent } from '../../types/events.js';
 import type { AsPropType } from '../../types/prop-types.js';
-import { Body, BodyProps } from '../Body/Body.js';
+import { Body, type BodyProps } from '../Body/Body.js';
 import { useComponents } from '../ComponentsContext/index.js';
 import { clsx } from '../../styles/clsx.js';
 import utilityClasses from '../../styles/utility.js';

--- a/packages/circuit-ui/components/AspectRatio/AspectRatio.tsx
+++ b/packages/circuit-ui/components/AspectRatio/AspectRatio.tsx
@@ -17,8 +17,8 @@ import {
   Children,
   forwardRef,
   cloneElement,
-  ReactElement,
-  HTMLAttributes,
+  type ReactElement,
+  type HTMLAttributes,
 } from 'react';
 
 import { clsx } from '../../styles/clsx.js';

--- a/packages/circuit-ui/components/Avatar/Avatar.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ImgHTMLAttributes } from 'react';
+import type { ImgHTMLAttributes } from 'react';
 import { Profile, Image as ImageIcon } from '@sumup/icons';
 
 import { CircuitError } from '../../util/errors.js';

--- a/packages/circuit-ui/components/Badge/Badge.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 import type { AsPropType } from '../../types/prop-types.js';
 import { clsx } from '../../styles/clsx.js';

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { forwardRef, HTMLAttributes } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 import type { AsPropType } from '../../types/prop-types.js';
 import { clsx } from '../../styles/clsx.js';

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { forwardRef, HTMLAttributes, Ref } from 'react';
+import { forwardRef, type HTMLAttributes, type Ref } from 'react';
 
 import type { AsPropType } from '../../types/prop-types.js';
 import { clsx } from '../../styles/clsx.js';

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -27,9 +27,9 @@ import { deprecate } from '../../util/logger.js';
 
 import classes from './Button.module.css';
 import {
-  SharedButtonProps,
   createButtonComponent,
   legacyButtonSizeMap,
+  type SharedButtonProps,
 } from './base.js';
 
 export type ButtonProps = SharedButtonProps & {

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { forwardRef, HTMLAttributes } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
-import Button, { ButtonProps } from '../Button/index.js';
+import Button, { type ButtonProps } from '../Button/index.js';
 import { clsx } from '../../styles/clsx.js';
 import { deprecate } from '../../util/logger.js';
 

--- a/packages/circuit-ui/components/Card/Card.tsx
+++ b/packages/circuit-ui/components/Card/Card.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
 import type { AsPropType } from '../../types/prop-types.js';

--- a/packages/circuit-ui/components/Card/components/Footer/Footer.tsx
+++ b/packages/circuit-ui/components/Card/components/Footer/Footer.tsx
@@ -13,21 +13,7 @@
  * limitations under the License.
  */
 
-/**
- * Copyright 2019, SumUp Ltd.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../../../styles/clsx.js';
 import type { AsPropType } from '../../../../types/prop-types.js';

--- a/packages/circuit-ui/components/Card/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Card/components/Header/Header.tsx
@@ -15,7 +15,7 @@
 
 'use client';
 
-import { ReactNode, HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type ReactNode, type HTMLAttributes } from 'react';
 
 import type { ClickEvent } from '../../../../types/events.js';
 import CloseButton from '../../../CloseButton/index.js';

--- a/packages/circuit-ui/components/Carousel/Carousel.tsx
+++ b/packages/circuit-ui/components/Carousel/Carousel.tsx
@@ -15,14 +15,14 @@
 
 'use client';
 
-import { ReactNode, useRef, useState } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
 
 import ProgressBar from '../ProgressBar/index.js';
 import Step from '../Step/index.js';
 import { useComponentSize } from '../../hooks/useComponentSize/index.js';
-import { ImageProps } from '../Image/index.js';
+import type { ImageProps } from '../Image/index.js';
 import { isFunction } from '../../util/type-check.js';
-import { Actions, State } from '../Step/types.js';
+import type { Actions, State } from '../Step/types.js';
 
 import { Container } from './components/Container/index.js';
 import { Slides } from './components/Slides/index.js';

--- a/packages/circuit-ui/components/Carousel/components/Buttons/Buttons.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Buttons/Buttons.tsx
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
 import { ChevronLeft, ChevronRight, Pause, Play } from '@sumup/icons';
 
-import { IconButton, IconButtonProps } from '../../../Button/index.js';
+import { IconButton, type IconButtonProps } from '../../../Button/index.js';
 import { clsx } from '../../../../styles/clsx.js';
 
 import classes from './Buttons.module.css';

--- a/packages/circuit-ui/components/Carousel/components/Slides/Slides.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Slides/Slides.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../../../styles/clsx.js';
 

--- a/packages/circuit-ui/components/Carousel/components/Status/Status.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Status/Status.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import Body, { BodyProps } from '../../../Body/index.js';
+import Body, { type BodyProps } from '../../../Body/index.js';
 import { clsx } from '../../../../styles/clsx.js';
 
 import classes from './Status.module.css';

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -16,11 +16,11 @@
 'use client';
 
 import {
-  InputHTMLAttributes,
   forwardRef,
   useEffect,
   useId,
   useRef,
+  type InputHTMLAttributes,
 } from 'react';
 import { Checkmark } from '@sumup/icons';
 

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
@@ -16,14 +16,14 @@
 'use client';
 
 import {
-  FieldsetHTMLAttributes,
-  InputHTMLAttributes,
-  Ref,
   forwardRef,
   useId,
+  type FieldsetHTMLAttributes,
+  type InputHTMLAttributes,
+  type Ref,
 } from 'react';
 
-import { Checkbox, CheckboxProps } from '../Checkbox/Checkbox.js';
+import { Checkbox, type CheckboxProps } from '../Checkbox/Checkbox.js';
 import {
   FieldLabelText,
   FieldValidationHint,

--- a/packages/circuit-ui/components/CloseButton/CloseButton.tsx
+++ b/packages/circuit-ui/components/CloseButton/CloseButton.tsx
@@ -16,7 +16,7 @@
 import { forwardRef } from 'react';
 import { Close } from '@sumup/icons';
 
-import { IconButton, IconButtonProps } from '../Button/IconButton.js';
+import { IconButton, type IconButtonProps } from '../Button/IconButton.js';
 
 export type CloseButtonProps = Omit<IconButtonProps, 'icon'>;
 

--- a/packages/circuit-ui/components/ComponentsContext/ComponentsContext.ts
+++ b/packages/circuit-ui/components/ComponentsContext/ComponentsContext.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { ComponentType, createContext } from 'react';
+import { createContext, type ComponentType } from 'react';
 
-import { Link, LinkProps } from './components/Link/index.js';
+import { Link, type LinkProps } from './components/Link/index.js';
 
 export const defaultComponents = { Link };
 

--- a/packages/circuit-ui/components/ComponentsContext/components/Link/Link.tsx
+++ b/packages/circuit-ui/components/ComponentsContext/components/Link/Link.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { forwardRef, AnchorHTMLAttributes, Ref } from 'react';
+import { forwardRef, type AnchorHTMLAttributes, type Ref } from 'react';
 
 export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   ref?: Ref<HTMLAnchorElement>;

--- a/packages/circuit-ui/components/ComponentsContext/useComponents.ts
+++ b/packages/circuit-ui/components/ComponentsContext/useComponents.ts
@@ -16,9 +16,9 @@
 import { useContext } from 'react';
 
 import {
-  ComponentsContext,
-  ComponentsContextType,
   defaultComponents,
+  ComponentsContext,
+  type ComponentsContextType,
 } from './ComponentsContext.js';
 
 /**

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -17,10 +17,10 @@
 
 import { forwardRef, useId } from 'react';
 import { resolveCurrencyFormat } from '@sumup/intl';
-import { NumericFormat, NumericFormatProps } from 'react-number-format';
+import { NumericFormat, type NumericFormatProps } from 'react-number-format';
 
 import { clsx } from '../../styles/clsx.js';
-import Input, { InputElement, InputProps } from '../Input/index.js';
+import Input, { type InputElement, type InputProps } from '../Input/index.js';
 
 import { formatPlaceholder } from './CurrencyInputService.js';
 import classes from './CurrencyInput.module.css';

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -18,7 +18,7 @@
 import { forwardRef, useState, useEffect } from 'react';
 import { PatternFormat } from 'react-number-format';
 
-import Input, { InputElement, InputProps } from '../Input/index.js';
+import Input, { type InputElement, type InputProps } from '../Input/index.js';
 import { clsx } from '../../styles/clsx.js';
 
 import classes from './DateInput.module.css';

--- a/packages/circuit-ui/components/Field/Field.tsx
+++ b/packages/circuit-ui/components/Field/Field.tsx
@@ -14,10 +14,10 @@
  */
 
 import {
-  FieldsetHTMLAttributes,
-  HTMLAttributes,
-  LabelHTMLAttributes,
   forwardRef,
+  type FieldsetHTMLAttributes,
+  type HTMLAttributes,
+  type LabelHTMLAttributes,
 } from 'react';
 import { Confirm, Notify, Alert } from '@sumup/icons';
 

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -18,7 +18,7 @@
 import { forwardRef } from 'react';
 
 import { legacyButtonSizeMap } from '../Button/index.js';
-import { IconButton, IconButtonProps } from '../Button/IconButton.js';
+import { IconButton, type IconButtonProps } from '../Button/IconButton.js';
 import { Skeleton } from '../Skeleton/index.js';
 import {
   AccessibilityError,

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
 import { CircuitError } from '../../util/errors.js';

--- a/packages/circuit-ui/components/Hr/Hr.tsx
+++ b/packages/circuit-ui/components/Hr/Hr.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 import type { AsPropType } from '../../types/prop-types.js';
 import { clsx } from '../../styles/clsx.js';

--- a/packages/circuit-ui/components/Image/Image.tsx
+++ b/packages/circuit-ui/components/Image/Image.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ImgHTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type ImgHTMLAttributes } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
 

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -18,16 +18,16 @@
 import {
   useState,
   useRef,
-  InputHTMLAttributes,
-  ChangeEvent,
-  ClipboardEvent,
-  DragEvent,
   useId,
-  ComponentType,
+  type InputHTMLAttributes,
+  type ChangeEvent,
+  type ClipboardEvent,
+  type DragEvent,
+  type ComponentType,
 } from 'react';
 import { Delete, Plus } from '@sumup/icons';
 
-import { ClickEvent } from '../../types/events.js';
+import type { ClickEvent } from '../../types/events.js';
 import utilityClasses from '../../styles/utility.js';
 import {
   FieldWrapper,

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -16,11 +16,11 @@
 'use client';
 
 import {
-  ComponentType,
   forwardRef,
-  InputHTMLAttributes,
-  TextareaHTMLAttributes,
   useId,
+  type ComponentType,
+  type InputHTMLAttributes,
+  type TextareaHTMLAttributes,
 } from 'react';
 
 import {
@@ -29,7 +29,7 @@ import {
   FieldLabelText,
   FieldValidationHint,
 } from '../Field/index.js';
-import { ReturnType } from '../../types/return-type.js';
+import type { ReturnType } from '../../types/return-type.js';
 import {
   AccessibilityError,
   isSufficientlyLabelled,

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { forwardRef, OlHTMLAttributes } from 'react';
+import { forwardRef, type OlHTMLAttributes } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
 

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -16,13 +16,13 @@
 'use client';
 
 import {
-  ReactNode,
   forwardRef,
-  ButtonHTMLAttributes,
-  AnchorHTMLAttributes,
-  HTMLAttributes,
+  type ReactNode,
+  type ButtonHTMLAttributes,
+  type AnchorHTMLAttributes,
+  type HTMLAttributes,
 } from 'react';
-import { ChevronRight, IconComponentType } from '@sumup/icons';
+import { ChevronRight, type IconComponentType } from '@sumup/icons';
 
 import type { ClickEvent } from '../../types/events.js';
 import type { AsPropType } from '../../types/prop-types.js';

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
@@ -15,11 +15,16 @@
 
 'use client';
 
-import { forwardRef, HTMLAttributes, ReactNode, useState } from 'react';
+import {
+  forwardRef,
+  useState,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
 
 import { AccessibilityError } from '../../util/errors.js';
 import Body from '../Body/index.js';
-import ListItem, { ListItemProps } from '../ListItem/index.js';
+import ListItem, { type ListItemProps } from '../ListItem/index.js';
 import { isString } from '../../util/type-check.js';
 import { clsx } from '../../styles/clsx.js';
 import utilityClasses from '../../styles/utility.js';

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -15,14 +15,14 @@
 
 'use client';
 
-import { HTMLAttributes, ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import ReactModal from 'react-modal';
 
 import { isFunction } from '../../util/type-check.js';
 import {
-  ModalComponent,
-  BaseModalProps,
   createUseModal,
+  type ModalComponent,
+  type BaseModalProps,
 } from '../ModalContext/index.js';
 import CloseButton from '../CloseButton/index.js';
 import { StackContext } from '../StackContext/index.js';

--- a/packages/circuit-ui/components/ModalContext/ModalContext.tsx
+++ b/packages/circuit-ui/components/ModalContext/ModalContext.tsx
@@ -19,15 +19,15 @@ import {
   createContext,
   useEffect,
   useCallback,
-  ReactNode,
   useMemo,
+  type ReactNode,
 } from 'react';
-import ReactModal, { Props as ReactModalProps } from 'react-modal';
+import ReactModal, { type Props as ReactModalProps } from 'react-modal';
 
-import { useStack, StackItem } from '../../hooks/useStack/index.js';
+import { useStack, type StackItem } from '../../hooks/useStack/index.js';
 import { warn } from '../../util/logger.js';
 
-import { BaseModalProps, ModalComponent } from './types.js';
+import type { BaseModalProps, ModalComponent } from './types.js';
 import './Modal.css';
 
 const PORTAL_CLASS_NAME = 'cui-modal-portal';

--- a/packages/circuit-ui/components/ModalContext/types.ts
+++ b/packages/circuit-ui/components/ModalContext/types.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { Props as ReactModalProps } from 'react-modal';
+import type { Props as ReactModalProps } from 'react-modal';
 
-import { ClickEvent } from '../../types/events.js';
+import type { ClickEvent } from '../../types/events.js';
 
 type OnClose = (event?: ClickEvent) => void;
 

--- a/packages/circuit-ui/components/Notification/constants.ts
+++ b/packages/circuit-ui/components/Notification/constants.ts
@@ -13,7 +13,13 @@
  * limitations under the License.
  */
 
-import { Alert, Confirm, IconComponentType, Info, Notify } from '@sumup/icons';
+import {
+  Alert,
+  Confirm,
+  Info,
+  Notify,
+  type IconComponentType,
+} from '@sumup/icons';
 
 export type NotificationVariant = 'info' | 'success' | 'warning' | 'danger';
 

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -16,20 +16,20 @@
 'use client';
 
 import {
-  MouseEvent,
-  KeyboardEvent,
-  useState,
-  useRef,
-  RefObject,
-  useEffect,
-  HTMLAttributes,
   forwardRef,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+  type KeyboardEvent,
+  type RefObject,
+  type HTMLAttributes,
 } from 'react';
 
-import Button, { ButtonProps } from '../Button/index.js';
+import Button, { type ButtonProps } from '../Button/index.js';
 import Headline from '../Headline/index.js';
 import Body from '../Body/index.js';
-import Image, { ImageProps } from '../Image/index.js';
+import Image, { type ImageProps } from '../Image/index.js';
 import CloseButton from '../CloseButton/index.js';
 import { useAnimation } from '../../hooks/useAnimation/index.js';
 import { applyMultipleRefs } from '../../util/refs.js';

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
@@ -13,12 +13,18 @@
  * limitations under the License.
  */
 
-import { FC, HTMLAttributes, ReactNode, SVGProps, forwardRef } from 'react';
+import {
+  forwardRef,
+  type FC,
+  type HTMLAttributes,
+  type ReactNode,
+  type SVGProps,
+} from 'react';
 
 import Body from '../Body/index.js';
 import Headline from '../Headline/index.js';
-import ButtonGroup, { ButtonGroupProps } from '../ButtonGroup/index.js';
-import Image, { ImageProps } from '../Image/index.js';
+import ButtonGroup, { type ButtonGroupProps } from '../ButtonGroup/index.js';
+import Image, { type ImageProps } from '../Image/index.js';
 import { isString } from '../../util/type-check.js';
 import { clsx } from '../../styles/clsx.js';
 

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -16,25 +16,25 @@
 'use client';
 
 import {
-  ForwardRefExoticComponent,
-  HTMLAttributes,
-  RefAttributes,
-  RefObject,
   forwardRef,
   useEffect,
   useRef,
   useState,
+  type ForwardRefExoticComponent,
+  type HTMLAttributes,
+  type RefAttributes,
+  type RefObject,
 } from 'react';
 
 import { useAnimation } from '../../hooks/useAnimation/index.js';
 import Body from '../Body/index.js';
 import CloseButton from '../CloseButton/index.js';
-import Anchor, { AnchorProps } from '../Anchor/index.js';
-import { ClickEvent } from '../../types/events.js';
+import Anchor, { type AnchorProps } from '../Anchor/index.js';
+import type { ClickEvent } from '../../types/events.js';
 import { isString } from '../../util/type-check.js';
 import {
   NOTIFICATION_ICONS,
-  NotificationVariant,
+  type NotificationVariant,
 } from '../Notification/constants.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { clsx } from '../../styles/clsx.js';

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
@@ -15,16 +15,16 @@
 
 'use client';
 
-import { FC, ReactNode, SVGProps } from 'react';
+import type { FC, ReactNode, SVGProps } from 'react';
 import ReactModal from 'react-modal';
 
-import { ClickEvent } from '../../types/events.js';
-import { ModalComponent, BaseModalProps } from '../ModalContext/index.js';
-import Image, { ImageProps } from '../Image/index.js';
+import type { ClickEvent } from '../../types/events.js';
+import type { ModalComponent, BaseModalProps } from '../ModalContext/index.js';
+import Image, { type ImageProps } from '../Image/index.js';
 import Headline from '../Headline/index.js';
 import Body from '../Body/index.js';
-import { ButtonProps } from '../Button/index.js';
-import ButtonGroup, { ButtonGroupProps } from '../ButtonGroup/index.js';
+import type { ButtonProps } from '../Button/index.js';
+import ButtonGroup, { type ButtonGroupProps } from '../ButtonGroup/index.js';
 import CloseButton from '../CloseButton/index.js';
 import { CircuitError } from '../../util/errors.js';
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -15,18 +15,24 @@
 
 'use client';
 
-import { HTMLAttributes, RefObject, useEffect, useRef, useState } from 'react';
+import {
+  useEffect,
+  useRef,
+  useState,
+  type HTMLAttributes,
+  type RefObject,
+} from 'react';
 
 import { useAnimation } from '../../hooks/useAnimation/index.js';
 import Body from '../Body/index.js';
 import CloseButton from '../CloseButton/index.js';
-import { ClickEvent } from '../../types/events.js';
-import { BaseToastProps, createUseToast } from '../ToastContext/index.js';
+import type { ClickEvent } from '../../types/events.js';
+import { type BaseToastProps, createUseToast } from '../ToastContext/index.js';
 import utilityClasses from '../../styles/utility.js';
 import { clsx } from '../../styles/clsx.js';
 import {
   NOTIFICATION_ICONS,
-  NotificationVariant,
+  type NotificationVariant,
 } from '../Notification/constants.js';
 
 import classes from './NotificationToast.module.css';

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -15,7 +15,7 @@
 
 'use client';
 
-import { HTMLAttributes, ReactElement } from 'react';
+import type { HTMLAttributes, ReactElement } from 'react';
 import { ChevronLeft, ChevronRight } from '@sumup/icons';
 
 import { IconButton } from '../Button/index.js';

--- a/packages/circuit-ui/components/Pagination/components/PageSelect/PageSelect.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageSelect/PageSelect.tsx
@@ -16,14 +16,14 @@
 'use client';
 
 import {
-  useCallback,
-  FunctionComponent,
-  ChangeEvent,
   Fragment,
+  useCallback,
   useId,
+  type FunctionComponent,
+  type ChangeEvent,
 } from 'react';
 
-import Select, { SelectProps } from '../../../Select/index.js';
+import Select, { type SelectProps } from '../../../Select/index.js';
 
 import classes from './PageSelect.module.css';
 

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
@@ -17,10 +17,10 @@
 
 import { forwardRef, useId } from 'react';
 import { resolveNumberFormat } from '@sumup/intl';
-import { NumericFormat, NumericFormatProps } from 'react-number-format';
+import { NumericFormat, type NumericFormatProps } from 'react-number-format';
 
 import { clsx } from '../../styles/clsx.js';
-import Input, { InputElement, InputProps } from '../Input/index.js';
+import Input, { type InputElement, type InputProps } from '../Input/index.js';
 
 import { formatPlaceholder } from './PercentageInputService.js';
 import classes from './PercentageInput.module.css';

--- a/packages/circuit-ui/components/Portal/Portal.ts
+++ b/packages/circuit-ui/components/Portal/Portal.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ReactNode, useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 export interface PortalProps {

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes, useId } from 'react';
+import { useId, type HTMLAttributes } from 'react';
 
-import { ReturnType } from '../../types/return-type.js';
+import type { ReturnType } from '../../types/return-type.js';
 import {
   AccessibilityError,
   isSufficientlyLabelled,

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -17,10 +17,10 @@
 
 import {
   createContext,
-  InputHTMLAttributes,
   forwardRef,
   useContext,
   useId,
+  type InputHTMLAttributes,
 } from 'react';
 
 import {

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -16,17 +16,17 @@
 'use client';
 
 import {
-  FieldsetHTMLAttributes,
-  InputHTMLAttributes,
-  Ref,
   forwardRef,
   useId,
+  type FieldsetHTMLAttributes,
+  type InputHTMLAttributes,
+  type Ref,
 } from 'react';
 
 import {
   RadioButton,
   RadioButtonGroupContext,
-  RadioButtonProps,
+  type RadioButtonProps,
 } from '../RadioButton/RadioButton.js';
 import {
   FieldLabelText,

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -14,15 +14,15 @@
  */
 
 import {
-  ComponentType,
-  ReactNode,
-  SelectHTMLAttributes,
   forwardRef,
   useId,
+  type ComponentType,
+  type ReactNode,
+  type SelectHTMLAttributes,
 } from 'react';
 import { ChevronDown } from '@sumup/icons';
 
-import { ReturnType } from '../../types/return-type.js';
+import type { ReturnType } from '../../types/return-type.js';
 import {
   FieldWrapper,
   FieldLabel,

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -16,13 +16,13 @@
 'use client';
 
 import {
-  ComponentType,
   Fragment,
-  InputHTMLAttributes,
   createContext,
   forwardRef,
   useContext,
   useId,
+  type ComponentType,
+  type InputHTMLAttributes,
 } from 'react';
 
 import {

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -15,13 +15,13 @@
 
 'use client';
 
-import { forwardRef, FieldsetHTMLAttributes, useId } from 'react';
+import { forwardRef, useId, type FieldsetHTMLAttributes } from 'react';
 
 import {
   Selector,
   SelectorGroupContext,
-  SelectorProps,
-  SelectorSize,
+  type SelectorProps,
+  type SelectorSize,
 } from '../Selector/Selector.js';
 import {
   AccessibilityError,

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
@@ -25,10 +25,10 @@ import {
 import { usePrevious } from '../../hooks/usePrevious/index.js';
 
 import { DesktopNavigation } from './components/DesktopNavigation/index.js';
-import { DesktopNavigationProps } from './components/DesktopNavigation/DesktopNavigation.js';
+import type { DesktopNavigationProps } from './components/DesktopNavigation/DesktopNavigation.js';
 import {
-  MobileNavigationProps,
   useMobileNavigation,
+  type MobileNavigationProps,
 } from './components/MobileNavigation/index.js';
 
 export interface SideNavigationProps

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -22,7 +22,7 @@ import { clsx } from '../../../../styles/clsx.js';
 import { useFocusList } from '../../../../hooks/useFocusList/index.js';
 import Headline from '../../../Headline/index.js';
 import { Skeleton, SkeletonContainer } from '../../../Skeleton/index.js';
-import { PrimaryLinkProps } from '../../types.js';
+import type { PrimaryLinkProps } from '../../types.js';
 import { SecondaryLinks } from '../SecondaryLinks/index.js';
 import { PrimaryLink } from '../PrimaryLink/index.js';
 

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
@@ -20,22 +20,22 @@ import ReactModal from 'react-modal';
 import { ChevronDown } from '@sumup/icons';
 
 import {
-  BaseModalProps,
   createUseModal,
-  ModalComponent,
+  type BaseModalProps,
+  type ModalComponent,
 } from '../../../ModalContext/index.js';
 import { StackContext } from '../../../StackContext/index.js';
 import CloseButton from '../../../CloseButton/index.js';
 import { useCollapsible } from '../../../../hooks/useCollapsible/index.js';
 import { useFocusList } from '../../../../hooks/useFocusList/index.js';
-import { PrimaryLinkProps } from '../../types.js';
+import type { PrimaryLinkProps } from '../../types.js';
 import { PrimaryLink } from '../PrimaryLink/index.js';
 import { SecondaryLinks } from '../SecondaryLinks/index.js';
-import { Require } from '../../../../types/util.js';
-import { ClickEvent } from '../../../../types/events.js';
+import type { Require } from '../../../../types/util.js';
+import type { ClickEvent } from '../../../../types/events.js';
 import {
   ComponentsContext,
-  ComponentsContextType,
+  type ComponentsContextType,
 } from '../../../ComponentsContext/index.js';
 import { defaultComponents } from '../../../ComponentsContext/ComponentsContext.js';
 import { clsx } from '../../../../styles/clsx.js';

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -16,13 +16,13 @@
 'use client';
 
 import { ArrowRight } from '@sumup/icons';
-import { ComponentType } from 'react';
+import type { ComponentType } from 'react';
 
 import type { AsPropType } from '../../../../types/prop-types.js';
 import { useComponents } from '../../../ComponentsContext/index.js';
 import Body from '../../../Body/index.js';
 import { Skeleton } from '../../../Skeleton/index.js';
-import { PrimaryLinkProps as PrimaryLinkType } from '../../types.js';
+import type { PrimaryLinkProps as PrimaryLinkType } from '../../types.js';
 import { clsx } from '../../../../styles/clsx.js';
 import utilityClasses from '../../../../styles/utility.js';
 

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -22,14 +22,14 @@ import { forwardRef } from 'react';
 import type { AsPropType } from '../../../../types/prop-types.js';
 import {
   useFocusList,
-  FocusProps,
+  type FocusProps,
 } from '../../../../hooks/useFocusList/index.js';
 import SubHeadline from '../../../SubHeadline/index.js';
 import Body from '../../../Body/index.js';
 import Badge from '../../../Badge/index.js';
 import { useComponents } from '../../../ComponentsContext/index.js';
 import { Skeleton } from '../../../Skeleton/index.js';
-import { SecondaryGroupProps, SecondaryLinkProps } from '../../types.js';
+import type { SecondaryGroupProps, SecondaryLinkProps } from '../../types.js';
 import { clsx } from '../../../../styles/clsx.js';
 import utilityClasses from '../../../../styles/utility.js';
 import sharedClasses from '../../../../styles/shared.js';

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -16,7 +16,7 @@
 import type { MouseEvent, KeyboardEvent, AnchorHTMLAttributes } from 'react';
 import type { IconComponentType } from '@sumup/icons';
 
-import { BadgeProps } from '../Badge/index.js';
+import type { BadgeProps } from '../Badge/index.js';
 
 export interface PrimaryLinkProps
   extends AnchorHTMLAttributes<HTMLAnchorElement> {

--- a/packages/circuit-ui/components/SidePanel/SidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.tsx
@@ -15,7 +15,7 @@
 
 'use client';
 
-import { UIEventHandler, useEffect, useId, useState } from 'react';
+import { useEffect, useId, useState, type UIEventHandler } from 'react';
 import type { Props as ReactModalProps } from 'react-modal';
 
 import { isFunction } from '../../util/type-check.js';

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
@@ -26,8 +26,8 @@ import {
 import ReactModal, { type Props as ReactModalProps } from 'react-modal';
 
 import { useMedia } from '../../hooks/useMedia/index.js';
-import { useStack, StackItem } from '../../hooks/useStack/index.js';
-import { Require } from '../../types/util.js';
+import { useStack, type StackItem } from '../../hooks/useStack/index.js';
+import type { Require } from '../../types/util.js';
 import { warn } from '../../util/logger.js';
 import { clsx } from '../../styles/clsx.js';
 import { useLatest } from '../../hooks/useLatest/useLatest.js';

--- a/packages/circuit-ui/components/SidePanel/components/DesktopSidePanel/DesktopSidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/DesktopSidePanel/DesktopSidePanel.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import ReactModal, { Props as ReactModalProps } from 'react-modal';
+import ReactModal, { type Props as ReactModalProps } from 'react-modal';
 
 import { StackContext } from '../../../StackContext/index.js';
 import type { SidePanelProps } from '../../SidePanel.js';

--- a/packages/circuit-ui/components/SidePanel/components/MobileSidePanel/MobileSidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/MobileSidePanel/MobileSidePanel.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import ReactModal, { Props as ReactModalProps } from 'react-modal';
+import ReactModal, { type Props as ReactModalProps } from 'react-modal';
 
 import { StackContext } from '../../../StackContext/index.js';
 import type { SidePanelProps } from '../../SidePanel.js';

--- a/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
@@ -14,17 +14,20 @@
  */
 
 import {
-  ReactNode,
   useContext,
   useCallback,
   useId,
   useRef,
   useEffect,
+  type ReactNode,
 } from 'react';
 
 import { uniqueId } from '../../util/id.js';
 
-import { SidePanelContext, SidePanelContextProps } from './SidePanelContext.js';
+import {
+  SidePanelContext,
+  type SidePanelContextProps,
+} from './SidePanelContext.js';
 
 export type Callback = () => void;
 

--- a/packages/circuit-ui/components/Skeleton/Skeleton.tsx
+++ b/packages/circuit-ui/components/Skeleton/Skeleton.tsx
@@ -17,10 +17,10 @@
 
 import {
   createContext,
-  useContext,
-  ReactNode,
   forwardRef,
-  HTMLAttributes,
+  useContext,
+  type ReactNode,
+  type HTMLAttributes,
 } from 'react';
 
 import type { AsPropType } from '../../types/prop-types.js';

--- a/packages/circuit-ui/components/Spinner/Spinner.tsx
+++ b/packages/circuit-ui/components/Spinner/Spinner.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
 import { deprecate } from '../../util/logger.js';

--- a/packages/circuit-ui/components/StackContext/StackContext.tsx
+++ b/packages/circuit-ui/components/StackContext/StackContext.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { createContext, ReactNode, useContext } from 'react';
+import { createContext, useContext, type ReactNode } from 'react';
 
 export const StackContext = createContext<string | number | null>(null);
 

--- a/packages/circuit-ui/components/Step/Step.ts
+++ b/packages/circuit-ui/components/Step/Step.ts
@@ -17,7 +17,7 @@ import { CircuitError } from '../../util/errors.js';
 import { isFunction } from '../../util/type-check.js';
 
 import { useStep } from './hooks/useStep.js';
-import { StateAndHelpers, StepOptions } from './types.js';
+import type { StateAndHelpers, StepOptions } from './types.js';
 
 export interface StepProps extends StepOptions {
   /**

--- a/packages/circuit-ui/components/Step/StepService.ts
+++ b/packages/circuit-ui/components/Step/StepService.ts
@@ -15,7 +15,7 @@
 
 import { eachFn } from '../../util/helpers.js';
 
-import { Actions, InternalState, PropGetters } from './types.js';
+import type { Actions, InternalState, PropGetters } from './types.js';
 
 type Data = {
   step?: number;

--- a/packages/circuit-ui/components/Step/examples/CarouselSlider.tsx
+++ b/packages/circuit-ui/components/Step/examples/CarouselSlider.tsx
@@ -17,7 +17,7 @@
 
 import Image from '../../Image/index.js';
 import Button from '../../Button/index.js';
-import Step, { StepProps } from '../Step.js';
+import Step, { type StepProps } from '../Step.js';
 
 import classes from './CarouselSlider.module.css';
 

--- a/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
+++ b/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
@@ -18,18 +18,18 @@
 
 'use client';
 
-import { ReactNode, useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import {
-  SwipeableProps,
   useSwipeable,
-  SwipeEventData,
-  SwipeDirections,
+  type SwipeableProps,
+  type SwipeEventData,
+  type SwipeDirections,
 } from 'react-swipeable';
 
 import Image from '../../Image/index.js';
 import Button from '../../Button/index.js';
-import Step, { StepProps } from '../Step.js';
-import { Actions } from '../types.js';
+import Step, { type StepProps } from '../Step.js';
+import type { Actions } from '../types.js';
 import { clsx } from '../../../styles/clsx.js';
 
 import classes from './YesOrNoSlider.module.css';

--- a/packages/circuit-ui/components/Step/hooks/useStep.ts
+++ b/packages/circuit-ui/components/Step/hooks/useStep.ts
@@ -18,7 +18,7 @@ import { useReducer, useEffect, useRef } from 'react';
 import { CircuitError } from '../../../util/errors.js';
 import { isFunction } from '../../../util/type-check.js';
 import * as StepService from '../StepService.js';
-import { Duration, StateAndHelpers, StepOptions } from '../types.js';
+import type { Duration, StateAndHelpers, StepOptions } from '../types.js';
 
 export function useStep({
   initialStep = 0,

--- a/packages/circuit-ui/components/Step/types.ts
+++ b/packages/circuit-ui/components/Step/types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ClickEvent } from '../../types/events.js';
+import type { ClickEvent } from '../../types/events.js';
 
 export type Play = () => void;
 export type Pause = () => void;

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
 import { CircuitError } from '../../util/errors.js';

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -15,7 +15,7 @@
 
 'use client';
 
-import { Component, createRef, HTMLAttributes, UIEvent } from 'react';
+import { Component, createRef, type HTMLAttributes, type UIEvent } from 'react';
 
 import { isNil } from '../../util/type-check.js';
 import { throttle } from '../../util/helpers.js';
@@ -25,7 +25,7 @@ import { deprecate } from '../../util/logger.js';
 import TableHead from './components/TableHead/index.js';
 import TableBody from './components/TableBody/index.js';
 import { defaultSortBy, getSortDirection } from './utils.js';
-import { Direction, Row, HeaderCell } from './types.js';
+import type { Direction, Row, HeaderCell } from './types.js';
 import classes from './Table.module.css';
 
 export interface TableProps extends HTMLAttributes<HTMLDivElement> {

--- a/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
+++ b/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
@@ -16,7 +16,7 @@
 'use client';
 
 import { mapRowProps, mapCellProps } from '../../utils.js';
-import { Row } from '../../types.js';
+import type { Row } from '../../types.js';
 import TableRow from '../TableRow/index.js';
 import TableHeader from '../TableHeader/index.js';
 import TableCell from '../TableCell/index.js';

--- a/packages/circuit-ui/components/Table/components/TableCell/TableCell.tsx
+++ b/packages/circuit-ui/components/Table/components/TableCell/TableCell.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { TdHTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type TdHTMLAttributes } from 'react';
 
 import { clsx } from '../../../../styles/clsx.js';
 import type { CellAlignment } from '../../types.js';

--- a/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
@@ -20,7 +20,7 @@ import { Fragment } from 'react';
 import TableRow from '../TableRow/index.js';
 import TableHeader from '../TableHeader/index.js';
 import { mapCellProps, getSortParams } from '../../utils.js';
-import { Direction, HeaderCell } from '../../types.js';
+import type { Direction, HeaderCell } from '../../types.js';
 import { clsx } from '../../../../styles/clsx.js';
 
 import classes from './TableHead.module.css';

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -18,8 +18,8 @@
 import type { ThHTMLAttributes } from 'react';
 
 import SortArrow from '../SortArrow/index.js';
-import { CellAlignment, SortParams } from '../../types.js';
-import { ClickEvent } from '../../../../types/events.js';
+import type { CellAlignment, SortParams } from '../../types.js';
+import type { ClickEvent } from '../../../../types/events.js';
 import {
   AccessibilityError,
   isSufficientlyLabelled,

--- a/packages/circuit-ui/components/Table/index.ts
+++ b/packages/circuit-ui/components/Table/index.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import Table, { TableProps } from './Table.js';
+import Table, { type TableProps } from './Table.js';
 import type {
   Direction as TableSortDirection,
   SortByValue as TableSortByValue,

--- a/packages/circuit-ui/components/Table/types.ts
+++ b/packages/circuit-ui/components/Table/types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 export type SortByValue = boolean | number | string | Date;
 

--- a/packages/circuit-ui/components/Table/utils.ts
+++ b/packages/circuit-ui/components/Table/utils.ts
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import { isArray, isFunction } from '../../util/type-check.js';
 
-import {
+import type {
   Direction,
   SortByValue,
   RowCellObject,

--- a/packages/circuit-ui/components/Tabs/Tabs.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.tsx
@@ -15,7 +15,13 @@
 
 'use client';
 
-import { Component, Fragment, ReactElement, ReactNode, createRef } from 'react';
+import {
+  createRef,
+  Component,
+  Fragment,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 
 import {
   isArrowLeft,
@@ -23,7 +29,7 @@ import {
   isArrowDown,
 } from '../../util/key-codes.js';
 
-import { TabList, TabListProps } from './components/TabList/index.js';
+import { TabList, type TabListProps } from './components/TabList/index.js';
 import { Tab } from './components/Tab/index.js';
 import { TabPanel } from './components/TabPanel/index.js';
 

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -15,10 +15,14 @@
 
 'use client';
 
-import { AnchorHTMLAttributes, ButtonHTMLAttributes, forwardRef } from 'react';
+import {
+  forwardRef,
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+} from 'react';
 
 import { useComponents } from '../../../ComponentsContext/index.js';
-import { EmotionAsPropType } from '../../../../types/prop-types.js';
+import type { EmotionAsPropType } from '../../../../types/prop-types.js';
 import { clsx } from '../../../../styles/clsx.js';
 
 import classes from './Tab.module.css';

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Children, HTMLAttributes } from 'react';
+import { Children, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../../../styles/clsx.js';
 import utilityClasses from '../../../../styles/utility.js';

--- a/packages/circuit-ui/components/Tabs/components/TabPanel/TabPanel.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabPanel/TabPanel.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 export type TabPanelProps = HTMLAttributes<HTMLDivElement>;
 

--- a/packages/circuit-ui/components/Tabs/components/TabPanels/TabPanels.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabPanels/TabPanels.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Children, ReactNode } from 'react';
+import { Children, type ReactNode } from 'react';
 
 export interface TabPanelsProps {
   selectedIndex: number;

--- a/packages/circuit-ui/components/TextArea/useAutoExpand.ts
+++ b/packages/circuit-ui/components/TextArea/useAutoExpand.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FormEvent, RefObject, useCallback, useEffect } from 'react';
+import { useCallback, useEffect, type FormEvent, type RefObject } from 'react';
 
 import type { InputElement } from '../Input/Input.js';
 import { useComponentSize } from '../../hooks/useComponentSize/index.js';

--- a/packages/circuit-ui/components/Title/Title.tsx
+++ b/packages/circuit-ui/components/Title/Title.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
 import { CircuitError } from '../../util/errors.js';

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -17,15 +17,15 @@
 
 import {
   createContext,
-  ReactNode,
   useCallback,
   useEffect,
   useMemo,
+  type ReactNode,
 } from 'react';
 
-import { useStack, StackItem } from '../../hooks/useStack/index.js';
+import { useStack, type StackItem } from '../../hooks/useStack/index.js';
 
-import { BaseToastProps, ToastComponent } from './types.js';
+import type { BaseToastProps, ToastComponent } from './types.js';
 import classes from './ToastContext.module.css';
 
 const DEFAULT_TOAST_DURATION = 6000;

--- a/packages/circuit-ui/components/ToastContext/types.ts
+++ b/packages/circuit-ui/components/ToastContext/types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ClickEvent } from '../../types/events.js';
+import type { ClickEvent } from '../../types/events.js';
 
 type OnClose = (event?: ClickEvent) => void;
 

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -15,7 +15,7 @@
 
 'use client';
 
-import { ButtonHTMLAttributes, forwardRef, useId } from 'react';
+import { forwardRef, useId, type ButtonHTMLAttributes } from 'react';
 
 import {
   AccessibilityError,

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
@@ -15,22 +15,22 @@
 
 'use client';
 
-import { HTMLAttributes, ReactNode, useEffect } from 'react';
+import { useEffect, type HTMLAttributes, type ReactNode } from 'react';
 
-import Hamburger, { HamburgerProps } from '../Hamburger/index.js';
+import Hamburger, { type HamburgerProps } from '../Hamburger/index.js';
 import { SkeletonContainer } from '../Skeleton/index.js';
 import { clsx } from '../../styles/clsx.js';
 import utilityClasses from '../../styles/utility.js';
 
 import {
   ProfileMenu,
-  ProfileMenuProps,
+  type ProfileMenuProps,
 } from './components/ProfileMenu/index.js';
 import {
   UtilityLinks,
-  UtilityLinksProps,
+  type UtilityLinksProps,
 } from './components/UtilityLinks/index.js';
-import { UserProps } from './types.js';
+import type { UserProps } from './types.js';
 import classes from './TopNavigation.module.css';
 
 /**

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -15,12 +15,12 @@
 
 'use client';
 
-import { useState, ButtonHTMLAttributes, useEffect } from 'react';
+import { useState, useEffect, type ButtonHTMLAttributes } from 'react';
 import { ChevronDown, Profile as ProfileIcon } from '@sumup/icons';
 
 import Avatar from '../../../Avatar/index.js';
 import Body from '../../../Body/index.js';
-import Popover, { PopoverProps } from '../../../Popover/index.js';
+import Popover, { type PopoverProps } from '../../../Popover/index.js';
 import { Skeleton } from '../../../Skeleton/index.js';
 import type { UserProps } from '../../types.js';
 import utilityClasses from '../../../../styles/utility.js';

--- a/packages/circuit-ui/components/TopNavigation/types.ts
+++ b/packages/circuit-ui/components/TopNavigation/types.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { AvatarProps } from '../Avatar/index.js';
+import type { AvatarProps } from '../Avatar/index.js';
 
 export type UserProps = {
   /**

--- a/packages/circuit-ui/components/legacy/Grid/Col/Col.ts
+++ b/packages/circuit-ui/components/legacy/Grid/Col/Col.ts
@@ -16,13 +16,13 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { Theme } from '@sumup/design-tokens';
+import type { Theme } from '@sumup/design-tokens';
 
 import isPropValid from '../../../../styles/is-prop-valid.js';
-import styled, { StyleProps } from '../../../../styles/styled.js';
+import styled, { type StyleProps } from '../../../../styles/styled.js';
 import { isNumber, isString } from '../../../../util/type-check.js';
 import { clamp } from '../../../../util/helpers.js';
-import { BreakpointOptions, GridValue } from '../types.js';
+import type { BreakpointOptions, GridValue } from '../types.js';
 import { wrapStyles, normalizeToNumber, composeBreakpoints } from '../utils.js';
 import { MAX_COL_WIDTH, MIN_COL_SPAN } from '../constants.js';
 

--- a/packages/circuit-ui/components/legacy/Grid/Grid/Grid.ts
+++ b/packages/circuit-ui/components/legacy/Grid/Grid/Grid.ts
@@ -16,10 +16,13 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { Theme } from '@sumup/design-tokens';
+import type { Theme } from '@sumup/design-tokens';
 
-import styled, { NoTheme, StyleProps } from '../../../../styles/styled.js';
-import { GridValue } from '../types.js';
+import styled, {
+  type NoTheme,
+  type StyleProps,
+} from '../../../../styles/styled.js';
+import type { GridValue } from '../types.js';
 import { composeBreakpoints, wrapStyles } from '../utils.js';
 
 const baseStyles = css`

--- a/packages/circuit-ui/components/legacy/Grid/Row/Row.ts
+++ b/packages/circuit-ui/components/legacy/Grid/Row/Row.ts
@@ -16,11 +16,14 @@
 /** @jsxImportSource @emotion/react */
 
 import { css } from '@emotion/react';
-import { Theme } from '@sumup/design-tokens';
+import type { Theme } from '@sumup/design-tokens';
 
 import { clearfix } from '../../../../styles/style-mixins.js';
-import styled, { NoTheme, StyleProps } from '../../../../styles/styled.js';
-import { GridValue } from '../types.js';
+import styled, {
+  type NoTheme,
+  type StyleProps,
+} from '../../../../styles/styled.js';
+import type { GridValue } from '../types.js';
 import { composeBreakpoints, wrapStyles } from '../utils.js';
 
 const baseStyles = css`

--- a/packages/circuit-ui/components/legacy/Grid/utils.ts
+++ b/packages/circuit-ui/components/legacy/Grid/utils.ts
@@ -22,7 +22,7 @@ import { css } from '@emotion/react';
 
 import { isString } from '../../../util/type-check.js';
 
-import { GridKey, BreakpointOptions, GridValue } from './types.js';
+import type { GridKey, BreakpointOptions, GridValue } from './types.js';
 
 export function normalizeToNumber(value: string | number): number {
   return isString(value) ? parseInt(value, 10) : value;

--- a/packages/circuit-ui/components/legacy/InlineElements/InlineElements.tsx
+++ b/packages/circuit-ui/components/legacy/InlineElements/InlineElements.tsx
@@ -15,10 +15,10 @@
 
 /** @jsxImportSource @emotion/react */
 
-import { Children, ReactElement } from 'react';
+import { Children, type ReactElement } from 'react';
 import { css } from '@emotion/react';
 
-import styled, { StyleProps } from '../../../styles/styled.js';
+import styled, { type StyleProps } from '../../../styles/styled.js';
 import { clearfix } from '../../../styles/style-mixins.js';
 
 export interface InlineElementsProps {

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.ts
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { useState, useRef, useCallback, RefObject, useId } from 'react';
+import { useState, useRef, useCallback, useId, type RefObject } from 'react';
 
-import { ClickEvent } from '../../types/events.js';
+import type { ClickEvent } from '../../types/events.js';
 import { useAnimation } from '../useAnimation/index.js';
 
 const DEFAULT_HEIGHT = 'auto';

--- a/packages/circuit-ui/hooks/useComponentSize/useComponentSize.ts
+++ b/packages/circuit-ui/hooks/useComponentSize/useComponentSize.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { useCallback, useState, useEffect, RefObject } from 'react';
+import { useCallback, useState, useEffect, type RefObject } from 'react';
 
 import { throttle } from '../../util/helpers.js';
 

--- a/packages/circuit-ui/hooks/useFocusList/useFocusList.ts
+++ b/packages/circuit-ui/hooks/useFocusList/useFocusList.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { KeyboardEvent, useCallback, useId } from 'react';
+import { useCallback, useId, type KeyboardEvent } from 'react';
 
 import { isArrowDown, isArrowUp } from '../../util/key-codes.js';
 

--- a/packages/circuit-ui/hooks/useStack/useStack.ts
+++ b/packages/circuit-ui/hooks/useStack/useStack.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Dispatch, useEffect, useReducer } from 'react';
+import { useEffect, useReducer, type Dispatch } from 'react';
 
 type Id = string | number;
 type Transition = {

--- a/packages/circuit-ui/styles/style-mixins.ts
+++ b/packages/circuit-ui/styles/style-mixins.ts
@@ -15,8 +15,8 @@
 
 /** @jsxImportSource @emotion/react */
 
-import { css, SerializedStyles } from '@emotion/react';
-import { Theme } from '@sumup/design-tokens';
+import { css, type SerializedStyles } from '@emotion/react';
+import type { Theme } from '@sumup/design-tokens';
 
 import { warn } from '../util/logger.js';
 import { isFunction } from '../util/type-check.js';

--- a/packages/circuit-ui/styles/styled.ts
+++ b/packages/circuit-ui/styles/styled.ts
@@ -14,7 +14,7 @@
  */
 
 import styled from '@emotion/styled';
-import { Theme } from '@sumup/design-tokens';
+import type { Theme } from '@sumup/design-tokens';
 
 export default styled;
 

--- a/packages/circuit-ui/tsconfig.json
+++ b/packages/circuit-ui/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
     "jsxImportSource": "react",

--- a/packages/circuit-ui/types/prop-types.ts
+++ b/packages/circuit-ui/types/prop-types.ts
@@ -14,7 +14,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ElementType } from 'react';
+import type { ElementType } from 'react';
 
 // This is how we should type the `as` prop in Circuit components, because the
 // prop should accept either a Component or a string (for an element)

--- a/packages/circuit-ui/types/return-type.ts
+++ b/packages/circuit-ui/types/return-type.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ReturnType = ReactElement<any, any> | null;

--- a/packages/circuit-ui/util/refs.ts
+++ b/packages/circuit-ui/util/refs.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ForwardedRef } from 'react';
+import type { ForwardedRef } from 'react';
 
 type Refs<T extends Element> = (ForwardedRef<T> | { current: T } | undefined)[];
 

--- a/packages/design-tokens/themes/legacy/light.ts
+++ b/packages/design-tokens/themes/legacy/light.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import {
+import type {
   Spacings,
   IconSizes,
   BorderRadius,

--- a/packages/design-tokens/utils/theme-prop-type.ts
+++ b/packages/design-tokens/utils/theme-prop-type.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import PropTypes, { Requireable, Validator } from 'prop-types';
+import PropTypes, { type Requireable, type Validator } from 'prop-types';
 
 import type {
   Theme,


### PR DESCRIPTION
## Purpose

By default, TypeScript does something called _import elision_ to strip type-only imports from the generated code. However, detecting whether an import is only used as a type and whether the imported module has side effects is unreliable. TypeScript v5 introduced the [`verbatimModuleSyntax` flag](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) to enforce the `type` annotation for type-only imports. 

## Approach and changes

- Enable the `verbatimModuleSyntax` flag and add missing `type` import annotations

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
