### PR TITLE
Fix PhoneNumberInput country code selector styling

### DIFF
--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
@@ -2,6 +2,11 @@
   display: flex;
 }
 
+.country-code,
+.subscriber-number {
+  flex-grow: 1;
+}
+
 @media (max-width: 479px) {
   .wrapper {
     flex-direction: column;
@@ -56,4 +61,10 @@
 .country-code-input:focus {
   position: relative;
   z-index: calc(var(--cui-z-index-input) + 2);
+}
+
+/* Elevate the input prefix above the country code select on hover and focus */
+svg:has(+ .country-code:hover),
+svg:has(+ .country-code:focus) {
+  z-index: calc(var(--cui-z-index-input) + 3);
 }


### PR DESCRIPTION
Addresses #SX-2130

## Purpose

Fix a bug where the country code flag is not visible if the field is focused or selected

Update field to take up all the available space of the parent container: `flex-grow: 1`

## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
