### PR TITLE
feat(circuit-ui): PasswordInput form component

### DIFF
--- a/packages/circuit-ui/components/PasswordInput/PasswordInput.mdx
+++ b/packages/circuit-ui/components/PasswordInput/PasswordInput.mdx
@@ -1,0 +1,13 @@
+import { Meta, Status, Props, Story } from '../../../../.storybook/components';
+import * as Stories from './PasswordInput.stories';
+
+<Meta of={Stories} />
+
+# PasswordInput
+
+<Status variant="experimental" />
+
+The PasswordInput is a password input that encapsulates logic for hidding/showing the password.
+
+<Story of={Stories.Base} />
+<Props />

--- a/packages/circuit-ui/components/PasswordInput/PasswordInput.spec.tsx
+++ b/packages/circuit-ui/components/PasswordInput/PasswordInput.spec.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { render, axe } from '../../util/test-utils.js';
+
+import { PasswordInput } from './PasswordInput.js';
+
+describe('PasswordInput', () => {
+  const baseProps = { label: 'Password' };
+
+  it('should have no accessibility violations', async () => {
+    const { container } = render(<PasswordInput {...baseProps} />);
+    const actual = await axe(container);
+    expect(actual).toHaveNoViolations();
+  });
+
+  // TODO: more tests
+});

--- a/packages/circuit-ui/components/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/circuit-ui/components/PasswordInput/PasswordInput.stories.tsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, type ChangeEvent } from 'react';
+
+import type { InputElement } from '../Input/index.js';
+
+import { PasswordInput, type PasswordInputProps } from './PasswordInput.js';
+
+export default {
+  title: 'Forms/Input/PasswordInput',
+  component: PasswordInput,
+};
+
+export const Base = (args: PasswordInputProps): JSX.Element => {
+  const [value, setValue] = useState('');
+
+  const handleChange = ({
+    target: { value: inputValue },
+  }: ChangeEvent<InputElement>) => {
+    setValue(inputValue);
+  };
+
+  return <PasswordInput {...args} value={value} onChange={handleChange} />;
+};
+
+Base.args = {
+  label: 'Password',
+  showLabel: 'Show',
+  hideLabel: 'Hide',
+};

--- a/packages/circuit-ui/components/PasswordInput/PasswordInput.tsx
+++ b/packages/circuit-ui/components/PasswordInput/PasswordInput.tsx
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use client';
+
+import { forwardRef, useState } from 'react';
+
+import Input from '../Input/index.js';
+import type { InputElement, InputProps } from '../Input/index.js';
+
+import { PasswordVisibilityToggle } from './PasswordVisibilityToggle.js';
+
+type ShowProps =
+  | { showLabel?: never; hideLabel?: never }
+  | {
+      /**
+       * Visually hidden text label on the button for toggling the password
+       * to visible state for screen readers.
+       * Crucial for accessibility.
+       */
+      showLabel: string;
+      /**
+       * Visually hidden text label on the button for toggling the password
+       * to hidden state for screen readers.
+       * Crucial for accessibility.
+       */
+      hideLabel: string;
+    };
+
+export type PasswordInputProps = InputProps & ShowProps;
+
+/**
+ * PasswordInput component for forms.
+ */
+export const PasswordInput = forwardRef<InputElement, PasswordInputProps>(
+  ({ value, showLabel, hideLabel, inputClassName, ...props }) => {
+    const [show, setShow] = useState(false);
+
+    return (
+      <Input
+        value={value}
+        type={show ? 'text' : 'password'}
+        {...(value && showLabel && hideLabel
+          ? {
+              renderSuffix: ({ className }) => (
+                <PasswordVisibilityToggle
+                  visible={show}
+                  className={className}
+                  onShowClick={() => setShow(!show)}
+                  showLabel={showLabel}
+                  hideLabel={hideLabel}
+                />
+              ),
+            }
+          : {})}
+        inputClassName={inputClassName}
+        {...props}
+      />
+    );
+  },
+);
+
+PasswordInput.displayName = 'SearchInput';

--- a/packages/circuit-ui/components/PasswordInput/PasswordVisibilityToggle.module.css
+++ b/packages/circuit-ui/components/PasswordInput/PasswordVisibilityToggle.module.css
@@ -1,0 +1,27 @@
+.resetButton {
+  padding: 2px;
+  font: inherit;
+  color: var(--cui-fg-subtle);
+  pointer-events: all;
+  cursor: pointer;
+  background: none;
+  border: none;
+  border-radius: var(--cui-border-radius-byte);
+  outline: none;
+  transition: fill var(--cui-transitions-default);
+}
+
+.resetButton:hover {
+  color: var(--cui-fg-subtle-hovered);
+}
+
+.resetButton:focus {
+  color: var(--cui-fg-subtle-pressed);
+}
+
+.visibilityToggleContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+}

--- a/packages/circuit-ui/components/PasswordInput/PasswordVisibilityToggle.tsx
+++ b/packages/circuit-ui/components/PasswordInput/PasswordVisibilityToggle.tsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use client';
+
+import type { FC, MouseEventHandler } from 'react';
+import { Hide, View } from '@sumup/icons';
+
+import { clsx } from '../../styles/clsx.js';
+
+import classes from './PasswordVisibilityToggle.module.css';
+
+export type PasswordVisibilityToggleProps = {
+  visible: boolean;
+  onShowClick: MouseEventHandler;
+  showLabel: string;
+  hideLabel: string;
+  className?: string;
+};
+
+export const PasswordVisibilityToggle: FC<PasswordVisibilityToggleProps> = ({
+  visible,
+  onShowClick,
+  showLabel,
+  hideLabel,
+  className,
+}) => (
+  <div className={clsx(classes.visibilityToggleContainer, className)}>
+    <button
+      data-selector="password-visibility-toggle"
+      type="button"
+      role="switch"
+      aria-checked={visible}
+      aria-label={visible ? hideLabel : showLabel}
+      onClick={onShowClick}
+      // Skip password visibility toggle when navigating using tab.
+      // Accessibility for password input is provided by the user-agents themselves.
+      tabIndex={-1}
+      className={classes.resetButton}
+    >
+      {visible ? (
+        <Hide role="img" style={{ display: 'block' }} />
+      ) : (
+        <View role="img" style={{ display: 'block' }} />
+      )}
+    </button>
+  </div>
+);

--- a/packages/circuit-ui/components/PasswordInput/index.ts
+++ b/packages/circuit-ui/components/PasswordInput/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PasswordInput } from './PasswordInput.js';
+
+export type { PasswordInputProps } from './PasswordInput.js';
+
+export default PasswordInput;


### PR DESCRIPTION
Add PasswordInput form component that wraps Input with `type=password` and provides additional trailing label button that allows the user to trigger between shown and hidden state of the password.
