### PR TITLE
Add new useMedia hook

### DIFF
--- a/.changeset/gentle-files-smell.md
+++ b/.changeset/gentle-files-smell.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": minor
+---
+
+Added a new `useMedia` hook to track the state of a [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries).

--- a/packages/circuit-ui/hooks/useMedia/useMedia.mdx
+++ b/packages/circuit-ui/hooks/useMedia/useMedia.mdx
@@ -1,0 +1,22 @@
+import { Meta, Status, Story } from '../../../../.storybook/components';
+import * as Stories from './useMedia.stories';
+
+<Meta of={Stories} />
+
+# useMedia()
+
+<Status variant="stable" />
+
+Tracks the state of a [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries).
+
+<Story of={Stories.Example} />
+
+```ts
+function useMedia(query: string, initialState = false): boolean;
+```
+
+## Usage
+
+[Media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries) allow you to apply conditional logic depending on a device's media type (such as print vs. screen) or other features or characteristics such as screen resolution or orientation, aspect ratio, browser viewport width or height, user preferences such as preferring reduced motion, data usage, or transparency.
+
+Whenever possible, use CSS instead of JavaScript to track the state of a media query. CSS is generally faster to load and parse, while JavaScript might be loaded asynchronously and needs to be executed before it takes effect. The `useMedia` uses the `window.matchMedia` browser API and has to default to a fallback value during server-side rendering, potentially causing a flash of wrong content.

--- a/packages/circuit-ui/hooks/useMedia/useMedia.stories.tsx
+++ b/packages/circuit-ui/hooks/useMedia/useMedia.stories.tsx
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Card } from '../../components/Card/Card.js';
+
+import { useMedia } from './useMedia.js';
+
+export default {
+  title: 'Hooks/useMedia',
+};
+
+export const Example = () => {
+  const isMatch = useMedia('(max-width: 800px)');
+
+  const background = isMatch
+    ? 'var(--cui-bg-success)'
+    : 'var(--cui-bg-warning)';
+
+  return (
+    <Card style={{ background }}>
+      {`The viewport is ${isMatch ? 'less' : 'more'} than 800px wide.`}
+    </Card>
+  );
+};

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -193,3 +193,4 @@ export { useClickOutside } from './hooks/useClickOutside/index.js';
 export { useEscapeKey } from './hooks/useEscapeKey/index.js';
 export { useFocusList } from './hooks/useFocusList/index.js';
 export { useCollapsible } from './hooks/useCollapsible/index.js';
+export { useMedia } from './hooks/useMedia/index.js';


### PR DESCRIPTION
## Purpose

The `useMedia` hook tracks the state of a media query. It has existed for a long time inside Circuit UI's codebase but was never exposed publicly despite its usefulness. Similar hooks, like the [`useMedia` hook from react-use](https://github.com/streamich/react-use) have been adopted in SumUp's applications. `react-use` is only sporadically maintained and broke compatibility with Safari <14 in [v17.4.3](https://github.com/streamich/react-use/releases/tag/v17.4.3), so switching to our own implementation will be an improvement.

## Approach and changes

- Add documentation for the `useMedia` hook and add it to the public exports

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
