### PR TITLE
feat: Update NotificationToast provider with position and className props

### DIFF
--- a/.changeset/clever-islands-hang.md
+++ b/.changeset/clever-islands-hang.md
@@ -1,5 +1,5 @@
 ---
-"@sumup/circuit-ui": patch
+"@sumup/circuit-ui": minor
 ---
 
 Added new `position` and `className` props to the ToastProvider component.

--- a/.changeset/clever-islands-hang.md
+++ b/.changeset/clever-islands-hang.md
@@ -2,4 +2,4 @@
 "@sumup/circuit-ui": patch
 ---
 
-feat: Update NotificationToast with position and className props
+feat: Update NotificationToast provider with position and className props

--- a/.changeset/clever-islands-hang.md
+++ b/.changeset/clever-islands-hang.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": patch
+---
+
+feat: add toast positioning prop

--- a/.changeset/clever-islands-hang.md
+++ b/.changeset/clever-islands-hang.md
@@ -2,4 +2,4 @@
 "@sumup/circuit-ui": patch
 ---
 
-feat: Update NotificationToast provider with position and className props
+Added new `position` and `className` props to the ToastProvider component.

--- a/.changeset/clever-islands-hang.md
+++ b/.changeset/clever-islands-hang.md
@@ -2,4 +2,4 @@
 "@sumup/circuit-ui": patch
 ---
 
-feat: add toast positioning prop
+feat: Update NotificationToast with position and className props

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.mdx
@@ -59,6 +59,20 @@ export function App({}) {
 }
 ```
 
+### Custom positioning
+
+It's possible to change a position of notifications in the by passing `position` prop. Supported values are `bottom` (default), `top` and  `top-right`:
+
+```tsx
+// _app.tsx for Next.js or App.js for CRA
+import { ToastProvider } from '@sumup/circuit-ui';
+
+export default function App() {
+  // all notifications will appear at the top of the screen
+  return <ToastProvider position="top">{/* Your content goes here... */}</ToastProvider>;
+}
+```
+
 ## Accessibility
 
 By their nature as status messages, toasts are rendered inside a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) using `role="status"` and `aria-live="polite"`.

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.mdx
@@ -61,17 +61,9 @@ export function App({}) {
 
 ### Custom positioning
 
-Change the position of notifications by passing the `position` prop. Supported values are `bottom` (default), `top` and  `top-right`:
+Change the position of notifications by passing the `position` prop. Supported values are `bottom` (default), `top` and `top-right`:
 
-```tsx
-// _app.tsx for Next.js or App.js for CRA
-import { ToastProvider } from '@sumup/circuit-ui';
-
-export default function App() {
-  // all notifications will appear at the top of the screen
-  return <ToastProvider position="top">{/* Your content goes here... */}</ToastProvider>;
-}
-```
+<Story of={Stories.Position} />
 
 ## Accessibility
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.mdx
@@ -61,7 +61,7 @@ export function App({}) {
 
 ### Custom positioning
 
-It's possible to change a position of notifications in the by passing `position` prop. Supported values are `bottom` (default), `top` and  `top-right`:
+Change the position of notifications by passing the `position` prop. Supported values are `bottom` (default), `top` and  `top-right`:
 
 ```tsx
 // _app.tsx for Next.js or App.js for CRA

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -55,29 +55,25 @@ const TOASTS = [
   },
 ] as NotificationToastProps[];
 
-export const Base = (toast: NotificationToastProps): JSX.Element => {
-  const App = () => {
-    const { setToast } = useNotificationToast();
-    const randomIndex = isChromatic()
-      ? 1
-      : Math.floor(Math.random() * TOASTS.length);
-    return (
-      <Button
-        type="button"
-        onClick={() => setToast({ ...toast, ...TOASTS[randomIndex] })}
-      >
-        Open toast
-      </Button>
-    );
-  };
+const App = ({ toast }: { toast: NotificationToastProps }) => {
+  const { setToast } = useNotificationToast();
+  const randomIndex = isChromatic()
+    ? 1
+    : Math.floor(Math.random() * TOASTS.length);
   return (
-    <ToastProvider>
-      <App />
-    </ToastProvider>
+    <Button
+      type="button"
+      onClick={() => setToast({ ...toast, ...TOASTS[randomIndex] })}
+    >
+      Open toast
+    </Button>
   );
 };
-
-Base.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
+const play = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLCanvasElement;
+}) => {
   const canvas = within(canvasElement);
   const button = canvas.getByRole('button', {
     name: 'Open toast',
@@ -86,6 +82,32 @@ Base.play = async ({ canvasElement }: { canvasElement: HTMLCanvasElement }) => {
   await userEvent.click(button);
   await screen.findByRole('status');
 };
+
+export const Base = (toast: NotificationToastProps): JSX.Element => (
+  <ToastProvider>
+    <App toast={toast} />
+  </ToastProvider>
+);
+
+Base.play = play;
+
+export const WithTopPosition = (toast: NotificationToastProps): JSX.Element => (
+  <ToastProvider position="top">
+    <App toast={toast} />
+  </ToastProvider>
+);
+
+WithTopPosition.play = play;
+
+export const WithTopRightPosition = (
+  toast: NotificationToastProps,
+): JSX.Element => (
+  <ToastProvider position="top-right">
+    <App toast={toast} />
+  </ToastProvider>
+);
+
+WithTopRightPosition.play = play;
 
 const variants = ['info', 'success', 'warning', 'danger'] as const;
 

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -30,6 +30,12 @@ import {
 export default {
   title: 'Notification/NotificationToast',
   component: NotificationToast,
+  argTypes: {
+    position: {
+      options: ['top', 'top-right', 'bottom'],
+      control: { type: 'select' },
+    },
+  },
 };
 
 const TOASTS = [
@@ -91,23 +97,17 @@ export const Base = (toast: NotificationToastProps): JSX.Element => (
 
 Base.play = play;
 
-export const WithTopPosition = (toast: NotificationToastProps): JSX.Element => (
-  <ToastProvider position="top">
+export const Position = (toast: NotificationToastProps): JSX.Element => (
+  <ToastProvider {...toast}>
     <App toast={toast} />
   </ToastProvider>
 );
 
-WithTopPosition.play = play;
+Position.args = {
+  position: 'top',
+};
 
-export const WithTopRightPosition = (
-  toast: NotificationToastProps,
-): JSX.Element => (
-  <ToastProvider position="top-right">
-    <App toast={toast} />
-  </ToastProvider>
-);
-
-WithTopRightPosition.play = play;
+Position.play = play;
 
 const variants = ['info', 'success', 'warning', 'danger'] as const;
 

--- a/packages/circuit-ui/components/ToastContext/ToastContext.module.css
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.module.css
@@ -8,21 +8,8 @@
   padding: 0 var(--cui-spacings-giga);
 }
 
-@media (min-width: 480px) {
-  .base {
-    left: 50%;
-    width: auto;
-    padding: 0;
-    transform: translateX(-50%);
-  }
-}
-
-.toast {
-  margin-top: var(--cui-spacings-byte);
-}
-
-/* Positions */
-.top {
+.top,
+.top-right {
   top: var(--cui-spacings-giga);
 }
 
@@ -30,9 +17,21 @@
   bottom: var(--cui-spacings-giga);
 }
 
-.top-right {
-  top: var(--cui-spacings-giga);
-  right: var(--cui-spacings-giga);
-  left: inherit;
-  transform: translateX(0%);
+@media (min-width: 480px) {
+  .base {
+    left: 50%;
+    width: auto;
+    padding: 0;
+    transform: translateX(-50%);
+  }
+
+  .top-right {
+    right: var(--cui-spacings-giga);
+    left: inherit;
+    transform: translateX(0%);
+  }
+}
+
+.toast {
+  margin-top: var(--cui-spacings-byte);
 }

--- a/packages/circuit-ui/components/ToastContext/ToastContext.module.css
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.module.css
@@ -1,6 +1,5 @@
 .base {
   position: fixed;
-  bottom: var(--cui-spacings-giga);
   left: 0;
   z-index: var(--cui-z-index-toast);
   display: flex;
@@ -20,4 +19,20 @@
 
 .toast {
   margin-top: var(--cui-spacings-byte);
+}
+
+/* Positions */
+.top {
+  top: var(--cui-spacings-giga);
+}
+
+.bottom {
+  bottom: var(--cui-spacings-giga);
+}
+
+.top-right {
+  top: var(--cui-spacings-giga);
+  right: var(--cui-spacings-giga);
+  left: inherit;
+  transform: translateX(0%);
 }

--- a/packages/circuit-ui/components/ToastContext/ToastContext.module.css
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.module.css
@@ -31,7 +31,7 @@
 
   .top-right {
     right: var(--cui-spacings-giga);
-    left: initial;
+    left: inherit;
   }
 }
 

--- a/packages/circuit-ui/components/ToastContext/ToastContext.module.css
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.module.css
@@ -19,16 +19,19 @@
 
 @media (min-width: 480px) {
   .base {
-    left: 50%;
     width: auto;
     padding: 0;
+  }
+
+  .top,
+  .bottom {
+    left: 50%;
     transform: translateX(-50%);
   }
 
   .top-right {
     right: var(--cui-spacings-giga);
-    left: inherit;
-    transform: translateX(0%);
+    left: initial;
   }
 }
 

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -52,7 +52,7 @@ export interface ToastProviderProps {
    */
   children: ReactNode;
   /**
-   * Choose the position of all toasts on screen. Default: 'bottom'.
+   * Choose the position of all toasts on screen (please consider sticking to default value if possible). Default: 'bottom'.
    */
   position?: 'bottom' | 'top' | 'top-right';
   /**

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -51,7 +51,13 @@ export interface ToastProviderProps {
    * The ToastProvider should wrap your entire application.
    */
   children: ReactNode;
+  /**
+   * Choose the position of all toasts on screen. Default: 'bottom'.
+   */
   position?: 'bottom' | 'top' | 'top-right';
+  /**
+   * The class name to add to the toast wrapper element.
+   */
   className?: string;
 }
 

--- a/packages/circuit-ui/components/ToastContext/ToastContext.tsx
+++ b/packages/circuit-ui/components/ToastContext/ToastContext.tsx
@@ -24,6 +24,7 @@ import {
 } from 'react';
 
 import { useStack, type StackItem } from '../../hooks/useStack/index.js';
+import { clsx } from '../../styles/clsx.js';
 
 import type { BaseToastProps, ToastComponent } from './types.js';
 import classes from './ToastContext.module.css';
@@ -50,10 +51,14 @@ export interface ToastProviderProps {
    * The ToastProvider should wrap your entire application.
    */
   children: ReactNode;
+  position?: 'bottom' | 'top' | 'top-right';
+  className?: string;
 }
 
 export function ToastProvider<TProps extends BaseToastProps>({
   children,
+  position = 'bottom',
+  className,
 }: ToastProviderProps): JSX.Element {
   const [toasts, dispatch] = useStack<ToastState<TProps>>([]);
 
@@ -109,7 +114,7 @@ export function ToastProvider<TProps extends BaseToastProps>({
     <ToastContext.Provider value={context}>
       {children}
       <div
-        className={classes.base}
+        className={clsx(classes.base, classes[position], className)}
         role="status"
         aria-live="polite"
         aria-atomic="false"


### PR DESCRIPTION
Addresses WPS-207.

## Purpose

In certain applications (e.g. shop or marketing website) it's necessary to change the placement of NotificationToast (e.g. put it closer to shopping cart). Unfortunately current implementation displays NotificationToasts only at the bottom of a page. This PR extends NotificationToast position possibilities by providing a prop that can place NotificationToast at the top and at the top right corner of a page.

## Approach and changes

- add `position` prop to `ToastProvider` with `bottom`, `top` and `top-right` as possible values (use `bottom` as default value)
- add CSS classes and styles for each position
- update storybook with examples and documentation
- additionally add `className` prop to `ToastProvider` to allow slight modifications (e.g. using bigger CSS space variable for a position)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [ ] Meets accessibility requirements
