### PR TITLE
Fix Calendar component's month navigation button styles

### DIFF
--- a/.changeset/kind-hotels-sing.md
+++ b/.changeset/kind-hotels-sing.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the positioning of the Calender component's month navigation buttons.

--- a/.changeset/light-rings-do.md
+++ b/.changeset/light-rings-do.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": patch
+---
+
+Deprecated the RangePickerController component. Use the experimental Calendar component instead.

--- a/packages/circuit-ui/components/Calendar/Calendar.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.tsx
@@ -287,30 +287,32 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
     return (
       <div ref={applyMultipleRefs(ref, calendarRef)} role="group" {...props}>
         <div className={classes.header}>
-          <IconButton
-            icon={ArrowLeft}
-            size="s"
-            variant="tertiary"
-            disabled={isPrevMonthDisabled}
-            onClick={() => {
-              dispatch({ type: CalendarActionType.PREV_MONTH });
-            }}
-            className={classes.prev}
-          >
-            {prevMonthButtonLabel}
-          </IconButton>
-          <IconButton
-            icon={ArrowRight}
-            size="s"
-            variant="tertiary"
-            disabled={isNextMonthDisabled}
-            onClick={() => {
-              dispatch({ type: CalendarActionType.NEXT_MONTH });
-            }}
-            className={classes.next}
-          >
-            {nextMonthButtonLabel}
-          </IconButton>
+          <div className={classes.prev}>
+            <IconButton
+              icon={ArrowLeft}
+              size="s"
+              variant="tertiary"
+              disabled={isPrevMonthDisabled}
+              onClick={() => {
+                dispatch({ type: CalendarActionType.PREV_MONTH });
+              }}
+            >
+              {prevMonthButtonLabel}
+            </IconButton>
+          </div>
+          <div className={classes.next}>
+            <IconButton
+              icon={ArrowRight}
+              size="s"
+              variant="tertiary"
+              disabled={isNextMonthDisabled}
+              onClick={() => {
+                dispatch({ type: CalendarActionType.NEXT_MONTH });
+              }}
+            >
+              {nextMonthButtonLabel}
+            </IconButton>
+          </div>
         </div>
         <div className={classes.months}>
           {months.map((month) => (

--- a/packages/circuit-ui/components/legacy/Calendar/RangePickerController.tsx
+++ b/packages/circuit-ui/components/legacy/Calendar/RangePickerController.tsx
@@ -20,18 +20,32 @@ import type { DayPickerRangeControllerShape } from 'react-dates';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'react-dates/initialize.js';
 
+import { deprecate } from '../../../util/logger.js';
+
 import { CalendarWrapper } from './components/index.js';
 
 export type RangePickerControllerProps = DayPickerRangeControllerShape;
 
-export const RangePickerController = (props: RangePickerControllerProps) => (
-  <CalendarWrapper>
-    <DayPickerRangeController
-      navNext={<ArrowRight size="16" />}
-      navPrev={<ArrowLeft size="16" />}
-      numberOfMonths={1}
-      hideKeyboardShortcutsPanel
-      {...props}
-    />
-  </CalendarWrapper>
-);
+/**
+ * @deprecated Use the experimental Calendar component instead.
+ */
+export const RangePickerController = (props: RangePickerControllerProps) => {
+  if (process.env.NODE_ENV !== 'production') {
+    deprecate(
+      'RangePickerController',
+      'The RangePickerController component is deprecated. Use the experimental Calendar component instead.',
+    );
+  }
+
+  return (
+    <CalendarWrapper>
+      <DayPickerRangeController
+        navNext={<ArrowRight size="16" />}
+        navPrev={<ArrowLeft size="16" />}
+        numberOfMonths={1}
+        hideKeyboardShortcutsPanel
+        {...props}
+      />
+    </CalendarWrapper>
+  );
+};


### PR DESCRIPTION
## Approach and changes

- Fix month navigation button styles: Vite orders the styles for experimental components before those of stable components, causing the custom styles applied to stable components to be overridden.
- Deprecate the RangePickerController component in favor of the experimental Calendar component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
