### PR TITLE
Add PhoneNumberInput component

### DIFF
--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.mdx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.mdx
@@ -1,0 +1,17 @@
+import { Meta, Status, Props, Story } from '../../../../.storybook/components';
+import * as Stories from './PhoneNumberInput.stories';
+
+<Meta of={Stories} />
+
+# PhoneNumberInput
+
+<Status variant="experimental" />
+
+TODO: Write short summary
+
+<Story of={Stories.Base} />
+<Props />
+
+## Usage
+
+TODO: Write detailed usage instructions

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
@@ -1,0 +1,19 @@
+.wrapper {
+  display: flex;
+}
+
+.country-code {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.subscriber-number {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+/* Elevate the input above the country code select */
+.subscriber-number:focus {
+  position: relative;
+  z-index: calc(var(--cui-z-index-input) + 1);
+}

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,14 +13,8 @@
  * limitations under the License.
  */
 
-export {
-  default as Tooltip,
-  type TooltipProps,
-  type TooltipReferenceProps,
-} from './components/Tooltip/index.js';
-export {
-  default as Toggletip,
-  type ToggletipProps,
-} from './components/Toggletip/index.js';
-export { PhoneNumberInput } from './components/PhoneNumberInput/index.js';
-export type { PhoneNumberInputProps } from './components/PhoneNumberInput/index.js';
+import { describe, it } from 'vitest';
+
+describe('PhoneNumberInput', () => {
+  it.todo('should have tests');
+});

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  PhoneNumberInput,
+  type PhoneNumberInputProps,
+} from './PhoneNumberInput.js';
+
+export default {
+  title: 'Forms/PhoneNumberInput',
+  component: PhoneNumberInput,
+  argTypes: {
+    disabled: { control: 'boolean' },
+  },
+};
+
+export const Base = (args: PhoneNumberInputProps) => (
+  <PhoneNumberInput {...args} />
+);
+
+Base.args = {
+  label: 'Phone number',
+  countryCode: {
+    label: 'Country code',
+    defaultValue: '+1',
+    options: [
+      { country: 'US', code: '+1' },
+      { country: 'DE', code: '+49' },
+    ],
+  },
+  subscriberNumber: {
+    label: 'Subscriber number',
+  },
+  validationHint: 'Maximum 15 digits',
+};

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -275,8 +275,9 @@ export const PhoneNumberInput = forwardRef<
           <Input
             hideLabel
             autoComplete="tel-national"
-            placeholder="123456789"
-            pattern="[0-9]+"
+            placeholder="123 456789"
+            pattern="[0-9]+[0-9 ]+"
+            inputMode="tel"
             invalid={invalid}
             disabled={disabled}
             inputClassName={classes['subscriber-number']}

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -1,0 +1,304 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use client';
+
+import {
+  forwardRef,
+  useCallback,
+  useId,
+  useRef,
+  type ChangeEvent,
+  type FieldsetHTMLAttributes,
+  type ForwardedRef,
+} from 'react';
+
+import Select, { type SelectProps } from '../Select/index.js';
+import Input, { type InputElement, type InputProps } from '../Input/index.js';
+import {
+  FieldLabelText,
+  FieldLegend,
+  FieldSet,
+  FieldValidationHint,
+} from '../Field/index.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
+import { applyMultipleRefs } from '../../util/refs.js';
+import { eachFn } from '../../util/helpers.js';
+
+import { normalizePhoneNumber } from './PhoneNumberInputService.js';
+import classes from './PhoneNumberInput.module.css';
+
+export interface PhoneNumberInputProps
+  extends Omit<
+    FieldsetHTMLAttributes<HTMLFieldSetElement>,
+    'onChange' | 'onBlur'
+  > {
+  /**
+   * A clear and concise description of the input purpose.
+   */
+  label: string;
+  /**
+   * Callback when the country code or subscriber number changes. Called with
+   * the normalized phone number in the [E.164 format](https://en.wikipedia.org/wiki/E.164),
+   * e.g. `+17024181234`.
+   */
+  onChange?: (phoneNumber: string) => void;
+  /**
+   * Label to indicate that the input is optional. Only displayed when the
+   * `required` prop is falsy.
+   */
+  optionalLabel?: string;
+  /**
+   * Triggers error styles on the component. Important for accessibility.
+   */
+  invalid?: boolean;
+  /**
+   * Triggers warning styles on the component.
+   */
+  hasWarning?: boolean;
+  /**
+   * Enables valid styles on the component.
+   */
+  showValid?: boolean;
+  /**
+   * Triggers readonly styles on the component.
+   */
+  readOnly?: boolean;
+  /**
+   * Makes the input group required.
+   */
+  required?: boolean;
+  /**
+   * Visually hide the label. This should only be used in rare cases and only
+   * if the purpose of the field can be inferred from other context.
+   */
+  hideLabel?: boolean;
+  /**
+   * An information, warning or error message, displayed below the input.
+   */
+  validationHint?: string;
+  /**
+   * One or more Unicode BCP 47 locale identifiers, e.g. `de-DE` or
+   * `['GB', 'en-US']`. Used to localize the country names and determine the
+   * preselected country code. Defaults to `navigator.languages`.
+   */
+  locale?: string | string[];
+  /**
+   * TODO: Write a description
+   */
+  countryCode: {
+    /**
+     * Visually hidden label for visually-impaired users.
+     */
+    label: string;
+    /**
+     * TODO: Write a description. See https://en.wikipedia.org/wiki/List_of_country_calling_codes
+     */
+    options: {
+      /**
+       * TODO: Write a description
+       */
+      country: string;
+      /**
+       * TODO: Write a description
+       */
+      code: string;
+    }[];
+    /**
+     * Initial country code.
+     */
+    defaultValue?: string;
+    /**
+     * TODO: Write a description.
+     * TODO: The HTML `select` element doesn't support the `readonly` attribute, so this will need to be implemented using CSS and the `aria-readonly` and/or `disabled` attributes. The element must remain perceivable by screen reader users.
+     */
+    readonly?: boolean;
+    onChange?: SelectProps['onChange'];
+    ref?: ForwardedRef<HTMLSelectElement>;
+  };
+  /**
+   * TODO: Write a description
+   */
+  subscriberNumber: {
+    /**
+     * Visually hidden label for visually-impaired users.
+     */
+    label: string;
+    /**
+     * Initial subscriber number.
+     */
+    defaultValue?: string;
+    onChange?: InputProps['onChange'];
+    ref?: ForwardedRef<InputElement>;
+  };
+}
+
+/**
+ * TODO: Write a description
+ */
+export const PhoneNumberInput = forwardRef<
+  HTMLFieldSetElement,
+  PhoneNumberInputProps
+>(
+  (
+    {
+      label,
+      hideLabel,
+      countryCode,
+      subscriberNumber,
+      optionalLabel,
+      required,
+      invalid,
+      hasWarning,
+      showValid,
+      disabled,
+      validationHint,
+      onChange,
+      'aria-describedby': descriptionId,
+      locale,
+      ...props
+    },
+    ref,
+  ) => {
+    const countryCodeRef = useRef<HTMLSelectElement>(null);
+    const subscriberNumberRef = useRef<InputElement>(null);
+
+    const validationHintId = useId();
+
+    const descriptionIds = `${
+      descriptionId ? `${descriptionId} ` : ''
+    }${validationHintId}`;
+
+    const formatCountryName = useCallback(
+      (country: string) =>
+        // TODO: Check whether Intl.DisplayNames is supported and add fallback logic
+        new Intl.DisplayNames(locale, { type: 'region' }).of(country),
+      [locale],
+    );
+
+    const options = countryCode.options.map(({ code, country }) => {
+      const countryName = formatCountryName(country);
+      return {
+        label: countryName ? `${countryName} (${code})` : code,
+        value: code,
+      };
+    });
+
+    const handleChange = () => {
+      if (
+        !onChange ||
+        !countryCodeRef.current ||
+        !subscriberNumberRef.current
+      ) {
+        return;
+      }
+      const phoneNumber = normalizePhoneNumber(
+        countryCodeRef.current.value,
+        subscriberNumberRef.current.value,
+      );
+      onChange(phoneNumber);
+    };
+
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
+      if (!isSufficientlyLabelled(label)) {
+        throw new AccessibilityError(
+          'PhoneNumberInput',
+          'The `label` prop is missing or invalid. Pass `hideLabel` if you intend to hide the label visually.',
+        );
+      }
+
+      if (!isSufficientlyLabelled(countryCode.label)) {
+        throw new AccessibilityError(
+          'PhoneNumberInput',
+          'The `countryCodeLabel` prop is missing or invalid.',
+        );
+      }
+
+      if (!isSufficientlyLabelled(subscriberNumber.label)) {
+        throw new AccessibilityError(
+          'PhoneNumberInput',
+          'The `subscriberNumberLabel` prop is missing or invalid.',
+        );
+      }
+    }
+
+    return (
+      <FieldSet
+        aria-describedby={descriptionIds}
+        aria-invalid={invalid && 'true'}
+        aria-required={required && 'true'}
+        disabled={disabled}
+        ref={ref}
+        {...props}
+      >
+        <FieldLegend>
+          <FieldLabelText
+            label={label}
+            hideLabel={hideLabel}
+            optionalLabel={optionalLabel}
+            required={required}
+          />
+        </FieldLegend>
+        <div className={classes.wrapper}>
+          <Select
+            hideLabel
+            autoComplete="tel-country-code"
+            invalid={invalid}
+            disabled={disabled}
+            className={classes['country-code']}
+            {...countryCode}
+            options={options}
+            onChange={eachFn<[ChangeEvent<HTMLSelectElement>]>([
+              countryCode.onChange,
+              handleChange,
+            ])}
+            ref={applyMultipleRefs(countryCodeRef, countryCode.ref)}
+          />
+          <Input
+            hideLabel
+            autoComplete="tel-national"
+            placeholder="123456789"
+            pattern="[0-9]+"
+            invalid={invalid}
+            disabled={disabled}
+            inputClassName={classes['subscriber-number']}
+            {...subscriberNumber}
+            onChange={eachFn<[ChangeEvent<InputElement>]>([
+              subscriberNumber.onChange,
+              handleChange,
+            ])}
+            ref={applyMultipleRefs(subscriberNumberRef, subscriberNumber.ref)}
+          />
+        </div>
+        <FieldValidationHint
+          id={validationHintId}
+          disabled={disabled}
+          invalid={invalid}
+          hasWarning={hasWarning}
+          showValid={showValid}
+          validationHint={validationHint}
+        />
+      </FieldSet>
+    );
+  },
+);
+
+PhoneNumberInput.displayName = 'PhoneNumberInput';

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it } from 'vitest';
+
+import { normalizePhoneNumber } from './PhoneNumberInputService.js';
+
+describe('PhoneNumberInputService', () => {
+  describe('normalizePhoneNumber', () => {
+    it('should merge the country code and subscriber number', () => {
+      const countryCode = '+1';
+      const subscriberNumber = '23456789';
+      const actual = normalizePhoneNumber(countryCode, subscriberNumber);
+      expect(actual).toBe('+123456789');
+    });
+
+    it('should strip non-numeric characters from the subscriber number', () => {
+      const countryCode = '+1';
+      const subscriberNumber = '(234) 567-8910';
+      const actual = normalizePhoneNumber(countryCode, subscriberNumber);
+      expect(actual).toBe('+12345678910');
+    });
+
+    it('should strip leading zeros from the subscriber number', () => {
+      const countryCode = '+1';
+      const subscriberNumber = '0023456789';
+      const actual = normalizePhoneNumber(countryCode, subscriberNumber);
+      expect(actual).toBe('+123456789');
+    });
+  });
+});

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -26,11 +26,19 @@ describe('PhoneNumberInputService', () => {
       expect(actual).toBe('+123456789');
     });
 
-    it('should strip non-numeric characters from the subscriber number', () => {
+    it('should strip non-numeric, non-whitespace characters from the subscriber number', () => {
       const countryCode = '+1';
       const subscriberNumber = '(234) 567-8910';
       const actual = normalizePhoneNumber(countryCode, subscriberNumber);
-      expect(actual).toBe('+12345678910');
+      expect(actual).toBe('+1234 5678910');
+    });
+
+    it('should replace unsupported whitespace characters with single spaces in the subscriber number', () => {
+      const countryCode = '+1';
+      // eslint-disable-next-line no-tabs
+      const subscriberNumber = '234	567 8910';
+      const actual = normalizePhoneNumber(countryCode, subscriberNumber);
+      expect(actual).toBe('+1234 567 8910');
     });
 
     it('should strip leading zeros from the subscriber number', () => {

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,14 +13,14 @@
  * limitations under the License.
  */
 
-export {
-  default as Tooltip,
-  type TooltipProps,
-  type TooltipReferenceProps,
-} from './components/Tooltip/index.js';
-export {
-  default as Toggletip,
-  type ToggletipProps,
-} from './components/Toggletip/index.js';
-export { PhoneNumberInput } from './components/PhoneNumberInput/index.js';
-export type { PhoneNumberInputProps } from './components/PhoneNumberInput/index.js';
+export function normalizePhoneNumber(
+  countryCode: string,
+  subscriberNumber: string,
+) {
+  const normalizedSubscriberNumber = subscriberNumber
+    // Strip non-numeric characters
+    .replace(/\D/g, '')
+    // Strip any leading zeros
+    .replace(/^0+/, '');
+  return `${countryCode}${normalizedSubscriberNumber}`;
+}

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
@@ -18,8 +18,10 @@ export function normalizePhoneNumber(
   subscriberNumber: string,
 ) {
   const normalizedSubscriberNumber = subscriberNumber
-    // Strip non-numeric characters
-    .replace(/\D/g, '')
+    // Strip non-numeric, non-whitespace characters
+    .replace(/[^0-9\s]/g, '')
+    // Replace unsupported whitespace characters with simple space
+    .replace(/\s/g, ' ')
     // Strip any leading zeros
     .replace(/^0+/, '');
   return `${countryCode}${normalizedSubscriberNumber}`;

--- a/packages/circuit-ui/components/PhoneNumberInput/index.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,14 +13,5 @@
  * limitations under the License.
  */
 
-export {
-  default as Tooltip,
-  type TooltipProps,
-  type TooltipReferenceProps,
-} from './components/Tooltip/index.js';
-export {
-  default as Toggletip,
-  type ToggletipProps,
-} from './components/Toggletip/index.js';
-export { PhoneNumberInput } from './components/PhoneNumberInput/index.js';
-export type { PhoneNumberInputProps } from './components/PhoneNumberInput/index.js';
+export { PhoneNumberInput } from './PhoneNumberInput.js';
+export type { PhoneNumberInputProps } from './PhoneNumberInput.js';


### PR DESCRIPTION
Addresses [DSYS-654](https://sumupteam.atlassian.net/browse/DSYS-654).

## Purpose

The new phone number input component should enable us to collect accurate, consistently formatted phone numbers including the country code and minimize the amount of friction for users.

## Requirements

- Users must be able to type or paste their (full) phone number
- The input must support [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#sect48) for the country code and subscriber number
- Any formatting must be transparent to users so they can verify the result
- The input must be accessible using different input modes: mouse, touch, keyboard, screen reader
- The input elements must be localizable
- The full phone number should adhere to the [E.164 international standard](https://en.wikipedia.org/wiki/E.164):
  - starts with a plus sign
  - followed by the 1-3 digit country code
  - followed by the subscriber number
  - using only spaces for digit grouping

## Approach and changes

- 

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
