### PR TITLE
Enable delay or cancelation of closing of SidePanel

### DIFF
--- a/.changeset/metal-horses-occur.md
+++ b/.changeset/metal-horses-occur.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": minor
+---
+
+Added support for the SidePanel's `onClose` prop to be asynchronous. The SidePanel is closed after the `onClose` callback resolves and is prevented from closing if the callback rejects.

--- a/packages/circuit-ui/components/SidePanel/SidePanel.mdx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.mdx
@@ -83,4 +83,6 @@ This is achieved with the use of the `onBack` and `onClose` render props which a
 `onBack` is available only for stacked side panels and imitates the behavior of the back button, closing only the topmost panel.
 Calling `onClose` will close the entire stack, just like clicking on the close button in the header.
 
+It is possible to delay or cancel the closing of a side panel by passing an asynchronous `onClose` callback to the `setSidePanel` function. This can be useful to prompt users to confirm the closing of the side panel if they have entered information but haven't saved it yet, to prevent data loss.
+
 <Story of={Stories.UpdateAndRemove} />

--- a/packages/circuit-ui/components/SidePanel/SidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.tsx
@@ -27,7 +27,7 @@ import {
 import { MobileSidePanel } from './components/MobileSidePanel/index.js';
 import { DesktopSidePanel } from './components/DesktopSidePanel/index.js';
 import { Header } from './components/Header/index.js';
-import type { SidePanelHookProps, Callback } from './useSidePanel.js';
+import type { SidePanelHookProps, OnBack, OnClose } from './useSidePanel.js';
 import classes from './SidePanel.module.css';
 
 export type SidePanelProps = Omit<ReactModalProps, 'children'> &
@@ -54,11 +54,11 @@ export type SidePanelProps = Omit<ReactModalProps, 'children'> &
     /**
      * Callback function that is called when the side panel is closed.
      */
-    onBack?: Callback;
+    onBack?: OnBack;
     /**
      * Callback function that is called when the side panel is closed.
      */
-    onClose: Callback;
+    onClose: OnClose;
   };
 
 export const SidePanel = ({

--- a/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
@@ -29,9 +29,10 @@ import {
   type SidePanelContextProps,
 } from './SidePanelContext.js';
 
-export type Callback = () => void;
+export type OnBack = () => void;
+export type OnClose = () => void | Promise<void>;
 
-export type ChildrenRenderProps = { onBack?: Callback; onClose: Callback };
+export type ChildrenRenderProps = { onBack?: OnBack; onClose: OnClose };
 
 export type SidePanelHookProps = {
   /**
@@ -62,7 +63,7 @@ export type SidePanelHookProps = {
   /**
    * Callback function that is called when the side panel is closed.
    */
-  onClose?: Callback;
+  onClose?: OnClose;
 };
 
 type SetSidePanel = (props: SidePanelHookProps) => void;

--- a/packages/circuit-ui/util/promises.spec.ts
+++ b/packages/circuit-ui/util/promises.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { promisify } from './promises.js';
+
+describe('promises', () => {
+  describe('promisify', () => {
+    it('should promisify a synchronous function', async () => {
+      const expected = 'expected';
+      const fn = () => expected;
+
+      await expect(promisify(fn)).resolves.toBe(expected);
+    });
+
+    it('should promisify an asynchronous function', async () => {
+      const expected = 'expected';
+      const fn = () => Promise.resolve(expected);
+
+      await expect(promisify(fn)).resolves.toBe(expected);
+    });
+  });
+});

--- a/packages/circuit-ui/util/promises.ts
+++ b/packages/circuit-ui/util/promises.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Forces any function to be asynchronous in a type-safe manner.
+ */
+export async function promisify<T>(fn: () => T | Promise<T>): Promise<T> {
+  return fn();
+}


### PR DESCRIPTION
## Purpose

Consider a scenario where a form is rendered inside a SidePanel. In such cases, it's crucial to prompt users to confirm the closing of the SidePanel if they have entered information but haven't saved it yet, to prevent data loss. This requires the ability to delay and optionally cancel the closing of the SidePanel.

## Approach and changes

- Added support for the SidePanel's `onClose` prop to be asynchronous. The SidePanel is closed after the `onClose` callback resolves and is prevented from closing if the callback rejects.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
