### PR TITLE
Fix SidePanel's main content size during async onClose callback

### DIFF
--- a/.changeset/eighty-dogs-shop.md
+++ b/.changeset/eighty-dogs-shop.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Fixed the size of the main content while the SidePanel's `onClose` callback is pending.

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
@@ -143,10 +143,6 @@ export function SidePanelProvider({
 
       const sidePanelIndex = sidePanelsRef.current.indexOf(panel);
 
-      if (!isInstantClose) {
-        setIsPrimaryContentResized(sidePanelIndex !== 0);
-      }
-
       // Remove the side panel and all panels above it in reverse order
       const sidePanelsToRemove = sidePanelsRef.current
         .slice(sidePanelIndex)
@@ -161,6 +157,10 @@ export function SidePanelProvider({
 
           if (sidePanel.onClose) {
             await promisify(sidePanel.onClose);
+          }
+
+          if (!isInstantClose) {
+            setIsPrimaryContentResized(sidePanelIndex !== 0);
           }
 
           await new Promise<void>((resolve) => {


### PR DESCRIPTION
## Purpose

#2499 added support for the SidePanel's `onClose` prop to be asynchronous. Unfortunately, I overlooked that the main content is resized before the `onClose` callback, which means it doesn't wait and/or isn't canceled based on the promise.

Thanks to @oskarkunik for reporting the bug and suggesting a solution! 

## Approach and changes

- Move the logic that updates the main content size after the call to the `onClose` callback

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
