### PR TITLE
Switch ImageInput's button variant

### DIFF
--- a/.changeset/thick-games-rescue.md
+++ b/.changeset/thick-games-rescue.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Switched the ImageInput's button variant from `primary` to `secondary` to improve its appearance on dark backgrounds.

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -264,7 +264,7 @@ export const ImageInput = ({
           <IconButton
             type="button"
             size="s"
-            variant="primary"
+            variant="secondary"
             destructive
             onClick={handleClear}
             disabled={isLoading || disabled}
@@ -277,7 +277,7 @@ export const ImageInput = ({
           <IconButton
             type="button"
             size="s"
-            variant="primary"
+            variant="secondary"
             aria-hidden="true"
             tabIndex={-1}
             disabled={isLoading || disabled}


### PR DESCRIPTION
## Purpose

The ImageInput's primary button doesn't have sufficient color contrast when used on dark backgrounds. It's rarely used as the sole element of the screen (to help justify the primary call to action). Switching to the secondary variant works on all background colors:

![multiples](https://github.com/user-attachments/assets/9963d9a8-9230-4250-a056-4c57db04b2eb)

## Approach and changes

- Switch ImageInput's button variant from `primary` to `secondary` to improve its appearance on dark backgrounds

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
