### PR TITLE
Sync color tokens with Figma

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import remarkGfm from 'remark-gfm';
 import { mergeConfig } from 'vite';
 
-const toPath = (_path: string) => path.join(process.cwd(), _path);
+const toPath = (filePath: string) => path.join(process.cwd(), filePath);
 
 const config: StorybookConfig = {
   staticDirs: [toPath('.storybook/public')],

--- a/packages/design-tokens/themes/dark.ts
+++ b/packages/design-tokens/themes/dark.ts
@@ -16,7 +16,6 @@
 import type { Token } from '../types/index.js';
 
 export const dark = [
-  /* Neutral backgrounds */
   {
     name: '--cui-bg-normal',
     value: '#171d24',
@@ -97,10 +96,9 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.0800)',
     type: 'color',
   },
-  /* Accent backgrounds */
   {
     name: '--cui-bg-accent',
-    value: '#0C0F12',
+    value: '#0c0f12',
     type: 'color',
   },
   {
@@ -120,17 +118,17 @@ export const dark = [
   },
   {
     name: '--cui-bg-accent-strong',
-    value: '#ffffff',
+    value: '#e1e7ef',
     type: 'color',
   },
   {
     name: '--cui-bg-accent-strong-hovered',
-    value: '#c1c1c1',
+    value: '#ffffff',
     type: 'color',
   },
   {
     name: '--cui-bg-accent-strong-pressed',
-    value: '#828282',
+    value: '#ffffff',
     type: 'color',
   },
   {
@@ -138,7 +136,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.0800)',
     type: 'color',
   },
-  /* Success backgrounds */
   {
     name: '--cui-bg-success',
     value: 'rgba(12, 211, 104, 0.2000)',
@@ -179,7 +176,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.0800)',
     type: 'color',
   },
-  /* Warning backgrounds */
   {
     name: '--cui-bg-warning',
     value: 'rgba(245, 158, 28, 0.2000)',
@@ -220,7 +216,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.0800)',
     type: 'color',
   },
-  /* Danger backgrounds */
   {
     name: '--cui-bg-danger',
     value: 'rgba(255, 76, 53, 0.2000)',
@@ -228,17 +223,17 @@ export const dark = [
   },
   {
     name: '--cui-bg-danger-hovered',
-    value: 'rgba(255, 76, 53, 0.2)',
+    value: 'rgba(255, 76, 53, 0.2000)',
     type: 'color',
   },
   {
     name: '--cui-bg-danger-pressed',
-    value: 'rgba(255, 76, 53, 0.4)',
+    value: 'rgba(255, 76, 53, 0.4000)',
     type: 'color',
   },
   {
     name: '--cui-bg-danger-disabled',
-    value: 'rgba(255, 69, 60, 0.13)',
+    value: 'rgba(255, 69, 60, 0.1300)',
     type: 'color',
   },
   {
@@ -261,7 +256,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.0800)',
     type: 'color',
   },
-  /* Promo backgrounds */
   {
     name: '--cui-bg-promo',
     value: 'rgba(195, 83, 247, 0.2000)',
@@ -302,7 +296,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.0800)',
     type: 'color',
   },
-  /* Neutral foregrounds */
   {
     name: '--cui-fg-normal',
     value: '#ffffff',
@@ -310,7 +303,7 @@ export const dark = [
   },
   {
     name: '--cui-fg-normal-hovered',
-    value: '#f6f8f9',
+    value: 'rgba(255, 255, 255, 0.8000)',
     type: 'color',
   },
   {
@@ -320,7 +313,7 @@ export const dark = [
   },
   {
     name: '--cui-fg-normal-disabled',
-    value: 'rgba(216, 232, 248, 0.3000)',
+    value: 'rgba(230, 224, 233, 0.2000)',
     type: 'color',
   },
   {
@@ -403,20 +396,19 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.2000)',
     type: 'color',
   },
-  /* Accent foregrounds */
   {
     name: '--cui-fg-accent',
-    value: '#ffffff',
+    value: '#e1e7ef',
     type: 'color',
   },
   {
     name: '--cui-fg-accent-hovered',
-    value: '#f6f8f9',
+    value: '#ffffff',
     type: 'color',
   },
   {
     name: '--cui-fg-accent-pressed',
-    value: '#e3e7eb',
+    value: '#ffffff',
     type: 'color',
   },
   {
@@ -424,7 +416,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.3000)',
     type: 'color',
   },
-  /* Success foregrounds */
   {
     name: '--cui-fg-success',
     value: '#17db72',
@@ -445,7 +436,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.3000)',
     type: 'color',
   },
-  /* Warning foregrounds */
   {
     name: '--cui-fg-warning',
     value: '#f5b81c',
@@ -466,7 +456,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.3000)',
     type: 'color',
   },
-  /* Danger foregrounds */
   {
     name: '--cui-fg-danger',
     value: '#ff634e',
@@ -484,10 +473,9 @@ export const dark = [
   },
   {
     name: '--cui-fg-danger-disabled',
-    value: 'rgba(255, 178, 167, 0.7)',
+    value: 'rgba(255, 178, 167, 0.7000)',
     type: 'color',
   },
-  /* Promo foregrounds */
   {
     name: '--cui-fg-promo',
     value: '#cf7bf6',
@@ -508,7 +496,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.3000)',
     type: 'color',
   },
-  /* Neutral borders */
   {
     name: '--cui-border-normal',
     value: 'rgba(223, 232, 241, 0.3000)',
@@ -526,7 +513,7 @@ export const dark = [
   },
   {
     name: '--cui-border-normal-disabled',
-    value: 'rgba(216, 232, 248, 0.1500)',
+    value: 'rgba(216, 232, 248, 0.3000)',
     type: 'color',
   },
   {
@@ -589,7 +576,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.1500)',
     type: 'color',
   },
-  /* Accent borders */
   {
     name: '--cui-border-accent',
     value: '#ffffff',
@@ -610,7 +596,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.1500)',
     type: 'color',
   },
-  /* Success borders */
   {
     name: '--cui-border-success',
     value: '#0cd368',
@@ -631,7 +616,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.1500)',
     type: 'color',
   },
-  /* Warning borders */
   {
     name: '--cui-border-warning',
     value: '#f5b81c',
@@ -652,7 +636,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.1500)',
     type: 'color',
   },
-  /* Danger borders */
   {
     name: '--cui-border-danger',
     value: '#ff634e',
@@ -670,10 +653,9 @@ export const dark = [
   },
   {
     name: '--cui-border-danger-disabled',
-    value: 'rgba(255, 178, 167, 0.7)',
+    value: 'rgba(255, 178, 167, 0.7000)',
     type: 'color',
   },
-  /* Promo borders */
   {
     name: '--cui-border-promo',
     value: '#c353f7',
@@ -694,7 +676,6 @@ export const dark = [
     value: 'rgba(216, 232, 248, 0.1500)',
     type: 'color',
   },
-  /* Special colors */
   {
     name: '--cui-bg-overlay',
     value: 'rgba(0, 0, 0, 0.7000)',

--- a/packages/design-tokens/themes/light.ts
+++ b/packages/design-tokens/themes/light.ts
@@ -16,7 +16,6 @@
 import type { Token } from '../types/index.js';
 
 export const light = [
-  /* Neutral backgrounds */
   {
     name: '--cui-bg-normal',
     value: '#ffffff',
@@ -24,27 +23,27 @@ export const light = [
   },
   {
     name: '--cui-bg-normal-hovered',
-    value: '#e3e7eb',
+    value: '#e9edf2',
     type: 'color',
   },
   {
     name: '--cui-bg-normal-pressed',
-    value: '#e3e7eb',
+    value: '#bfc6cf',
     type: 'color',
   },
   {
     name: '--cui-bg-normal-disabled',
-    value: 'rgba(255, 255, 255, 0.4)',
+    value: 'rgba(255, 255, 255, 0.4000)',
     type: 'color',
   },
   {
     name: '--cui-bg-subtle',
-    value: '#f6f7f9',
+    value: '#f0f1f5',
     type: 'color',
   },
   {
     name: '--cui-bg-subtle-hovered',
-    value: '#d1d5d9',
+    value: '#e0e2ea',
     type: 'color',
   },
   {
@@ -54,7 +53,7 @@ export const light = [
   },
   {
     name: '--cui-bg-subtle-disabled',
-    value: 'rgba(227, 231, 235, 0.4)',
+    value: 'rgba(227, 231, 235, 0.4000)',
     type: 'color',
   },
   {
@@ -74,30 +73,29 @@ export const light = [
   },
   {
     name: '--cui-bg-highlight-disabled',
-    value: 'rgba(15, 19, 25, 0.08)',
+    value: 'rgba(15, 19, 26, 0.0800)',
     type: 'color',
   },
   {
     name: '--cui-bg-strong',
-    value: '#0f131a',
+    value: '#000000',
     type: 'color',
   },
   {
     name: '--cui-bg-strong-hovered',
-    value: '#000000',
+    value: '#313941',
     type: 'color',
   },
   {
     name: '--cui-bg-strong-pressed',
-    value: '#000000',
+    value: '#4f5a65',
     type: 'color',
   },
   {
     name: '--cui-bg-strong-disabled',
-    value: 'rgba(15, 19, 26, 0.4)',
+    value: 'rgba(23, 29, 36, 0.4000)',
     type: 'color',
   },
-  /* Accent backgrounds */
   {
     name: '--cui-bg-accent',
     value: '#eef0f2',
@@ -115,7 +113,7 @@ export const light = [
   },
   {
     name: '--cui-bg-accent-disabled',
-    value: 'rgba(238, 240, 242, 0.4)',
+    value: 'rgba(238, 240, 242, 0.4000)',
     type: 'color',
   },
   {
@@ -135,10 +133,9 @@ export const light = [
   },
   {
     name: '--cui-bg-accent-strong-disabled',
-    value: 'rgba(15, 19, 26, 0.4)',
+    value: 'rgba(15, 19, 26, 0.4000)',
     type: 'color',
   },
-  /* Success backgrounds */
   {
     name: '--cui-bg-success',
     value: '#e9fbe9',
@@ -156,7 +153,7 @@ export const light = [
   },
   {
     name: '--cui-bg-success-disabled',
-    value: 'rgba(233, 251, 233, 0.4)',
+    value: 'rgba(233, 251, 233, 0.4000)',
     type: 'color',
   },
   {
@@ -176,10 +173,9 @@ export const light = [
   },
   {
     name: '--cui-bg-success-strong-disabled',
-    value: 'rgba(1, 136, 80, 0.4)',
+    value: 'rgba(1, 136, 80, 0.4000)',
     type: 'color',
   },
-  /* Warning backgrounds */
   {
     name: '--cui-bg-warning',
     value: '#fdf4db',
@@ -197,7 +193,7 @@ export const light = [
   },
   {
     name: '--cui-bg-warning-disabled',
-    value: 'rgba(253, 244, 219, 0.4)',
+    value: 'rgba(253, 244, 219, 0.4000)',
     type: 'color',
   },
   {
@@ -217,10 +213,9 @@ export const light = [
   },
   {
     name: '--cui-bg-warning-strong-disabled',
-    value: 'rgba(232, 124, 0, 0.4)',
+    value: 'rgba(232, 124, 0, 0.4000)',
     type: 'color',
   },
-  /* Danger backgrounds */
   {
     name: '--cui-bg-danger',
     value: '#fbe9e7',
@@ -238,7 +233,7 @@ export const light = [
   },
   {
     name: '--cui-bg-danger-disabled',
-    value: 'rgba(251, 233, 231, 0.64)',
+    value: 'rgba(251, 233, 231, 0.6400)',
     type: 'color',
   },
   {
@@ -258,10 +253,9 @@ export const light = [
   },
   {
     name: '--cui-bg-danger-strong-disabled',
-    value: 'rgba(222, 51, 29, 0.4)',
+    value: 'rgba(222, 51, 29, 0.4000)',
     type: 'color',
   },
-  /* Promo backgrounds */
   {
     name: '--cui-bg-promo',
     value: '#f5edfe',
@@ -279,7 +273,7 @@ export const light = [
   },
   {
     name: '--cui-bg-promo-disabled',
-    value: 'rgba(245, 237, 254, 0.4)',
+    value: 'rgba(245, 237, 254, 0.4000)',
     type: 'color',
   },
   {
@@ -299,10 +293,9 @@ export const light = [
   },
   {
     name: '--cui-bg-promo-strong-disabled',
-    value: 'rgba(158, 51, 224, 0.4)',
+    value: 'rgba(158, 51, 224, 0.4000)',
     type: 'color',
   },
-  /* Neutral foregrounds */
   {
     name: '--cui-fg-normal',
     value: '#0f131a',
@@ -310,17 +303,17 @@ export const light = [
   },
   {
     name: '--cui-fg-normal-hovered',
-    value: '#0f131a',
+    value: '#52565d',
     type: 'color',
   },
   {
     name: '--cui-fg-normal-pressed',
-    value: '#0f131a',
+    value: '#565c65',
     type: 'color',
   },
   {
     name: '--cui-fg-normal-disabled',
-    value: 'rgba(15, 19, 26, 0.4)',
+    value: 'rgba(15, 19, 26, 0.4000)',
     type: 'color',
   },
   {
@@ -330,7 +323,7 @@ export const light = [
   },
   {
     name: '--cui-fg-subtle-hovered',
-    value: '#6a737c',
+    value: '#33373e',
     type: 'color',
   },
   {
@@ -340,7 +333,7 @@ export const light = [
   },
   {
     name: '--cui-fg-subtle-disabled',
-    value: 'rgba(106, 115, 124, 0.4)',
+    value: 'rgba(106, 115, 124, 0.4000)',
     type: 'color',
   },
   {
@@ -350,17 +343,17 @@ export const light = [
   },
   {
     name: '--cui-fg-placeholder-hovered',
-    value: '#9da7b1',
+    value: '#86929e',
     type: 'color',
   },
   {
     name: '--cui-fg-placeholder-pressed',
-    value: '#9da7b1',
+    value: '#657381',
     type: 'color',
   },
   {
     name: '--cui-fg-placeholder-disabled',
-    value: 'rgba(157, 167, 177, 0.4)',
+    value: 'rgba(157, 167, 177, 0.4000)',
     type: 'color',
   },
   {
@@ -370,17 +363,17 @@ export const light = [
   },
   {
     name: '--cui-fg-on-strong-hovered',
-    value: '#ffffff',
+    value: 'rgba(255, 255, 255, 0.8000)',
     type: 'color',
   },
   {
     name: '--cui-fg-on-strong-pressed',
-    value: '#ffffff',
+    value: 'rgba(255, 255, 255, 0.8000)',
     type: 'color',
   },
   {
     name: '--cui-fg-on-strong-disabled',
-    value: 'rgba(255, 255, 255, 0.4)',
+    value: 'rgba(255, 255, 255, 0.4000)',
     type: 'color',
   },
   {
@@ -395,7 +388,7 @@ export const light = [
   },
   {
     name: '--cui-fg-on-strong-subtle-pressed',
-    value: 'rgba(255, 255, 255, 0.9000)',
+    value: 'rgba(255, 255, 255, 0.8000)',
     type: 'color',
   },
   {
@@ -403,7 +396,6 @@ export const light = [
     value: 'rgba(255, 255, 255, 0.3000)',
     type: 'color',
   },
-  /* Accent foregrounds */
   {
     name: '--cui-fg-accent',
     value: '#0f131a',
@@ -411,20 +403,19 @@ export const light = [
   },
   {
     name: '--cui-fg-accent-hovered',
-    value: '#000000',
+    value: '#52565d',
     type: 'color',
   },
   {
     name: '--cui-fg-accent-pressed',
-    value: '#000000',
+    value: '#676e7a',
     type: 'color',
   },
   {
     name: '--cui-fg-accent-disabled',
-    value: 'rgba(15, 19, 26, 0.4)',
+    value: 'rgba(15, 19, 26, 0.4000)',
     type: 'color',
   },
-  /* Success foregrounds */
   {
     name: '--cui-fg-success',
     value: '#018850',
@@ -442,10 +433,9 @@ export const light = [
   },
   {
     name: '--cui-fg-success-disabled',
-    value: 'rgba(1, 136, 80, 0.4)',
+    value: 'rgba(1, 136, 80, 0.4000)',
     type: 'color',
   },
-  /* Warning foregrounds */
   {
     name: '--cui-fg-warning',
     value: '#e27900',
@@ -463,10 +453,9 @@ export const light = [
   },
   {
     name: '--cui-fg-warning-disabled',
-    value: 'rgba(226, 121, 0, 0.4)',
+    value: 'rgba(226, 121, 0, 0.4000)',
     type: 'color',
   },
-  /* Danger foregrounds */
   {
     name: '--cui-fg-danger',
     value: '#de331d',
@@ -474,7 +463,7 @@ export const light = [
   },
   {
     name: '--cui-fg-danger-hovered',
-    value: '#a62110',
+    value: '#bd2c19',
     type: 'color',
   },
   {
@@ -484,10 +473,9 @@ export const light = [
   },
   {
     name: '--cui-fg-danger-disabled',
-    value: 'rgba(222, 51, 29, 0.64)',
+    value: 'rgba(222, 51, 29, 0.6400)',
     type: 'color',
   },
-  /* Promo foregrounds */
   {
     name: '--cui-fg-promo',
     value: '#9e33e0',
@@ -505,10 +493,9 @@ export const light = [
   },
   {
     name: '--cui-fg-promo-disabled',
-    value: 'rgba(158, 51, 224, 0.4)',
+    value: 'rgba(158, 51, 224, 0.4000)',
     type: 'color',
   },
-  /* Neutral borders */
   {
     name: '--cui-border-normal',
     value: '#aeb6be',
@@ -516,27 +503,27 @@ export const light = [
   },
   {
     name: '--cui-border-normal-hovered',
-    value: '#9da7b1',
+    value: '#85919e',
     type: 'color',
   },
   {
     name: '--cui-border-normal-pressed',
-    value: '#6a737c',
+    value: '#687686',
     type: 'color',
   },
   {
     name: '--cui-border-normal-disabled',
-    value: 'rgba(194, 201, 209, 0.4)',
+    value: 'rgba(194, 201, 209, 0.4000)',
     type: 'color',
   },
   {
     name: '--cui-border-subtle',
-    value: '#d6dbe1',
+    value: '#e3e7ec',
     type: 'color',
   },
   {
     name: '--cui-border-subtle-hovered',
-    value: '#6a737c',
+    value: '#c2c9d1',
     type: 'color',
   },
   {
@@ -546,7 +533,7 @@ export const light = [
   },
   {
     name: '--cui-border-subtle-disabled',
-    value: 'rgba(230, 230, 230, 0.4)',
+    value: 'rgba(230, 230, 230, 0.4000)',
     type: 'color',
   },
   {
@@ -566,7 +553,7 @@ export const light = [
   },
   {
     name: '--cui-border-divider-disabled',
-    value: 'rgba(194, 201, 209, 0.4)',
+    value: 'rgba(194, 201, 209, 0.4000)',
     type: 'color',
   },
   {
@@ -576,20 +563,19 @@ export const light = [
   },
   {
     name: '--cui-border-strong-hovered',
-    value: '#000000',
+    value: '#494a4a',
     type: 'color',
   },
   {
     name: '--cui-border-strong-pressed',
-    value: '#000000',
+    value: '#696969',
     type: 'color',
   },
   {
     name: '--cui-border-strong-disabled',
-    value: 'rgba(15, 19, 26, 0.4)',
+    value: 'rgba(15, 19, 26, 0.4000)',
     type: 'color',
   },
-  /* Accent borders */
   {
     name: '--cui-border-accent',
     value: '#0f131a',
@@ -597,20 +583,19 @@ export const light = [
   },
   {
     name: '--cui-border-accent-hovered',
-    value: '#000000',
+    value: '#52565d',
     type: 'color',
   },
   {
     name: '--cui-border-accent-pressed',
-    value: '#000000',
+    value: '#676e7a',
     type: 'color',
   },
   {
     name: '--cui-border-accent-disabled',
-    value: 'rgba(15, 19, 26, 0.4)',
+    value: 'rgba(15, 19, 26, 0.4000)',
     type: 'color',
   },
-  /* Success borders */
   {
     name: '--cui-border-success',
     value: '#018850',
@@ -628,10 +613,9 @@ export const light = [
   },
   {
     name: '--cui-border-success-disabled',
-    value: 'rgba(1, 136, 80, 0.4)',
+    value: 'rgba(1, 136, 80, 0.4000)',
     type: 'color',
   },
-  /* Warning borders */
   {
     name: '--cui-border-warning',
     value: '#e87c00',
@@ -649,10 +633,9 @@ export const light = [
   },
   {
     name: '--cui-border-warning-disabled',
-    value: 'rgba(226, 121, 0, 0.4)',
+    value: 'rgba(226, 121, 0, 0.4000)',
     type: 'color',
   },
-  /* Danger borders */
   {
     name: '--cui-border-danger',
     value: '#de331d',
@@ -660,7 +643,7 @@ export const light = [
   },
   {
     name: '--cui-border-danger-hovered',
-    value: '#a62110',
+    value: '#bd2c19',
     type: 'color',
   },
   {
@@ -670,10 +653,9 @@ export const light = [
   },
   {
     name: '--cui-border-danger-disabled',
-    value: 'rgba(222, 51, 29, 0.4)',
+    value: 'rgba(222, 51, 29, 0.4000)',
     type: 'color',
   },
-  /* Promo borders */
   {
     name: '--cui-border-promo',
     value: '#9e33e0',
@@ -691,13 +673,12 @@ export const light = [
   },
   {
     name: '--cui-border-promo-disabled',
-    value: 'rgba(158, 51, 224, 0.4)',
+    value: 'rgba(158, 51, 224, 0.4000)',
     type: 'color',
   },
-  /* Special colors */
   {
     name: '--cui-bg-overlay',
-    value: 'rgba(0, 0, 0, 0.4)',
+    value: 'rgba(0, 0, 0, 0.4000)',
     type: 'color',
   },
   {


### PR DESCRIPTION
## Purpose

I missed a couple of changes when manually updating the color tokens from Figma, so instead, we exported the tokens using the [Variables Exporter for Dev mode](https://www.figma.com/community/plugin/1306814436222162088/variables-exporter-for-dev-mode) Figma plugin.

<details>
<summary>Script to transform the Figma export</summary>

```js
const order = [
  '--cui-bg-normal',
  '--cui-bg-normal-hovered',
  '--cui-bg-normal-pressed',
  '--cui-bg-normal-disabled',
  '--cui-bg-subtle',
  '--cui-bg-subtle-hovered',
  '--cui-bg-subtle-pressed',
  '--cui-bg-subtle-disabled',
  '--cui-bg-highlight',
  '--cui-bg-highlight-hovered',
  '--cui-bg-highlight-pressed',
  '--cui-bg-highlight-disabled',
  '--cui-bg-strong',
  '--cui-bg-strong-hovered',
  '--cui-bg-strong-pressed',
  '--cui-bg-strong-disabled',
  '--cui-bg-accent',
  '--cui-bg-accent-hovered',
  '--cui-bg-accent-pressed',
  '--cui-bg-accent-disabled',
  '--cui-bg-accent-strong',
  '--cui-bg-accent-strong-hovered',
  '--cui-bg-accent-strong-pressed',
  '--cui-bg-accent-strong-disabled',
  '--cui-bg-success',
  '--cui-bg-success-hovered',
  '--cui-bg-success-pressed',
  '--cui-bg-success-disabled',
  '--cui-bg-success-strong',
  '--cui-bg-success-strong-hovered',
  '--cui-bg-success-strong-pressed',
  '--cui-bg-success-strong-disabled',
  '--cui-bg-warning',
  '--cui-bg-warning-hovered',
  '--cui-bg-warning-pressed',
  '--cui-bg-warning-disabled',
  '--cui-bg-warning-strong',
  '--cui-bg-warning-strong-hovered',
  '--cui-bg-warning-strong-pressed',
  '--cui-bg-warning-strong-disabled',
  '--cui-bg-danger',
  '--cui-bg-danger-hovered',
  '--cui-bg-danger-pressed',
  '--cui-bg-danger-disabled',
  '--cui-bg-danger-strong',
  '--cui-bg-danger-strong-hovered',
  '--cui-bg-danger-strong-pressed',
  '--cui-bg-danger-strong-disabled',
  '--cui-bg-promo',
  '--cui-bg-promo-hovered',
  '--cui-bg-promo-pressed',
  '--cui-bg-promo-disabled',
  '--cui-bg-promo-strong',
  '--cui-bg-promo-strong-hovered',
  '--cui-bg-promo-strong-pressed',
  '--cui-bg-promo-strong-disabled',
  '--cui-fg-normal',
  '--cui-fg-normal-hovered',
  '--cui-fg-normal-pressed',
  '--cui-fg-normal-disabled',
  '--cui-fg-subtle',
  '--cui-fg-subtle-hovered',
  '--cui-fg-subtle-pressed',
  '--cui-fg-subtle-disabled',
  '--cui-fg-placeholder',
  '--cui-fg-placeholder-hovered',
  '--cui-fg-placeholder-pressed',
  '--cui-fg-placeholder-disabled',
  '--cui-fg-on-strong',
  '--cui-fg-on-strong-hovered',
  '--cui-fg-on-strong-pressed',
  '--cui-fg-on-strong-disabled',
  '--cui-fg-on-strong-subtle',
  '--cui-fg-on-strong-subtle-hovered',
  '--cui-fg-on-strong-subtle-pressed',
  '--cui-fg-on-strong-subtle-disabled',
  '--cui-fg-accent',
  '--cui-fg-accent-hovered',
  '--cui-fg-accent-pressed',
  '--cui-fg-accent-disabled',
  '--cui-fg-success',
  '--cui-fg-success-hovered',
  '--cui-fg-success-pressed',
  '--cui-fg-success-disabled',
  '--cui-fg-warning',
  '--cui-fg-warning-hovered',
  '--cui-fg-warning-pressed',
  '--cui-fg-warning-disabled',
  '--cui-fg-danger',
  '--cui-fg-danger-hovered',
  '--cui-fg-danger-pressed',
  '--cui-fg-danger-disabled',
  '--cui-fg-promo',
  '--cui-fg-promo-hovered',
  '--cui-fg-promo-pressed',
  '--cui-fg-promo-disabled',
  '--cui-border-normal',
  '--cui-border-normal-hovered',
  '--cui-border-normal-pressed',
  '--cui-border-normal-disabled',
  '--cui-border-subtle',
  '--cui-border-subtle-hovered',
  '--cui-border-subtle-pressed',
  '--cui-border-subtle-disabled',
  '--cui-border-divider',
  '--cui-border-divider-hovered',
  '--cui-border-divider-pressed',
  '--cui-border-divider-disabled',
  '--cui-border-strong',
  '--cui-border-strong-hovered',
  '--cui-border-strong-pressed',
  '--cui-border-strong-disabled',
  '--cui-border-accent',
  '--cui-border-accent-hovered',
  '--cui-border-accent-pressed',
  '--cui-border-accent-disabled',
  '--cui-border-success',
  '--cui-border-success-hovered',
  '--cui-border-success-pressed',
  '--cui-border-success-disabled',
  '--cui-border-warning',
  '--cui-border-warning-hovered',
  '--cui-border-warning-pressed',
  '--cui-border-warning-disabled',
  '--cui-border-danger',
  '--cui-border-danger-hovered',
  '--cui-border-danger-pressed',
  '--cui-border-danger-disabled',
  '--cui-border-promo',
  '--cui-border-promo-hovered',
  '--cui-border-promo-pressed',
  '--cui-border-promo-disabled',
  '--cui-bg-overlay',
  '--cui-bg-elevated',
  '--cui-border-focus',
];

function toKebabCase(camelCase) {
  return camelCase.replace(
    /[A-Z]+(?![a-z])|[A-Z]/g,
    ($, offset) => (offset ? '-' : '') + $.toLowerCase(),
  );
}

function transformTheme(theme) {
  const tokens = [];

  function traverse(obj, path = []) {
    if (obj.value) {
      tokens.push({
        name: `--cui-${path.map(toKebabCase).join('-')}`,
        value: obj.value,
        type: 'color',
      });
    } else {
      Object.entries(obj).forEach(([key, value]) => {
        traverse(value, [...path, key]);
      });
    }
  }

  const { states, ...rest } = theme;

  traverse(states);
  traverse(rest);

  console.log(
    tokens.sort(
      (a, b) =>
        order.findIndex((i) => i === a.name) -
        order.findIndex((i) => i === b.name),
    ),
  );
}
```

</details>

## Approach and changes

- Sync the light and dark color tokens with Figma

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
