### PR TITLE
Fix type imports in test and story files

### DIFF
--- a/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createRef } from 'react';
 
 import { render, axe, userEvent, screen } from '../../util/test-utils.js';
-import { ClickEvent } from '../../types/events.js';
+import type { ClickEvent } from '../../types/events.js';
 
 import { Anchor } from './Anchor.js';
 

--- a/packages/circuit-ui/components/Anchor/Anchor.stories.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Anchor, AnchorProps } from './Anchor.js';
+import { Anchor, type AnchorProps } from './Anchor.js';
 
 export default {
   title: 'Typography/Anchor',

--- a/packages/circuit-ui/components/AspectRatio/AspectRatio.stories.tsx
+++ b/packages/circuit-ui/components/AspectRatio/AspectRatio.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { AspectRatio, AspectRatioProps } from './AspectRatio.js';
+import { AspectRatio, type AspectRatioProps } from './AspectRatio.js';
 
 export default {
   title: 'Components/AspectRatio',

--- a/packages/circuit-ui/components/Avatar/Avatar.spec.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it } from 'vitest';
 
 import { render, axe, screen } from '../../util/test-utils.js';
 
-import { Avatar, AvatarProps } from './Avatar.js';
+import { Avatar, type AvatarProps } from './Avatar.js';
 
 const defaultProps = {
   alt: '',

--- a/packages/circuit-ui/components/Avatar/Avatar.stories.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.stories.tsx
@@ -15,7 +15,7 @@
 
 import { Stack } from '../../../../.storybook/components/index.js';
 
-import { Avatar, AvatarProps } from './Avatar.js';
+import { Avatar, type AvatarProps } from './Avatar.js';
 
 export default {
   title: 'Components/Avatar',

--- a/packages/circuit-ui/components/Badge/Badge.stories.tsx
+++ b/packages/circuit-ui/components/Badge/Badge.stories.tsx
@@ -15,7 +15,7 @@
 
 import { Stack } from '../../../../.storybook/components/index.js';
 
-import { Badge, BadgeProps } from './Badge.js';
+import { Badge, type BadgeProps } from './Badge.js';
 
 export default {
   title: 'Components/Badge',

--- a/packages/circuit-ui/components/Body/Body.stories.tsx
+++ b/packages/circuit-ui/components/Body/Body.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { BodyProps } from './Body.js';
+import type { BodyProps } from './Body.js';
 
 import Body from './index.js';
 

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.stories.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { BodyLargeProps } from './BodyLarge.js';
+import type { BodyLargeProps } from './BodyLarge.js';
 
 import BodyLarge from './index.js';
 

--- a/packages/circuit-ui/components/Button/Button.stories.tsx
+++ b/packages/circuit-ui/components/Button/Button.stories.tsx
@@ -21,7 +21,7 @@ import ButtonGroup from '../ButtonGroup/index.js';
 import CloseButton from '../CloseButton/index.js';
 
 import { IconButton } from './IconButton.js';
-import { Button, ButtonProps } from './Button.js';
+import { Button, type ButtonProps } from './Button.js';
 
 export default {
   title: 'Components/Button',

--- a/packages/circuit-ui/components/Button/IconButton.stories.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.stories.tsx
@@ -18,7 +18,7 @@ import { Plus } from '@sumup/icons';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 
-import { IconButton, IconButtonProps } from './IconButton.js';
+import { IconButton, type IconButtonProps } from './IconButton.js';
 
 export default {
   title: 'Components/Button/IconButton',

--- a/packages/circuit-ui/components/Button/base.spec.tsx
+++ b/packages/circuit-ui/components/Button/base.spec.tsx
@@ -18,7 +18,7 @@ import { createRef } from 'react';
 
 import { render, axe, userEvent, screen } from '../../util/test-utils.js';
 
-import { SharedButtonProps, createButtonComponent } from './base.js';
+import { createButtonComponent, type SharedButtonProps } from './base.js';
 
 const Button = createButtonComponent<SharedButtonProps>(
   'TestButton',

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.spec.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.spec.tsx
@@ -18,7 +18,7 @@ import { createRef } from 'react';
 
 import { render, axe, screen } from '../../util/test-utils.js';
 
-import { ButtonGroup, ButtonGroupProps } from './ButtonGroup.js';
+import { ButtonGroup, type ButtonGroupProps } from './ButtonGroup.js';
 
 describe('ButtonGroup', () => {
   const defaultProps: ButtonGroupProps = {

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -18,7 +18,7 @@ import { action } from '@storybook/addon-actions';
 import { Stack } from '../../../../.storybook/components/index.js';
 import { modes } from '../../../../.storybook/modes.js';
 
-import { ButtonGroup, ButtonGroupProps } from './ButtonGroup.js';
+import { ButtonGroup, type ButtonGroupProps } from './ButtonGroup.js';
 
 export default {
   title: 'Components/ButtonGroup',

--- a/packages/circuit-ui/components/Carousel/Carousel.stories.tsx
+++ b/packages/circuit-ui/components/Carousel/Carousel.stories.tsx
@@ -26,7 +26,7 @@ import {
   PrevButton,
 } from './components/Buttons/index.js';
 import { Status } from './components/Status/index.js';
-import { Carousel, CarouselProps } from './Carousel.js';
+import { Carousel, type CarouselProps } from './Carousel.js';
 import {
   ASPECT_RATIO,
   ANIMATION_DURATION,

--- a/packages/circuit-ui/components/Carousel/components/Slide/Slide.stories.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Slide/Slide.stories.tsx
@@ -16,7 +16,7 @@
 import Headline from '../../../Headline/index.js';
 import Image from '../../../Image/index.js';
 
-import { Slide, SlideProps } from './Slide.js';
+import { Slide, type SlideProps } from './Slide.js';
 
 export default {
   title: 'Components/Carousel/Slide',

--- a/packages/circuit-ui/components/Carousel/components/Status/Status.stories.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Status/Status.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Status, StatusProps } from './Status.js';
+import { Status, type StatusProps } from './Status.js';
 
 export default {
   title: 'Components/Carousel/Status',

--- a/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.stories.tsx
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-import { ChangeEvent, useState } from 'react';
+import { useState, type ChangeEvent } from 'react';
 
-import { Checkbox, CheckboxProps } from './Checkbox.js';
+import { Checkbox, type CheckboxProps } from './Checkbox.js';
 
 export default {
   title: 'Forms/Checkbox',

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.mdx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.mdx
@@ -49,8 +49,8 @@ The CheckboxGroup can be used as a controlled or uncontrolled component.
 ### Controlled
 
 ```tsx
-import { useState, ChangeEvent } from 'react';
-import { CheckboxGroup, CheckboxProps } from '@sumup/circuit-ui';
+import { useState, type ChangeEvent } from 'react';
+import { CheckboxGroup, type CheckboxProps } from '@sumup/circuit-ui';
 
 function Controlled() {
   const [value, setValue] = useState<CheckboxProps['value'][]>([]);

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.spec.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.spec.tsx
@@ -24,7 +24,7 @@ import {
   fireEvent,
 } from '../../util/test-utils.js';
 
-import { CheckboxGroup, CheckboxGroupProps } from './CheckboxGroup.js';
+import { CheckboxGroup, type CheckboxGroupProps } from './CheckboxGroup.js';
 
 const defaultProps: CheckboxGroupProps = {
   label: 'Label',

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -18,7 +18,7 @@ import { action } from '@storybook/addon-actions';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 
-import { CheckboxGroup, CheckboxGroupProps } from './CheckboxGroup.js';
+import { CheckboxGroup, type CheckboxGroupProps } from './CheckboxGroup.js';
 
 export default {
   title: 'Forms/CheckboxGroup',

--- a/packages/circuit-ui/components/CloseButton/CloseButton.stories.tsx
+++ b/packages/circuit-ui/components/CloseButton/CloseButton.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { CloseButton, CloseButtonProps } from './CloseButton.js';
+import { CloseButton, type CloseButtonProps } from './CloseButton.js';
 
 export default {
   title: 'Components/Button/CloseButton',

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -14,12 +14,12 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { ChangeEvent, createRef, useState } from 'react';
+import { createRef, useState, type ChangeEvent } from 'react';
 
 import { render, userEvent, axe, screen } from '../../util/test-utils.js';
 import type { InputElement } from '../Input/index.js';
 
-import { CurrencyInput, CurrencyInputProps } from './CurrencyInput.js';
+import { CurrencyInput, type CurrencyInputProps } from './CurrencyInput.js';
 
 // Note: these defaults render a '€' as an input suffix
 const defaultProps = {

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.stories.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.stories.tsx
@@ -15,7 +15,7 @@
 
 import { Stack } from '../../../../.storybook/components/index.js';
 
-import { CurrencyInput, CurrencyInputProps } from './CurrencyInput.js';
+import { CurrencyInput, type CurrencyInputProps } from './CurrencyInput.js';
 
 export default {
   title: 'Forms/Input/CurrencyInput',

--- a/packages/circuit-ui/components/DateInput/DateInput.stories.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { DateInput, DateInputProps } from './DateInput.js';
+import { DateInput, type DateInputProps } from './DateInput.js';
 
 export default {
   title: 'Forms/Input/DateInput',

--- a/packages/circuit-ui/components/Hamburger/Hamburger.stories.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.stories.tsx
@@ -15,7 +15,7 @@
 
 import { useState } from 'react';
 
-import { Hamburger, HamburgerProps } from './Hamburger.js';
+import { Hamburger, type HamburgerProps } from './Hamburger.js';
 
 export default {
   title: 'Navigation/Hamburger',

--- a/packages/circuit-ui/components/Headline/Headline.stories.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Headline, HeadlineProps } from './Headline.js';
+import { Headline, type HeadlineProps } from './Headline.js';
 
 export default {
   title: 'Typography/Headline',

--- a/packages/circuit-ui/components/Image/Image.stories.tsx
+++ b/packages/circuit-ui/components/Image/Image.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Image, ImageProps } from './Image.js';
+import { Image, type ImageProps } from './Image.js';
 
 export default {
   title: 'Components/Image',

--- a/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
@@ -27,7 +27,7 @@ import {
   screen,
 } from '../../util/test-utils.js';
 
-import { ImageInput, ImageInputProps } from './ImageInput.js';
+import { ImageInput, type ImageInputProps } from './ImageInput.js';
 
 const defaultProps: ImageInputProps = {
   label: 'Upload an image',

--- a/packages/circuit-ui/components/ImageInput/ImageInput.stories.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.stories.tsx
@@ -17,7 +17,7 @@ import { useState } from 'react';
 
 import Avatar from '../Avatar/index.js';
 
-import { ImageInputProps } from './ImageInput.js';
+import type { ImageInputProps } from './ImageInput.js';
 
 import ImageInput from './index.js';
 

--- a/packages/circuit-ui/components/Input/Input.spec.tsx
+++ b/packages/circuit-ui/components/Input/Input.spec.tsx
@@ -18,7 +18,7 @@ import { createRef } from 'react';
 
 import { render, axe, screen } from '../../util/test-utils.js';
 
-import { Input, InputElement } from './Input.js';
+import { Input, type InputElement } from './Input.js';
 
 const defaultProps = {
   label: 'Label',

--- a/packages/circuit-ui/components/Input/Input.stories.tsx
+++ b/packages/circuit-ui/components/Input/Input.stories.tsx
@@ -18,7 +18,7 @@ import SearchInput from '../SearchInput/index.js';
 import CurrencyInput from '../CurrencyInput/index.js';
 import DateInput from '../DateInput/index.js';
 
-import { Input, InputProps } from './Input.js';
+import { Input, type InputProps } from './Input.js';
 
 export default {
   title: 'Forms/Input',

--- a/packages/circuit-ui/components/List/List.stories.tsx
+++ b/packages/circuit-ui/components/List/List.stories.tsx
@@ -17,7 +17,7 @@ import { Fragment } from 'react';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 
-import { List, ListProps } from './List.js';
+import { List, type ListProps } from './List.js';
 
 export default {
   title: 'Typography/List',

--- a/packages/circuit-ui/components/ListItem/ListItem.spec.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.spec.tsx
@@ -14,20 +14,20 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { createRef, FC } from 'react';
-import { IconProps, SumUpCard } from '@sumup/icons';
+import { createRef, type FC } from 'react';
+import { SumUpCard, type IconProps } from '@sumup/icons';
 
 import {
   render,
   axe,
-  RenderFn,
   userEvent,
   screen,
+  type RenderFn,
 } from '../../util/test-utils.js';
 import Body from '../Body/index.js';
 import Badge from '../Badge/index.js';
 
-import { ListItem, ListItemProps } from './ListItem.js';
+import { ListItem, type ListItemProps } from './ListItem.js';
 
 describe('ListItem', () => {
   function renderListItem<T>(renderFn: RenderFn<T>, props: ListItemProps) {

--- a/packages/circuit-ui/components/ListItem/ListItem.stories.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.stories.tsx
@@ -20,7 +20,7 @@ import { Stack } from '../../../../.storybook/components/index.js';
 import Body from '../Body/index.js';
 import Badge from '../Badge/index.js';
 
-import { ListItem, ListItemProps } from './ListItem.js';
+import { ListItem, type ListItemProps } from './ListItem.js';
 
 interface Item {
   title: string;

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
@@ -16,10 +16,10 @@
 import { describe, expect, it } from 'vitest';
 import { createRef } from 'react';
 
-import { screen, render, axe, RenderFn } from '../../util/test-utils.js';
+import { screen, render, axe, type RenderFn } from '../../util/test-utils.js';
 import Body from '../Body/index.js';
 
-import { ListItemGroup, ListItemGroupProps } from './ListItemGroup.js';
+import { ListItemGroup, type ListItemGroupProps } from './ListItemGroup.js';
 
 describe('ListItemGroup', () => {
   function renderListItemGroup<T>(

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.stories.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.stories.tsx
@@ -19,7 +19,7 @@ import { SumUpCard, Confirm, Alert } from '@sumup/icons';
 import { Stack } from '../../../../.storybook/components/index.js';
 import Body from '../Body/index.js';
 
-import { ListItemGroup, ListItemGroupProps } from './ListItemGroup.js';
+import { ListItemGroup, type ListItemGroupProps } from './ListItemGroup.js';
 
 interface Item {
   id: number;

--- a/packages/circuit-ui/components/Modal/Modal.spec.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.spec.tsx
@@ -23,7 +23,7 @@ import {
   screen,
 } from '../../util/test-utils.js';
 
-import { Modal, ModalProps } from './Modal.js';
+import { Modal, type ModalProps } from './Modal.js';
 
 describe('Modal', () => {
   const defaultModal: ModalProps = {

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -28,7 +28,7 @@ import Body from '../Body/index.js';
 import Image from '../Image/index.js';
 import { ModalProvider } from '../ModalContext/index.js';
 
-import { Modal, ModalProps, useModal } from './Modal.js';
+import { useModal, Modal, type ModalProps } from './Modal.js';
 
 export default {
   title: 'Components/Modal',

--- a/packages/circuit-ui/components/ModalContext/createUseModal.spec.tsx
+++ b/packages/circuit-ui/components/ModalContext/createUseModal.spec.tsx
@@ -14,6 +14,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import type { PropsWithChildren } from 'react';
 
 import { renderHook, act } from '../../util/test-utils.js';
 
@@ -34,7 +35,7 @@ describe('createUseModal', () => {
   const setModal = vi.fn();
   const removeModal = vi.fn();
 
-  const wrapper = ({ children }) => (
+  const wrapper = ({ children }: PropsWithChildren) => (
     <ModalContext.Provider value={{ setModal, removeModal }}>
       {children}
     </ModalContext.Provider>

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.spec.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.spec.tsx
@@ -20,7 +20,7 @@ import { render, axe, userEvent, screen } from '../../util/test-utils.js';
 
 import {
   NotificationBanner,
-  NotificationBannerProps,
+  type NotificationBannerProps,
 } from './NotificationBanner.js';
 
 describe('NotificationBanner', () => {

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.stories.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.stories.tsx
@@ -18,7 +18,7 @@ import { useState } from 'react';
 
 import {
   NotificationBanner,
-  NotificationBannerProps,
+  type NotificationBannerProps,
 } from './NotificationBanner.js';
 
 export default {

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.spec.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.spec.tsx
@@ -21,7 +21,7 @@ import { render, axe, screen } from '../../util/test-utils.js';
 
 import {
   NotificationFullscreen,
-  NotificationFullscreenProps,
+  type NotificationFullscreenProps,
 } from './NotificationFullscreen.js';
 
 describe('NotificationFullscreen', () => {

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.stories.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.stories.tsx
@@ -17,7 +17,7 @@ import { action } from '@storybook/addon-actions';
 
 import {
   NotificationFullscreen,
-  NotificationFullscreenProps,
+  type NotificationFullscreenProps,
 } from './NotificationFullscreen.js';
 
 export default {

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
@@ -26,7 +26,7 @@ import {
 
 import {
   NotificationInline,
-  NotificationInlineProps,
+  type NotificationInlineProps,
 } from './NotificationInline.js';
 
 describe('NotificationInline', () => {

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
@@ -20,7 +20,7 @@ import { Stack } from '../../../../.storybook/components/index.js';
 
 import {
   NotificationInline,
-  NotificationInlineProps,
+  type NotificationInlineProps,
 } from './NotificationInline.js';
 
 export default {

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.spec.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.spec.tsx
@@ -20,7 +20,7 @@ import { axe, render, userEvent, screen } from '../../util/test-utils.js';
 
 import {
   NotificationModal,
-  NotificationModalProps,
+  type NotificationModalProps,
 } from './NotificationModal.js';
 
 describe('NotificationModal', () => {

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
@@ -23,7 +23,7 @@ import Button from '../Button/index.js';
 
 import {
   NotificationModal,
-  NotificationModalProps,
+  type NotificationModalProps,
 } from './NotificationModal.js';
 import { useNotificationModal } from './useNotificationModal.js';
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
@@ -27,8 +27,8 @@ import Button from '../Button/index.js';
 import { ToastProvider } from '../ToastContext/ToastContext.js';
 
 import {
-  NotificationToastProps,
   useNotificationToast,
+  type NotificationToastProps,
 } from './NotificationToast.js';
 
 describe('NotificationToast', () => {
@@ -53,7 +53,7 @@ describe('NotificationToast', () => {
     );
   };
 
-  const baseNotificationToast: NotificationToastProps = {
+  const baseNotificationToast = {
     onClose: vi.fn(),
     iconLabel: '',
     isVisible: false,

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -22,9 +22,9 @@ import Button from '../Button/index.js';
 import { ToastProvider } from '../ToastContext/index.js';
 
 import {
-  NotificationToast,
-  NotificationToastProps,
   useNotificationToast,
+  NotificationToast,
+  type NotificationToastProps,
 } from './NotificationToast.js';
 
 export default {

--- a/packages/circuit-ui/components/Pagination/Pagination.spec.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { render, axe, userEvent, screen } from '../../util/test-utils.js';
 
-import { Pagination, PaginationProps } from './Pagination.js';
+import { Pagination, type PaginationProps } from './Pagination.js';
 
 describe('Pagination', () => {
   const baseProps: PaginationProps = {

--- a/packages/circuit-ui/components/Pagination/Pagination.stories.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.stories.tsx
@@ -15,7 +15,7 @@
 
 import { useState } from 'react';
 
-import { Pagination, PaginationProps } from './Pagination.js';
+import { Pagination, type PaginationProps } from './Pagination.js';
 
 export default {
   title: 'Navigation/Pagination',

--- a/packages/circuit-ui/components/Pagination/components/PageList/PageList.spec.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageList/PageList.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { render, axe, userEvent, screen } from '../../../../util/test-utils.js';
 
-import { PageList, PageListProps } from './PageList.js';
+import { PageList, type PageListProps } from './PageList.js';
 
 describe('PageList', () => {
   const baseProps: PageListProps = {

--- a/packages/circuit-ui/components/Pagination/components/PageSelect/PageSelect.spec.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageSelect/PageSelect.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { render, fireEvent, axe, screen } from '../../../../util/test-utils.js';
 
-import { PageSelect, PageSelectProps } from './PageSelect.js';
+import { PageSelect, type PageSelectProps } from './PageSelect.js';
 
 describe('PageSelect', () => {
   const baseProps: PageSelectProps = {

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.spec.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.spec.tsx
@@ -14,12 +14,15 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { ChangeEvent, createRef, useState } from 'react';
+import { createRef, useState, type ChangeEvent } from 'react';
 
 import { render, userEvent, axe, screen } from '../../util/test-utils.js';
 import type { InputElement } from '../Input/index.js';
 
-import { PercentageInput, PercentageInputProps } from './PercentageInput.js';
+import {
+  PercentageInput,
+  type PercentageInputProps,
+} from './PercentageInput.js';
 
 const defaultProps = {
   locale: 'de-DE',
@@ -37,7 +40,7 @@ describe('PercentageInput', () => {
   it('should format an en-GB amount', async () => {
     render(<PercentageInput {...defaultProps} locale="en-GB" />);
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole<HTMLInputElement>('textbox');
 
     await userEvent.type(input, '1234');
 
@@ -47,7 +50,7 @@ describe('PercentageInput', () => {
   it('should format an de-DE amount', async () => {
     render(<PercentageInput {...defaultProps} locale="de-DE" />);
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole<HTMLInputElement>('textbox');
 
     await userEvent.type(input, '1234');
 
@@ -57,7 +60,7 @@ describe('PercentageInput', () => {
   it('should format an amount with decimals', async () => {
     render(<PercentageInput {...defaultProps} decimalScale={2} />);
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole<HTMLInputElement>('textbox');
 
     await userEvent.type(input, '1234,56');
 
@@ -79,7 +82,7 @@ describe('PercentageInput', () => {
     };
     render(<ControlledPercentageInput />);
 
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole<HTMLInputElement>('textbox');
     expect(input.value).toBe('1.234');
 
     await userEvent.clear(input);

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.stories.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.stories.tsx
@@ -15,7 +15,10 @@
 
 import { Stack } from '../../../../.storybook/components/index.js';
 
-import { PercentageInput, PercentageInputProps } from './PercentageInput.js';
+import {
+  PercentageInput,
+  type PercentageInputProps,
+} from './PercentageInput.js';
 
 export default {
   title: 'Forms/Input/PercentageInput',

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -20,10 +20,10 @@ import { Delete, Add, Download, type IconProps } from '@sumup/icons';
 import {
   act,
   axe,
-  RenderFn,
   render,
   userEvent,
   screen,
+  type RenderFn,
 } from '../../util/test-utils.js';
 import type { ClickEvent } from '../../types/events.js';
 

--- a/packages/circuit-ui/components/Popover/Popover.stories.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.stories.tsx
@@ -15,11 +15,11 @@
 
 import { action } from '@storybook/addon-actions';
 import { Add, Edit, Delete } from '@sumup/icons';
-import { useState, ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import Button from '../Button/index.js';
 
-import { Popover, PopoverProps } from './Popover.js';
+import { Popover, type PopoverProps } from './Popover.js';
 
 export default {
   title: 'Components/Popover',

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.stories.tsx
@@ -15,7 +15,7 @@
 
 import { Fragment } from 'react';
 
-import { ProgressBar, ProgressBarProps } from './ProgressBar.js';
+import { ProgressBar, type ProgressBarProps } from './ProgressBar.js';
 
 export default {
   title: 'Components/ProgressBar',

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.mdx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.mdx
@@ -44,8 +44,8 @@ The RadioButtonGroup can be used as a controlled or uncontrolled component.
 ### Controlled
 
 ```tsx
-import { useState, ChangeEvent } from 'react';
-import { RadioButtonGroup, RadioButtonProps } from '@sumup/circuit-ui';
+import { useState, type ChangeEvent } from 'react';
+import { RadioButtonGroup, type RadioButtonProps } from '@sumup/circuit-ui';
 
 function Controlled() {
   const [value, setValue] = useState<RadioButtonProps['value']>();

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.spec.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.spec.tsx
@@ -24,7 +24,10 @@ import {
   fireEvent,
 } from '../../util/test-utils.js';
 
-import { RadioButtonGroup, RadioButtonGroupProps } from './RadioButtonGroup.js';
+import {
+  RadioButtonGroup,
+  type RadioButtonGroupProps,
+} from './RadioButtonGroup.js';
 
 const defaultProps: RadioButtonGroupProps = {
   label: 'label',

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.stories.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.stories.tsx
@@ -19,7 +19,10 @@ import { action } from '@storybook/addon-actions';
 import { Stack } from '../../../../.storybook/components/index.js';
 import { RadioButton } from '../RadioButton/RadioButton.js';
 
-import { RadioButtonGroup, RadioButtonGroupProps } from './RadioButtonGroup.js';
+import {
+  RadioButtonGroup,
+  type RadioButtonGroupProps,
+} from './RadioButtonGroup.js';
 
 export default {
   title: 'Forms/RadioButtonGroup',

--- a/packages/circuit-ui/components/SearchInput/SearchInput.stories.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.stories.tsx
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
-import { useState, ChangeEvent } from 'react';
+import { useState, type ChangeEvent } from 'react';
 
 import type { InputElement } from '../Input/index.js';
 
-import { SearchInput, SearchInputProps } from './SearchInput.js';
+import { SearchInput, type SearchInputProps } from './SearchInput.js';
 
 export default {
   title: 'Forms/Input/SearchInput',

--- a/packages/circuit-ui/components/Select/Select.stories.tsx
+++ b/packages/circuit-ui/components/Select/Select.stories.tsx
@@ -14,9 +14,9 @@
  */
 
 import { useState } from 'react';
-import { FlagDe, FlagUs, FlagFr, IconComponentType } from '@sumup/icons';
+import { FlagDe, FlagUs, FlagFr, type IconComponentType } from '@sumup/icons';
 
-import { Select, SelectProps } from './Select.js';
+import { Select, type SelectProps } from './Select.js';
 
 export default {
   title: 'Forms/Select',

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.mdx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.mdx
@@ -69,8 +69,8 @@ The SelectorGroup can be used as a controlled or uncontrolled component.
 ### Controlled
 
 ```tsx
-import { useState, ChangeEvent } from 'react';
-import { SelectorGroup, SelectorProps } from '@sumup/circuit-ui';
+import { useState, type ChangeEvent } from 'react';
+import { SelectorGroup, type SelectorProps } from '@sumup/circuit-ui';
 
 function Controlled() {
   const [value, setValue] = useState<SelectorProps['value']>();

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
@@ -24,7 +24,7 @@ import {
   userEvent,
 } from '../../util/test-utils.js';
 
-import { SelectorGroup, SelectorGroupProps } from './SelectorGroup.js';
+import { SelectorGroup, type SelectorGroupProps } from './SelectorGroup.js';
 
 const defaultProps: SelectorGroupProps = {
   label: 'label',

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.stories.tsx
@@ -13,14 +13,14 @@
  * limitations under the License.
  */
 
-import { ChangeEvent, FocusEvent, useState } from 'react';
+import { useState, type ChangeEvent, type FocusEvent } from 'react';
 import { action } from '@storybook/addon-actions';
 import { CardReaderAir, CardReaderSolo, MobilePhone } from '@sumup/icons';
 
 import { Stack } from '../../../../.storybook/components/index.js';
-import { Selector, SelectorProps } from '../Selector/Selector.js';
+import { Selector, type SelectorProps } from '../Selector/Selector.js';
 
-import { SelectorGroup, SelectorGroupProps } from './SelectorGroup.js';
+import { SelectorGroup, type SelectorGroupProps } from './SelectorGroup.js';
 
 export default {
   title: 'Forms/SelectorGroup',

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.spec.tsx
@@ -20,13 +20,13 @@ import { Shop } from '@sumup/icons';
 import {
   render,
   axe,
-  RenderFn,
   waitFor,
   screen,
+  type RenderFn,
 } from '../../util/test-utils.js';
 import { ModalProvider } from '../ModalContext/index.js';
 
-import { SideNavigation, SideNavigationProps } from './SideNavigation.js';
+import { SideNavigation, type SideNavigationProps } from './SideNavigation.js';
 
 describe('SideNavigation', () => {
   function setMediaMatches(matches: boolean) {

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
@@ -19,7 +19,7 @@ import { Like, Home, LiveChat, Package, Shop } from '@sumup/icons';
 import { modes } from '../../../../.storybook/modes.js';
 import { ModalProvider } from '../ModalContext/index.js';
 
-import { SideNavigation, SideNavigationProps } from './SideNavigation.js';
+import { SideNavigation, type SideNavigationProps } from './SideNavigation.js';
 
 export default {
   title: 'Navigation/SideNavigation',

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.spec.tsx
@@ -17,11 +17,16 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Home, Shop } from '@sumup/icons';
 
-import { render, axe, RenderFn, screen } from '../../../../util/test-utils.js';
+import {
+  render,
+  axe,
+  screen,
+  type RenderFn,
+} from '../../../../util/test-utils.js';
 
 import {
   DesktopNavigation,
-  DesktopNavigationProps,
+  type DesktopNavigationProps,
 } from './DesktopNavigation.js';
 
 describe('DesktopNavigation', () => {

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.spec.tsx
@@ -20,13 +20,16 @@ import type { ClickEvent } from '../../../../types/events.js';
 import {
   render,
   axe,
-  RenderFn,
   userEvent,
   waitFor,
   screen,
+  type RenderFn,
 } from '../../../../util/test-utils.js';
 
-import { MobileNavigation, MobileNavigationProps } from './MobileNavigation.js';
+import {
+  MobileNavigation,
+  type MobileNavigationProps,
+} from './MobileNavigation.js';
 
 describe('MobileNavigation', () => {
   function renderMobileNavigation<T>(

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
@@ -14,19 +14,19 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { FC } from 'react';
-import { IconProps, Plus } from '@sumup/icons';
+import type { FC } from 'react';
+import { Plus, type IconProps } from '@sumup/icons';
 
 import type { ClickEvent } from '../../../../types/events.js';
 import {
   render,
   axe,
-  RenderFn,
   userEvent,
   screen,
+  type RenderFn,
 } from '../../../../util/test-utils.js';
 
-import { PrimaryLink, PrimaryLinkProps } from './PrimaryLink.js';
+import { PrimaryLink, type PrimaryLinkProps } from './PrimaryLink.js';
 
 describe('PrimaryLink', () => {
   function renderPrimaryLink<T>(

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.spec.tsx
@@ -19,12 +19,12 @@ import type { ClickEvent } from '../../../../types/events.js';
 import {
   render,
   axe,
-  RenderFn,
   userEvent,
   screen,
+  type RenderFn,
 } from '../../../../util/test-utils.js';
 
-import { SecondaryLinks, SecondaryLinksProps } from './SecondaryLinks.js';
+import { SecondaryLinks, type SecondaryLinksProps } from './SecondaryLinks.js';
 
 describe('SecondaryLinks', () => {
   function renderSecondaryLinks<T>(

--- a/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
@@ -23,7 +23,7 @@ import {
   screen,
 } from '../../util/test-utils.js';
 
-import { SidePanel, SidePanelProps } from './SidePanel.js';
+import { SidePanel, type SidePanelProps } from './SidePanel.js';
 
 describe('SidePanel', () => {
   const baseProps: SidePanelProps = {

--- a/packages/circuit-ui/components/SidePanel/SidePanel.stories.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.stories.tsx
@@ -29,8 +29,8 @@ import { baseArgs as sideNavigationProps } from '../SideNavigation/SideNavigatio
 import { SidePanelProvider } from './SidePanelContext.js';
 import {
   useSidePanel,
-  ChildrenRenderProps,
-  SidePanelHookProps,
+  type ChildrenRenderProps,
+  type SidePanelHookProps,
 } from './useSidePanel.js';
 
 export default {

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.spec.tsx
@@ -14,7 +14,6 @@
  */
 
 import {
-  Mock,
   afterAll,
   afterEach,
   beforeEach,
@@ -22,8 +21,9 @@ import {
   expect,
   it,
   vi,
+  type Mock,
 } from 'vitest';
-import { ComponentType, useContext } from 'react';
+import { useContext, type ComponentType } from 'react';
 
 import {
   render,
@@ -38,10 +38,10 @@ import { useMedia } from '../../hooks/useMedia/index.js';
 import {
   SidePanelProvider,
   SidePanelContext,
-  SetSidePanel,
-  RemoveSidePanel,
-  UpdateSidePanel,
-  SidePanelContextProps,
+  type SetSidePanel,
+  type RemoveSidePanel,
+  type UpdateSidePanel,
+  type SidePanelContextProps,
 } from './SidePanelContext.js';
 
 vi.mock('../../hooks/useMedia');

--- a/packages/circuit-ui/components/SidePanel/components/DesktopSidePanel/DesktopSidePanel.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/DesktopSidePanel/DesktopSidePanel.spec.tsx
@@ -17,12 +17,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { render, axe, screen } from '../../../../util/test-utils.js';
 
-import { DesktopSidePanel, DesktopSidePanelProps } from './DesktopSidePanel.js';
+import {
+  DesktopSidePanel,
+  type DesktopSidePanelProps,
+} from './DesktopSidePanel.js';
 
 describe('DesktopSidePanel', () => {
   const baseProps: DesktopSidePanelProps = {
     isInstantOpen: false,
-    top: '0px',
     // Silences the warning about the missing app element.
     // In user land, the side panel is always rendered by the SidePanelProvider,
     // which takes care of setting the app element.

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { render, userEvent, axe, screen } from '../../../../util/test-utils.js';
 
-import { Header, HeaderProps } from './Header.js';
+import { Header, type HeaderProps } from './Header.js';
 
 describe('Header', () => {
   const baseProps = {

--- a/packages/circuit-ui/components/SidePanel/components/MobileSidePanel/MobileSidePanel.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/MobileSidePanel/MobileSidePanel.spec.tsx
@@ -17,7 +17,10 @@ import { describe, expect, it } from 'vitest';
 
 import { render, axe, screen } from '../../../../util/test-utils.js';
 
-import { MobileSidePanel, MobileSidePanelProps } from './MobileSidePanel.js';
+import {
+  MobileSidePanel,
+  type MobileSidePanelProps,
+} from './MobileSidePanel.js';
 
 describe('MobileSidePanel', () => {
   const baseProps: MobileSidePanelProps = {

--- a/packages/circuit-ui/components/SidePanel/useSidePanel.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/useSidePanel.spec.tsx
@@ -14,6 +14,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PropsWithChildren } from 'react';
 
 import { renderHook } from '../../util/test-utils.js';
 
@@ -36,7 +37,7 @@ describe('useSidePanel', () => {
   const updateSidePanel = vi.fn();
   const removeSidePanel = vi.fn().mockResolvedValue(undefined);
 
-  const wrapper = ({ children }) => (
+  const wrapper = ({ children }: PropsWithChildren) => (
     <SidePanelContext.Provider
       value={{
         setSidePanel,

--- a/packages/circuit-ui/components/Skeleton/Skeleton.spec.tsx
+++ b/packages/circuit-ui/components/Skeleton/Skeleton.spec.tsx
@@ -16,13 +16,13 @@
 import { describe, expect, it } from 'vitest';
 import { createRef } from 'react';
 
-import { render, axe, RenderFn } from '../../util/test-utils.js';
+import { render, axe, type RenderFn } from '../../util/test-utils.js';
 
 import {
   Skeleton,
-  SkeletonProps,
+  type SkeletonProps,
   SkeletonContainer,
-  SkeletonContainerProps,
+  type SkeletonContainerProps,
 } from './Skeleton.js';
 
 describe('Skeleton', () => {

--- a/packages/circuit-ui/components/Step/Step.spec.tsx
+++ b/packages/circuit-ui/components/Step/Step.spec.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Mock, afterAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, describe, expect, it, vi, type Mock } from 'vitest';
 
 import { render } from '../../util/test-utils.js';
 

--- a/packages/circuit-ui/components/Step/Step.stories.tsx
+++ b/packages/circuit-ui/components/Step/Step.stories.tsx
@@ -16,8 +16,12 @@
 import { action } from '@storybook/addon-actions';
 
 import Step from './Step.js';
-import CarouselSlider from './examples/CarouselSlider.js';
-import YesOrNoSlider from './examples/YesOrNoSlider.js';
+import CarouselSlider, {
+  type CarouselSliderProps,
+} from './examples/CarouselSlider.js';
+import YesOrNoSlider, {
+  type YesOrNoSliderProps,
+} from './examples/YesOrNoSlider.js';
 import MultiStepForm from './examples/MultiStepForm.js';
 
 const IMAGES = [
@@ -44,7 +48,9 @@ const baseArgs = {
   onAfterChange: action('onAfterChange'),
 };
 
-export const Slider = (args) => <CarouselSlider {...args} />;
+export const Slider = (args: CarouselSliderProps) => (
+  <CarouselSlider {...args} />
+);
 
 Slider.args = {
   ...baseArgs,
@@ -52,10 +58,8 @@ Slider.args = {
   animationDuration: ANIMATION_DURATION,
 };
 
-export const Swiper = (args) => <YesOrNoSlider {...args} />;
+export const Swiper = (args: YesOrNoSliderProps) => <YesOrNoSlider {...args} />;
 
 Swiper.args = baseArgs;
 
-export const Form = (args) => <MultiStepForm {...args} />;
-
-Form.args = baseArgs;
+export const Form = () => <MultiStepForm />;

--- a/packages/circuit-ui/components/Step/StepService.spec.ts
+++ b/packages/circuit-ui/components/Step/StepService.spec.ts
@@ -125,10 +125,10 @@ describe('StepService', () => {
     it('should add actions to elements onclick handler', () => {
       const getters = StepService.generatePropGetters(actions);
 
-      getters.getPlayControlProps().onClick();
-      getters.getPauseControlProps().onClick();
-      getters.getNextControlProps().onClick();
-      getters.getPreviousControlProps().onClick();
+      getters.getPlayControlProps().onClick?.();
+      getters.getPauseControlProps().onClick?.();
+      getters.getNextControlProps().onClick?.();
+      getters.getPreviousControlProps().onClick?.();
 
       expect(actions.play).toHaveBeenCalledTimes(1);
       expect(actions.pause).toHaveBeenCalledTimes(1);

--- a/packages/circuit-ui/components/Step/examples/CarouselSlider.tsx
+++ b/packages/circuit-ui/components/Step/examples/CarouselSlider.tsx
@@ -21,7 +21,7 @@ import Step, { type StepProps } from '../Step.js';
 
 import classes from './CarouselSlider.module.css';
 
-interface CarouselSliderProps extends StepProps {
+export interface CarouselSliderProps extends StepProps {
   images: string[];
 }
 

--- a/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
+++ b/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
@@ -48,7 +48,7 @@ const Swipeable = ({
   return <div {...handlers}>{children}</div>;
 };
 
-interface YesOrNoSliderProps extends StepProps {
+export interface YesOrNoSliderProps extends StepProps {
   images: string[];
 }
 

--- a/packages/circuit-ui/components/SubHeadline/SubHeadline.stories.tsx
+++ b/packages/circuit-ui/components/SubHeadline/SubHeadline.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { SubHeadline, SubHeadlineProps } from './SubHeadline.js';
+import { SubHeadline, type SubHeadlineProps } from './SubHeadline.js';
 
 export default {
   title: 'Typography/SubHeadline',

--- a/packages/circuit-ui/components/Table/Table.spec.tsx
+++ b/packages/circuit-ui/components/Table/Table.spec.tsx
@@ -19,7 +19,7 @@ import { render, axe, userEvent, screen } from '../../util/test-utils.js';
 import Badge from '../Badge/index.js';
 
 import Table from './Table.js';
-import { HeaderCell, Direction } from './types.js';
+import type { HeaderCell, Direction } from './types.js';
 
 const sortLabel = ({ direction }: { direction?: Direction }) => {
   const order = direction === 'ascending' ? 'descending' : 'ascending';

--- a/packages/circuit-ui/components/Table/Table.stories.tsx
+++ b/packages/circuit-ui/components/Table/Table.stories.tsx
@@ -18,8 +18,8 @@ import { action } from '@storybook/addon-actions';
 import Badge from '../Badge/index.js';
 import { isString } from '../../util/type-check.js';
 
-import { TableProps } from './Table.js';
-import { Direction } from './types.js';
+import type { TableProps } from './Table.js';
+import type { Direction } from './types.js';
 
 import Table from './index.js';
 

--- a/packages/circuit-ui/components/Table/components/TableCell/TableCell.stories.tsx
+++ b/packages/circuit-ui/components/Table/components/TableCell/TableCell.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { TableCellProps } from './TableCell.js';
+import type { TableCellProps } from './TableCell.js';
 
 import TableCell from './index.js';
 

--- a/packages/circuit-ui/components/Table/components/TableHead/TableHead.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHead/TableHead.spec.tsx
@@ -16,7 +16,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { render, axe, userEvent, screen } from '../../../../util/test-utils.js';
-import { HeaderCell, Direction } from '../../types.js';
+import type { HeaderCell, Direction } from '../../types.js';
 
 import TableHead from './index.js';
 

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.stories.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { TableHeaderProps } from './TableHeader.js';
+import type { TableHeaderProps } from './TableHeader.js';
 
 import TableHeader from './index.js';
 

--- a/packages/circuit-ui/components/Table/utils.spec.ts
+++ b/packages/circuit-ui/components/Table/utils.spec.ts
@@ -15,7 +15,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { RowCell, Direction, SortParams } from './types.js';
+import type { RowCell, Direction, SortParams } from './types.js';
 import * as utils from './utils.js';
 
 describe('Table utils', () => {

--- a/packages/circuit-ui/components/Tag/Tag.spec.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.spec.tsx
@@ -58,7 +58,7 @@ describe('Tag', () => {
 
   it('should render with a prefix', () => {
     render(<Tag prefix={DummyIcon}>SomeTest</Tag>);
-    expect(screen.getByTestId('tag-icon')).not.toBeNull();
+    expect(screen.getByTestId('tag-icon')).toBeVisible();
   });
 
   it('should render with a suffix', () => {

--- a/packages/circuit-ui/components/Tag/Tag.stories.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.stories.tsx
@@ -16,7 +16,7 @@
 import { action } from '@storybook/addon-actions';
 import { Checkmark } from '@sumup/icons';
 
-import { Tag, TagProps } from './Tag.js';
+import { Tag, type TagProps } from './Tag.js';
 
 export default {
   title: 'Components/Tag',

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -71,7 +71,10 @@ type RemoveProps =
   | { onRemove?: never; removeButtonLabel?: never };
 
 type DivElProps = Omit<HTMLAttributes<HTMLDivElement>, 'onClick' | 'prefix'>;
-type LinkElProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'>;
+type LinkElProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  'onClick' | 'prefix'
+>;
 type ButtonElProps = Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
   'onClick' | 'prefix'

--- a/packages/circuit-ui/components/TextArea/TextArea.stories.tsx
+++ b/packages/circuit-ui/components/TextArea/TextArea.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { TextArea, TextAreaProps } from './TextArea.js';
+import { TextArea, type TextAreaProps } from './TextArea.js';
 
 export default {
   title: 'Forms/TextArea',

--- a/packages/circuit-ui/components/TextArea/useAutoExpand.spec.tsx
+++ b/packages/circuit-ui/components/TextArea/useAutoExpand.spec.tsx
@@ -14,7 +14,7 @@
  */
 
 import { describe, expect, test, vi } from 'vitest';
-import { MutableRefObject, FormEvent } from 'react';
+import type { MutableRefObject, FormEvent } from 'react';
 
 import {
   renderHook,
@@ -24,7 +24,7 @@ import {
 } from '../../util/test-utils.js';
 import type { InputElement } from '../Input/Input.js';
 
-import { TextArea, TextAreaProps } from './TextArea.js';
+import { TextArea, type TextAreaProps } from './TextArea.js';
 import { useAutoExpand } from './useAutoExpand.js';
 
 const baseTextareaProps: TextAreaProps = {

--- a/packages/circuit-ui/components/Title/Title.stories.tsx
+++ b/packages/circuit-ui/components/Title/Title.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Title, TitleProps } from './Title.js';
+import { Title, type TitleProps } from './Title.js';
 
 export default {
   title: 'Typography/Title',

--- a/packages/circuit-ui/components/ToastContext/createUseToast.spec.tsx
+++ b/packages/circuit-ui/components/ToastContext/createUseToast.spec.tsx
@@ -14,7 +14,7 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { ReactElement } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { renderHook, act } from '../../util/test-utils.js';
 
@@ -35,7 +35,7 @@ describe('createUseToast', () => {
   const setToast = vi.fn();
   const removeToast = vi.fn();
 
-  const wrapper = ({ children }: { children: ReactElement }) => (
+  const wrapper = ({ children }: PropsWithChildren) => (
     <ToastContext.Provider value={{ setToast, removeToast }}>
       {children}
     </ToastContext.Provider>

--- a/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
@@ -17,7 +17,7 @@ import { useState } from 'react';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 
-import { Toggle, ToggleProps } from './Toggle.js';
+import { Toggle, type ToggleProps } from './Toggle.js';
 
 export default {
   title: 'Forms/Toggle',

--- a/packages/circuit-ui/components/Toggletip/Toggletip.spec.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.spec.tsx
@@ -18,7 +18,7 @@ import { createRef } from 'react';
 
 import { render, axe, screen, userEvent } from '../../util/test-utils.js';
 
-import { Toggletip, ToggletipReferenceProps } from './Toggletip.js';
+import { Toggletip, type ToggletipReferenceProps } from './Toggletip.js';
 
 const baseProps = {
   headline: 'What is a chargeback?',

--- a/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.spec.tsx
@@ -18,7 +18,7 @@ import { createRef } from 'react';
 
 import { render, axe, screen, userEvent } from '../../util/test-utils.js';
 
-import { Tooltip, TooltipProps } from './Tooltip.js';
+import { Tooltip, type TooltipProps } from './Tooltip.js';
 
 const baseProps: TooltipProps = {
   label: 'Label',

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -19,7 +19,11 @@ import { TransferOut, UploadCloud } from '@sumup/icons';
 import { Stack } from '../../../../.storybook/components/index.js';
 import Button, { IconButton } from '../Button/index.js';
 
-import { Tooltip, TooltipProps, TooltipReferenceProps } from './Tooltip.js';
+import {
+  Tooltip,
+  type TooltipProps,
+  type TooltipReferenceProps,
+} from './Tooltip.js';
 
 export default {
   title: 'Components/Tooltip',

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.spec.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.spec.tsx
@@ -17,9 +17,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { Shop, SumUpLogo } from '@sumup/icons';
 
 import { axe, render } from '../../util/test-utils.js';
-import { PopoverProps } from '../Popover/index.js';
+import type { PopoverProps } from '../Popover/index.js';
 
-import { TopNavigation, TopNavigationProps } from './TopNavigation.js';
+import { TopNavigation, type TopNavigationProps } from './TopNavigation.js';
 
 describe('TopNavigation', () => {
   const baseProps: TopNavigationProps = {

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
@@ -23,7 +23,7 @@ import { baseArgs as sideNavigationProps } from '../SideNavigation/SideNavigatio
 import { ModalProvider } from '../ModalContext/index.js';
 import Body from '../Body/index.js';
 
-import { TopNavigation, TopNavigationProps } from './TopNavigation.js';
+import { TopNavigation, type TopNavigationProps } from './TopNavigation.js';
 
 export default {
   title: 'Navigation/TopNavigation',

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.spec.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.spec.tsx
@@ -22,7 +22,7 @@ import {
   screen,
   userEvent,
 } from '../../../../util/test-utils.js';
-import { PopoverProps } from '../../../Popover/index.js';
+import type { PopoverProps } from '../../../Popover/index.js';
 
 import { ProfileMenu } from './ProfileMenu.js';
 

--- a/packages/circuit-ui/components/legacy/Calendar/RangePicker.spec.tsx
+++ b/packages/circuit-ui/components/legacy/Calendar/RangePicker.spec.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { render } from '../../../util/test-utils.js';
 
@@ -24,7 +24,17 @@ describe('RangePicker', () => {
    * Style tests.
    */
   it('should render with default styles', () => {
-    const { container } = render(<RangePicker />);
+    const { container } = render(
+      <RangePicker
+        startDate={null}
+        startDateId="startDate"
+        endDate={null}
+        endDateId="endDate"
+        focusedInput={null}
+        onDatesChange={vi.fn()}
+        onFocusChange={vi.fn()}
+      />,
+    );
     expect(container).toMatchSnapshot();
   });
 });

--- a/packages/circuit-ui/components/legacy/Calendar/RangePicker.stories.tsx
+++ b/packages/circuit-ui/components/legacy/Calendar/RangePicker.stories.tsx
@@ -17,7 +17,7 @@ import { useState } from 'react';
 import type { Moment } from 'moment';
 import type { FocusedInputShape } from 'react-dates';
 
-import { RangePicker, RangePickerProps } from './RangePicker.js';
+import { RangePicker, type RangePickerProps } from './RangePicker.js';
 
 export default {
   title: 'Forms/Calendar/RangePicker',

--- a/packages/circuit-ui/components/legacy/Calendar/SingleDayPicker.spec.tsx
+++ b/packages/circuit-ui/components/legacy/Calendar/SingleDayPicker.spec.tsx
@@ -19,7 +19,13 @@ import { render } from '../../../util/test-utils.js';
 
 import { SingleDayPicker } from './index.js';
 
-const props = { onDateChange: vi.fn(), onFocusChange: vi.fn() };
+const props = {
+  onDateChange: vi.fn(),
+  onFocusChange: vi.fn(),
+  id: 'date',
+  date: null,
+  focused: false,
+};
 
 describe('SingleDayPicker', () => {
   /**

--- a/packages/circuit-ui/components/legacy/Calendar/SingleDayPicker.stories.tsx
+++ b/packages/circuit-ui/components/legacy/Calendar/SingleDayPicker.stories.tsx
@@ -16,7 +16,10 @@
 import { useState } from 'react';
 import type { Moment } from 'moment';
 
-import { SingleDayPicker, SingleDayPickerProps } from './SingleDayPicker.js';
+import {
+  SingleDayPicker,
+  type SingleDayPickerProps,
+} from './SingleDayPicker.js';
 
 export default {
   title: 'Forms/Calendar/SingleDayPicker',

--- a/packages/circuit-ui/components/legacy/CalendarTag/CalendarTag.stories.tsx
+++ b/packages/circuit-ui/components/legacy/CalendarTag/CalendarTag.stories.tsx
@@ -15,7 +15,7 @@
 
 import { action } from '@storybook/addon-actions';
 
-import { CalendarTag, CalendarTagProps } from './CalendarTag.js';
+import { CalendarTag, type CalendarTagProps } from './CalendarTag.js';
 
 export default {
   title: 'Forms/Calendar/CalendarTag',

--- a/packages/circuit-ui/components/legacy/CalendarTagTwoStep/CalendarTagTwoStep.stories.tsx
+++ b/packages/circuit-ui/components/legacy/CalendarTagTwoStep/CalendarTagTwoStep.stories.tsx
@@ -17,7 +17,7 @@ import { action } from '@storybook/addon-actions';
 
 import {
   CalendarTagTwoStep,
-  CalendarTagTwoStepProps,
+  type CalendarTagTwoStepProps,
 } from './CalendarTagTwoStep.js';
 
 export default {

--- a/packages/circuit-ui/components/legacy/Grid/Col/Col.stories.tsx
+++ b/packages/circuit-ui/components/legacy/Grid/Col/Col.stories.tsx
@@ -15,7 +15,7 @@
 
 import styled from '../../../../styles/styled.js';
 
-import { Col, ColProps } from './Col.js';
+import { Col, type ColProps } from './Col.js';
 
 const colControl = {
   control: {

--- a/packages/circuit-ui/components/legacy/InlineElements/InlineElements.spec.tsx
+++ b/packages/circuit-ui/components/legacy/InlineElements/InlineElements.spec.tsx
@@ -15,9 +15,9 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { render, axe, RenderFn } from '../../../util/test-utils.js';
+import { render, axe, type RenderFn } from '../../../util/test-utils.js';
 
-import { InlineElements, InlineElementsProps } from './InlineElements.js';
+import { InlineElements, type InlineElementsProps } from './InlineElements.js';
 
 describe('InlineElements', () => {
   function renderInlineElements<T>(

--- a/packages/circuit-ui/components/legacy/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/legacy/Tooltip/Tooltip.stories.tsx
@@ -18,7 +18,7 @@ import { Info } from '@sumup/icons';
 import { Stack } from '../../../../../.storybook/components/index.js';
 import styled from '../../../styles/styled.js';
 
-import { Tooltip, TooltipProps } from './Tooltip.js';
+import { Tooltip, type TooltipProps } from './Tooltip.js';
 
 export default {
   title: 'Components/Tooltip/Legacy',

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.spec.ts
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.spec.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
+import type { MouseEvent } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { MouseEvent } from 'react';
 
 import { renderHook, act, waitFor } from '../../util/test-utils.js';
 

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.stories.tsx
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.stories.tsx
@@ -16,7 +16,7 @@
 import Body from '../../components/Body/index.js';
 import Button from '../../components/Button/index.js';
 
-import { CollapsibleOptions, useCollapsible } from './useCollapsible.js';
+import { useCollapsible, type CollapsibleOptions } from './useCollapsible.js';
 
 export default {
   title: 'Hooks/useCollapsible',

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -30,8 +30,8 @@ import {
   clearfix,
   hideVisually,
   hideScrollbar,
-  SpacingValue,
   center,
+  type SpacingValue,
 } from './style-mixins.js';
 
 export default {

--- a/packages/circuit-ui/util/refs.spec.tsx
+++ b/packages/circuit-ui/util/refs.spec.tsx
@@ -23,9 +23,9 @@ describe('applyMultipleRefs function', () => {
   test("should populate a reference's `current` member'", () => {
     const {
       result: { current: refAsObject },
-    } = renderHook(() => useRef<HTMLDivElement>());
+    } = renderHook(() => useRef<HTMLDivElement>(null));
 
-    render(<div ref={applyMultipleRefs(refAsObject)} />);
+    render(<div ref={applyMultipleRefs<HTMLDivElement>(refAsObject)} />);
     expect(refAsObject.current).toMatchInlineSnapshot('<div />');
   });
 

--- a/packages/circuit-ui/util/test-utils.tsx
+++ b/packages/circuit-ui/util/test-utils.tsx
@@ -13,14 +13,14 @@
  * limitations under the License.
  */
 
-import { FunctionComponent, ReactElement, PropsWithChildren } from 'react';
+import type { FunctionComponent, ReactElement, PropsWithChildren } from 'react';
 import '@testing-library/jest-dom/vitest';
 import { configureAxe } from 'jest-axe';
 import {
   render as renderTest,
-  RenderOptions,
-  RenderResult,
   renderHook,
+  type RenderOptions,
+  type RenderResult,
 } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { ThemeProvider } from '@emotion/react';


### PR DESCRIPTION
Fixes #2493.

## Purpose

Test and story files are excluded from the TypeScript config to prevent them from being included in the `dist` folder. That's why the missing `type` import annotations weren't flagged in #2493.

## Approach and changes

- Add `type` import annotations in `*.spec.*` and `*.stories.*` files

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
