### PR TITLE
Revert button overflow behavior

### DIFF
--- a/.changeset/nice-rice-rescue.md
+++ b/.changeset/nice-rice-rescue.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Reverted the overflow behaviour of long Button labels. Text that would previously be truncated to a single line with a trailing ellipsis once again wraps to multiple lines, as it did before v8.

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -301,7 +301,7 @@
 
 .tertiary .label {
   text-decoration: underline dashed var(--cui-border-normal);
-  text-underline-offset: 4px;
+  text-underline-offset: 0.25em;
   transition: text-decoration-color var(--cui-transitions-default);
 }
 
@@ -367,7 +367,7 @@
     border-color: var(--cui-border-danger-pressed);
   }
 
-  .tertiary .label::after {
+  .tertiary .label {
     text-decoration: none;
   }
 }

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -13,7 +13,8 @@
   cursor: pointer;
   border-style: solid;
   border-width: var(--cui-border-width-kilo);
-  transition: opacity var(--cui-transitions-default),
+  transition:
+    opacity var(--cui-transitions-default),
     color var(--cui-transitions-default),
     background-color var(--cui-transitions-default),
     border-color var(--cui-transitions-default);
@@ -37,7 +38,8 @@
   height: 100%;
   visibility: hidden;
   opacity: 0;
-  transition: opacity var(--cui-transitions-default),
+  transition:
+    opacity var(--cui-transitions-default),
     visibility var(--cui-transitions-default);
 }
 
@@ -143,12 +145,6 @@
 
 .base[aria-busy="true"] .content {
   opacity: 0;
-}
-
-.label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .leading-icon {
@@ -304,36 +300,24 @@
 }
 
 .tertiary .label {
-  position: relative;
+  text-decoration: underline dashed var(--cui-border-normal);
+  text-underline-offset: 4px;
+  transition: text-decoration-color var(--cui-transitions-default);
 }
 
-.tertiary .label::after {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  content: "";
-  border-top: var(--cui-border-width-kilo) dashed var(--cui-border-normal);
-  opacity: 1;
-  transition: transform var(--cui-transitions-default),
-    opacity var(--cui-transitions-default);
+.tertiary:focus-visible .label {
+  text-decoration-color: transparent;
 }
 
-.tertiary:focus-visible .label::after {
-  opacity: 0;
-  transform: translateY(2px);
-}
-
-.tertiary:hover .label::after,
-.tertiary:active .label::after,
-.tertiary[aria-expanded="true"] .label::after,
-.tertiary[aria-pressed="true"] .label::after,
-.tertiary[aria-busy="true"] .label::after,
-.tertiary:disabled .label::after,
-.tertiary[disabled] .label::after,
-.tertiary[aria-disabled="true"] .label::after {
-  opacity: 0;
-  transform: translateY(2px);
+.tertiary:hover .label,
+.tertiary:active .label,
+.tertiary[aria-expanded="true"] .label,
+.tertiary[aria-pressed="true"] .label,
+.tertiary[aria-busy="true"] .label,
+.tertiary:disabled .label,
+.tertiary[disabled] .label,
+.tertiary[aria-disabled="true"] .label {
+  text-decoration-color: transparent;
 }
 
 /* ButtonGroup */
@@ -384,7 +368,7 @@
   }
 
   .tertiary .label::after {
-    display: none;
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
Reverts #2352.

## Purpose

In v8, the design team insisted on truncating long Button labels to a single line with a trailing ellipsis. Somewhat predictably, this didn't work out well in practice, we we're reverting this change to allow long labels to wrap to multiple lines.

The guideline for Button labels doesn't change: We strive to keep the copy short & sweet. However, we recognize that sometimes it's just very challenging for certain languages and use cases.

## Approach and changes

- Removed the Button styles that truncated the label
- Changed the tertiary Button's underline from a pseudo-element to a regular underline to enable it to wrap with the text. This required removing the subtle vertical animation which was barely visible anyway.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
