### PR TITLE
Match interactive color tokens to default values

### DIFF
--- a/.changeset/small-pots-think.md
+++ b/.changeset/small-pots-think.md
@@ -1,0 +1,5 @@
+---
+'@sumup/design-tokens': patch
+---
+
+Matched the interactive variants of the `fg-normal`, `fg-subtle`, `fg-on-strong`, and `fg-on-strong-subtle` color tokens to their default values.

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -42,3 +42,4 @@ jobs:
           externals: |
             '.storybook/public/**'
             'packages/design-tokens/**'
+            'packages/icons/**'

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,10 +3,8 @@ import path from 'node:path';
 import remarkGfm from 'remark-gfm';
 import { mergeConfig } from 'vite';
 
-const toPath = (filePath: string) => path.join(process.cwd(), filePath);
-
 const config: StorybookConfig = {
-  staticDirs: [toPath('.storybook/public')],
+  staticDirs: [path.join(process.cwd(), '.storybook/public')],
   stories: [
     '../packages/circuit-ui/**/*.@(mdx|stories.@(js|jsx|ts|tsx))',
     '../docs/**/*.@(mdx|stories.@(js|jsx|ts|tsx))',

--- a/packages/design-tokens/themes/light.ts
+++ b/packages/design-tokens/themes/light.ts
@@ -303,12 +303,12 @@ export const light = [
   },
   {
     name: '--cui-fg-normal-hovered',
-    value: '#52565d',
+    value: '#0f131a',
     type: 'color',
   },
   {
     name: '--cui-fg-normal-pressed',
-    value: '#565c65',
+    value: '#0f131a',
     type: 'color',
   },
   {
@@ -323,12 +323,12 @@ export const light = [
   },
   {
     name: '--cui-fg-subtle-hovered',
-    value: '#33373e',
+    value: '#6a737c',
     type: 'color',
   },
   {
     name: '--cui-fg-subtle-pressed',
-    value: '#0f131a',
+    value: '#6a737c',
     type: 'color',
   },
   {
@@ -343,12 +343,12 @@ export const light = [
   },
   {
     name: '--cui-fg-placeholder-hovered',
-    value: '#86929e',
+    value: '#9da7b1',
     type: 'color',
   },
   {
     name: '--cui-fg-placeholder-pressed',
-    value: '#657381',
+    value: '#9da7b1',
     type: 'color',
   },
   {
@@ -363,12 +363,12 @@ export const light = [
   },
   {
     name: '--cui-fg-on-strong-hovered',
-    value: 'rgba(255, 255, 255, 0.8000)',
+    value: '#ffffff',
     type: 'color',
   },
   {
     name: '--cui-fg-on-strong-pressed',
-    value: 'rgba(255, 255, 255, 0.8000)',
+    value: '#ffffff',
     type: 'color',
   },
   {
@@ -383,12 +383,12 @@ export const light = [
   },
   {
     name: '--cui-fg-on-strong-subtle-hovered',
-    value: 'rgba(255, 255, 255, 0.8000)',
+    value: 'rgba(255, 255, 255, 0.7000)',
     type: 'color',
   },
   {
     name: '--cui-fg-on-strong-subtle-pressed',
-    value: 'rgba(255, 255, 255, 0.8000)',
+    value: 'rgba(255, 255, 255, 0.7000)',
     type: 'color',
   },
   {


### PR DESCRIPTION
## Purpose

The tweaks to the color tokens in #2551 make the buttons look washed out in their hovered and pressed states because both the background and foreground colors change, significantly reducing the contrast between them.

We want to avoid further large-scale changes to the color tokens without extensive testing. In the future, we'll consider whether interactive foreground color variants should be used on interactive background colors at all.

## Approach and changes

- Matched the interactive variants of the `fg-normal`, `fg-subtle`, `fg-on-strong`, and `fg-on-strong-subtle` color tokens to their default values

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
