### PR TITLE
Increase NotificationBanner content's max width

### DIFF
--- a/.changeset/poor-geckos-sin.md
+++ b/.changeset/poor-geckos-sin.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': patch
+---
+
+Increased the NotificationBanner content's maximum width to better use the available space on wide viewports.

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.module.css
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.module.css
@@ -25,7 +25,6 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  min-width: 66vw;
   max-width: 640px;
   padding: var(--cui-spacings-giga);
   padding-right: var(--cui-spacings-byte);

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.module.css
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.module.css
@@ -25,7 +25,8 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  max-width: 420px;
+  min-width: 66vw;
+  max-width: 640px;
   padding: var(--cui-spacings-giga);
   padding-right: var(--cui-spacings-byte);
 }
@@ -63,6 +64,7 @@
 }
 
 .base .image {
+  flex-shrink: 0;
   width: var(--notification-image-width);
   min-width: 0;
   height: auto;

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.module.css
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.module.css
@@ -26,6 +26,7 @@
   flex-direction: column;
   align-items: flex-start;
   max-width: 640px;
+  max-width: max(640px, 66vw);
   padding: var(--cui-spacings-giga);
   padding-right: var(--cui-spacings-byte);
 }


### PR DESCRIPTION
Addresses [DSCB-22](https://sumupteam.atlassian.net/browse/DSCB-22).

## Purpose

The NotificationBanner's content currently has a maximum width of 420px. This makes the component look strange on wide viewports:

![Screenshot](https://github.com/user-attachments/assets/bfdf94a9-1e9a-4c84-8fce-3e70e46edd99)

## Approach and changes

- Increase the maximum width to 640px

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
