### PR TITLE
Fix Calendar header in different timezone

### DIFF
--- a/packages/circuit-ui/components/Calendar/Calendar.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.tsx
@@ -28,7 +28,6 @@ import {
   type MouseEvent,
 } from 'react';
 import { Temporal } from 'temporal-polyfill';
-import { formatDateTime } from '@sumup/intl';
 import { ArrowLeft, ArrowRight } from '@sumup/icons';
 
 import utilityClasses from '../../styles/utility.js';
@@ -39,7 +38,6 @@ import { clsx } from '../../styles/clsx.js';
 import {
   getFirstDateOfWeek,
   getLastDateOfWeek,
-  yearMonthToDate,
   type FirstDayOfWeek,
   type PlainDateRange,
 } from '../../util/date.js';
@@ -55,6 +53,7 @@ import { last } from '../../util/helpers.js';
 import {
   CalendarActionType,
   calendarReducer,
+  getMonthHeadline,
   getSelectionType,
   getViewOfMonth,
   getWeekdays,
@@ -93,6 +92,10 @@ interface SharedProps {
    * Defaults to `navigator.language` in supported environments.
    */
   locale?: Locale;
+  /**
+   * The identifier for the used [calendar](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar). Default: `iso8601`.
+   */
+  calendar?: 'iso8601' | 'gregory';
   /**
    * An integer indicating the first day of the week. Can be either `1` (Monday)
    * or `7` (Sunday). Default: `1`.
@@ -148,6 +151,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
       nextMonthButtonLabel,
       modifiers,
       numberOfMonths = 1,
+      calendar = 'iso8601',
       ...props
     },
     ref,
@@ -328,6 +332,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
               firstDayOfWeek={firstDayOfWeek}
               daysInWeek={daysInWeek}
               locale={locale}
+              calendar={calendar}
               modifiers={modifiers}
               onFocus={handleFocusDate}
               onSelect={onSelect}
@@ -374,21 +379,22 @@ function Month({
   firstDayOfWeek = 1,
   daysInWeek,
   locale,
+  calendar,
 }: MonthProps) {
   const descriptionIds = useId();
+  const headlineId = useId();
+  const headline = useMemo(
+    () => getMonthHeadline(yearMonth, locale, calendar),
+    [yearMonth, locale, calendar],
+  );
+  const weekdays = useMemo(
+    () => getWeekdays(firstDayOfWeek, daysInWeek, locale, calendar),
+    [firstDayOfWeek, daysInWeek, locale, calendar],
+  );
   const weeks = useMemo(
     () => getViewOfMonth(yearMonth, firstDayOfWeek, daysInWeek),
     [yearMonth, firstDayOfWeek, daysInWeek],
   );
-  const weekdays = useMemo(
-    () => getWeekdays(firstDayOfWeek, daysInWeek, locale),
-    [firstDayOfWeek, daysInWeek, locale],
-  );
-  const headlineId = useId();
-  const headline = formatDateTime(yearMonthToDate(yearMonth), locale, {
-    year: 'numeric',
-    month: 'long',
-  });
   return (
     <div
       className={classes.month}

--- a/packages/circuit-ui/components/Calendar/CalendarService.spec.ts
+++ b/packages/circuit-ui/components/Calendar/CalendarService.spec.ts
@@ -22,6 +22,7 @@ import {
   CalendarActionType,
   calendarReducer,
   getDatesInRange,
+  getMonthHeadline,
   getMonths,
   getSelectionType,
   getViewOfMonth,
@@ -246,6 +247,15 @@ describe('CalendarService', () => {
       const action = { type: CalendarActionType.MOUSE_LEAVE_DATE } as const;
       const actual = calendarReducer(state, action);
       expect(actual.hoveredDate).toBeNull();
+    });
+  });
+
+  describe('getMonthHeadline', () => {
+    it('should return the localized month name and year', () => {
+      const yearMonth = new Temporal.PlainYearMonth(2020, 3);
+      const locale = 'en-US';
+      const actual = getMonthHeadline(yearMonth, locale);
+      expect(actual).toBe('March 2020');
     });
   });
 

--- a/packages/circuit-ui/components/Calendar/CalendarService.ts
+++ b/packages/circuit-ui/components/Calendar/CalendarService.ts
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-import { Temporal } from 'temporal-polyfill';
-import { formatDateTime } from '@sumup/intl';
+import { Temporal, Intl } from 'temporal-polyfill';
 
 import type { Locale } from '../../util/i18n.js';
 import { chunk, last } from '../../util/helpers.js';
@@ -144,16 +143,37 @@ export function getWeekdays(
   firstDayOfWeek: FirstDayOfWeek = 1,
   daysInWeek: DaysInWeek = 7,
   locale?: Locale,
+  calendar?: string,
 ) {
-  return Array.from(Array(daysInWeek)).map((_, i) => {
-    const index = i + firstDayOfWeek;
-    // 1971 started with a Monday
-    const date = new Date(Date.UTC(1971, 1, index));
+  const narrow = new Intl.DateTimeFormat(locale, {
+    weekday: 'narrow',
+    calendar,
+  });
+  const long = new Intl.DateTimeFormat(locale, {
+    weekday: 'long',
+    calendar,
+  });
+  return Array.from(Array(daysInWeek)).map((_, index) => {
+    // 1973 started with a Monday
+    const date = new Temporal.PlainDate(1973, 1, index + firstDayOfWeek);
     return {
-      narrow: formatDateTime(date, locale, { weekday: 'narrow' }),
-      long: formatDateTime(date, locale, { weekday: 'long' }),
+      narrow: narrow.format(date),
+      long: long.format(date),
     };
   }) as Weekdays;
+}
+
+export function getMonthHeadline(
+  yearMonth: Temporal.PlainYearMonth,
+  locale?: Locale,
+  calendar = 'iso8601',
+) {
+  const intl = new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'long',
+    calendar,
+  });
+  return intl.format(yearMonth);
 }
 
 export function getDatesInRange(

--- a/packages/circuit-ui/util/date.spec.ts
+++ b/packages/circuit-ui/util/date.spec.ts
@@ -23,19 +23,10 @@ import {
   isPlainDate,
   sortDateRange,
   toPlainDate,
-  yearMonthToDate,
   type PlainDateRange,
 } from './date.js';
 
 describe('CalendarService', () => {
-  describe('yearMonthToDate', () => {
-    it('should convert a PlainYearMonth to a legacy Date', () => {
-      const yearMonth = new Temporal.PlainYearMonth(2020, 3);
-      const actual = yearMonthToDate(yearMonth);
-      expect(actual).toEqual(new Date(Date.UTC(2020, 2)));
-    });
-  });
-
   describe('isPlainDate', () => {
     it('should return true for a PlainDate', () => {
       const date = new Temporal.PlainDate(2020, 3, 15);

--- a/packages/circuit-ui/util/date.ts
+++ b/packages/circuit-ui/util/date.ts
@@ -26,10 +26,6 @@ export function getTodaysDate() {
   return Temporal.Now.plainDateISO();
 }
 
-export function yearMonthToDate(yearMonth: Temporal.PlainYearMonth): Date {
-  return new Date(Date.UTC(yearMonth.year, yearMonth.month - 1));
-}
-
 export function isPlainDate(date: unknown): date is Temporal.PlainDate {
   return date instanceof Temporal.PlainDate;
 }


### PR DESCRIPTION
## Purpose

The Calendar displays the wrong month and weekday names in timezones other than UTC. The initial approach converted the Temporal date objects to the legacy Date objects to pass them to the `@sumup/intl` functions for formatting. Given the non-existent support for timezone in the legacy Date API, this caused off-by-one bugs.

## Approach and changes

- Format the month and weekdays using the polyfilled `Intl` constructors from the `temporal-polyfill` package

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
