### PR TITLE
Improve Stylelint config for CSS Modules

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,5 +1,5 @@
 module.exports = require('@sumup-oss/foundry/stylelint')({
-  extends: ['stylelint-config-css-modules'],
+  extends: ['stylelint-prettier/recommended', 'stylelint-config-css-modules'],
   rules: {
     'selector-class-pattern': [
       '^([a-z][a-z0-9]*)(-[a-z0-9]+)*$',

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,4 +1,5 @@
 module.exports = require('@sumup-oss/foundry/stylelint')({
+  extends: ['stylelint-config-css-modules'],
   rules: {
     'selector-class-pattern': [
       '^([a-z][a-z0-9]*)(-[a-z0-9]+)*$',

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "remark-gfm": "^4.0.0",
         "storybook": "^8.0.10",
         "stylelint": "^16.6.1",
+        "stylelint-config-css-modules": "^4.4.0",
         "stylelint-config-recess-order": "^5.0.0",
         "stylelint-config-standard": "^36.0.0",
         "stylelint-no-unsupported-browser-features": "^8.0.1",
@@ -1589,12 +1590,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.1.tgz",
-      "integrity": "sha512-sxi2kLTI5DeW5vDtMUsk4mTPwvlUDbjOnoWayhynCwrw4QXRld4QEYwqzY8JmQXaJUtgUuCIurtSRH5sn4c7mA==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.6.tgz",
+      "integrity": "sha512-gNkksSdV8RbsCoHF9sjVYrHfYACMl/8U32UfUhJ9+84/ASXw8dlx+eHyyF0m6ncQJ9IBSxfuCkB36GJqYdXTOA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2034,13 +2035,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-flow-strip-types": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.1.tgz",
-      "integrity": "sha512-iIYPIWt3dUmUKKE10s3W+jsQ3icFkw0JyRVyY1B7G4yK/nngAOHLVx8xlhA6b/Jzl/Y0nis8gjqhqKtRDQqHWQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.6.tgz",
+      "integrity": "sha512-1l8b24NoCpaQ13Vi6FtLG1nv6kNoi8PWvQb1AYO7GHZDpFfBYc3lbXArx1lP2KRt8b4pej1eWc/zrRmsQTfOdQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0",
-        "@babel/plugin-syntax-flow": "^7.24.1"
+        "@babel/helper-plugin-utils": "^7.24.6",
+        "@babel/plugin-syntax-flow": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2790,14 +2791,14 @@
       }
     },
     "node_modules/@babel/preset-flow": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.24.1.tgz",
-      "integrity": "sha512-sWCV2G9pcqZf+JHyv/RyqEIpFypxdCSxWIxQjpdaQxenNog7cN1pr76hg8u0Fz8Qgg0H4ETkGcJnXL8d4j0PPA==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.24.6.tgz",
+      "integrity": "sha512-huoe0T1Qs9fQhMWbmqE/NHUeZbqmHDsN6n/jYvPcUUHfuKiPV32C9i8tDhMbQ1DEKTjbBP7Rjm3nSLwlB2X05g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0",
-        "@babel/helper-validator-option": "^7.23.5",
-        "@babel/plugin-transform-flow-strip-types": "^7.24.1"
+        "@babel/helper-plugin-utils": "^7.24.6",
+        "@babel/helper-validator-option": "^7.24.6",
+        "@babel/plugin-transform-flow-strip-types": "^7.24.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2860,9 +2861,9 @@
       }
     },
     "node_modules/@babel/register": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.23.7.tgz",
-      "integrity": "sha512-EjJeB6+kvpk+Y5DAkEAmbOBEFkh9OASx0huoEkqYTFxAZHzOAX2Oh5uwAUuL2rUddqfM0SA+KPXV2TbzoZ2kvQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.24.6.tgz",
+      "integrity": "sha512-WSuFCc2wCqMeXkz/i3yfAAsxwWflEgbVkZzivgAmXl/MxrXeoYFZOOPllbC8R8WTF7u61wSRQtDVZ1879cdu6w==",
       "dev": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -8620,6 +8621,18 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -8871,19 +8884,19 @@
       }
     },
     "node_modules/@storybook/builder-manager": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-8.0.10.tgz",
-      "integrity": "sha512-lo57jeeYuYCKYrmGOdLg25rMyiGYSTwJ+zYsQ3RvClVICjP6X0I1RCKAJDzkI0BixH6s1+w5ynD6X3PtDnhUuw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-8.1.5.tgz",
+      "integrity": "sha512-wDiHLV+UPaUN+765WwXkocVRB2QnJ61CjLHbpWaLiJvryFJt+JQ6nAvgSalCRnZxI046ztbS9T6okhpFI011IA==",
       "dev": true,
       "dependencies": {
         "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
-        "@storybook/core-common": "8.0.10",
-        "@storybook/manager": "8.0.10",
-        "@storybook/node-logger": "8.0.10",
+        "@storybook/core-common": "8.1.5",
+        "@storybook/manager": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
         "@types/ejs": "^3.1.1",
         "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.10",
         "browser-assert": "^1.2.1",
-        "ejs": "^3.1.8",
+        "ejs": "^3.1.10",
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
         "esbuild-plugin-alias": "^0.2.1",
         "express": "^4.17.3",
@@ -8894,6 +8907,314 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/channels": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+      "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/client-logger": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+      "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/core-common": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.5.tgz",
+      "integrity": "sha512-1QDOT6KPZ9KV7Gs1yyqzvSwGBmNSUB33gckUldSBF4aqP+tZ7W5JIQ6/YTtp3V02sEokZGdL9Ud4LczQxTgy3A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "8.1.5",
+        "@storybook/csf-tools": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
+        "@storybook/types": "8.1.5",
+        "@yarnpkg/fslib": "2.10.3",
+        "@yarnpkg/libzip": "2.3.0",
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+        "esbuild-register": "^3.5.0",
+        "execa": "^5.0.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "prettier-fallback": "npm:prettier@^3",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.7",
+        "tempy": "^3.1.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/core-events": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+      "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/csf-tools": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.5.tgz",
+      "integrity": "sha512-jOfUo0arlaG4LlsdWaRfZCS0I1FhUnkf06ThzRBrrp8mFAPtOpf9iW16J3fYMS5vAdE/v+Z1RxuTRich4/JGdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/types": "8.1.5",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/node-logger": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.5.tgz",
+      "integrity": "sha512-9qwPX/uGhdHaVjeVUSwJUSbKX7g9goyhGYdKVuCEyl7vHR9Kp7Zkag2sEHmVdd9ixTea3jk2GZQEbnBDNQNGnw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/types": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+      "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.5",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/glob": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/jackspeak": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
+      "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/builder-vite": {
@@ -8960,22 +9281,22 @@
       }
     },
     "node_modules/@storybook/cli": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-8.0.10.tgz",
-      "integrity": "sha512-KUZEO2lyvOS2sRJEFXovt6+5b65iWsh7F8e8S1cM20fCM1rZAlWtwmoxmDVXDmyEp0wTrq4FrRxKnbo9UO518w==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-8.1.5.tgz",
+      "integrity": "sha512-VEYluZEMleNEnD5wTD90KTh03pwjvQwEEmzHAJQJdLbWTAcgBxZ3Gb45nbUPauSqBL+HdJx0QXF8Ielk+iBttw==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/core": "^7.24.4",
+        "@babel/types": "^7.24.0",
         "@ndelangen/get-tarball": "^3.0.7",
-        "@storybook/codemod": "8.0.10",
-        "@storybook/core-common": "8.0.10",
-        "@storybook/core-events": "8.0.10",
-        "@storybook/core-server": "8.0.10",
-        "@storybook/csf-tools": "8.0.10",
-        "@storybook/node-logger": "8.0.10",
-        "@storybook/telemetry": "8.0.10",
-        "@storybook/types": "8.0.10",
+        "@storybook/codemod": "8.1.5",
+        "@storybook/core-common": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/core-server": "8.1.5",
+        "@storybook/csf-tools": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
+        "@storybook/telemetry": "8.1.5",
+        "@storybook/types": "8.1.5",
         "@types/semver": "^7.3.4",
         "@yarnpkg/fslib": "2.10.3",
         "@yarnpkg/libzip": "2.3.0",
@@ -8989,7 +9310,7 @@
         "fs-extra": "^11.1.0",
         "get-npm-tarball-url": "^2.0.3",
         "giget": "^1.0.0",
-        "globby": "^11.0.2",
+        "globby": "^14.0.1",
         "jscodeshift": "^0.15.1",
         "leven": "^3.1.0",
         "ora": "^5.4.1",
@@ -8998,13 +9319,152 @@
         "read-pkg-up": "^7.0.1",
         "semver": "^7.3.7",
         "strip-json-comments": "^3.0.1",
-        "tempy": "^1.0.1",
+        "tempy": "^3.1.0",
         "tiny-invariant": "^1.3.1",
         "ts-dedent": "^2.0.0"
       },
       "bin": {
         "getstorybook": "bin/index.js",
         "sb": "bin/index.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/channels": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+      "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/client-logger": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+      "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/core-common": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.5.tgz",
+      "integrity": "sha512-1QDOT6KPZ9KV7Gs1yyqzvSwGBmNSUB33gckUldSBF4aqP+tZ7W5JIQ6/YTtp3V02sEokZGdL9Ud4LczQxTgy3A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "8.1.5",
+        "@storybook/csf-tools": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
+        "@storybook/types": "8.1.5",
+        "@yarnpkg/fslib": "2.10.3",
+        "@yarnpkg/libzip": "2.3.0",
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+        "esbuild-register": "^3.5.0",
+        "execa": "^5.0.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "prettier-fallback": "npm:prettier@^3",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.7",
+        "tempy": "^3.1.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/core-events": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+      "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/csf-tools": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.5.tgz",
+      "integrity": "sha512-jOfUo0arlaG4LlsdWaRfZCS0I1FhUnkf06ThzRBrrp8mFAPtOpf9iW16J3fYMS5vAdE/v+Z1RxuTRich4/JGdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/types": "8.1.5",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/node-logger": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.5.tgz",
+      "integrity": "sha512-9qwPX/uGhdHaVjeVUSwJUSbKX7g9goyhGYdKVuCEyl7vHR9Kp7Zkag2sEHmVdd9ixTea3jk2GZQEbnBDNQNGnw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/types": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+      "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.5",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9018,6 +9478,219 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/glob": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/globby": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
+      "integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/jackspeak": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
+      "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/client-logger": {
@@ -9034,21 +9707,21 @@
       }
     },
     "node_modules/@storybook/codemod": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-8.0.10.tgz",
-      "integrity": "sha512-t45jKGs/eyR/nKVX6QgRtMZSAjJo5aXWWk3B24xVbW6ywr0jt1LC100FkHG4Af8cApIfh8uUmS9X05hMG5zGGA==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-8.1.5.tgz",
+      "integrity": "sha512-eGoYozT2XPfsIFrzm4cJo9tRTX0yuK1y4uTYmKvnomezHu5kiY8qo2fUzQa5DHxiAzRDTpGlQTzb0PsxHOxYoA==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.23.2",
-        "@babel/preset-env": "^7.23.2",
-        "@babel/types": "^7.23.0",
-        "@storybook/csf": "^0.1.4",
-        "@storybook/csf-tools": "8.0.10",
-        "@storybook/node-logger": "8.0.10",
-        "@storybook/types": "8.0.10",
+        "@babel/core": "^7.24.4",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/csf-tools": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
+        "@storybook/types": "8.1.5",
         "@types/cross-spawn": "^6.0.2",
         "cross-spawn": "^7.0.3",
-        "globby": "^11.0.2",
+        "globby": "^14.0.1",
         "jscodeshift": "^0.15.1",
         "lodash": "^4.17.21",
         "prettier": "^3.1.1",
@@ -9058,6 +9731,140 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/channels": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+      "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/client-logger": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+      "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/core-events": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+      "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/csf-tools": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.5.tgz",
+      "integrity": "sha512-jOfUo0arlaG4LlsdWaRfZCS0I1FhUnkf06ThzRBrrp8mFAPtOpf9iW16J3fYMS5vAdE/v+Z1RxuTRich4/JGdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/types": "8.1.5",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/node-logger": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.5.tgz",
+      "integrity": "sha512-9qwPX/uGhdHaVjeVUSwJUSbKX7g9goyhGYdKVuCEyl7vHR9Kp7Zkag2sEHmVdd9ixTea3jk2GZQEbnBDNQNGnw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/types": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+      "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.5",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/globby": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
+      "integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/components": {
@@ -9197,29 +10004,31 @@
       }
     },
     "node_modules/@storybook/core-server": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-8.0.10.tgz",
-      "integrity": "sha512-HYDw2QFBxg1X/d6g0rUhirOB5Jq6g90HBnyrZzxKoqKWJCNsCADSgM+h9HgtUw0jA97qBpIqmNO9n3mXFPWU/Q==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-8.1.5.tgz",
+      "integrity": "sha512-y16W2sg5KIHG6qgbd+a0nBUYHAgiUpPDFF7cdcIpbeOIoqFn+6ECp93MVefukumiSj3sQiJFU/tSm2A8apGltw==",
       "dev": true,
       "dependencies": {
         "@aw-web-design/x-default-browser": "1.4.126",
-        "@babel/core": "^7.23.9",
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
         "@discoveryjs/json-ext": "^0.5.3",
-        "@storybook/builder-manager": "8.0.10",
-        "@storybook/channels": "8.0.10",
-        "@storybook/core-common": "8.0.10",
-        "@storybook/core-events": "8.0.10",
-        "@storybook/csf": "^0.1.4",
-        "@storybook/csf-tools": "8.0.10",
-        "@storybook/docs-mdx": "3.0.0",
+        "@storybook/builder-manager": "8.1.5",
+        "@storybook/channels": "8.1.5",
+        "@storybook/core-common": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/csf-tools": "8.1.5",
+        "@storybook/docs-mdx": "3.1.0-next.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager": "8.0.10",
-        "@storybook/manager-api": "8.0.10",
-        "@storybook/node-logger": "8.0.10",
-        "@storybook/preview-api": "8.0.10",
-        "@storybook/telemetry": "8.0.10",
-        "@storybook/types": "8.0.10",
+        "@storybook/manager": "8.1.5",
+        "@storybook/manager-api": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
+        "@storybook/preview-api": "8.1.5",
+        "@storybook/telemetry": "8.1.5",
+        "@storybook/types": "8.1.5",
         "@types/detect-port": "^1.3.0",
+        "@types/diff": "^5.0.9",
         "@types/node": "^18.0.0",
         "@types/pretty-hrtime": "^1.0.0",
         "@types/semver": "^7.3.4",
@@ -9228,9 +10037,10 @@
         "cli-table3": "^0.6.1",
         "compression": "^1.7.4",
         "detect-port": "^1.3.0",
+        "diff": "^5.2.0",
         "express": "^4.17.3",
         "fs-extra": "^11.1.0",
-        "globby": "^11.0.2",
+        "globby": "^14.0.1",
         "ip": "^2.0.1",
         "lodash": "^4.17.21",
         "open": "^8.4.0",
@@ -9249,6 +10059,454 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/channels": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+      "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/client-logger": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+      "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/core-common": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.5.tgz",
+      "integrity": "sha512-1QDOT6KPZ9KV7Gs1yyqzvSwGBmNSUB33gckUldSBF4aqP+tZ7W5JIQ6/YTtp3V02sEokZGdL9Ud4LczQxTgy3A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "8.1.5",
+        "@storybook/csf-tools": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
+        "@storybook/types": "8.1.5",
+        "@yarnpkg/fslib": "2.10.3",
+        "@yarnpkg/libzip": "2.3.0",
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+        "esbuild-register": "^3.5.0",
+        "execa": "^5.0.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "prettier-fallback": "npm:prettier@^3",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.7",
+        "tempy": "^3.1.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/core-events": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+      "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/csf-tools": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.5.tgz",
+      "integrity": "sha512-jOfUo0arlaG4LlsdWaRfZCS0I1FhUnkf06ThzRBrrp8mFAPtOpf9iW16J3fYMS5vAdE/v+Z1RxuTRich4/JGdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/types": "8.1.5",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/manager-api": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.1.5.tgz",
+      "integrity": "sha512-iVP7FOKDf9L7zWCb8C2XeZjWSILS3hHeNwILvd9YSX9dg9du41kJYahsAHxDCR/jp/gv0ZM/V0vuHzi+naVPkQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.5",
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^1.2.5",
+        "@storybook/router": "8.1.5",
+        "@storybook/theming": "8.1.5",
+        "@storybook/types": "8.1.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "store2": "^2.14.2",
+        "telejson": "^7.2.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/node-logger": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.5.tgz",
+      "integrity": "sha512-9qwPX/uGhdHaVjeVUSwJUSbKX7g9goyhGYdKVuCEyl7vHR9Kp7Zkag2sEHmVdd9ixTea3jk2GZQEbnBDNQNGnw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/preview-api": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.1.5.tgz",
+      "integrity": "sha512-pv0aT5WbnSYR7KWQgy3jLfuBM0ocYG6GTcmZLREW5554oiBPHhzNFv+ZrBI47RzbrbFxq1h5dj4v8lkEcKIrbA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.5",
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/global": "^5.0.0",
+        "@storybook/types": "8.1.5",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/router": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-8.1.5.tgz",
+      "integrity": "sha512-DCwvAswlbLhQu6REPV04XNRhtPvsrRqHjMHKzjlfs+qYJWY7Egkofy05qlegqjkMDve33czfnRGBm0C16IydkA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.5",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/theming": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.1.5.tgz",
+      "integrity": "sha512-E4z1t49fMbVvd/t2MSL0Ecp5zbqsU/QfWBX/eorJ+m+Xc9skkwwG5qf/FnP9x4RZ9KaX8U8+862t0eafVvf4Tw==",
+      "dev": true,
+      "dependencies": {
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/global": "^5.0.0",
+        "memoizerific": "^1.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/types": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+      "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.5",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/glob": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/globby": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
+      "integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.2",
+        "ignore": "^5.2.4",
+        "path-type": "^5.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/jackspeak": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
+      "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/path-type": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+      "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/csf": {
@@ -9308,9 +10566,9 @@
       }
     },
     "node_modules/@storybook/docs-mdx": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/docs-mdx/-/docs-mdx-3.0.0.tgz",
-      "integrity": "sha512-NmiGXl2HU33zpwTv1XORe9XG9H+dRUC1Jl11u92L4xr062pZtrShLmD4VKIsOQujxhhOrbxpwhNOt+6TdhyIdQ==",
+      "version": "3.1.0-next.0",
+      "resolved": "https://registry.npmjs.org/@storybook/docs-mdx/-/docs-mdx-3.1.0-next.0.tgz",
+      "integrity": "sha512-t4syFIeSyufieNovZbLruPt2DmRKpbwL4fERCZ1MifWDRIORCKLc4NCEHy+IqvIqd71/SJV2k4B51nF7vlJfmQ==",
       "dev": true
     },
     "node_modules/@storybook/docs-tools": {
@@ -9372,9 +10630,9 @@
       }
     },
     "node_modules/@storybook/manager": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-8.0.10.tgz",
-      "integrity": "sha512-bojGglUQNry48L4siURc2zQKswavLzMh69rqsfL3ZXx+i+USfRfB7593azTlaZh0q6HO4bUAjB24RfQCyifLLQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-8.1.5.tgz",
+      "integrity": "sha512-qMYwD1cXW0hJ3pMmdMlbsqktVBlsjsqwMH5PBzAN4FoWiCQ/yHeAnDXRUgFFaLcORS72h9H/cQuJ+p//RdeURg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -9615,14 +10873,14 @@
       }
     },
     "node_modules/@storybook/telemetry": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-8.0.10.tgz",
-      "integrity": "sha512-s4Uc+KZQkdmD2d+64Qf8wYknhQZwmjf2CxjIjv9b4KLsU/nyfDheK7Fzd1jhBKb2UQUlLW5HhZkBgs1RsZcDHA==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-8.1.5.tgz",
+      "integrity": "sha512-QbB1Ox7oBaCvIF2TacFjPLi1XYeHxSPeZUuFXeE+tSMdvvWZzYLnXfj/oISmV6Q+X5VZfyJVMrZ2LfeW9CuFNg==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "8.0.10",
-        "@storybook/core-common": "8.0.10",
-        "@storybook/csf-tools": "8.0.10",
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-common": "8.1.5",
+        "@storybook/csf-tools": "8.1.5",
         "chalk": "^4.1.0",
         "detect-package-manager": "^2.0.1",
         "fetch-retry": "^5.0.2",
@@ -9632,6 +10890,314 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/channels": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+      "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/client-logger": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+      "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/core-common": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.5.tgz",
+      "integrity": "sha512-1QDOT6KPZ9KV7Gs1yyqzvSwGBmNSUB33gckUldSBF4aqP+tZ7W5JIQ6/YTtp3V02sEokZGdL9Ud4LczQxTgy3A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "8.1.5",
+        "@storybook/csf-tools": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
+        "@storybook/types": "8.1.5",
+        "@yarnpkg/fslib": "2.10.3",
+        "@yarnpkg/libzip": "2.3.0",
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+        "esbuild-register": "^3.5.0",
+        "execa": "^5.0.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "prettier-fallback": "npm:prettier@^3",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.7",
+        "tempy": "^3.1.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/core-events": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+      "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/csf-tools": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.5.tgz",
+      "integrity": "sha512-jOfUo0arlaG4LlsdWaRfZCS0I1FhUnkf06ThzRBrrp8mFAPtOpf9iW16J3fYMS5vAdE/v+Z1RxuTRich4/JGdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/types": "8.1.5",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/node-logger": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.5.tgz",
+      "integrity": "sha512-9qwPX/uGhdHaVjeVUSwJUSbKX7g9goyhGYdKVuCEyl7vHR9Kp7Zkag2sEHmVdd9ixTea3jk2GZQEbnBDNQNGnw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/types": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+      "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.5",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/glob": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/jackspeak": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
+      "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/test": {
@@ -10200,6 +11766,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.5.tgz",
       "integrity": "sha512-Rf3/lB9WkDfIL9eEKaSYKc+1L/rNVYBjThk22JTqQw0YozXarX8YljFAz+HCoC6h4B4KwCMsBPZHaFezwT4BNA==",
+      "dev": true
+    },
+    "node_modules/@types/diff": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.1.tgz",
+      "integrity": "sha512-uxpcuwWJGhe2AR1g8hD9F5OYGCqjqWnBUQFD8gMZsDbv8oPHzxJF6iMO6n8Tk0AdzlxoaaoQhOYlIg/PukVU8g==",
       "dev": true
     },
     "node_modules/@types/doctrine": {
@@ -19083,9 +20655,9 @@
       }
     },
     "node_modules/flow-parser": {
-      "version": "0.236.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.236.0.tgz",
-      "integrity": "sha512-0OEk9Gr+Yj7wjDW2KgaNYUypKau71jAfFyeLQF5iVtxqc6uJHag/MT7pmaEApf4qM7u86DkBcd4ualddYMfbLw==",
+      "version": "0.237.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.237.1.tgz",
+      "integrity": "sha512-PUeG8GQLmrv49vEcFcag7mriJvVs7Yyegnv1DGskvcokhP8UyqWsLV0KoTQ1iAW3ePVUIGUc3MFfBaXwz9MmIg==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -21207,6 +22779,25 @@
       "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "dev": true
     },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -22907,6 +24498,12 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
     },
     "node_modules/jscodeshift": {
       "version": "0.15.2",
@@ -33367,6 +34964,13 @@
         }
       }
     },
+    "node_modules/postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/postcss-modules": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-6.0.0.tgz",
@@ -33527,6 +35131,22 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-fallback": {
+      "name": "prettier",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
+      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -37116,16 +38736,16 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -37435,12 +39055,12 @@
       "dev": true
     },
     "node_modules/storybook": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.0.10.tgz",
-      "integrity": "sha512-9/4oxISopLyr5xz7Du27mmQgcIfB7UTLlNzkK4IklWTiSgsOgYgZpsmIwymoXNtkrvh+QsqskdcUP1C7nNiEtw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.1.5.tgz",
+      "integrity": "sha512-v4o8AfTvxWpdGa9Pa9x8EAmqbN5yJc+2fW8b6ZaCsDOTh2t5Y3EUHbIzdtvX+1Gb6ALsOs5e2Q9GlCAzjz+WNQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/cli": "8.0.10"
+        "@storybook/cli": "8.1.5"
       },
       "bin": {
         "sb": "index.js",
@@ -37882,6 +39502,18 @@
         "node": ">=18.12.0"
       }
     },
+    "node_modules/stylelint-config-css-modules": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-css-modules/-/stylelint-config-css-modules-4.4.0.tgz",
+      "integrity": "sha512-J93MtxPjRzs/TjwbJ5y9SQy4iIqULXwL1CF1yx2tQCJfS/VZUcDAmoGOwqlLbhHXSQtZO5XQiA75NVWUR3KDCQ==",
+      "dev": true,
+      "optionalDependencies": {
+        "stylelint-scss": "^6.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.5.1 || ^15.0.0 || ^16.0.0"
+      }
+    },
     "node_modules/stylelint-config-recess-order": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/stylelint-config-recess-order/-/stylelint-config-recess-order-5.0.1.tgz",
@@ -37949,6 +39581,33 @@
       "peerDependencies": {
         "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.1"
       }
+    },
+    "node_modules/stylelint-scss": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.3.0.tgz",
+      "integrity": "sha512-8OSpiuf1xC7f8kllJsBOFAOYp/mR/C1FXMVeOFjtJPw+AFvEmC93FaklHt7MlOqU4poxuQ1TkYMyfI0V+1SxjA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "known-css-properties": "^0.30.0",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.15",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.0.2"
+      }
+    },
+    "node_modules/stylelint-scss/node_modules/known-css-properties": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.30.0.tgz",
+      "integrity": "sha512-VSWXYUnsPu9+WYKkfmJyLKtIvaRJi1kXUqVmBACORXZQxT5oZDsoZ2vQP+bQFDnWtpI/4eq3MLoRMjI2fnLzTQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/stylelint/node_modules/ansi-regex": {
       "version": "6.0.1",
@@ -38496,6 +40155,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
@@ -39667,6 +41327,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unified": {
@@ -43051,12 +44723,12 @@
       }
     },
     "@babel/plugin-syntax-flow": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.1.tgz",
-      "integrity": "sha512-sxi2kLTI5DeW5vDtMUsk4mTPwvlUDbjOnoWayhynCwrw4QXRld4QEYwqzY8JmQXaJUtgUuCIurtSRH5sn4c7mA==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.6.tgz",
+      "integrity": "sha512-gNkksSdV8RbsCoHF9sjVYrHfYACMl/8U32UfUhJ9+84/ASXw8dlx+eHyyF0m6ncQJ9IBSxfuCkB36GJqYdXTOA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.6"
       }
     },
     "@babel/plugin-syntax-import-assertions": {
@@ -43350,13 +45022,13 @@
       }
     },
     "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.1.tgz",
-      "integrity": "sha512-iIYPIWt3dUmUKKE10s3W+jsQ3icFkw0JyRVyY1B7G4yK/nngAOHLVx8xlhA6b/Jzl/Y0nis8gjqhqKtRDQqHWQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.6.tgz",
+      "integrity": "sha512-1l8b24NoCpaQ13Vi6FtLG1nv6kNoi8PWvQb1AYO7GHZDpFfBYc3lbXArx1lP2KRt8b4pej1eWc/zrRmsQTfOdQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.0",
-        "@babel/plugin-syntax-flow": "^7.24.1"
+        "@babel/helper-plugin-utils": "^7.24.6",
+        "@babel/plugin-syntax-flow": "^7.24.6"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -43853,14 +45525,14 @@
       }
     },
     "@babel/preset-flow": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.24.1.tgz",
-      "integrity": "sha512-sWCV2G9pcqZf+JHyv/RyqEIpFypxdCSxWIxQjpdaQxenNog7cN1pr76hg8u0Fz8Qgg0H4ETkGcJnXL8d4j0PPA==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.24.6.tgz",
+      "integrity": "sha512-huoe0T1Qs9fQhMWbmqE/NHUeZbqmHDsN6n/jYvPcUUHfuKiPV32C9i8tDhMbQ1DEKTjbBP7Rjm3nSLwlB2X05g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.24.0",
-        "@babel/helper-validator-option": "^7.23.5",
-        "@babel/plugin-transform-flow-strip-types": "^7.24.1"
+        "@babel/helper-plugin-utils": "^7.24.6",
+        "@babel/helper-validator-option": "^7.24.6",
+        "@babel/plugin-transform-flow-strip-types": "^7.24.6"
       }
     },
     "@babel/preset-modules": {
@@ -43902,9 +45574,9 @@
       }
     },
     "@babel/register": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.23.7.tgz",
-      "integrity": "sha512-EjJeB6+kvpk+Y5DAkEAmbOBEFkh9OASx0huoEkqYTFxAZHzOAX2Oh5uwAUuL2rUddqfM0SA+KPXV2TbzoZ2kvQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.24.6.tgz",
+      "integrity": "sha512-WSuFCc2wCqMeXkz/i3yfAAsxwWflEgbVkZzivgAmXl/MxrXeoYFZOOPllbC8R8WTF7u61wSRQtDVZ1879cdu6w==",
       "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
@@ -47694,6 +49366,12 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
+    "@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true
+    },
     "@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -47876,25 +49554,233 @@
       }
     },
     "@storybook/builder-manager": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-8.0.10.tgz",
-      "integrity": "sha512-lo57jeeYuYCKYrmGOdLg25rMyiGYSTwJ+zYsQ3RvClVICjP6X0I1RCKAJDzkI0BixH6s1+w5ynD6X3PtDnhUuw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-8.1.5.tgz",
+      "integrity": "sha512-wDiHLV+UPaUN+765WwXkocVRB2QnJ61CjLHbpWaLiJvryFJt+JQ6nAvgSalCRnZxI046ztbS9T6okhpFI011IA==",
       "dev": true,
       "requires": {
         "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
-        "@storybook/core-common": "8.0.10",
-        "@storybook/manager": "8.0.10",
-        "@storybook/node-logger": "8.0.10",
+        "@storybook/core-common": "8.1.5",
+        "@storybook/manager": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
         "@types/ejs": "^3.1.1",
         "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.10",
         "browser-assert": "^1.2.1",
-        "ejs": "^3.1.8",
+        "ejs": "^3.1.10",
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
         "esbuild-plugin-alias": "^0.2.1",
         "express": "^4.17.3",
         "fs-extra": "^11.1.0",
         "process": "^0.11.10",
         "util": "^0.12.4"
+      },
+      "dependencies": {
+        "@storybook/channels": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+          "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "8.1.5",
+            "@storybook/core-events": "8.1.5",
+            "@storybook/global": "^5.0.0",
+            "telejson": "^7.2.0",
+            "tiny-invariant": "^1.3.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+          "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
+          "dev": true,
+          "requires": {
+            "@storybook/global": "^5.0.0"
+          }
+        },
+        "@storybook/core-common": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.5.tgz",
+          "integrity": "sha512-1QDOT6KPZ9KV7Gs1yyqzvSwGBmNSUB33gckUldSBF4aqP+tZ7W5JIQ6/YTtp3V02sEokZGdL9Ud4LczQxTgy3A==",
+          "dev": true,
+          "requires": {
+            "@storybook/core-events": "8.1.5",
+            "@storybook/csf-tools": "8.1.5",
+            "@storybook/node-logger": "8.1.5",
+            "@storybook/types": "8.1.5",
+            "@yarnpkg/fslib": "2.10.3",
+            "@yarnpkg/libzip": "2.3.0",
+            "chalk": "^4.1.0",
+            "cross-spawn": "^7.0.3",
+            "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+            "esbuild-register": "^3.5.0",
+            "execa": "^5.0.0",
+            "file-system-cache": "2.3.0",
+            "find-cache-dir": "^3.0.0",
+            "find-up": "^5.0.0",
+            "fs-extra": "^11.1.0",
+            "glob": "^10.0.0",
+            "handlebars": "^4.7.7",
+            "lazy-universal-dotenv": "^4.0.0",
+            "node-fetch": "^2.0.0",
+            "picomatch": "^2.3.0",
+            "pkg-dir": "^5.0.0",
+            "prettier-fallback": "npm:prettier@^3",
+            "pretty-hrtime": "^1.0.3",
+            "resolve-from": "^5.0.0",
+            "semver": "^7.3.7",
+            "tempy": "^3.1.0",
+            "tiny-invariant": "^1.3.1",
+            "ts-dedent": "^2.0.0",
+            "util": "^0.12.4"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+          "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
+          "dev": true,
+          "requires": {
+            "@storybook/csf": "^0.1.7",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/csf-tools": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.5.tgz",
+          "integrity": "sha512-jOfUo0arlaG4LlsdWaRfZCS0I1FhUnkf06ThzRBrrp8mFAPtOpf9iW16J3fYMS5vAdE/v+Z1RxuTRich4/JGdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/generator": "^7.24.4",
+            "@babel/parser": "^7.24.4",
+            "@babel/traverse": "^7.24.1",
+            "@babel/types": "^7.24.0",
+            "@storybook/csf": "^0.1.7",
+            "@storybook/types": "8.1.5",
+            "fs-extra": "^11.1.0",
+            "recast": "^0.23.5",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.5.tgz",
+          "integrity": "sha512-9qwPX/uGhdHaVjeVUSwJUSbKX7g9goyhGYdKVuCEyl7vHR9Kp7Zkag2sEHmVdd9ixTea3jk2GZQEbnBDNQNGnw==",
+          "dev": true
+        },
+        "@storybook/types": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+          "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "8.1.5",
+            "@types/express": "^4.7.0",
+            "file-system-cache": "2.3.0"
+          }
+        },
+        "crypto-random-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+          "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^1.0.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+              "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+              "dev": true
+            }
+          }
+        },
+        "glob": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+          "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "jackspeak": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
+          "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+          "dev": true,
+          "requires": {
+            "@isaacs/cliui": "^8.0.2",
+            "@pkgjs/parseargs": "^0.11.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+          "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
+        "temp-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+          "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+          "dev": true
+        },
+        "tempy": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+          "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+          "dev": true,
+          "requires": {
+            "is-stream": "^3.0.0",
+            "temp-dir": "^3.0.0",
+            "type-fest": "^2.12.2",
+            "unique-string": "^3.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        },
+        "unique-string": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+          "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+          "dev": true,
+          "requires": {
+            "crypto-random-string": "^4.0.0"
+          }
+        }
       }
     },
     "@storybook/builder-vite": {
@@ -47936,22 +49822,22 @@
       }
     },
     "@storybook/cli": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-8.0.10.tgz",
-      "integrity": "sha512-KUZEO2lyvOS2sRJEFXovt6+5b65iWsh7F8e8S1cM20fCM1rZAlWtwmoxmDVXDmyEp0wTrq4FrRxKnbo9UO518w==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-8.1.5.tgz",
+      "integrity": "sha512-VEYluZEMleNEnD5wTD90KTh03pwjvQwEEmzHAJQJdLbWTAcgBxZ3Gb45nbUPauSqBL+HdJx0QXF8Ielk+iBttw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.23.0",
-        "@babel/types": "^7.23.0",
+        "@babel/core": "^7.24.4",
+        "@babel/types": "^7.24.0",
         "@ndelangen/get-tarball": "^3.0.7",
-        "@storybook/codemod": "8.0.10",
-        "@storybook/core-common": "8.0.10",
-        "@storybook/core-events": "8.0.10",
-        "@storybook/core-server": "8.0.10",
-        "@storybook/csf-tools": "8.0.10",
-        "@storybook/node-logger": "8.0.10",
-        "@storybook/telemetry": "8.0.10",
-        "@storybook/types": "8.0.10",
+        "@storybook/codemod": "8.1.5",
+        "@storybook/core-common": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/core-server": "8.1.5",
+        "@storybook/csf-tools": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
+        "@storybook/telemetry": "8.1.5",
+        "@storybook/types": "8.1.5",
         "@types/semver": "^7.3.4",
         "@yarnpkg/fslib": "2.10.3",
         "@yarnpkg/libzip": "2.3.0",
@@ -47965,7 +49851,7 @@
         "fs-extra": "^11.1.0",
         "get-npm-tarball-url": "^2.0.3",
         "giget": "^1.0.0",
-        "globby": "^11.0.2",
+        "globby": "^14.0.1",
         "jscodeshift": "^0.15.1",
         "leven": "^3.1.0",
         "ora": "^5.4.1",
@@ -47974,16 +49860,248 @@
         "read-pkg-up": "^7.0.1",
         "semver": "^7.3.7",
         "strip-json-comments": "^3.0.1",
-        "tempy": "^1.0.1",
+        "tempy": "^3.1.0",
         "tiny-invariant": "^1.3.1",
         "ts-dedent": "^2.0.0"
       },
       "dependencies": {
+        "@storybook/channels": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+          "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "8.1.5",
+            "@storybook/core-events": "8.1.5",
+            "@storybook/global": "^5.0.0",
+            "telejson": "^7.2.0",
+            "tiny-invariant": "^1.3.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+          "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
+          "dev": true,
+          "requires": {
+            "@storybook/global": "^5.0.0"
+          }
+        },
+        "@storybook/core-common": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.5.tgz",
+          "integrity": "sha512-1QDOT6KPZ9KV7Gs1yyqzvSwGBmNSUB33gckUldSBF4aqP+tZ7W5JIQ6/YTtp3V02sEokZGdL9Ud4LczQxTgy3A==",
+          "dev": true,
+          "requires": {
+            "@storybook/core-events": "8.1.5",
+            "@storybook/csf-tools": "8.1.5",
+            "@storybook/node-logger": "8.1.5",
+            "@storybook/types": "8.1.5",
+            "@yarnpkg/fslib": "2.10.3",
+            "@yarnpkg/libzip": "2.3.0",
+            "chalk": "^4.1.0",
+            "cross-spawn": "^7.0.3",
+            "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+            "esbuild-register": "^3.5.0",
+            "execa": "^5.0.0",
+            "file-system-cache": "2.3.0",
+            "find-cache-dir": "^3.0.0",
+            "find-up": "^5.0.0",
+            "fs-extra": "^11.1.0",
+            "glob": "^10.0.0",
+            "handlebars": "^4.7.7",
+            "lazy-universal-dotenv": "^4.0.0",
+            "node-fetch": "^2.0.0",
+            "picomatch": "^2.3.0",
+            "pkg-dir": "^5.0.0",
+            "prettier-fallback": "npm:prettier@^3",
+            "pretty-hrtime": "^1.0.3",
+            "resolve-from": "^5.0.0",
+            "semver": "^7.3.7",
+            "tempy": "^3.1.0",
+            "tiny-invariant": "^1.3.1",
+            "ts-dedent": "^2.0.0",
+            "util": "^0.12.4"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+          "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
+          "dev": true,
+          "requires": {
+            "@storybook/csf": "^0.1.7",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/csf-tools": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.5.tgz",
+          "integrity": "sha512-jOfUo0arlaG4LlsdWaRfZCS0I1FhUnkf06ThzRBrrp8mFAPtOpf9iW16J3fYMS5vAdE/v+Z1RxuTRich4/JGdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/generator": "^7.24.4",
+            "@babel/parser": "^7.24.4",
+            "@babel/traverse": "^7.24.1",
+            "@babel/types": "^7.24.0",
+            "@storybook/csf": "^0.1.7",
+            "@storybook/types": "8.1.5",
+            "fs-extra": "^11.1.0",
+            "recast": "^0.23.5",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.5.tgz",
+          "integrity": "sha512-9qwPX/uGhdHaVjeVUSwJUSbKX7g9goyhGYdKVuCEyl7vHR9Kp7Zkag2sEHmVdd9ixTea3jk2GZQEbnBDNQNGnw==",
+          "dev": true
+        },
+        "@storybook/types": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+          "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "8.1.5",
+            "@types/express": "^4.7.0",
+            "file-system-cache": "2.3.0"
+          }
+        },
         "commander": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
           "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
           "dev": true
+        },
+        "crypto-random-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+          "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^1.0.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+              "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+              "dev": true
+            }
+          }
+        },
+        "glob": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+          "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "globby": {
+          "version": "14.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
+          "integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/merge-streams": "^2.1.0",
+            "fast-glob": "^3.3.2",
+            "ignore": "^5.2.4",
+            "path-type": "^5.0.0",
+            "slash": "^5.1.0",
+            "unicorn-magic": "^0.1.0"
+          }
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "jackspeak": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
+          "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+          "dev": true,
+          "requires": {
+            "@isaacs/cliui": "^8.0.2",
+            "@pkgjs/parseargs": "^0.11.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+          "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+          "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
+        "slash": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+          "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+          "dev": true
+        },
+        "temp-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+          "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+          "dev": true
+        },
+        "tempy": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+          "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+          "dev": true,
+          "requires": {
+            "is-stream": "^3.0.0",
+            "temp-dir": "^3.0.0",
+            "type-fest": "^2.12.2",
+            "unique-string": "^3.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        },
+        "unique-string": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+          "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+          "dev": true,
+          "requires": {
+            "crypto-random-string": "^4.0.0"
+          }
         }
       }
     },
@@ -47997,26 +50115,120 @@
       }
     },
     "@storybook/codemod": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-8.0.10.tgz",
-      "integrity": "sha512-t45jKGs/eyR/nKVX6QgRtMZSAjJo5aXWWk3B24xVbW6ywr0jt1LC100FkHG4Af8cApIfh8uUmS9X05hMG5zGGA==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-8.1.5.tgz",
+      "integrity": "sha512-eGoYozT2XPfsIFrzm4cJo9tRTX0yuK1y4uTYmKvnomezHu5kiY8qo2fUzQa5DHxiAzRDTpGlQTzb0PsxHOxYoA==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.23.2",
-        "@babel/preset-env": "^7.23.2",
-        "@babel/types": "^7.23.0",
-        "@storybook/csf": "^0.1.4",
-        "@storybook/csf-tools": "8.0.10",
-        "@storybook/node-logger": "8.0.10",
-        "@storybook/types": "8.0.10",
+        "@babel/core": "^7.24.4",
+        "@babel/preset-env": "^7.24.4",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/csf-tools": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
+        "@storybook/types": "8.1.5",
         "@types/cross-spawn": "^6.0.2",
         "cross-spawn": "^7.0.3",
-        "globby": "^11.0.2",
+        "globby": "^14.0.1",
         "jscodeshift": "^0.15.1",
         "lodash": "^4.17.21",
         "prettier": "^3.1.1",
         "recast": "^0.23.5",
         "tiny-invariant": "^1.3.1"
+      },
+      "dependencies": {
+        "@storybook/channels": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+          "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "8.1.5",
+            "@storybook/core-events": "8.1.5",
+            "@storybook/global": "^5.0.0",
+            "telejson": "^7.2.0",
+            "tiny-invariant": "^1.3.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+          "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
+          "dev": true,
+          "requires": {
+            "@storybook/global": "^5.0.0"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+          "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
+          "dev": true,
+          "requires": {
+            "@storybook/csf": "^0.1.7",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/csf-tools": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.5.tgz",
+          "integrity": "sha512-jOfUo0arlaG4LlsdWaRfZCS0I1FhUnkf06ThzRBrrp8mFAPtOpf9iW16J3fYMS5vAdE/v+Z1RxuTRich4/JGdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/generator": "^7.24.4",
+            "@babel/parser": "^7.24.4",
+            "@babel/traverse": "^7.24.1",
+            "@babel/types": "^7.24.0",
+            "@storybook/csf": "^0.1.7",
+            "@storybook/types": "8.1.5",
+            "fs-extra": "^11.1.0",
+            "recast": "^0.23.5",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.5.tgz",
+          "integrity": "sha512-9qwPX/uGhdHaVjeVUSwJUSbKX7g9goyhGYdKVuCEyl7vHR9Kp7Zkag2sEHmVdd9ixTea3jk2GZQEbnBDNQNGnw==",
+          "dev": true
+        },
+        "@storybook/types": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+          "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "8.1.5",
+            "@types/express": "^4.7.0",
+            "file-system-cache": "2.3.0"
+          }
+        },
+        "globby": {
+          "version": "14.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
+          "integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/merge-streams": "^2.1.0",
+            "fast-glob": "^3.3.2",
+            "ignore": "^5.2.4",
+            "path-type": "^5.0.0",
+            "slash": "^5.1.0",
+            "unicorn-magic": "^0.1.0"
+          }
+        },
+        "path-type": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+          "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+          "dev": true
+        },
+        "slash": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+          "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+          "dev": true
+        }
       }
     },
     "@storybook/components": {
@@ -48121,29 +50333,31 @@
       }
     },
     "@storybook/core-server": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-8.0.10.tgz",
-      "integrity": "sha512-HYDw2QFBxg1X/d6g0rUhirOB5Jq6g90HBnyrZzxKoqKWJCNsCADSgM+h9HgtUw0jA97qBpIqmNO9n3mXFPWU/Q==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-8.1.5.tgz",
+      "integrity": "sha512-y16W2sg5KIHG6qgbd+a0nBUYHAgiUpPDFF7cdcIpbeOIoqFn+6ECp93MVefukumiSj3sQiJFU/tSm2A8apGltw==",
       "dev": true,
       "requires": {
         "@aw-web-design/x-default-browser": "1.4.126",
-        "@babel/core": "^7.23.9",
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
         "@discoveryjs/json-ext": "^0.5.3",
-        "@storybook/builder-manager": "8.0.10",
-        "@storybook/channels": "8.0.10",
-        "@storybook/core-common": "8.0.10",
-        "@storybook/core-events": "8.0.10",
-        "@storybook/csf": "^0.1.4",
-        "@storybook/csf-tools": "8.0.10",
-        "@storybook/docs-mdx": "3.0.0",
+        "@storybook/builder-manager": "8.1.5",
+        "@storybook/channels": "8.1.5",
+        "@storybook/core-common": "8.1.5",
+        "@storybook/core-events": "8.1.5",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/csf-tools": "8.1.5",
+        "@storybook/docs-mdx": "3.1.0-next.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager": "8.0.10",
-        "@storybook/manager-api": "8.0.10",
-        "@storybook/node-logger": "8.0.10",
-        "@storybook/preview-api": "8.0.10",
-        "@storybook/telemetry": "8.0.10",
-        "@storybook/types": "8.0.10",
+        "@storybook/manager": "8.1.5",
+        "@storybook/manager-api": "8.1.5",
+        "@storybook/node-logger": "8.1.5",
+        "@storybook/preview-api": "8.1.5",
+        "@storybook/telemetry": "8.1.5",
+        "@storybook/types": "8.1.5",
         "@types/detect-port": "^1.3.0",
+        "@types/diff": "^5.0.9",
         "@types/node": "^18.0.0",
         "@types/pretty-hrtime": "^1.0.0",
         "@types/semver": "^7.3.4",
@@ -48152,9 +50366,10 @@
         "cli-table3": "^0.6.1",
         "compression": "^1.7.4",
         "detect-port": "^1.3.0",
+        "diff": "^5.2.0",
         "express": "^4.17.3",
         "fs-extra": "^11.1.0",
-        "globby": "^11.0.2",
+        "globby": "^14.0.1",
         "ip": "^2.0.1",
         "lodash": "^4.17.21",
         "open": "^8.4.0",
@@ -48169,6 +50384,308 @@
         "util-deprecate": "^1.0.2",
         "watchpack": "^2.2.0",
         "ws": "^8.2.3"
+      },
+      "dependencies": {
+        "@storybook/channels": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+          "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "8.1.5",
+            "@storybook/core-events": "8.1.5",
+            "@storybook/global": "^5.0.0",
+            "telejson": "^7.2.0",
+            "tiny-invariant": "^1.3.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+          "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
+          "dev": true,
+          "requires": {
+            "@storybook/global": "^5.0.0"
+          }
+        },
+        "@storybook/core-common": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.5.tgz",
+          "integrity": "sha512-1QDOT6KPZ9KV7Gs1yyqzvSwGBmNSUB33gckUldSBF4aqP+tZ7W5JIQ6/YTtp3V02sEokZGdL9Ud4LczQxTgy3A==",
+          "dev": true,
+          "requires": {
+            "@storybook/core-events": "8.1.5",
+            "@storybook/csf-tools": "8.1.5",
+            "@storybook/node-logger": "8.1.5",
+            "@storybook/types": "8.1.5",
+            "@yarnpkg/fslib": "2.10.3",
+            "@yarnpkg/libzip": "2.3.0",
+            "chalk": "^4.1.0",
+            "cross-spawn": "^7.0.3",
+            "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+            "esbuild-register": "^3.5.0",
+            "execa": "^5.0.0",
+            "file-system-cache": "2.3.0",
+            "find-cache-dir": "^3.0.0",
+            "find-up": "^5.0.0",
+            "fs-extra": "^11.1.0",
+            "glob": "^10.0.0",
+            "handlebars": "^4.7.7",
+            "lazy-universal-dotenv": "^4.0.0",
+            "node-fetch": "^2.0.0",
+            "picomatch": "^2.3.0",
+            "pkg-dir": "^5.0.0",
+            "prettier-fallback": "npm:prettier@^3",
+            "pretty-hrtime": "^1.0.3",
+            "resolve-from": "^5.0.0",
+            "semver": "^7.3.7",
+            "tempy": "^3.1.0",
+            "tiny-invariant": "^1.3.1",
+            "ts-dedent": "^2.0.0",
+            "util": "^0.12.4"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+          "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
+          "dev": true,
+          "requires": {
+            "@storybook/csf": "^0.1.7",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/csf-tools": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.5.tgz",
+          "integrity": "sha512-jOfUo0arlaG4LlsdWaRfZCS0I1FhUnkf06ThzRBrrp8mFAPtOpf9iW16J3fYMS5vAdE/v+Z1RxuTRich4/JGdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/generator": "^7.24.4",
+            "@babel/parser": "^7.24.4",
+            "@babel/traverse": "^7.24.1",
+            "@babel/types": "^7.24.0",
+            "@storybook/csf": "^0.1.7",
+            "@storybook/types": "8.1.5",
+            "fs-extra": "^11.1.0",
+            "recast": "^0.23.5",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/manager-api": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.1.5.tgz",
+          "integrity": "sha512-iVP7FOKDf9L7zWCb8C2XeZjWSILS3hHeNwILvd9YSX9dg9du41kJYahsAHxDCR/jp/gv0ZM/V0vuHzi+naVPkQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "8.1.5",
+            "@storybook/client-logger": "8.1.5",
+            "@storybook/core-events": "8.1.5",
+            "@storybook/csf": "^0.1.7",
+            "@storybook/global": "^5.0.0",
+            "@storybook/icons": "^1.2.5",
+            "@storybook/router": "8.1.5",
+            "@storybook/theming": "8.1.5",
+            "@storybook/types": "8.1.5",
+            "dequal": "^2.0.2",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "store2": "^2.14.2",
+            "telejson": "^7.2.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.5.tgz",
+          "integrity": "sha512-9qwPX/uGhdHaVjeVUSwJUSbKX7g9goyhGYdKVuCEyl7vHR9Kp7Zkag2sEHmVdd9ixTea3jk2GZQEbnBDNQNGnw==",
+          "dev": true
+        },
+        "@storybook/preview-api": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.1.5.tgz",
+          "integrity": "sha512-pv0aT5WbnSYR7KWQgy3jLfuBM0ocYG6GTcmZLREW5554oiBPHhzNFv+ZrBI47RzbrbFxq1h5dj4v8lkEcKIrbA==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "8.1.5",
+            "@storybook/client-logger": "8.1.5",
+            "@storybook/core-events": "8.1.5",
+            "@storybook/csf": "^0.1.7",
+            "@storybook/global": "^5.0.0",
+            "@storybook/types": "8.1.5",
+            "@types/qs": "^6.9.5",
+            "dequal": "^2.0.2",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "tiny-invariant": "^1.3.1",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-8.1.5.tgz",
+          "integrity": "sha512-DCwvAswlbLhQu6REPV04XNRhtPvsrRqHjMHKzjlfs+qYJWY7Egkofy05qlegqjkMDve33czfnRGBm0C16IydkA==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "8.1.5",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.1.5.tgz",
+          "integrity": "sha512-E4z1t49fMbVvd/t2MSL0Ecp5zbqsU/QfWBX/eorJ+m+Xc9skkwwG5qf/FnP9x4RZ9KaX8U8+862t0eafVvf4Tw==",
+          "dev": true,
+          "requires": {
+            "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+            "@storybook/client-logger": "8.1.5",
+            "@storybook/global": "^5.0.0",
+            "memoizerific": "^1.11.3"
+          }
+        },
+        "@storybook/types": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+          "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "8.1.5",
+            "@types/express": "^4.7.0",
+            "file-system-cache": "2.3.0"
+          }
+        },
+        "crypto-random-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+          "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^1.0.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+              "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+              "dev": true
+            }
+          }
+        },
+        "glob": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+          "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "globby": {
+          "version": "14.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
+          "integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/merge-streams": "^2.1.0",
+            "fast-glob": "^3.3.2",
+            "ignore": "^5.2.4",
+            "path-type": "^5.0.0",
+            "slash": "^5.1.0",
+            "unicorn-magic": "^0.1.0"
+          }
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "jackspeak": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
+          "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+          "dev": true,
+          "requires": {
+            "@isaacs/cliui": "^8.0.2",
+            "@pkgjs/parseargs": "^0.11.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+          "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+          "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
+        "slash": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+          "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+          "dev": true
+        },
+        "temp-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+          "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+          "dev": true
+        },
+        "tempy": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+          "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+          "dev": true,
+          "requires": {
+            "is-stream": "^3.0.0",
+            "temp-dir": "^3.0.0",
+            "type-fest": "^2.12.2",
+            "unique-string": "^3.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        },
+        "unique-string": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+          "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+          "dev": true,
+          "requires": {
+            "crypto-random-string": "^4.0.0"
+          }
+        }
       }
     },
     "@storybook/csf": {
@@ -48216,9 +50733,9 @@
       }
     },
     "@storybook/docs-mdx": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@storybook/docs-mdx/-/docs-mdx-3.0.0.tgz",
-      "integrity": "sha512-NmiGXl2HU33zpwTv1XORe9XG9H+dRUC1Jl11u92L4xr062pZtrShLmD4VKIsOQujxhhOrbxpwhNOt+6TdhyIdQ==",
+      "version": "3.1.0-next.0",
+      "resolved": "https://registry.npmjs.org/@storybook/docs-mdx/-/docs-mdx-3.1.0-next.0.tgz",
+      "integrity": "sha512-t4syFIeSyufieNovZbLruPt2DmRKpbwL4fERCZ1MifWDRIORCKLc4NCEHy+IqvIqd71/SJV2k4B51nF7vlJfmQ==",
       "dev": true
     },
     "@storybook/docs-tools": {
@@ -48266,9 +50783,9 @@
       }
     },
     "@storybook/manager": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-8.0.10.tgz",
-      "integrity": "sha512-bojGglUQNry48L4siURc2zQKswavLzMh69rqsfL3ZXx+i+USfRfB7593azTlaZh0q6HO4bUAjB24RfQCyifLLQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-8.1.5.tgz",
+      "integrity": "sha512-qMYwD1cXW0hJ3pMmdMlbsqktVBlsjsqwMH5PBzAN4FoWiCQ/yHeAnDXRUgFFaLcORS72h9H/cQuJ+p//RdeURg==",
       "dev": true
     },
     "@storybook/manager-api": {
@@ -48434,19 +50951,227 @@
       }
     },
     "@storybook/telemetry": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-8.0.10.tgz",
-      "integrity": "sha512-s4Uc+KZQkdmD2d+64Qf8wYknhQZwmjf2CxjIjv9b4KLsU/nyfDheK7Fzd1jhBKb2UQUlLW5HhZkBgs1RsZcDHA==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-8.1.5.tgz",
+      "integrity": "sha512-QbB1Ox7oBaCvIF2TacFjPLi1XYeHxSPeZUuFXeE+tSMdvvWZzYLnXfj/oISmV6Q+X5VZfyJVMrZ2LfeW9CuFNg==",
       "dev": true,
       "requires": {
-        "@storybook/client-logger": "8.0.10",
-        "@storybook/core-common": "8.0.10",
-        "@storybook/csf-tools": "8.0.10",
+        "@storybook/client-logger": "8.1.5",
+        "@storybook/core-common": "8.1.5",
+        "@storybook/csf-tools": "8.1.5",
         "chalk": "^4.1.0",
         "detect-package-manager": "^2.0.1",
         "fetch-retry": "^5.0.2",
         "fs-extra": "^11.1.0",
         "read-pkg-up": "^7.0.1"
+      },
+      "dependencies": {
+        "@storybook/channels": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.5.tgz",
+          "integrity": "sha512-R+puP4tWYzQUbpIp8sX6U5oI+ZUevVOaFxXGaAN3PRXjIRC38oKTVWzj/G6GdziVFzN6rDn+JsYPmiRMYo1sYg==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "8.1.5",
+            "@storybook/core-events": "8.1.5",
+            "@storybook/global": "^5.0.0",
+            "telejson": "^7.2.0",
+            "tiny-invariant": "^1.3.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.5.tgz",
+          "integrity": "sha512-zd+aENXnOHsxBATppELmhw/UywLzCxQjz/8i/xkUjeTRB4Ggp0hJlOUdJUEdIJz631ydyytfvM70ktBj9gMl1w==",
+          "dev": true,
+          "requires": {
+            "@storybook/global": "^5.0.0"
+          }
+        },
+        "@storybook/core-common": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.5.tgz",
+          "integrity": "sha512-1QDOT6KPZ9KV7Gs1yyqzvSwGBmNSUB33gckUldSBF4aqP+tZ7W5JIQ6/YTtp3V02sEokZGdL9Ud4LczQxTgy3A==",
+          "dev": true,
+          "requires": {
+            "@storybook/core-events": "8.1.5",
+            "@storybook/csf-tools": "8.1.5",
+            "@storybook/node-logger": "8.1.5",
+            "@storybook/types": "8.1.5",
+            "@yarnpkg/fslib": "2.10.3",
+            "@yarnpkg/libzip": "2.3.0",
+            "chalk": "^4.1.0",
+            "cross-spawn": "^7.0.3",
+            "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+            "esbuild-register": "^3.5.0",
+            "execa": "^5.0.0",
+            "file-system-cache": "2.3.0",
+            "find-cache-dir": "^3.0.0",
+            "find-up": "^5.0.0",
+            "fs-extra": "^11.1.0",
+            "glob": "^10.0.0",
+            "handlebars": "^4.7.7",
+            "lazy-universal-dotenv": "^4.0.0",
+            "node-fetch": "^2.0.0",
+            "picomatch": "^2.3.0",
+            "pkg-dir": "^5.0.0",
+            "prettier-fallback": "npm:prettier@^3",
+            "pretty-hrtime": "^1.0.3",
+            "resolve-from": "^5.0.0",
+            "semver": "^7.3.7",
+            "tempy": "^3.1.0",
+            "tiny-invariant": "^1.3.1",
+            "ts-dedent": "^2.0.0",
+            "util": "^0.12.4"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.5.tgz",
+          "integrity": "sha512-fgwbrHoLtSX6kfmamTGJqD+KfuEgun8cc4mWKZK094ByaqbSjhnOyeYO1sfVk8qst7QTFlOfhLAUe4cz1z149A==",
+          "dev": true,
+          "requires": {
+            "@storybook/csf": "^0.1.7",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/csf-tools": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.5.tgz",
+          "integrity": "sha512-jOfUo0arlaG4LlsdWaRfZCS0I1FhUnkf06ThzRBrrp8mFAPtOpf9iW16J3fYMS5vAdE/v+Z1RxuTRich4/JGdQ==",
+          "dev": true,
+          "requires": {
+            "@babel/generator": "^7.24.4",
+            "@babel/parser": "^7.24.4",
+            "@babel/traverse": "^7.24.1",
+            "@babel/types": "^7.24.0",
+            "@storybook/csf": "^0.1.7",
+            "@storybook/types": "8.1.5",
+            "fs-extra": "^11.1.0",
+            "recast": "^0.23.5",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/node-logger": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.5.tgz",
+          "integrity": "sha512-9qwPX/uGhdHaVjeVUSwJUSbKX7g9goyhGYdKVuCEyl7vHR9Kp7Zkag2sEHmVdd9ixTea3jk2GZQEbnBDNQNGnw==",
+          "dev": true
+        },
+        "@storybook/types": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.5.tgz",
+          "integrity": "sha512-/PfAZh1xtXN2MvAZZKpiL/nPkC3bZj8BQ7P7z5a/aQarP+y7qdXuoitYQ6oOH3rkaiYywmkWzA/y4iW70KXLKg==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "8.1.5",
+            "@types/express": "^4.7.0",
+            "file-system-cache": "2.3.0"
+          }
+        },
+        "crypto-random-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+          "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^1.0.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+              "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+              "dev": true
+            }
+          }
+        },
+        "glob": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+          "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "jackspeak": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
+          "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+          "dev": true,
+          "requires": {
+            "@isaacs/cliui": "^8.0.2",
+            "@pkgjs/parseargs": "^0.11.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+          "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+          "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
+        "temp-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+          "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+          "dev": true
+        },
+        "tempy": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+          "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+          "dev": true,
+          "requires": {
+            "is-stream": "^3.0.0",
+            "temp-dir": "^3.0.0",
+            "type-fest": "^2.12.2",
+            "unique-string": "^3.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        },
+        "unique-string": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+          "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+          "dev": true,
+          "requires": {
+            "crypto-random-string": "^4.0.0"
+          }
+        }
       }
     },
     "@storybook/test": {
@@ -49008,6 +51733,12 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/detect-port/-/detect-port-1.3.5.tgz",
       "integrity": "sha512-Rf3/lB9WkDfIL9eEKaSYKc+1L/rNVYBjThk22JTqQw0YozXarX8YljFAz+HCoC6h4B4KwCMsBPZHaFezwT4BNA==",
+      "dev": true
+    },
+    "@types/diff": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.1.tgz",
+      "integrity": "sha512-uxpcuwWJGhe2AR1g8hD9F5OYGCqjqWnBUQFD8gMZsDbv8oPHzxJF6iMO6n8Tk0AdzlxoaaoQhOYlIg/PukVU8g==",
       "dev": true
     },
     "@types/doctrine": {
@@ -55272,9 +58003,9 @@
       "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="
     },
     "flow-parser": {
-      "version": "0.236.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.236.0.tgz",
-      "integrity": "sha512-0OEk9Gr+Yj7wjDW2KgaNYUypKau71jAfFyeLQF5iVtxqc6uJHag/MT7pmaEApf4qM7u86DkBcd4ualddYMfbLw==",
+      "version": "0.237.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.237.1.tgz",
+      "integrity": "sha512-PUeG8GQLmrv49vEcFcag7mriJvVs7Yyegnv1DGskvcokhP8UyqWsLV0KoTQ1iAW3ePVUIGUc3MFfBaXwz9MmIg==",
       "dev": true
     },
     "follow-redirects": {
@@ -56828,6 +59559,24 @@
       "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "dev": true
     },
+    "ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "requires": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+          "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+          "dev": true
+        }
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -58068,6 +60817,12 @@
           }
         }
       }
+    },
+    "jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
     },
     "jscodeshift": {
       "version": "0.15.2",
@@ -64994,6 +67749,13 @@
         "yaml": "^1.10.2"
       }
     },
+    "postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
+      "dev": true,
+      "optional": true
+    },
     "postcss-modules": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-6.0.0.tgz",
@@ -65098,6 +67860,12 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true
+    },
+    "prettier-fallback": {
+      "version": "npm:prettier@3.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
+      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -67721,12 +70489,12 @@
       }
     },
     "socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "requires": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       }
     },
@@ -67982,12 +70750,12 @@
       "dev": true
     },
     "storybook": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.0.10.tgz",
-      "integrity": "sha512-9/4oxISopLyr5xz7Du27mmQgcIfB7UTLlNzkK4IklWTiSgsOgYgZpsmIwymoXNtkrvh+QsqskdcUP1C7nNiEtw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.1.5.tgz",
+      "integrity": "sha512-v4o8AfTvxWpdGa9Pa9x8EAmqbN5yJc+2fW8b6ZaCsDOTh2t5Y3EUHbIzdtvX+1Gb6ALsOs5e2Q9GlCAzjz+WNQ==",
       "dev": true,
       "requires": {
-        "@storybook/cli": "8.0.10"
+        "@storybook/cli": "8.1.5"
       }
     },
     "stream-combiner": {
@@ -68420,6 +71188,15 @@
         }
       }
     },
+    "stylelint-config-css-modules": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-css-modules/-/stylelint-config-css-modules-4.4.0.tgz",
+      "integrity": "sha512-J93MtxPjRzs/TjwbJ5y9SQy4iIqULXwL1CF1yx2tQCJfS/VZUcDAmoGOwqlLbhHXSQtZO5XQiA75NVWUR3KDCQ==",
+      "dev": true,
+      "requires": {
+        "stylelint-scss": "^6.0.0"
+      }
+    },
     "stylelint-config-recess-order": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/stylelint-config-recess-order/-/stylelint-config-recess-order-5.0.1.tgz",
@@ -68463,6 +71240,29 @@
       "requires": {
         "postcss": "^8.4.32",
         "postcss-sorting": "^8.0.2"
+      }
+    },
+    "stylelint-scss": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.3.0.tgz",
+      "integrity": "sha512-8OSpiuf1xC7f8kllJsBOFAOYp/mR/C1FXMVeOFjtJPw+AFvEmC93FaklHt7MlOqU4poxuQ1TkYMyfI0V+1SxjA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "known-css-properties": "^0.30.0",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.15",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "dependencies": {
+        "known-css-properties": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.30.0.tgz",
+          "integrity": "sha512-VSWXYUnsPu9+WYKkfmJyLKtIvaRJi1kXUqVmBACORXZQxT5oZDsoZ2vQP+bQFDnWtpI/4eq3MLoRMjI2fnLzTQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "stylis": {
@@ -69532,6 +72332,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "dev": true
+    },
+    "unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
       "dev": true
     },
     "unified": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "stylelint-config-recess-order": "^5.0.0",
         "stylelint-config-standard": "^36.0.0",
         "stylelint-no-unsupported-browser-features": "^8.0.1",
+        "stylelint-prettier": "^5.0.0",
         "svgo": "^3.2.0",
         "typescript": "^5.4.5",
         "vite": "^5.2.12",
@@ -35128,9 +35129,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
+      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -39580,6 +39581,22 @@
       },
       "peerDependencies": {
         "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.1"
+      }
+    },
+    "node_modules/stylelint-prettier": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-5.0.0.tgz",
+      "integrity": "sha512-RHfSlRJIsaVg5Br94gZVdWlz/rBTyQzZflNE6dXvSxt/GthWMY3gEHsWZEBaVGg7GM+XrtVSp4RznFlB7i0oyw==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "prettier": ">=3.0.0",
+        "stylelint": ">=16.0.0"
       }
     },
     "node_modules/stylelint-scss": {
@@ -67857,9 +67874,9 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
     "prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
+      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
       "dev": true
     },
     "prettier-fallback": {
@@ -71240,6 +71257,15 @@
       "requires": {
         "postcss": "^8.4.32",
         "postcss-sorting": "^8.0.2"
+      }
+    },
+    "stylelint-prettier": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-5.0.0.tgz",
+      "integrity": "sha512-RHfSlRJIsaVg5Br94gZVdWlz/rBTyQzZflNE6dXvSxt/GthWMY3gEHsWZEBaVGg7GM+XrtVSp4RznFlB7i0oyw==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "stylelint-scss": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "remark-gfm": "^4.0.0",
     "storybook": "^8.0.10",
     "stylelint": "^16.6.1",
+    "stylelint-config-css-modules": "^4.4.0",
     "stylelint-config-recess-order": "^5.0.0",
     "stylelint-config-standard": "^36.0.0",
     "stylelint-no-unsupported-browser-features": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "stylelint-config-recess-order": "^5.0.0",
     "stylelint-config-standard": "^36.0.0",
     "stylelint-no-unsupported-browser-features": "^8.0.1",
+    "stylelint-prettier": "^5.0.0",
     "svgo": "^3.2.0",
     "typescript": "^5.4.5",
     "vite": "^5.2.12",

--- a/packages/circuit-ui/components/Anchor/Anchor.module.css
+++ b/packages/circuit-ui/components/Anchor/Anchor.module.css
@@ -11,7 +11,8 @@
   border: 0;
   border-radius: var(--cui-border-radius-bit);
   outline: none;
-  transition: opacity var(--cui-transitions-default),
+  transition:
+    opacity var(--cui-transitions-default),
     color var(--cui-transitions-default),
     background-color var(--cui-transitions-default),
     border-color var(--cui-transitions-default);

--- a/packages/circuit-ui/components/Card/components/Header/Header.module.css
+++ b/packages/circuit-ui/components/Card/components/Header/Header.module.css
@@ -6,7 +6,7 @@
 }
 
 .no-headline {
-  justify-content: flex-end
+  justify-content: flex-end;
 }
 
 .base .close {

--- a/packages/circuit-ui/components/Checkbox/Checkbox.module.css
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.module.css
@@ -20,7 +20,8 @@
   border: 1px solid var(--cui-border-normal);
   border-radius: 3px;
   box-shadow: none;
-  transition: border var(--cui-transitions-default),
+  transition:
+    border var(--cui-transitions-default),
     background-color var(--cui-transitions-default);
   transform: translateY(-50%);
 }
@@ -37,7 +38,8 @@
   line-height: 0;
   color: var(--cui-fg-on-strong);
   opacity: 0;
-  transition: transform var(--cui-transitions-default),
+  transition:
+    transform var(--cui-transitions-default),
     opacity var(--cui-transitions-default);
   transform: translateY(-50%) scale(0, 0);
 }
@@ -49,7 +51,9 @@
 .base:focus + .label::before {
   border-color: var(--cui-border-accent);
   outline: 0;
-  box-shadow: 0 0 0 2px var(--cui-bg-normal), 0 0 0 4px var(--cui-border-focus);
+  box-shadow:
+    0 0 0 2px var(--cui-bg-normal),
+    0 0 0 4px var(--cui-border-focus);
 }
 
 .base:focus:not(:focus-visible) + .label::before {

--- a/packages/circuit-ui/components/Field/Field.module.css
+++ b/packages/circuit-ui/components/Field/Field.module.css
@@ -22,7 +22,6 @@
   color: var(--cui-fg-normal-disabled);
 }
 
-
 .label-text-optional {
   color: var(--cui-fg-subtle);
 }
@@ -58,7 +57,6 @@
   color: var(--cui-fg-subtle-disabled);
 }
 
-
 .valid {
   color: var(--cui-fg-success);
 }
@@ -93,7 +91,8 @@
   width: var(--cui-icon-sizes-kilo);
   height: var(--cui-icon-sizes-kilo);
   margin-top: calc(
-    (var(--cui-typography-body-two-line-height) - var(--cui-icon-sizes-kilo)) / 2
+    (var(--cui-typography-body-two-line-height) - var(--cui-icon-sizes-kilo)) /
+      2
   );
-  margin-right: var(--cui-spacings-bit)
+  margin-right: var(--cui-spacings-bit);
 }

--- a/packages/circuit-ui/components/Hamburger/Hamburger.module.css
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.module.css
@@ -34,7 +34,9 @@
   height: var(--hamburger-height);
   background-color: currentColor;
   border-radius: 1px;
-  transition: width 0.2s ease-out 0.15s, opacity 0.1s ease-in,
+  transition:
+    width 0.2s ease-out 0.15s,
+    opacity 0.1s ease-in,
     transform 0.3s cubic-bezier(0.55, 0.055, 0.675, 0.19);
 }
 
@@ -76,7 +78,9 @@
 [aria-pressed="true"] .base::before,
 [aria-pressed="true"] .base::after {
   width: var(--hamburger-width);
-  transition: width 0.2s ease-out 0.15s, opacity 0.1s ease-out 0.15s,
+  transition:
+    width 0.2s ease-out 0.15s,
+    opacity 0.1s ease-out 0.15s,
     transform 0.3s cubic-bezier(0.215, 0.61, 0.355, 1) 0.15s;
 }
 

--- a/packages/circuit-ui/components/ImageInput/ImageInput.module.css
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.module.css
@@ -6,7 +6,9 @@
 
 .input:focus + label > *:last-child {
   outline: 0;
-  box-shadow: 0 0 0 2px var(--cui-bg-normal), 0 0 0 4px var(--cui-border-focus);
+  box-shadow:
+    0 0 0 2px var(--cui-bg-normal),
+    0 0 0 4px var(--cui-border-focus);
 }
 
 .input:focus + label > *:last-child::-moz-focus-inner {
@@ -97,7 +99,9 @@
 
 .label.dragging *:last-child {
   outline: 0;
-  box-shadow: 0 0 0 2px var(--cui-bg-normal), 0 0 0 4px var(--cui-border-focus);
+  box-shadow:
+    0 0 0 2px var(--cui-bg-normal),
+    0 0 0 4px var(--cui-border-focus);
 }
 
 .label.dragging *:last-child::-moz-focus-inner {
@@ -148,7 +152,8 @@
   pointer-events: none;
   visibility: hidden;
   opacity: 0;
-  transition: opacity var(--cui-transitions-default),
+  transition:
+    opacity var(--cui-transitions-default),
     visibility var(--cui-transitions-default);
 }
 

--- a/packages/circuit-ui/components/ListItem/ListItem.module.css
+++ b/packages/circuit-ui/components/ListItem/ListItem.module.css
@@ -40,7 +40,9 @@ button.base:focus {
   z-index: 2;
   border-color: transparent;
   outline: 0;
-  box-shadow: 0 0 0 4px var(--cui-bg-normal), 0 0 0 6px var(--cui-border-focus);
+  box-shadow:
+    0 0 0 4px var(--cui-bg-normal),
+    0 0 0 6px var(--cui-border-focus);
 }
 
 a.base:focus::-moz-focus-inner,

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.module.css
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.module.css
@@ -60,10 +60,9 @@
   top: calc(-1 * var(--cui-spacings-kilo));
   right: calc(-1 * var(--cui-spacings-mega));
   left: 0;
-  content: '';
+  content: "";
   border-top: var(--cui-border-width-kilo) solid var(--cui-border-divider);
 }
-
 
 .interactive:hover:not(:first-of-type) > * > div:last-of-type::before,
 .interactive:hover + li:not(:first-of-type) > * > div:last-of-type::before {
@@ -73,7 +72,7 @@
 .focused:not(:first-of-type) > * > div:last-of-type::before,
 .focused + li:not(:first-of-type) > * > div:last-of-type::before,
 .selected:not(:first-of-type) > * > div:last-of-type::before,
-.selected + li:not(:first-of-type) > * > div:last-of-type::before  {
+.selected + li:not(:first-of-type) > * > div:last-of-type::before {
   border-top-width: 0;
 }
 

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.module.css
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.module.css
@@ -5,7 +5,9 @@
   justify-content: space-between;
   overflow: hidden;
   border-radius: var(--cui-border-radius-mega);
-  transition: opacity 200ms ease-in-out, height 200ms ease-in-out,
+  transition:
+    opacity 200ms ease-in-out,
+    height 200ms ease-in-out,
     visibility 200ms ease-in-out;
 }
 

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.module.css
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.module.css
@@ -1,7 +1,9 @@
 .base {
   overflow: hidden;
-  transition: opacity var(--cui-transitions-slow),
-    height var(--cui-transitions-slow), visibility var(--cui-transitions-slow);
+  transition:
+    opacity var(--cui-transitions-slow),
+    height var(--cui-transitions-slow),
+    visibility var(--cui-transitions-slow);
   will-change: height;
 }
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.module.css
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.module.css
@@ -2,7 +2,8 @@
   overflow: hidden;
   background-color: var(--cui-bg-elevated);
   border-radius: var(--cui-border-radius-byte);
-  transition: opacity var(--cui-transitions-slow),
+  transition:
+    opacity var(--cui-transitions-slow),
     height var(--cui-transitions-slow),
     visibility var(--cui-transitions-slow);
   will-change: height;

--- a/packages/circuit-ui/components/Popover/Popover.module.css
+++ b/packages/circuit-ui/components/Popover/Popover.module.css
@@ -35,7 +35,8 @@
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
     opacity: 1;
-    transition: transform var(--cui-transitions-default),
+    transition:
+      transform var(--cui-transitions-default),
       visibility var(--cui-transitions-default);
     transform: translateY(100%);
   }
@@ -67,7 +68,8 @@
     visibility: hidden;
     background-color: var(--cui-bg-overlay);
     opacity: 0;
-    transition: opacity var(--cui-transitions-default),
+    transition:
+      opacity var(--cui-transitions-default),
       visibility var(--cui-transitions-default);
   }
 

--- a/packages/circuit-ui/components/RadioButton/RadioButton.module.css
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.module.css
@@ -19,7 +19,8 @@
   border: 1px solid var(--cui-border-normal);
   border-radius: 100%;
   box-shadow: none;
-  transition: border var(--cui-transitions-default),
+  transition:
+    border var(--cui-transitions-default),
     background-color var(--cui-transitions-default);
   transform: translateY(-50%);
 }
@@ -36,7 +37,8 @@
   background-color: var(--cui-fg-accent);
   border-radius: 100%;
   opacity: 0;
-  transition: transform var(--cui-transitions-default),
+  transition:
+    transform var(--cui-transitions-default),
     opacity var(--cui-transitions-default);
   transform: translateY(-50%) scale(0, 0);
 }
@@ -48,7 +50,9 @@
 .base:focus + label::before {
   border-color: var(--cui-border-accent);
   outline: 0;
-  box-shadow: 0 0 0 2px var(--cui-bg-normal), 0 0 0 4px var(--cui-border-focus);
+  box-shadow:
+    0 0 0 2px var(--cui-bg-normal),
+    0 0 0 4px var(--cui-border-focus);
 }
 
 .base:focus:not(:focus-visible) + label::before {

--- a/packages/circuit-ui/components/Selector/Selector.module.css
+++ b/packages/circuit-ui/components/Selector/Selector.module.css
@@ -1,6 +1,8 @@
 .base:focus + .label::before {
   outline: 0;
-  box-shadow: 0 0 0 2px var(--cui-bg-normal), 0 0 0 4px var(--cui-border-focus);
+  box-shadow:
+    0 0 0 2px var(--cui-bg-normal),
+    0 0 0 4px var(--cui-border-focus);
 }
 
 .base:focus:not(:focus-visible) + .label::before {

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.module.css
@@ -37,7 +37,8 @@
   overflow-y: auto;
   background-color: var(--cui-bg-normal);
   box-shadow: 1px 0 var(--cui-border-divider);
-  transition: width var(--cui-transitions-default),
+  transition:
+    width var(--cui-transitions-default),
     box-shadow var(--cui-transitions-default);
 }
 

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.module.css
@@ -10,7 +10,8 @@
   background-color: var(--cui-bg-normal);
   outline: none;
   opacity: 0;
-  transition: opacity var(--cui-transitions-default),
+  transition:
+    opacity var(--cui-transitions-default),
     transform var(--cui-transitions-default);
   transform: translateY(-25%);
 }

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.module.css
@@ -12,7 +12,8 @@
   background: none;
   border: none;
   outline: none;
-  transition: color var(--cui-transitions-default),
+  transition:
+    color var(--cui-transitions-default),
     background-color var(--cui-transitions-default);
 }
 
@@ -59,8 +60,10 @@
     width: calc(100% - 2 * var(--cui-spacings-giga));
     content: "";
     border-bottom: var(--cui-border-width-kilo) solid var(--cui-border-divider);
-    transition: width var(--cui-transitions-default),
-      right var(--cui-transitions-default), left var(--cui-transitions-default);
+    transition:
+      width var(--cui-transitions-default),
+      right var(--cui-transitions-default),
+      left var(--cui-transitions-default);
   }
 
   .base[aria-expanded="true"]::after {

--- a/packages/circuit-ui/components/SidePanel/components/DesktopSidePanel/DesktopSidePanel.module.css
+++ b/packages/circuit-ui/components/SidePanel/components/DesktopSidePanel/DesktopSidePanel.module.css
@@ -2,8 +2,7 @@
   height: 100%;
   background-color: var(--cui-bg-normal);
   outline: none;
-  box-shadow: inset var(--cui-border-width-kilo) 0 0
-    var(--cui-border-divider);
+  box-shadow: inset var(--cui-border-width-kilo) 0 0 var(--cui-border-divider);
   transition: transform var(--cui-transitions-slow);
   transform: translateX(100%);
 }

--- a/packages/circuit-ui/components/Skeleton/Skeleton.module.css
+++ b/packages/circuit-ui/components/Skeleton/Skeleton.module.css
@@ -3,7 +3,6 @@
   user-select: none;
 }
 
-
 @keyframes pulse {
   0% {
     background-position: calc(-1 * var(--skeleton-pulse-width)) 0;
@@ -35,13 +34,14 @@
   );
   background-repeat: no-repeat;
   background-size: var(--skeleton-pulse-width) 100%;
-  border-radius:var(--cui-border-radius-byte);
+  border-radius: var(--cui-border-radius-byte);
   animation: pulse 3s ease-in-out infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .placeholder {
-    animation: none;}
+    animation: none;
+  }
 }
 
 .placeholder > * {

--- a/packages/circuit-ui/components/Step/examples/CarouselSlider.module.css
+++ b/packages/circuit-ui/components/Step/examples/CarouselSlider.module.css
@@ -8,7 +8,11 @@
   display: flex;
   width: 100%;
   transition: all var(--slide-animation-duration) ease-in-out;
-  transform: translate3d(calc(-1 * var(--slide-step) * var(--slide-width)), 0, 0);
+  transform: translate3d(
+    calc(-1 * var(--slide-step) * var(--slide-width)),
+    0,
+    0
+  );
 }
 
 .image {

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.module.css
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.module.css
@@ -2,7 +2,8 @@
   padding: var(--cui-spacings-giga);
   background-color: var(--cui-bg-normal);
   border-bottom: var(--cui-border-width-kilo) solid var(--cui-border-divider);
-  transition: background-color var(--cui-transitions-default),
+  transition:
+    background-color var(--cui-transitions-default),
     color var(--cui-transitions-default);
 }
 
@@ -87,7 +88,9 @@
   height: 100%;
   content: "";
   outline: 0;
-  box-shadow: 0 0 0 2px var(--cui-bg-normal), 0 0 0 4px var(--cui-border-focus);
+  box-shadow:
+    0 0 0 2px var(--cui-bg-normal),
+    0 0 0 4px var(--cui-border-focus);
 }
 
 .base[aria-sort]:focus-within,

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.module.css
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.module.css
@@ -15,7 +15,9 @@ tbody .base:last-child td {
 .base[tabindex]:focus {
   z-index: 1;
   outline: 0;
-  box-shadow: 0 0 0 2px var(--cui-bg-normal), 0 0 0 4px var(--cui-border-focus);
+  box-shadow:
+    0 0 0 2px var(--cui-bg-normal),
+    0 0 0 4px var(--cui-border-focus);
 
   /* Chrome doesn't respect position: relative; on table elements so the transform property is used to create a separate stacking context which is needed to show the focus outline above the other table rows. */
   transform: translate(0, 0);

--- a/packages/circuit-ui/components/Tag/Tag.module.css
+++ b/packages/circuit-ui/components/Tag/Tag.module.css
@@ -17,7 +17,8 @@
   background-color: var(--cui-bg-normal);
   border: var(--tag-border-width) solid var(--cui-border-normal);
   border-radius: var(--cui-border-radius-byte);
-  transition: opacity var(--cui-transitions-default),
+  transition:
+    opacity var(--cui-transitions-default),
     color var(--cui-transitions-default),
     background-color var(--cui-transitions-default),
     border-color var(--cui-transitions-default);

--- a/packages/circuit-ui/components/ToastContext/ToastContext.module.css
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.module.css
@@ -19,5 +19,5 @@
 }
 
 .toast {
-  margin-top: var(--cui-spacings-byte)
+  margin-top: var(--cui-spacings-byte);
 }

--- a/packages/circuit-ui/components/Toggle/Toggle.module.css
+++ b/packages/circuit-ui/components/Toggle/Toggle.module.css
@@ -59,7 +59,8 @@
   background-color: #fff;
   border-radius: var(--toggle-knob-size);
   box-shadow: 0 2px 4px 0 rgb(0 0 0 / 25%);
-  transition: box-shadow var(--toggle-animation-timing),
+  transition:
+    box-shadow var(--toggle-animation-timing),
     transform var(--toggle-animation-timing);
   transform: translate3d(var(--cui-spacings-bit), -50%, 0);
 }

--- a/packages/circuit-ui/styles/base.css
+++ b/packages/circuit-ui/styles/base.css
@@ -4,7 +4,8 @@
 @font-face {
   font-family: aktiv-grotesk;
   font-weight: 400;
-  src: url("https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff2")
+  src:
+    url("https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff2")
       format("woff2"),
     url("https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-400.woff")
       format("woff"),
@@ -16,7 +17,8 @@
 @font-face {
   font-family: aktiv-grotesk;
   font-weight: 700;
-  src: url("https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff2")
+  src:
+    url("https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff2")
       format("woff2"),
     url("https://static.sumup.com/fonts/latin-greek-cyrillic/aktiv-grotest-700.woff")
       format("woff"),

--- a/packages/circuit-ui/styles/shared.module.css
+++ b/packages/circuit-ui/styles/shared.module.css
@@ -57,7 +57,8 @@
   background-color: var(--cui-bg-normal);
   border: none;
   outline: none;
-  transition: color var(--cui-transitions-default),
+  transition:
+    color var(--cui-transitions-default),
     background-color var(--cui-transitions-default);
 }
 

--- a/packages/circuit-ui/styles/utility.module.css
+++ b/packages/circuit-ui/styles/utility.module.css
@@ -28,7 +28,9 @@
 
 .focus-visible:focus {
   outline: 0;
-  box-shadow: 0 0 0 2px var(--cui-bg-normal), 0 0 0 4px var(--cui-border-focus);
+  box-shadow:
+    0 0 0 2px var(--cui-bg-normal),
+    0 0 0 4px var(--cui-border-focus);
 }
 
 .focus-visible:focus::-moz-focus-inner {


### PR DESCRIPTION
## Purpose

CSS Modules extend vanilla CSS syntax with custom keywords such as `composes` and `:global`. Stylelint doesn't support these out of the box.

## Approach and changes

- Install and configure [`stylelint-config-css-modules`](https://www.npmjs.com/package/stylelint-config-css-modules)
- Integrate Prettier with Stylelint using [`stylelint-prettier`](https://github.com/prettier/stylelint-prettier)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
