### PR TITLE
Migrate default exports to named ones

### DIFF
--- a/.storybook/components/DocsContainer.tsx
+++ b/.storybook/components/DocsContainer.tsx
@@ -8,7 +8,7 @@ const themes = { light, dark };
 /**
  * Switch color scheme based on the global types or system preferences
  */
-const DocsContainer: typeof BaseContainer = ({ children, context }) => {
+export const DocsContainer: typeof BaseContainer = ({ children, context }) => {
   const [colorScheme, setColorScheme] = useState('light');
 
   useEffect(
@@ -28,5 +28,3 @@ const DocsContainer: typeof BaseContainer = ({ children, context }) => {
     </BaseContainer>
   );
 };
-
-export default DocsContainer;

--- a/.storybook/components/FullViewport.tsx
+++ b/.storybook/components/FullViewport.tsx
@@ -21,6 +21,6 @@ interface FullViewportProps {
   children: ReactNode;
 }
 
-export default function FullViewport({ children }: FullViewportProps) {
+export function FullViewport({ children }: FullViewportProps) {
   return <div className={classes.base}>{children}</div>;
 }

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -70,7 +70,7 @@ function getComponentName(name: string) {
   return pascalCased.join('');
 }
 
-const Icons = () => {
+export function Icons() {
   const [search, setSearch] = useState('');
   const [size, setSize] = useState('all');
   const [color, setColor] = useState('var(--cui-fg-normal)');
@@ -208,6 +208,4 @@ const Icons = () => {
       )}
     </Unstyled>
   );
-};
-
-export default Icons;
+}

--- a/.storybook/components/Image.tsx
+++ b/.storybook/components/Image.tsx
@@ -26,21 +26,21 @@ interface ImageProps extends BaseImageProps {
   darkSrc?: string;
 }
 
-const Image = ({ children, src, darkSrc, ...props }: ImageProps) => (
-  <Fragment>
-    {darkSrc && (
+export function Image({ children, src, darkSrc, ...props }: ImageProps) {
+  return (
+    <Fragment>
+      {darkSrc && (
+        <BaseImage
+          src={darkSrc}
+          {...props}
+          className={clsx(classes.dark, props.className)}
+        />
+      )}
       <BaseImage
-        src={darkSrc}
+        src={src}
         {...props}
-        className={clsx(classes.dark, props.className)}
+        className={clsx(classes.light, props.className)}
       />
-    )}
-    <BaseImage
-      src={src}
-      {...props}
-      className={clsx(classes.light, props.className)}
-    />
-  </Fragment>
-);
-
-export default Image;
+    </Fragment>
+  );
+}

--- a/.storybook/components/Intro.tsx
+++ b/.storybook/components/Intro.tsx
@@ -19,7 +19,7 @@ import type { BodyLargeProps } from '../../packages/circuit-ui/index.js';
 
 import classes from './Intro.module.css';
 
-export default function Intro({
+export function Intro({
   children,
   ...props
 }: {

--- a/.storybook/components/Link.tsx
+++ b/.storybook/components/Link.tsx
@@ -7,7 +7,7 @@ interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string;
 }
 
-export default function Link({ children, href, ...props }: LinkProps) {
+export function Link({ children, href, ...props }: LinkProps) {
   const storyName = decodeURIComponent(href);
 
   const isStoryName = !LINK_PREFIXES.some((prefix) =>

--- a/.storybook/components/Preview.tsx
+++ b/.storybook/components/Preview.tsx
@@ -17,6 +17,6 @@ import type { PropsWithChildren } from 'react';
 import { ThemeProvider } from '@emotion/react';
 import { light } from '@sumup/design-tokens';
 
-export default function Preview({ children }: PropsWithChildren) {
+export function Preview({ children }: PropsWithChildren) {
   return <ThemeProvider theme={light}>{children}</ThemeProvider>;
 }

--- a/.storybook/components/Stack.tsx
+++ b/.storybook/components/Stack.tsx
@@ -23,7 +23,7 @@ interface StackProps {
   vertical?: boolean;
 }
 
-export default function Stack({ children, vertical }: StackProps) {
+export function Stack({ children, vertical }: StackProps) {
   return (
     <div className={clsx(classes.base, vertical && classes.vertical)}>
       {children}

--- a/.storybook/components/Statuses.tsx
+++ b/.storybook/components/Statuses.tsx
@@ -47,7 +47,7 @@ const variantMap: Record<
   'deprecated': { variant: 'danger', label: 'Deprecated' },
 };
 
-export default function Status({
+export function Status({
   variant: status = 'stable',
   children,
   ...props

--- a/.storybook/components/Story.tsx
+++ b/.storybook/components/Story.tsx
@@ -15,9 +15,9 @@
 
 import { Canvas } from '@storybook/addon-docs';
 
-import Preview from './Preview';
+import { Preview } from './Preview';
 
-export default function Story({ withToolbar = true, ...props }) {
+export function Story({ withToolbar = true, ...props }) {
   return (
     <Preview>
       <Canvas withToolbar={withToolbar} {...props} />

--- a/.storybook/components/Teaser.tsx
+++ b/.storybook/components/Teaser.tsx
@@ -24,14 +24,14 @@ interface TeaserProps {
   children: ReactNode;
 }
 
-const Teaser = ({ title, children }: TeaserProps) => (
-  <Card className={classes.base}>
-    <Headline as="h2" size="three" id={slugify(title)}>
-      {title}
-    </Headline>
+export function Teaser({ title, children }: TeaserProps) {
+  return (
+    <Card className={classes.base}>
+      <Headline as="h2" size="three" id={slugify(title)}>
+        {title}
+      </Headline>
 
-    {children}
-  </Card>
-);
-
-export default Teaser;
+      {children}
+    </Card>
+  );
+}

--- a/.storybook/components/index.ts
+++ b/.storybook/components/index.ts
@@ -19,17 +19,17 @@ export { Props };
 
 export { Meta, IconGallery, IconItem, Typeset } from '@storybook/addon-docs';
 
-export { default as DocsContainer } from './DocsContainer.js';
-export { default as Status } from './Statuses.js';
-export { default as Preview } from './Preview.js';
-export { default as Story } from './Story.js';
-export { default as Icons } from './Icons.js';
-export { default as Intro } from './Intro.js';
-export { default as Teaser } from './Teaser.js';
-export { default as Link } from './Link.js';
-export { default as Image } from './Image.js';
-export { default as Stack } from './Stack.js';
-export { default as FullViewport } from './FullViewport.js';
+export { DocsContainer } from './DocsContainer.js';
+export { Status } from './Statuses.js';
+export { Preview } from './Preview.js';
+export { Story } from './Story.js';
+export { Icons } from './Icons.js';
+export { Intro } from './Intro.js';
+export { Teaser } from './Teaser.js';
+export { Link } from './Link.js';
+export { Image } from './Image.js';
+export { Stack } from './Stack.js';
+export { FullViewport } from './FullViewport.js';
 
 export {
   CustomPropertiesTable,

--- a/.storybook/themes.ts
+++ b/.storybook/themes.ts
@@ -1,6 +1,7 @@
 import { create } from '@storybook/theming';
 import { GLOBALS_UPDATED } from '@storybook/core-events';
-import Link from './components/Link';
+
+import { Link } from './components/Link';
 
 const brand = {
   brandTitle: 'Circuit UI',

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -34,7 +34,7 @@
     "rules": {
       "recommended": true,
       "style": {
-        "noDefaultExport": "warn",
+        "noDefaultExport": "error",
         "useFilenamingConvention": {
           "level": "error",
           "options": {
@@ -74,6 +74,23 @@
       "css": {
         "parser": {
           "cssModules": true
+        }
+      }
+    },
+    {
+      "include": [
+        "*.stories.*",
+        "**/vite.config.*",
+        "**/vitest.config.*",
+        "**/vitest.workspace.*",
+        "packages/stylelint-plugin-circuit-ui/**",
+        ".storybook/main.*"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDefaultExport": "off"
+          }
         }
       }
     },

--- a/global.d.ts
+++ b/global.d.ts
@@ -15,5 +15,6 @@
 
 declare module '*.module.css' {
   const classes: Record<string, string>;
+  // biome-ignore lint/style/noDefaultExport:
   export default classes;
 }

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -29,7 +29,7 @@ import type { AsPropType } from '../../types/prop-types.js';
 import { Body, type BodyProps } from '../Body/Body.js';
 import { useComponents } from '../ComponentsContext/index.js';
 import { clsx } from '../../styles/clsx.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 
 import classes from './Anchor.module.css';
 
@@ -69,7 +69,7 @@ export const Anchor = forwardRef(
       return (
         <Body
           {...props}
-          className={clsx(classes.base, utilityClasses.focusVisible, className)}
+          className={clsx(classes.base, utilClasses.focusVisible, className)}
           as={Link}
           ref={ref}
         />
@@ -80,7 +80,7 @@ export const Anchor = forwardRef(
       <Body
         as="button"
         {...props}
-        className={clsx(classes.base, utilityClasses.focusVisible, className)}
+        className={clsx(classes.base, utilClasses.focusVisible, className)}
         ref={ref}
       />
     );

--- a/packages/circuit-ui/components/Anchor/index.ts
+++ b/packages/circuit-ui/components/Anchor/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Anchor } from './Anchor.js';
+export { Anchor } from './Anchor.js';
 
 export type { AnchorProps } from './Anchor.js';
-
-export default Anchor;

--- a/packages/circuit-ui/components/AspectRatio/index.ts
+++ b/packages/circuit-ui/components/AspectRatio/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { AspectRatio } from './AspectRatio.js';
+export { AspectRatio } from './AspectRatio.js';
 
 export type { AspectRatioProps } from './AspectRatio.js';
-
-export default AspectRatio;

--- a/packages/circuit-ui/components/Avatar/index.ts
+++ b/packages/circuit-ui/components/Avatar/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Avatar } from './Avatar.js';
+export { Avatar } from './Avatar.js';
 
 export type { AvatarProps } from './Avatar.js';
-
-export default Avatar;

--- a/packages/circuit-ui/components/Badge/index.ts
+++ b/packages/circuit-ui/components/Badge/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Badge } from './Badge.js';
+export { Badge } from './Badge.js';
 
 export type { BadgeProps } from './Badge.js';
-
-export default Badge;

--- a/packages/circuit-ui/components/Body/Body.stories.tsx
+++ b/packages/circuit-ui/components/Body/Body.stories.tsx
@@ -15,7 +15,7 @@
 
 import type { BodyProps } from './Body.js';
 
-import Body from './index.js';
+import { Body } from './index.js';
 
 const content =
   'An electronic circuit is composed of individual electronic components, such as resistors, transistors, capacitors, inductors and diodes, connected by conductive wires or traces through which electric current can flow.';

--- a/packages/circuit-ui/components/Body/index.ts
+++ b/packages/circuit-ui/components/Body/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Body } from './Body.js';
+export { Body } from './Body.js';
 
 export type { BodyProps } from './Body.js';
-
-export default Body;

--- a/packages/circuit-ui/components/BodyLarge/BodyLarge.stories.tsx
+++ b/packages/circuit-ui/components/BodyLarge/BodyLarge.stories.tsx
@@ -15,7 +15,7 @@
 
 import type { BodyLargeProps } from './BodyLarge.js';
 
-import BodyLarge from './index.js';
+import { BodyLarge } from './index.js';
 
 const content =
   'An electronic circuit is composed of individual electronic components, such as resistors, transistors, capacitors, inductors and diodes, connected by conductive wires or traces through which electric current can flow.';

--- a/packages/circuit-ui/components/BodyLarge/index.ts
+++ b/packages/circuit-ui/components/BodyLarge/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { BodyLarge } from './BodyLarge.js';
+export { BodyLarge } from './BodyLarge.js';
 
 export type { BodyLargeProps } from './BodyLarge.js';
-
-export default BodyLarge;

--- a/packages/circuit-ui/components/Button/Button.stories.tsx
+++ b/packages/circuit-ui/components/Button/Button.stories.tsx
@@ -17,8 +17,8 @@ import { useEffect, useState } from 'react';
 import { ArrowSlanted, Plus } from '@sumup/icons';
 
 import { Stack } from '../../../../.storybook/components/index.js';
-import ButtonGroup from '../ButtonGroup/index.js';
-import CloseButton from '../CloseButton/index.js';
+import { ButtonGroup } from '../ButtonGroup/index.js';
+import { CloseButton } from '../CloseButton/index.js';
 
 import { IconButton } from './IconButton.js';
 import { Button, type ButtonProps } from './Button.js';

--- a/packages/circuit-ui/components/Button/base.tsx
+++ b/packages/circuit-ui/components/Button/base.tsx
@@ -30,7 +30,7 @@ import {
   AccessibilityError,
   isSufficientlyLabelled,
 } from '../../util/errors.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 import { clsx } from '../../styles/clsx.js';
 
 import classes from './base.module.css';
@@ -202,7 +202,7 @@ export function createButtonComponent<Props>(
           classes[variant],
           classes[size],
           destructive && classes.destructive,
-          utilityClasses.focusVisible,
+          utilClasses.focusVisible,
           className,
         )}
         ref={ref}
@@ -211,7 +211,7 @@ export function createButtonComponent<Props>(
           <span className={classes.dot} />
           <span className={classes.dot} />
           <span className={classes.dot} />
-          <span className={utilityClasses.hideVisually}>{loadingLabel}</span>
+          <span className={utilClasses.hideVisually}>{loadingLabel}</span>
         </span>
         <span className={classes.content}>
           {LeadingIcon && (

--- a/packages/circuit-ui/components/Button/index.ts
+++ b/packages/circuit-ui/components/Button/index.ts
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 
-import { Button } from './Button.js';
-
+export { Button } from './Button.js';
 export type { ButtonProps } from './Button.js';
 export { IconButton } from './IconButton.js';
 export type { IconButtonProps } from './IconButton.js';
 export { legacyButtonSizeMap } from './base.js';
-
-export default Button;

--- a/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/circuit-ui/components/ButtonGroup/ButtonGroup.tsx
@@ -15,7 +15,7 @@
 
 import { forwardRef, type HTMLAttributes } from 'react';
 
-import Button, { type ButtonProps } from '../Button/index.js';
+import { Button, type ButtonProps } from '../Button/index.js';
 import { clsx } from '../../styles/clsx.js';
 import { deprecate } from '../../util/logger.js';
 

--- a/packages/circuit-ui/components/ButtonGroup/index.ts
+++ b/packages/circuit-ui/components/ButtonGroup/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { ButtonGroup } from './ButtonGroup.js';
+export { ButtonGroup } from './ButtonGroup.js';
 
 export type { ButtonGroupProps } from './ButtonGroup.js';
-
-export default ButtonGroup;

--- a/packages/circuit-ui/components/Calendar/Calendar.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.tsx
@@ -30,7 +30,7 @@ import {
 import { Temporal } from 'temporal-polyfill';
 import { ArrowLeft, ArrowRight } from '@sumup/icons';
 
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 import { getBrowserLocale, type Locale } from '../../util/i18n.js';
 import { IconButton } from '../Button/IconButton.js';
 import { Headline } from '../Headline/Headline.js';
@@ -409,9 +409,7 @@ function Month({
           <tr>
             {weekdays.map((weekday) => (
               <th key={weekday.long} scope="col">
-                <span className={utilityClasses.hideVisually}>
-                  {weekday.long}
-                </span>
+                <span className={utilClasses.hideVisually}>{weekday.long}</span>
                 <span aria-hidden="true" className={classes.weekday}>
                   {weekday.narrow}
                 </span>
@@ -478,7 +476,7 @@ function Month({
                         selectionType && classes[selectionType],
                         isFirstDay && classes['first-day'],
                         isLastDay && classes['last-day'],
-                        utilityClasses.focusVisible,
+                        utilClasses.focusVisible,
                       )}
                       tabIndex={isFocused ? 0 : -1}
                       {...(isToday && { 'aria-current': 'date' })}
@@ -493,7 +491,7 @@ function Month({
                     {description && (
                       <span
                         id={descriptionId}
-                        className={clsx(utilityClasses.hideVisually)}
+                        className={clsx(utilClasses.hideVisually)}
                       >
                         {description}
                       </span>

--- a/packages/circuit-ui/components/Card/Card.stories.tsx
+++ b/packages/circuit-ui/components/Card/Card.stories.tsx
@@ -16,11 +16,11 @@
 import { action } from '@storybook/addon-actions';
 
 import { Stack } from '../../../../.storybook/components/index.js';
-import Headline from '../Headline/index.js';
-import Body from '../Body/index.js';
-import ButtonGroup from '../ButtonGroup/index.js';
+import { Headline } from '../Headline/index.js';
+import { Body } from '../Body/index.js';
+import { ButtonGroup } from '../ButtonGroup/index.js';
 
-import Card, { CardHeader, CardFooter } from './index.js';
+import { Card, CardHeader, CardFooter } from './index.js';
 
 export default {
   title: 'Components/Card',

--- a/packages/circuit-ui/components/Card/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Card/components/Header/Header.tsx
@@ -18,7 +18,7 @@
 import { forwardRef, type ReactNode, type HTMLAttributes } from 'react';
 
 import type { ClickEvent } from '../../../../types/events.js';
-import CloseButton from '../../../CloseButton/index.js';
+import { CloseButton } from '../../../CloseButton/index.js';
 import { isArray } from '../../../../util/type-check.js';
 import { clsx } from '../../../../styles/clsx.js';
 

--- a/packages/circuit-ui/components/Card/index.ts
+++ b/packages/circuit-ui/components/Card/index.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Card } from './Card.js';
+export { Card } from './Card.js';
 
 export type { CardProps } from './Card.js';
 
@@ -24,5 +24,3 @@ export {
 
 export type { HeaderProps as CardHeaderProps } from './components/index.js';
 export type { FooterProps as CardFooterProps } from './components/index.js';
-
-export default Card;

--- a/packages/circuit-ui/components/Carousel/Carousel.tsx
+++ b/packages/circuit-ui/components/Carousel/Carousel.tsx
@@ -17,8 +17,8 @@
 
 import { useRef, useState, type ReactNode } from 'react';
 
-import ProgressBar from '../ProgressBar/index.js';
-import Step from '../Step/index.js';
+import { ProgressBar } from '../ProgressBar/index.js';
+import { Step } from '../Step/index.js';
 import { useComponentSize } from '../../hooks/useComponentSize/index.js';
 import type { ImageProps } from '../Image/index.js';
 import { isFunction } from '../../util/type-check.js';

--- a/packages/circuit-ui/components/Carousel/components/Slide/Slide.stories.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Slide/Slide.stories.tsx
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import Headline from '../../../Headline/index.js';
-import Image from '../../../Image/index.js';
+import { Headline } from '../../../Headline/index.js';
+import { Image } from '../../../Image/index.js';
 
 import { Slide, type SlideProps } from './Slide.js';
 

--- a/packages/circuit-ui/components/Carousel/components/SlideImage/SlideImage.tsx
+++ b/packages/circuit-ui/components/Carousel/components/SlideImage/SlideImage.tsx
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import Image from '../../../Image/index.js';
-import AspectRatio from '../../../AspectRatio/index.js';
+import { Image } from '../../../Image/index.js';
+import { AspectRatio } from '../../../AspectRatio/index.js';
 import { ASPECT_RATIO } from '../../constants.js';
 
 import classes from './SlideImage.module.css';

--- a/packages/circuit-ui/components/Carousel/components/Status/Status.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Status/Status.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import Body, { type BodyProps } from '../../../Body/index.js';
+import { Body, type BodyProps } from '../../../Body/index.js';
 import { clsx } from '../../../../styles/clsx.js';
 
 import classes from './Status.module.css';

--- a/packages/circuit-ui/components/Carousel/index.ts
+++ b/packages/circuit-ui/components/Carousel/index.ts
@@ -25,7 +25,8 @@ import {
   NextButton,
   PrevButton,
 } from './components/Buttons/index.js';
-import { Carousel } from './Carousel.js';
+
+export { Carousel } from './Carousel.js';
 
 export type { CarouselProps } from './Carousel.js';
 
@@ -41,5 +42,3 @@ export const CarouselComposer = {
   NextButton,
   PrevButton,
 };
-
-export default Carousel;

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -31,7 +31,7 @@ import {
 } from '../../util/errors.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { clsx } from '../../styles/clsx.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 
 import { IndeterminateIcon } from './IndeterminateIcon.js';
 import classes from './Checkbox.module.css';
@@ -126,7 +126,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           className={clsx(
             classes.base,
             invalid && classes.invalid,
-            utilityClasses.hideVisually,
+            utilClasses.hideVisually,
           )}
         />
         <label htmlFor={checkboxId} className={classes.label}>

--- a/packages/circuit-ui/components/Checkbox/index.ts
+++ b/packages/circuit-ui/components/Checkbox/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Checkbox } from './Checkbox.js';
+export { Checkbox } from './Checkbox.js';
 
 export type { CheckboxProps } from './Checkbox.js';
-
-export default Checkbox;

--- a/packages/circuit-ui/components/CheckboxGroup/index.ts
+++ b/packages/circuit-ui/components/CheckboxGroup/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { CheckboxGroup } from './CheckboxGroup.js';
+export { CheckboxGroup } from './CheckboxGroup.js';
 
 export type { CheckboxGroupProps } from './CheckboxGroup.js';
-
-export default CheckboxGroup;

--- a/packages/circuit-ui/components/CloseButton/index.ts
+++ b/packages/circuit-ui/components/CloseButton/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { CloseButton } from './CloseButton.js';
+export { CloseButton } from './CloseButton.js';
 
 export type { CloseButtonProps } from './CloseButton.js';
-
-export default CloseButton;

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -20,7 +20,7 @@ import { resolveCurrencyFormat } from '@sumup/intl';
 import { NumericFormat, type NumericFormatProps } from 'react-number-format';
 
 import { clsx } from '../../styles/clsx.js';
-import Input, { type InputElement, type InputProps } from '../Input/index.js';
+import { Input, type InputElement, type InputProps } from '../Input/index.js';
 
 import { formatPlaceholder } from './CurrencyInputService.js';
 import classes from './CurrencyInput.module.css';

--- a/packages/circuit-ui/components/CurrencyInput/index.ts
+++ b/packages/circuit-ui/components/CurrencyInput/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { CurrencyInput } from './CurrencyInput.js';
+export { CurrencyInput } from './CurrencyInput.js';
 
 export type { CurrencyInputProps } from './CurrencyInput.js';
-
-export default CurrencyInput;

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -18,7 +18,7 @@
 import { forwardRef, useState, useEffect } from 'react';
 import { PatternFormat } from 'react-number-format';
 
-import Input, { type InputElement, type InputProps } from '../Input/index.js';
+import { Input, type InputElement, type InputProps } from '../Input/index.js';
 import { clsx } from '../../styles/clsx.js';
 
 import classes from './DateInput.module.css';

--- a/packages/circuit-ui/components/DateInput/index.ts
+++ b/packages/circuit-ui/components/DateInput/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { DateInput } from './DateInput.js';
+export { DateInput } from './DateInput.js';
 
 export type { DateInputProps } from './DateInput.js';
-
-export default DateInput;

--- a/packages/circuit-ui/components/Field/Field.tsx
+++ b/packages/circuit-ui/components/Field/Field.tsx
@@ -22,7 +22,7 @@ import {
 import { Confirm, Notify, Alert } from '@sumup/icons';
 
 import { clsx } from '../../styles/clsx.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 
 import classes from './Field.module.css';
 import { getFieldValidity } from './FieldService.js';
@@ -127,7 +127,7 @@ export function FieldLabelText({
     <span
       className={clsx(
         classes['label-text'],
-        hideLabel && utilityClasses.hideVisually,
+        hideLabel && utilClasses.hideVisually,
       )}
     >
       {label}

--- a/packages/circuit-ui/components/Hamburger/index.ts
+++ b/packages/circuit-ui/components/Hamburger/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Hamburger } from './Hamburger.js';
+export { Hamburger } from './Hamburger.js';
 
 export type { HamburgerProps } from './Hamburger.js';
-
-export default Hamburger;

--- a/packages/circuit-ui/components/Headline/index.ts
+++ b/packages/circuit-ui/components/Headline/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Headline } from './Headline.js';
+export { Headline } from './Headline.js';
 
 export type { HeadlineProps } from './Headline.js';
-
-export default Headline;

--- a/packages/circuit-ui/components/Hr/index.ts
+++ b/packages/circuit-ui/components/Hr/index.ts
@@ -13,6 +13,4 @@
  * limitations under the License.
  */
 
-import { Hr } from './Hr.js';
-
-export default Hr;
+export { Hr } from './Hr.js';

--- a/packages/circuit-ui/components/Image/index.ts
+++ b/packages/circuit-ui/components/Image/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Image } from './Image.js';
+export { Image } from './Image.js';
 
 export type { ImageProps } from './Image.js';
-
-export default Image;

--- a/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
@@ -16,7 +16,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { useState } from 'react';
 
-import Avatar from '../Avatar/index.js';
+import { Avatar } from '../Avatar/index.js';
 import {
   render,
   axe,

--- a/packages/circuit-ui/components/ImageInput/ImageInput.stories.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.stories.tsx
@@ -15,11 +15,11 @@
 
 import { useState } from 'react';
 
-import Avatar from '../Avatar/index.js';
+import { Avatar } from '../Avatar/index.js';
 
 import type { ImageInputProps } from './ImageInput.js';
 
-import ImageInput from './index.js';
+import { ImageInput } from './index.js';
 
 export default {
   title: 'Forms/ImageInput',

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -28,14 +28,14 @@ import {
 import { Delete, Plus } from '@sumup/icons';
 
 import type { ClickEvent } from '../../types/events.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 import {
   FieldWrapper,
   FieldLabel,
   FieldValidationHint,
 } from '../Field/index.js';
 import { IconButton } from '../Button/index.js';
-import Spinner from '../Spinner/index.js';
+import { Spinner } from '../Spinner/index.js';
 import {
   AccessibilityError,
   isSufficientlyLabelled,
@@ -233,7 +233,7 @@ export const ImageInput = ({
     <FieldWrapper className={className} style={style} disabled={disabled}>
       <div onPaste={handlePaste} className={classes.base}>
         <input
-          className={clsx(classes.input, utilityClasses.hideVisually)}
+          className={clsx(classes.input, utilClasses.hideVisually)}
           ref={inputRef}
           id={inputId}
           type="file"
@@ -257,7 +257,7 @@ export const ImageInput = ({
             isDragging && classes.dragging,
           )}
         >
-          <span className={utilityClasses.hideVisually}>{label}</span>
+          <span className={utilClasses.hideVisually}>{label}</span>
           <Component src={src || previewImage} aria-hidden="true" />
         </FieldLabel>
         {src ? (
@@ -288,7 +288,7 @@ export const ImageInput = ({
         <Spinner
           className={clsx(classes.spinner, isLoading && classes.loading)}
         >
-          <span className={utilityClasses.hideVisually}>{loadingLabel}</span>
+          <span className={utilClasses.hideVisually}>{loadingLabel}</span>
         </Spinner>
       </div>
       <FieldValidationHint

--- a/packages/circuit-ui/components/ImageInput/index.ts
+++ b/packages/circuit-ui/components/ImageInput/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { ImageInput } from './ImageInput.js';
+export { ImageInput } from './ImageInput.js';
 
 export type { ImageInputProps } from './ImageInput.js';
-
-export default ImageInput;

--- a/packages/circuit-ui/components/Input/Input.stories.tsx
+++ b/packages/circuit-ui/components/Input/Input.stories.tsx
@@ -14,9 +14,9 @@
  */
 
 import { Stack } from '../../../../.storybook/components/index.js';
-import SearchInput from '../SearchInput/index.js';
-import CurrencyInput from '../CurrencyInput/index.js';
-import DateInput from '../DateInput/index.js';
+import { SearchInput } from '../SearchInput/index.js';
+import { CurrencyInput } from '../CurrencyInput/index.js';
+import { DateInput } from '../DateInput/index.js';
 
 import { Input, type InputProps } from './Input.js';
 

--- a/packages/circuit-ui/components/Input/index.ts
+++ b/packages/circuit-ui/components/Input/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Input } from './Input.js';
+export { Input } from './Input.js';
 
 export type { InputProps, InputElement } from './Input.js';
-
-export default Input;

--- a/packages/circuit-ui/components/List/index.ts
+++ b/packages/circuit-ui/components/List/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { List } from './List.js';
+export { List } from './List.js';
 
 export type { ListProps } from './List.js';
-
-export default List;

--- a/packages/circuit-ui/components/ListItem/ListItem.spec.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.spec.tsx
@@ -24,8 +24,8 @@ import {
   screen,
   type RenderFn,
 } from '../../util/test-utils.js';
-import Body from '../Body/index.js';
-import Badge from '../Badge/index.js';
+import { Body } from '../Body/index.js';
+import { Badge } from '../Badge/index.js';
 
 import { ListItem, type ListItemProps } from './ListItem.js';
 

--- a/packages/circuit-ui/components/ListItem/ListItem.stories.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.stories.tsx
@@ -17,8 +17,8 @@ import { action } from '@storybook/addon-actions';
 import { SumUpCard, Confirm } from '@sumup/icons';
 
 import { Stack } from '../../../../.storybook/components/index.js';
-import Body from '../Body/index.js';
-import Badge from '../Badge/index.js';
+import { Body } from '../Body/index.js';
+import { Badge } from '../Badge/index.js';
 
 import { ListItem, type ListItemProps } from './ListItem.js';
 

--- a/packages/circuit-ui/components/ListItem/ListItem.tsx
+++ b/packages/circuit-ui/components/ListItem/ListItem.tsx
@@ -29,7 +29,7 @@ import type { AsPropType } from '../../types/prop-types.js';
 import { isFunction, isString } from '../../util/type-check.js';
 import { CircuitError } from '../../util/errors.js';
 import { useComponents } from '../ComponentsContext/index.js';
-import Body from '../Body/index.js';
+import { Body } from '../Body/index.js';
 import { clsx } from '../../styles/clsx.js';
 
 import classes from './ListItem.module.css';

--- a/packages/circuit-ui/components/ListItem/index.ts
+++ b/packages/circuit-ui/components/ListItem/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { ListItem } from './ListItem.js';
+export { ListItem } from './ListItem.js';
 
 export type { ListItemProps } from './ListItem.js';
-
-export default ListItem;

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it } from 'vitest';
 import { createRef } from 'react';
 
 import { screen, render, axe, type RenderFn } from '../../util/test-utils.js';
-import Body from '../Body/index.js';
+import { Body } from '../Body/index.js';
 
 import { ListItemGroup, type ListItemGroupProps } from './ListItemGroup.js';
 

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.stories.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.stories.tsx
@@ -17,7 +17,7 @@ import { useState } from 'react';
 import { SumUpCard, Confirm, Alert } from '@sumup/icons';
 
 import { Stack } from '../../../../.storybook/components/index.js';
-import Body from '../Body/index.js';
+import { Body } from '../Body/index.js';
 
 import { ListItemGroup, type ListItemGroupProps } from './ListItemGroup.js';
 

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
@@ -23,11 +23,11 @@ import {
 } from 'react';
 
 import { AccessibilityError } from '../../util/errors.js';
-import Body from '../Body/index.js';
-import ListItem, { type ListItemProps } from '../ListItem/index.js';
+import { Body } from '../Body/index.js';
+import { ListItem, type ListItemProps } from '../ListItem/index.js';
 import { isString } from '../../util/type-check.js';
 import { clsx } from '../../styles/clsx.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 
 import classes from './ListItemGroup.module.css';
 
@@ -106,7 +106,7 @@ export const ListItemGroup = forwardRef<HTMLDivElement, ListItemGroupProps>(
           <div
             className={clsx(
               classes.label,
-              hideLabel && utilityClasses.hideVisually,
+              hideLabel && utilClasses.hideVisually,
             )}
           >
             {isString(label) ? (

--- a/packages/circuit-ui/components/ListItemGroup/index.ts
+++ b/packages/circuit-ui/components/ListItemGroup/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { ListItemGroup } from './ListItemGroup.js';
+export { ListItemGroup } from './ListItemGroup.js';
 
 export type { ListItemGroupProps } from './ListItemGroup.js';
-
-export default ListItemGroup;

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -22,10 +22,10 @@ import {
   Stack,
 } from '../../../../.storybook/components/index.js';
 import { modes } from '../../../../.storybook/modes.js';
-import Button from '../Button/index.js';
-import Headline from '../Headline/index.js';
-import Body from '../Body/index.js';
-import Image from '../Image/index.js';
+import { Button } from '../Button/index.js';
+import { Headline } from '../Headline/index.js';
+import { Body } from '../Body/index.js';
+import { Image } from '../Image/index.js';
 import { ModalProvider } from '../ModalContext/index.js';
 
 import { useModal, Modal, type ModalProps } from './Modal.js';

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -24,7 +24,7 @@ import {
   type ModalComponent,
   type BaseModalProps,
 } from '../ModalContext/index.js';
-import CloseButton from '../CloseButton/index.js';
+import { CloseButton } from '../CloseButton/index.js';
 import { StackContext } from '../StackContext/index.js';
 import {
   AccessibilityError,

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -26,11 +26,11 @@ import {
   type HTMLAttributes,
 } from 'react';
 
-import Button, { type ButtonProps } from '../Button/index.js';
-import Headline from '../Headline/index.js';
-import Body from '../Body/index.js';
-import Image, { type ImageProps } from '../Image/index.js';
-import CloseButton from '../CloseButton/index.js';
+import { Button, type ButtonProps } from '../Button/index.js';
+import { Headline } from '../Headline/index.js';
+import { Body } from '../Body/index.js';
+import { Image, type ImageProps } from '../Image/index.js';
+import { CloseButton } from '../CloseButton/index.js';
 import { useAnimation } from '../../hooks/useAnimation/index.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { clsx } from '../../styles/clsx.js';

--- a/packages/circuit-ui/components/NotificationBanner/index.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/index.tsx
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { NotificationBanner } from './NotificationBanner.js';
+export { NotificationBanner } from './NotificationBanner.js';
 
 export type { NotificationBannerProps } from './NotificationBanner.js';
-
-export default NotificationBanner;

--- a/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
+++ b/packages/circuit-ui/components/NotificationFullscreen/NotificationFullscreen.tsx
@@ -21,10 +21,10 @@ import {
   type SVGProps,
 } from 'react';
 
-import Body from '../Body/index.js';
-import Headline from '../Headline/index.js';
-import ButtonGroup, { type ButtonGroupProps } from '../ButtonGroup/index.js';
-import Image, { type ImageProps } from '../Image/index.js';
+import { Body } from '../Body/index.js';
+import { Headline } from '../Headline/index.js';
+import { ButtonGroup, type ButtonGroupProps } from '../ButtonGroup/index.js';
+import { Image, type ImageProps } from '../Image/index.js';
 import { isString } from '../../util/type-check.js';
 import { clsx } from '../../styles/clsx.js';
 

--- a/packages/circuit-ui/components/NotificationFullscreen/index.ts
+++ b/packages/circuit-ui/components/NotificationFullscreen/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { NotificationFullscreen } from './NotificationFullscreen.js';
+export { NotificationFullscreen } from './NotificationFullscreen.js';
 
 export type { NotificationFullscreenProps } from './NotificationFullscreen.js';
-
-export default NotificationFullscreen;

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.tsx
@@ -27,9 +27,9 @@ import {
 } from 'react';
 
 import { useAnimation } from '../../hooks/useAnimation/index.js';
-import Body from '../Body/index.js';
-import CloseButton from '../CloseButton/index.js';
-import Anchor, { type AnchorProps } from '../Anchor/index.js';
+import { Body } from '../Body/index.js';
+import { CloseButton } from '../CloseButton/index.js';
+import { Anchor, type AnchorProps } from '../Anchor/index.js';
 import type { ClickEvent } from '../../types/events.js';
 import { isString } from '../../util/type-check.js';
 import {
@@ -38,7 +38,7 @@ import {
 } from '../Notification/constants.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { clsx } from '../../styles/clsx.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 
 import classes from './NotificationInline.module.css';
 
@@ -160,7 +160,7 @@ export const NotificationInline = forwardRef<
           <div className={classes.icon}>
             <Icon aria-hidden="true" />
           </div>
-          <span className={utilityClasses.hideVisually}>{iconLabel}</span>
+          <span className={utilClasses.hideVisually}>{iconLabel}</span>
           <div className={classes.content}>
             {headline && (
               <Body

--- a/packages/circuit-ui/components/NotificationInline/index.tsx
+++ b/packages/circuit-ui/components/NotificationInline/index.tsx
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { NotificationInline } from './NotificationInline.js';
+export { NotificationInline } from './NotificationInline.js';
 
 export type { NotificationInlineProps } from './NotificationInline.js';
-
-export default NotificationInline;

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.stories.tsx
@@ -19,7 +19,7 @@ import { screen, userEvent, within } from '@storybook/test';
 
 import { FullViewport } from '../../../../.storybook/components/index.js';
 import { ModalProvider } from '../ModalContext/index.js';
-import Button from '../Button/index.js';
+import { Button } from '../Button/index.js';
 
 import {
   NotificationModal,

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.tsx
@@ -20,12 +20,12 @@ import ReactModal from 'react-modal';
 
 import type { ClickEvent } from '../../types/events.js';
 import type { ModalComponent, BaseModalProps } from '../ModalContext/index.js';
-import Image, { type ImageProps } from '../Image/index.js';
-import Headline from '../Headline/index.js';
-import Body from '../Body/index.js';
+import { Image, type ImageProps } from '../Image/index.js';
+import { Headline } from '../Headline/index.js';
+import { Body } from '../Body/index.js';
 import type { ButtonProps } from '../Button/index.js';
-import ButtonGroup, { type ButtonGroupProps } from '../ButtonGroup/index.js';
-import CloseButton from '../CloseButton/index.js';
+import { ButtonGroup, type ButtonGroupProps } from '../ButtonGroup/index.js';
+import { CloseButton } from '../CloseButton/index.js';
 import { CircuitError } from '../../util/errors.js';
 
 import classes from './NotificationModal.module.css';

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.spec.tsx
@@ -23,7 +23,7 @@ import {
   waitForElementToBeRemoved,
   screen,
 } from '../../util/test-utils.js';
-import Button from '../Button/index.js';
+import { Button } from '../Button/index.js';
 import { ToastProvider } from '../ToastContext/ToastContext.js';
 
 import {

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -18,7 +18,7 @@ import { screen, userEvent, within } from '@storybook/test';
 import isChromatic from 'chromatic/isChromatic';
 
 import { Stack } from '../../../../.storybook/components/index.js';
-import Button from '../Button/index.js';
+import { Button } from '../Button/index.js';
 import { ToastProvider } from '../ToastContext/index.js';
 
 import {

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -24,11 +24,11 @@ import {
 } from 'react';
 
 import { useAnimation } from '../../hooks/useAnimation/index.js';
-import Body from '../Body/index.js';
-import CloseButton from '../CloseButton/index.js';
+import { Body } from '../Body/index.js';
+import { CloseButton } from '../CloseButton/index.js';
 import type { ClickEvent } from '../../types/events.js';
 import { type BaseToastProps, createUseToast } from '../ToastContext/index.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 import { clsx } from '../../styles/clsx.js';
 import {
   NOTIFICATION_ICONS,
@@ -120,7 +120,7 @@ export function NotificationToast({
         <div className={classes.icon}>
           <Icon aria-hidden="true" />
         </div>
-        <span className={utilityClasses.hideVisually}>{iconLabel}</span>
+        <span className={utilClasses.hideVisually}>{iconLabel}</span>
         <div className={classes.content}>
           {headline && (
             <Body variant={'highlight'} as="h3">

--- a/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
@@ -17,7 +17,7 @@
 
 import type { FC, OlHTMLAttributes } from 'react';
 
-import Button from '../../../Button/index.js';
+import { Button } from '../../../Button/index.js';
 import { clsx } from '../../../../styles/clsx.js';
 
 import classes from './PageList.module.css';

--- a/packages/circuit-ui/components/Pagination/components/PageSelect/PageSelect.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageSelect/PageSelect.tsx
@@ -23,7 +23,7 @@ import {
   type ChangeEvent,
 } from 'react';
 
-import Select, { type SelectProps } from '../../../Select/index.js';
+import { Select, type SelectProps } from '../../../Select/index.js';
 
 import classes from './PageSelect.module.css';
 

--- a/packages/circuit-ui/components/Pagination/index.ts
+++ b/packages/circuit-ui/components/Pagination/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Pagination } from './Pagination.js';
+export { Pagination } from './Pagination.js';
 
 export type { PaginationProps } from './Pagination.js';
-
-export default Pagination;

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
@@ -20,7 +20,7 @@ import { resolveNumberFormat } from '@sumup/intl';
 import { NumericFormat, type NumericFormatProps } from 'react-number-format';
 
 import { clsx } from '../../styles/clsx.js';
-import Input, { type InputElement, type InputProps } from '../Input/index.js';
+import { Input, type InputElement, type InputProps } from '../Input/index.js';
 
 import { formatPlaceholder } from './PercentageInputService.js';
 import classes from './PercentageInput.module.css';

--- a/packages/circuit-ui/components/PercentageInput/index.ts
+++ b/packages/circuit-ui/components/PercentageInput/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { PercentageInput } from './PercentageInput.js';
+export { PercentageInput } from './PercentageInput.js';
 
 export type { PercentageInputProps } from './PercentageInput.js';
-
-export default PercentageInput;

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -28,8 +28,8 @@ import {
   type RefObject,
 } from 'react';
 
-import Select, { type SelectProps } from '../Select/index.js';
-import Input, { type InputElement, type InputProps } from '../Input/index.js';
+import { Select, type SelectProps } from '../Select/index.js';
+import { Input, type InputElement, type InputProps } from '../Input/index.js';
 import {
   FieldLabelText,
   FieldLegend,

--- a/packages/circuit-ui/components/Popover/Popover.stories.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.stories.tsx
@@ -17,7 +17,7 @@ import { action } from '@storybook/addon-actions';
 import { Add, Edit, Delete } from '@sumup/icons';
 import { useState, type ReactNode } from 'react';
 
-import Button from '../Button/index.js';
+import { Button } from '../Button/index.js';
 
 import { Popover, type PopoverProps } from './Popover.js';
 

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -48,9 +48,9 @@ import { useFocusList } from '../../hooks/useFocusList/index.js';
 import { usePrevious } from '../../hooks/usePrevious/index.js';
 import { useStackContext } from '../StackContext/index.js';
 import { useComponents } from '../ComponentsContext/index.js';
-import Portal from '../Portal/index.js';
-import Hr from '../Hr/index.js';
-import sharedClasses from '../../styles/shared.js';
+import { Portal } from '../Portal/index.js';
+import { Hr } from '../Hr/index.js';
+import { sharedClasses } from '../../styles/shared.js';
 
 import classes from './Popover.module.css';
 

--- a/packages/circuit-ui/components/Popover/index.tsx
+++ b/packages/circuit-ui/components/Popover/index.tsx
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Popover } from './Popover.js';
+export { Popover } from './Popover.js';
 
 export type { PopoverProps, PopoverItemProps } from './Popover.js';
-
-export default Popover;

--- a/packages/circuit-ui/components/Portal/index.ts
+++ b/packages/circuit-ui/components/Portal/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Portal } from './Portal.js';
+export { Portal } from './Portal.js';
 
 export type { PortalProps } from './Portal.js';
-
-export default Portal;

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.tsx
@@ -20,7 +20,7 @@ import {
   AccessibilityError,
   isSufficientlyLabelled,
 } from '../../util/errors.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 import { clsx } from '../../styles/clsx.js';
 import { deprecate } from '../../util/logger.js';
 
@@ -166,10 +166,7 @@ export function ProgressBar({
       )}
       <span
         id={ariaId}
-        className={clsx(
-          classes.label,
-          hideLabel && utilityClasses.hideVisually,
-        )}
+        className={clsx(classes.label, hideLabel && utilClasses.hideVisually)}
       >
         {label}
       </span>

--- a/packages/circuit-ui/components/ProgressBar/index.ts
+++ b/packages/circuit-ui/components/ProgressBar/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { ProgressBar } from './ProgressBar.js';
+export { ProgressBar } from './ProgressBar.js';
 
 export type { ProgressBarProps } from './ProgressBar.js';
-
-export default ProgressBar;

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -29,7 +29,7 @@ import {
 } from '../../util/errors.js';
 import { FieldWrapper, FieldDescription } from '../Field/index.js';
 import { clsx } from '../../styles/clsx.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 import { deprecate } from '../../util/logger.js';
 
 import classes from './RadioButton.module.css';
@@ -106,7 +106,7 @@ export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
           disabled={disabled}
           checked={checked}
           ref={ref}
-          className={clsx(classes.base, utilityClasses.hideVisually)}
+          className={clsx(classes.base, utilClasses.hideVisually)}
         />
         <label
           htmlFor={inputId}
@@ -122,7 +122,7 @@ export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
           )}
         </label>
         {description && (
-          <p id={descriptionIds} className={utilityClasses.hideVisually}>
+          <p id={descriptionIds} className={utilClasses.hideVisually}>
             {description}
           </p>
         )}

--- a/packages/circuit-ui/components/RadioButton/index.ts
+++ b/packages/circuit-ui/components/RadioButton/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { RadioButton } from './RadioButton.js';
+export { RadioButton } from './RadioButton.js';
 
 export type { RadioButtonProps } from './RadioButton.js';
-
-export default RadioButton;

--- a/packages/circuit-ui/components/RadioButtonGroup/index.ts
+++ b/packages/circuit-ui/components/RadioButtonGroup/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { RadioButtonGroup } from './RadioButtonGroup.js';
+export { RadioButtonGroup } from './RadioButtonGroup.js';
 
 export type { RadioButtonGroupProps } from './RadioButtonGroup.js';
-
-export default RadioButtonGroup;

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -18,9 +18,8 @@
 import { forwardRef, useRef } from 'react';
 import { Search } from '@sumup/icons';
 
-import Input from '../Input/index.js';
-import type { InputElement, InputProps } from '../Input/index.js';
-import CloseButton from '../CloseButton/index.js';
+import { Input, type InputElement, type InputProps } from '../Input/index.js';
+import { CloseButton } from '../CloseButton/index.js';
 import {
   AccessibilityError,
   isSufficientlyLabelled,

--- a/packages/circuit-ui/components/SearchInput/index.ts
+++ b/packages/circuit-ui/components/SearchInput/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { SearchInput } from './SearchInput.js';
+export { SearchInput } from './SearchInput.js';
 
 export type { SearchInputProps } from './SearchInput.js';
-
-export default SearchInput;

--- a/packages/circuit-ui/components/Select/index.ts
+++ b/packages/circuit-ui/components/Select/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Select } from './Select.js';
+export { Select } from './Select.js';
 
 export type { SelectProps, SelectOption } from './Select.js';
-
-export default Select;

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -31,7 +31,7 @@ import {
 } from '../../util/errors.js';
 import { FieldWrapper } from '../Field/index.js';
 import { clsx } from '../../styles/clsx.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 import { deprecate } from '../../util/logger.js';
 
 import classes from './Selector.module.css';
@@ -187,7 +187,7 @@ export const Selector = forwardRef<HTMLInputElement, SelectorProps>(
           className={clsx(
             classes.base,
             invalid && classes.invalid,
-            utilityClasses.hideVisually,
+            utilClasses.hideVisually,
           )}
           ref={ref}
           {...props}
@@ -213,7 +213,7 @@ export const Selector = forwardRef<HTMLInputElement, SelectorProps>(
           )}
         </label>
         {hasDescription && (
-          <p id={descriptionId} className={utilityClasses.hideVisually}>
+          <p id={descriptionId} className={utilClasses.hideVisually}>
             {description}
           </p>
         )}

--- a/packages/circuit-ui/components/Selector/index.ts
+++ b/packages/circuit-ui/components/Selector/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Selector } from './Selector.js';
+export { Selector } from './Selector.js';
 
 export type { SelectorProps } from './Selector.js';
-
-export default Selector;

--- a/packages/circuit-ui/components/SelectorGroup/index.ts
+++ b/packages/circuit-ui/components/SelectorGroup/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { SelectorGroup } from './SelectorGroup.js';
+export { SelectorGroup } from './SelectorGroup.js';
 
 export type { SelectorGroupProps } from './SelectorGroup.js';
-
-export default SelectorGroup;

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -17,10 +17,10 @@
 
 'use client';
 
-import utilityClasses from '../../../../styles/utility.js';
+import { utilClasses } from '../../../../styles/utility.js';
 import { clsx } from '../../../../styles/clsx.js';
 import { useFocusList } from '../../../../hooks/useFocusList/index.js';
-import Headline from '../../../Headline/index.js';
+import { Headline } from '../../../Headline/index.js';
 import { Skeleton, SkeletonContainer } from '../../../Skeleton/index.js';
 import type { PrimaryLinkProps } from '../../types.js';
 import { SecondaryLinks } from '../SecondaryLinks/index.js';
@@ -66,7 +66,7 @@ export function DesktopNavigation({
       className={classes.wrapper}
     >
       <nav
-        className={clsx(classes.primary, utilityClasses.hideScrollbar)}
+        className={clsx(classes.primary, utilClasses.hideScrollbar)}
         aria-label={primaryNavigationLabel}
       >
         <ul role="list" className={classes.list}>

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
@@ -25,7 +25,7 @@ import {
   type ModalComponent,
 } from '../../../ModalContext/index.js';
 import { StackContext } from '../../../StackContext/index.js';
-import CloseButton from '../../../CloseButton/index.js';
+import { CloseButton } from '../../../CloseButton/index.js';
 import { useCollapsible } from '../../../../hooks/useCollapsible/index.js';
 import { useFocusList } from '../../../../hooks/useFocusList/index.js';
 import type { PrimaryLinkProps } from '../../types.js';

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -20,11 +20,11 @@ import type { ComponentType } from 'react';
 
 import type { AsPropType } from '../../../../types/prop-types.js';
 import { useComponents } from '../../../ComponentsContext/index.js';
-import Body from '../../../Body/index.js';
+import { Body } from '../../../Body/index.js';
 import { Skeleton } from '../../../Skeleton/index.js';
 import type { PrimaryLinkProps as PrimaryLinkType } from '../../types.js';
 import { clsx } from '../../../../styles/clsx.js';
-import utilityClasses from '../../../../styles/utility.js';
+import { utilClasses } from '../../../../styles/utility.js';
 
 import classes from './PrimaryLink.module.css';
 
@@ -59,11 +59,7 @@ export function PrimaryLink({
   return (
     <Element
       {...props}
-      className={clsx(
-        classes.base,
-        utilityClasses.focusVisibleInset,
-        className,
-      )}
+      className={clsx(classes.base, utilClasses.focusVisibleInset, className)}
       aria-current={isActive ? 'page' : undefined}
     >
       <Skeleton className={clsx(classes.icon, badge && classes['icon-badge'])}>

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -24,15 +24,15 @@ import {
   useFocusList,
   type FocusProps,
 } from '../../../../hooks/useFocusList/index.js';
-import SubHeadline from '../../../SubHeadline/index.js';
-import Body from '../../../Body/index.js';
-import Badge from '../../../Badge/index.js';
+import { SubHeadline } from '../../../SubHeadline/index.js';
+import { Body } from '../../../Body/index.js';
+import { Badge } from '../../../Badge/index.js';
 import { useComponents } from '../../../ComponentsContext/index.js';
 import { Skeleton } from '../../../Skeleton/index.js';
 import type { SecondaryGroupProps, SecondaryLinkProps } from '../../types.js';
 import { clsx } from '../../../../styles/clsx.js';
-import utilityClasses from '../../../../styles/utility.js';
-import sharedClasses from '../../../../styles/shared.js';
+import { utilClasses } from '../../../../styles/utility.js';
+import { sharedClasses } from '../../../../styles/shared.js';
 
 import classes from './SecondaryLinks.module.css';
 
@@ -53,7 +53,7 @@ function SecondaryLink({
         className={clsx(
           classes.anchor,
           sharedClasses.navigationItem,
-          utilityClasses.focusVisibleInset,
+          utilClasses.focusVisibleInset,
         )}
         aria-current={isActive ? 'page' : undefined}
       >

--- a/packages/circuit-ui/components/SidePanel/SidePanel.stories.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.stories.tsx
@@ -17,9 +17,9 @@ import { useState } from 'react';
 import { within, userEvent } from '@storybook/test';
 
 import { modes } from '../../../../.storybook/modes.js';
-import Body from '../Body/index.js';
-import Button from '../Button/index.js';
-import ListItemGroup from '../ListItemGroup/index.js';
+import { Body } from '../Body/index.js';
+import { Button } from '../Button/index.js';
+import { ListItemGroup } from '../ListItemGroup/index.js';
 import { ModalProvider } from '../ModalContext/index.js';
 import { TopNavigation } from '../TopNavigation/index.js';
 import { baseArgs as topNavigationProps } from '../TopNavigation/TopNavigation.stories.js';

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.tsx
@@ -20,8 +20,8 @@ import { ArrowLeft } from '@sumup/icons';
 
 import { clsx } from '../../../../styles/clsx.js';
 import { IconButton } from '../../../Button/index.js';
-import CloseButton from '../../../CloseButton/index.js';
-import Headline from '../../../Headline/index.js';
+import { CloseButton } from '../../../CloseButton/index.js';
+import { Headline } from '../../../Headline/index.js';
 import type { SidePanelProps } from '../../SidePanel.js';
 
 import classes from './Header.module.css';

--- a/packages/circuit-ui/components/Spinner/index.ts
+++ b/packages/circuit-ui/components/Spinner/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Spinner } from './Spinner.js';
+export { Spinner } from './Spinner.js';
 
 export type { SpinnerProps } from './Spinner.js';
-
-export default Spinner;

--- a/packages/circuit-ui/components/Step/Step.spec.tsx
+++ b/packages/circuit-ui/components/Step/Step.spec.tsx
@@ -17,7 +17,7 @@ import { afterAll, describe, expect, it, vi, type Mock } from 'vitest';
 
 import { render } from '../../util/test-utils.js';
 
-import Step from './Step.js';
+import { Step } from './Step.js';
 import { useStep } from './hooks/useStep.js';
 
 vi.mock('./hooks/useStep', () => ({ useStep: vi.fn(() => ({})) }));

--- a/packages/circuit-ui/components/Step/Step.stories.tsx
+++ b/packages/circuit-ui/components/Step/Step.stories.tsx
@@ -15,14 +15,16 @@
 
 import { action } from '@storybook/addon-actions';
 
-import Step from './Step.js';
-import CarouselSlider, {
+import { Step } from './Step.js';
+import {
+  CarouselSlider,
   type CarouselSliderProps,
 } from './examples/CarouselSlider.js';
-import YesOrNoSlider, {
+import {
+  YesOrNoSlider,
   type YesOrNoSliderProps,
 } from './examples/YesOrNoSlider.js';
-import MultiStepForm from './examples/MultiStepForm.js';
+import { MultiStepForm } from './examples/MultiStepForm.js';
 
 const IMAGES = [
   '/images/illustration-waves.jpg',

--- a/packages/circuit-ui/components/Step/Step.ts
+++ b/packages/circuit-ui/components/Step/Step.ts
@@ -28,7 +28,7 @@ export interface StepProps extends StepOptions {
   children: (stateAndHelpers: StateAndHelpers) => React.JSX.Element;
 }
 
-export default function Step({ children, ...props }: StepProps) {
+export function Step({ children, ...props }: StepProps) {
   const stateAndHelpers = useStep(props);
 
   if (!isFunction(children)) {

--- a/packages/circuit-ui/components/Step/examples/CarouselSlider.tsx
+++ b/packages/circuit-ui/components/Step/examples/CarouselSlider.tsx
@@ -15,9 +15,9 @@
 
 /* istanbul ignore file */
 
-import Image from '../../Image/index.js';
-import Button from '../../Button/index.js';
-import Step, { type StepProps } from '../Step.js';
+import { Image } from '../../Image/index.js';
+import { Button } from '../../Button/index.js';
+import { Step, type StepProps } from '../Step.js';
 
 import classes from './CarouselSlider.module.css';
 
@@ -25,7 +25,7 @@ export interface CarouselSliderProps extends StepProps {
   images: string[];
 }
 
-export default function CarouselSlider({
+export function CarouselSlider({
   images = [],
   ...stepProps
 }: CarouselSliderProps) {

--- a/packages/circuit-ui/components/Step/examples/MultiStepForm.tsx
+++ b/packages/circuit-ui/components/Step/examples/MultiStepForm.tsx
@@ -17,13 +17,13 @@
 
 'use client';
 
-import Headline from '../../Headline/index.js';
-import Button from '../../Button/index.js';
-import ButtonGroup from '../../ButtonGroup/index.js';
-import Input from '../../Input/index.js';
-import Select from '../../Select/index.js';
-import ProgressBar from '../../ProgressBar/index.js';
-import Step from '../Step.js';
+import { Headline } from '../../Headline/index.js';
+import { Button } from '../../Button/index.js';
+import { ButtonGroup } from '../../ButtonGroup/index.js';
+import { Input } from '../../Input/index.js';
+import { Select } from '../../Select/index.js';
+import { ProgressBar } from '../../ProgressBar/index.js';
+import { Step } from '../Step.js';
 
 import classes from './MultiStepForm.module.css';
 
@@ -81,7 +81,7 @@ const Thanks = () => (
   </section>
 );
 
-export default function MultiStepForm() {
+export function MultiStepForm() {
   const steps = [FormOne, FormTwo, Thanks];
   const totalSteps = steps.length;
 

--- a/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
+++ b/packages/circuit-ui/components/Step/examples/YesOrNoSlider.tsx
@@ -26,9 +26,9 @@ import {
   type SwipeDirections,
 } from 'react-swipeable';
 
-import Image from '../../Image/index.js';
-import Button from '../../Button/index.js';
-import Step, { type StepProps } from '../Step.js';
+import { Image } from '../../Image/index.js';
+import { Button } from '../../Button/index.js';
+import { Step, type StepProps } from '../Step.js';
 import type { Actions } from '../types.js';
 import { clsx } from '../../../styles/clsx.js';
 
@@ -52,10 +52,7 @@ export interface YesOrNoSliderProps extends StepProps {
   images: string[];
 }
 
-export default function YesOrNoSlider({
-  images,
-  ...stepProps
-}: YesOrNoSliderProps) {
+export function YesOrNoSlider({ images, ...stepProps }: YesOrNoSliderProps) {
   const [swipe, setSwipe] = useState<SwipeEventData | null>(null);
   const handleSwipe = (eventData: SwipeEventData, actions: Actions) => {
     setSwipe(eventData);

--- a/packages/circuit-ui/components/Step/index.ts
+++ b/packages/circuit-ui/components/Step/index.ts
@@ -13,10 +13,9 @@
  * limitations under the License.
  */
 
-import Step from './Step.js';
+export { Step } from './Step.js';
 
 export { useStep } from './hooks/useStep.js';
 
 export type { StepOptions } from './types.js';
 export type { StepProps } from './Step.js';
-export default Step;

--- a/packages/circuit-ui/components/SubHeadline/index.ts
+++ b/packages/circuit-ui/components/SubHeadline/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { SubHeadline } from './SubHeadline.js';
+export { SubHeadline } from './SubHeadline.js';
 
 export type { SubHeadlineProps } from './SubHeadline.js';
-
-export default SubHeadline;

--- a/packages/circuit-ui/components/Table/Table.spec.tsx
+++ b/packages/circuit-ui/components/Table/Table.spec.tsx
@@ -16,9 +16,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { render, axe, userEvent, screen } from '../../util/test-utils.js';
-import Badge from '../Badge/index.js';
+import { Badge } from '../Badge/index.js';
 
-import Table from './Table.js';
+import { Table } from './Table.js';
 import type { HeaderCell, Direction } from './types.js';
 
 const sortLabel = ({ direction }: { direction?: Direction }) => {

--- a/packages/circuit-ui/components/Table/Table.stories.tsx
+++ b/packages/circuit-ui/components/Table/Table.stories.tsx
@@ -15,13 +15,13 @@
 
 import { action } from '@storybook/addon-actions';
 
-import Badge from '../Badge/index.js';
+import { Badge } from '../Badge/index.js';
 import { isString } from '../../util/type-check.js';
 
 import type { TableProps } from './Table.js';
 import type { Direction } from './types.js';
 
-import Table from './index.js';
+import { Table } from './index.js';
 
 export default {
   title: 'Components/Table',

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -22,8 +22,8 @@ import { throttle } from '../../util/helpers.js';
 import { clsx } from '../../styles/clsx.js';
 import { deprecate } from '../../util/logger.js';
 
-import TableHead from './components/TableHead/index.js';
-import TableBody from './components/TableBody/index.js';
+import { TableHead } from './components/TableHead/index.js';
+import { TableBody } from './components/TableBody/index.js';
 import { defaultSortBy, getSortDirection } from './utils.js';
 import type { Direction, Row, HeaderCell } from './types.js';
 import classes from './Table.module.css';
@@ -101,7 +101,7 @@ type TableState = {
 /**
  * Table interface component. It handles rendering rows/headers properly
  */
-class Table extends Component<TableProps, TableState> {
+export class Table extends Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
     if (process.env.NODE_ENV !== 'production' && this.props.initialSortedRow) {
@@ -299,5 +299,3 @@ class Table extends Component<TableProps, TableState> {
     );
   }
 }
-
-export default Table;

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { render, axe, userEvent, screen } from '../../../../util/test-utils.js';
 
-import SortArrow from './index.js';
+import { SortArrow } from './index.js';
 
 describe('SortArrow', () => {
   it('should render with both arrows styles', () => {

--- a/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
+++ b/packages/circuit-ui/components/Table/components/SortArrow/SortArrow.tsx
@@ -20,7 +20,7 @@ import { ChevronUp, ChevronDown } from '@sumup/icons';
 
 import type { Direction } from '../../types.js';
 import { clsx } from '../../../../styles/clsx.js';
-import utilityClasses from '../../../../styles/utility.js';
+import { utilClasses } from '../../../../styles/utility.js';
 
 import classes from './SortArrow.module.css';
 
@@ -46,7 +46,7 @@ export function SortArrow({
       {direction !== 'descending' && (
         <ChevronDown size="16" aria-hidden="true" className={classes.icon} />
       )}
-      <span className={utilityClasses.hideVisually}>{label}</span>
+      <span className={utilClasses.hideVisually}>{label}</span>
     </button>
   );
 }

--- a/packages/circuit-ui/components/Table/components/SortArrow/index.ts
+++ b/packages/circuit-ui/components/Table/components/SortArrow/index.ts
@@ -13,6 +13,4 @@
  * limitations under the License.
  */
 
-import { SortArrow } from './SortArrow.js';
-
-export default SortArrow;
+export { SortArrow } from './SortArrow.js';

--- a/packages/circuit-ui/components/Table/components/TableBody/TableBody.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableBody/TableBody.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it } from 'vitest';
 
 import { render, axe, screen } from '../../../../util/test-utils.js';
 
-import TableBody from './index.js';
+import { TableBody } from './index.js';
 
 const fixtureRows = [['Foo', 'Bar']];
 

--- a/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
+++ b/packages/circuit-ui/components/Table/components/TableBody/TableBody.tsx
@@ -17,9 +17,9 @@
 
 import { mapRowProps, mapCellProps } from '../../utils.js';
 import type { Row } from '../../types.js';
-import TableRow from '../TableRow/index.js';
-import TableHeader from '../TableHeader/index.js';
-import TableCell from '../TableCell/index.js';
+import { TableRow } from '../TableRow/index.js';
+import { TableHeader } from '../TableHeader/index.js';
+import { TableCell } from '../TableCell/index.js';
 
 type TableBodyProps = {
   /**

--- a/packages/circuit-ui/components/Table/components/TableBody/index.ts
+++ b/packages/circuit-ui/components/Table/components/TableBody/index.ts
@@ -13,6 +13,4 @@
  * limitations under the License.
  */
 
-import { TableBody } from './TableBody.js';
-
-export default TableBody;
+export { TableBody } from './TableBody.js';

--- a/packages/circuit-ui/components/Table/components/TableCell/TableCell.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableCell/TableCell.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it } from 'vitest';
 
 import { render, axe } from '../../../../util/test-utils.js';
 
-import TableCell from './index.js';
+import { TableCell } from './index.js';
 
 const children = 'Foo';
 

--- a/packages/circuit-ui/components/Table/components/TableCell/TableCell.stories.tsx
+++ b/packages/circuit-ui/components/Table/components/TableCell/TableCell.stories.tsx
@@ -15,7 +15,7 @@
 
 import type { TableCellProps } from './TableCell.js';
 
-import TableCell from './index.js';
+import { TableCell } from './index.js';
 
 export default {
   title: 'Components/Table/TableCell',

--- a/packages/circuit-ui/components/Table/components/TableCell/index.ts
+++ b/packages/circuit-ui/components/Table/components/TableCell/index.ts
@@ -13,6 +13,4 @@
  * limitations under the License.
  */
 
-import { TableCell } from './TableCell.js';
-
-export default TableCell;
+export { TableCell } from './TableCell.js';

--- a/packages/circuit-ui/components/Table/components/TableHead/TableHead.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHead/TableHead.spec.tsx
@@ -18,7 +18,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, axe, userEvent, screen } from '../../../../util/test-utils.js';
 import type { HeaderCell, Direction } from '../../types.js';
 
-import TableHead from './index.js';
+import { TableHead } from './index.js';
 
 const sortLabel = ({ direction }: { direction?: Direction }) => {
   const order = direction === 'ascending' ? 'descending' : 'ascending';

--- a/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
@@ -17,8 +17,8 @@
 
 import { Fragment } from 'react';
 
-import TableRow from '../TableRow/index.js';
-import TableHeader from '../TableHeader/index.js';
+import { TableRow } from '../TableRow/index.js';
+import { TableHeader } from '../TableHeader/index.js';
 import { mapCellProps, getSortParams } from '../../utils.js';
 import type { Direction, HeaderCell } from '../../types.js';
 import { clsx } from '../../../../styles/clsx.js';

--- a/packages/circuit-ui/components/Table/components/TableHead/index.ts
+++ b/packages/circuit-ui/components/Table/components/TableHead/index.ts
@@ -13,6 +13,4 @@
  * limitations under the License.
  */
 
-import { TableHead } from './TableHead.js';
-
-export default TableHead;
+export { TableHead } from './TableHead.js';

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it } from 'vitest';
 
 import { render, axe } from '../../../../util/test-utils.js';
 
-import TableHeader from './index.js';
+import { TableHeader } from './index.js';
 
 const children = 'Foo';
 

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.stories.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.stories.tsx
@@ -15,7 +15,7 @@
 
 import type { TableHeaderProps } from './TableHeader.js';
 
-import TableHeader from './index.js';
+import { TableHeader } from './index.js';
 
 export default {
   title: 'Components/Table/TableHeader',

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.tsx
@@ -17,7 +17,7 @@
 
 import type { ThHTMLAttributes } from 'react';
 
-import SortArrow from '../SortArrow/index.js';
+import { SortArrow } from '../SortArrow/index.js';
 import type { CellAlignment, SortParams } from '../../types.js';
 import type { ClickEvent } from '../../../../types/events.js';
 import {

--- a/packages/circuit-ui/components/Table/components/TableHeader/index.ts
+++ b/packages/circuit-ui/components/Table/components/TableHeader/index.ts
@@ -13,6 +13,4 @@
  * limitations under the License.
  */
 
-import { TableHeader } from './TableHeader.js';
-
-export default TableHeader;
+export { TableHeader } from './TableHeader.js';

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { render, axe, userEvent, screen } from '../../../../util/test-utils.js';
 
-import TableRow from './index.js';
+import { TableRow } from './index.js';
 
 const children = 'Foo';
 

--- a/packages/circuit-ui/components/Table/components/TableRow/index.ts
+++ b/packages/circuit-ui/components/Table/components/TableRow/index.ts
@@ -13,6 +13,4 @@
  * limitations under the License.
  */
 
-import { TableRow } from './TableRow.js';
-
-export default TableRow;
+export { TableRow } from './TableRow.js';

--- a/packages/circuit-ui/components/Table/index.ts
+++ b/packages/circuit-ui/components/Table/index.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import Table, { type TableProps } from './Table.js';
+import type { TableProps } from './Table.js';
 import type {
   Direction as TableSortDirection,
   SortByValue as TableSortByValue,
@@ -21,6 +21,8 @@ import type {
   HeaderCell as TableHeaderCell,
   Row as TableRow,
 } from './types.js';
+
+export { Table } from './Table.js';
 
 /**
  * @deprecated
@@ -37,5 +39,3 @@ export type {
   TableHeaderCell,
   TableRow,
 };
-
-export default Table;

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.tsx
@@ -16,7 +16,7 @@
 import { Children, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../../../styles/clsx.js';
-import utilityClasses from '../../../../styles/utility.js';
+import { utilClasses } from '../../../../styles/utility.js';
 
 import classes from './TabList.module.css';
 
@@ -41,7 +41,7 @@ export function TabList({
   const stretchOnMobile = numberOfTabs <= MOBILE_AUTOSTRETCH_ITEMS_MAX;
   return (
     <div
-      className={clsx(classes.wrapper, utilityClasses.hideScrollbar, className)}
+      className={clsx(classes.wrapper, utilClasses.hideScrollbar, className)}
       style={{ ...style, '--tab-list-width': tabWidth }}
     >
       <div

--- a/packages/circuit-ui/components/Tabs/components/TabPanels/index.ts
+++ b/packages/circuit-ui/components/Tabs/components/TabPanels/index.ts
@@ -13,6 +13,4 @@
  * limitations under the License.
  */
 
-import { TabPanels } from './TabPanels.js';
-
-export default TabPanels;
+export { TabPanels } from './TabPanels.js';

--- a/packages/circuit-ui/components/Tag/Tag.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.tsx
@@ -30,8 +30,8 @@ import {
   isSufficientlyLabelled,
 } from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
-import utilityClasses from '../../styles/utility.js';
-import CloseButton from '../CloseButton/index.js';
+import { utilClasses } from '../../styles/utility.js';
+import { CloseButton } from '../CloseButton/index.js';
 import { useComponents } from '../ComponentsContext/index.js';
 
 import classes from './Tag.module.css';
@@ -137,10 +137,7 @@ export const Tag = forwardRef<HTMLDivElement & HTMLButtonElement, TagProps>(
         style={style}
       >
         <Element
-          className={clsx(
-            classes.content,
-            onClick && utilityClasses.focusVisible,
-          )}
+          className={clsx(classes.content, onClick && utilClasses.focusVisible)}
           type={isButton ? 'button' : undefined}
           aria-pressed={isButton && selected ? 'true' : undefined}
           onClick={onClick}

--- a/packages/circuit-ui/components/Tag/index.ts
+++ b/packages/circuit-ui/components/Tag/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Tag } from './Tag.js';
+export { Tag } from './Tag.js';
 
 export type { TagProps } from './Tag.js';
-
-export default Tag;

--- a/packages/circuit-ui/components/TextArea/TextArea.tsx
+++ b/packages/circuit-ui/components/TextArea/TextArea.tsx
@@ -17,8 +17,7 @@
 
 import { forwardRef, useRef } from 'react';
 
-import Input from '../Input/index.js';
-import type { InputElement, InputProps } from '../Input/index.js';
+import { Input, type InputElement, type InputProps } from '../Input/index.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { clsx } from '../../styles/clsx.js';
 

--- a/packages/circuit-ui/components/TextArea/index.ts
+++ b/packages/circuit-ui/components/TextArea/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { TextArea } from './TextArea.js';
+export { TextArea } from './TextArea.js';
 
 export type { TextAreaProps } from './TextArea.js';
-
-export default TextArea;

--- a/packages/circuit-ui/components/Title/index.ts
+++ b/packages/circuit-ui/components/Title/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Title } from './Title.js';
+export { Title } from './Title.js';
 
 export type { TitleProps } from './Title.js';
-
-export default Title;

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../util/errors.js';
 import { FieldDescription, FieldWrapper } from '../Field/index.js';
 import { clsx } from '../../styles/clsx.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 
 import classes from './Toggle.module.css';
 
@@ -116,12 +116,12 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
           aria-labelledby={labelId}
           aria-describedby={descriptionIds}
           id={switchId}
-          className={clsx(classes.track, utilityClasses.focusVisible)}
+          className={clsx(classes.track, utilClasses.focusVisible)}
           {...props}
           ref={ref}
         >
           <span className={classes.knob} />
-          <span className={utilityClasses.hideVisually}>
+          <span className={utilClasses.hideVisually}>
             {checked ? checkedLabel : uncheckedLabel}
           </span>
         </button>
@@ -134,7 +134,7 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
           )}
         </label>
         {description && (
-          <p id={descriptionId} className={utilityClasses.hideVisually}>
+          <p id={descriptionId} className={utilClasses.hideVisually}>
             {description}
           </p>
         )}

--- a/packages/circuit-ui/components/Toggle/index.ts
+++ b/packages/circuit-ui/components/Toggle/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Toggle } from './Toggle.js';
+export { Toggle } from './Toggle.js';
 
 export type { ToggleProps } from './Toggle.js';
-
-export default Toggle;

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -45,10 +45,10 @@ import { useMedia } from '../../hooks/useMedia/index.js';
 import { useEscapeKey } from '../../hooks/useEscapeKey/index.js';
 import { useClickOutside } from '../../hooks/useClickOutside/index.js';
 import { useStackContext } from '../StackContext/index.js';
-import CloseButton from '../CloseButton/index.js';
-import Headline from '../Headline/index.js';
-import Body from '../Body/index.js';
-import Button, { type ButtonProps } from '../Button/index.js';
+import { CloseButton } from '../CloseButton/index.js';
+import { Headline } from '../Headline/index.js';
+import { Body } from '../Body/index.js';
+import { Button, type ButtonProps } from '../Button/index.js';
 
 import classes from './Toggletip.module.css';
 

--- a/packages/circuit-ui/components/Toggletip/index.ts
+++ b/packages/circuit-ui/components/Toggletip/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Toggletip } from './Toggletip.js';
+export { Toggletip } from './Toggletip.js';
 
 export type { ToggletipProps } from './Toggletip.js';
-
-export default Toggletip;

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -17,7 +17,7 @@ import { userEvent } from '@storybook/test';
 import { TransferOut, UploadCloud } from '@sumup/icons';
 
 import { Stack } from '../../../../.storybook/components/index.js';
-import Button, { IconButton } from '../Button/index.js';
+import { Button, IconButton } from '../Button/index.js';
 
 import {
   Tooltip,

--- a/packages/circuit-ui/components/Tooltip/index.ts
+++ b/packages/circuit-ui/components/Tooltip/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Tooltip } from './Tooltip.js';
+export { Tooltip } from './Tooltip.js';
 
 export type { TooltipProps, TooltipReferenceProps } from './Tooltip.js';
-
-export default Tooltip;

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.stories.tsx
@@ -21,7 +21,7 @@ import { modes } from '../../../../.storybook/modes.js';
 import { SideNavigation } from '../SideNavigation/index.js';
 import { baseArgs as sideNavigationProps } from '../SideNavigation/SideNavigation.stories.js';
 import { ModalProvider } from '../ModalContext/index.js';
-import Body from '../Body/index.js';
+import { Body } from '../Body/index.js';
 import type { HamburgerProps } from '../Hamburger/Hamburger.js';
 
 import { TopNavigation, type TopNavigationProps } from './TopNavigation.js';

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.tsx
@@ -17,10 +17,10 @@
 
 import { useEffect, type HTMLAttributes, type ReactNode } from 'react';
 
-import Hamburger, { type HamburgerProps } from '../Hamburger/index.js';
+import { Hamburger, type HamburgerProps } from '../Hamburger/index.js';
 import { SkeletonContainer } from '../Skeleton/index.js';
 import { clsx } from '../../styles/clsx.js';
-import utilityClasses from '../../styles/utility.js';
+import { utilClasses } from '../../styles/utility.js';
 
 import {
   ProfileMenu,
@@ -81,10 +81,7 @@ export function TopNavigation({
           <SkeletonContainer isLoading={Boolean(isLoading)}>
             <Hamburger
               {...hamburger}
-              className={clsx(
-                classes.hamburger,
-                utilityClasses.focusVisibleInset,
-              )}
+              className={clsx(classes.hamburger, utilClasses.focusVisibleInset)}
             />
           </SkeletonContainer>
         )}

--- a/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/ProfileMenu/ProfileMenu.tsx
@@ -18,13 +18,13 @@
 import { useState, useEffect, type ButtonHTMLAttributes } from 'react';
 import { ChevronDown, Profile as ProfileIcon } from '@sumup/icons';
 
-import Avatar from '../../../Avatar/index.js';
-import Body from '../../../Body/index.js';
-import Popover, { type PopoverProps } from '../../../Popover/index.js';
+import { Avatar } from '../../../Avatar/index.js';
+import { Body } from '../../../Body/index.js';
+import { Popover, type PopoverProps } from '../../../Popover/index.js';
 import { Skeleton } from '../../../Skeleton/index.js';
 import type { UserProps } from '../../types.js';
-import utilityClasses from '../../../../styles/utility.js';
-import sharedClasses from '../../../../styles/shared.js';
+import { utilClasses } from '../../../../styles/utility.js';
+import { sharedClasses } from '../../../../styles/shared.js';
 import { clsx } from '../../../../styles/clsx.js';
 
 import classes from './ProfileMenu.module.css';
@@ -51,7 +51,7 @@ function Profile({ user, label, className, ...props }: ProfileProps) {
       className={clsx(
         classes.profile,
         sharedClasses.navigationItem,
-        utilityClasses.focusVisibleInset,
+        utilClasses.focusVisibleInset,
         className,
       )}
       type="button"

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.tsx
@@ -24,12 +24,12 @@ import type {
 import type { IconComponentType } from '@sumup/icons';
 
 import type { AsPropType } from '../../../../types/prop-types.js';
-import Body from '../../../Body/index.js';
+import { Body } from '../../../Body/index.js';
 import { useComponents } from '../../../ComponentsContext/index.js';
 import { Skeleton } from '../../../Skeleton/index.js';
 import { clsx } from '../../../../styles/clsx.js';
-import utilityClasses from '../../../../styles/utility.js';
-import sharedClasses from '../../../../styles/shared.js';
+import { utilClasses } from '../../../../styles/utility.js';
+import { sharedClasses } from '../../../../styles/shared.js';
 
 import classes from './UtilityLinks.module.css';
 
@@ -79,7 +79,7 @@ function UtilityLink({
       className={clsx(
         classes.anchor,
         sharedClasses.navigationItem,
-        utilityClasses.focusVisibleInset,
+        utilClasses.focusVisibleInset,
         className,
       )}
     >

--- a/packages/circuit-ui/components/legacy/Calendar/components/CalendarWrapper/CalendarImportedStyles.ts
+++ b/packages/circuit-ui/components/legacy/Calendar/components/CalendarWrapper/CalendarImportedStyles.ts
@@ -15,7 +15,7 @@
 
 import { css } from '@emotion/react';
 
-const calendarInheritStyles = () => css`
+export const calendarInheritStyles = () => css`
   .PresetDateRangePicker_panel {
     padding: 0 22px 11px;
   }
@@ -904,5 +904,3 @@ const calendarInheritStyles = () => css`
     fill: #cacccd;
   }
 `;
-
-export default calendarInheritStyles;

--- a/packages/circuit-ui/components/legacy/Calendar/components/CalendarWrapper/CalendarWrapper.tsx
+++ b/packages/circuit-ui/components/legacy/Calendar/components/CalendarWrapper/CalendarWrapper.tsx
@@ -26,7 +26,7 @@ import {
   cx,
 } from '../../../../../styles/style-mixins.js';
 
-import calendarInheritStyles from './CalendarImportedStyles.js';
+import { calendarInheritStyles } from './CalendarImportedStyles.js';
 
 const dayDefault = css`
   .CalendarDay__default {

--- a/packages/circuit-ui/components/legacy/CalendarTag/CalendarTag.spec.tsx
+++ b/packages/circuit-ui/components/legacy/CalendarTag/CalendarTag.spec.tsx
@@ -17,7 +17,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { axe, render } from '../../../util/test-utils.js';
 
-import CalendarTag from './index.js';
+import { CalendarTag } from './index.js';
 
 describe('CalendarTag', () => {
   const baseProps = {

--- a/packages/circuit-ui/components/legacy/CalendarTag/CalendarTag.tsx
+++ b/packages/circuit-ui/components/legacy/CalendarTag/CalendarTag.tsx
@@ -21,7 +21,7 @@ import type { Moment } from 'moment';
 import type { ClickEvent } from '../../../types/events.js';
 import styled from '../../../styles/styled.js';
 import { RangePickerController } from '../Calendar/index.js';
-import Tag from '../../Tag/index.js';
+import { Tag } from '../../Tag/index.js';
 import { START_DATE } from '../Calendar/constants.js';
 
 export interface CalendarTagProps {

--- a/packages/circuit-ui/components/legacy/CalendarTag/index.ts
+++ b/packages/circuit-ui/components/legacy/CalendarTag/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { CalendarTag } from './CalendarTag.js';
+export { CalendarTag } from './CalendarTag.js';
 
 export type { CalendarTagProps } from './CalendarTag.js';
-
-export default CalendarTag;

--- a/packages/circuit-ui/components/legacy/CalendarTagTwoStep/CalendarTagTwoStep.tsx
+++ b/packages/circuit-ui/components/legacy/CalendarTagTwoStep/CalendarTagTwoStep.tsx
@@ -24,8 +24,8 @@ import type { Moment } from 'moment';
 import type { ClickEvent } from '../../../types/events.js';
 import styled from '../../../styles/styled.js';
 import { RangePickerController } from '../Calendar/index.js';
-import Tag from '../../Tag/index.js';
-import ButtonGroup from '../../ButtonGroup/index.js';
+import { Tag } from '../../Tag/index.js';
+import { ButtonGroup } from '../../ButtonGroup/index.js';
 import { END_DATE, START_DATE } from '../Calendar/constants.js';
 
 export interface CalendarTagTwoStepProps {

--- a/packages/circuit-ui/components/legacy/CalendarTagTwoStep/index.ts
+++ b/packages/circuit-ui/components/legacy/CalendarTagTwoStep/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { CalendarTagTwoStep } from './CalendarTagTwoStep.js';
+export { CalendarTagTwoStep } from './CalendarTagTwoStep.js';
 
 export type { CalendarTagTwoStepProps } from './CalendarTagTwoStep.js';
-
-export default CalendarTagTwoStep;

--- a/packages/circuit-ui/components/legacy/InlineElements/index.ts
+++ b/packages/circuit-ui/components/legacy/InlineElements/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { InlineElements } from './InlineElements.js';
+export { InlineElements } from './InlineElements.js';
 
 export type { InlineElementsProps } from './InlineElements.js';
-
-export default InlineElements;

--- a/packages/circuit-ui/components/legacy/Tooltip/TooltipContainer.tsx
+++ b/packages/circuit-ui/components/legacy/Tooltip/TooltipContainer.tsx
@@ -15,7 +15,7 @@
 
 import styled from '../../../styles/styled.js';
 
-const TooltipContainer = styled.div`
+export const TooltipContainer = styled.div`
   position: relative;
   line-height: 0;
   width: 32px;
@@ -24,5 +24,3 @@ const TooltipContainer = styled.div`
     opacity: 1;
   }
 `;
-
-export default TooltipContainer;

--- a/packages/circuit-ui/components/legacy/Tooltip/index.ts
+++ b/packages/circuit-ui/components/legacy/Tooltip/index.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import { Tooltip } from './Tooltip.js';
+export { Tooltip } from './Tooltip.js';
 
 export type { TooltipProps } from './Tooltip.js';
-
-export default Tooltip;

--- a/packages/circuit-ui/experimental.ts
+++ b/packages/circuit-ui/experimental.ts
@@ -14,12 +14,12 @@
  */
 
 export {
-  default as Tooltip,
+  Tooltip,
   type TooltipProps,
   type TooltipReferenceProps,
 } from './components/Tooltip/index.js';
 export {
-  default as Toggletip,
+  Toggletip,
   type ToggletipProps,
 } from './components/Toggletip/index.js';
 export { Calendar, type CalendarProps } from './components/Calendar/index.js';

--- a/packages/circuit-ui/hooks/useClickOutside/useClickOutside.stories.tsx
+++ b/packages/circuit-ui/hooks/useClickOutside/useClickOutside.stories.tsx
@@ -15,8 +15,8 @@
 
 import { useRef, useState } from 'react';
 
-import Button from '../../components/Button/index.js';
-import Card from '../../components/Card/index.js';
+import { Button } from '../../components/Button/index.js';
+import { Card } from '../../components/Card/index.js';
 
 import { useClickOutside } from './useClickOutside.js';
 

--- a/packages/circuit-ui/hooks/useCollapsible/useCollapsible.stories.tsx
+++ b/packages/circuit-ui/hooks/useCollapsible/useCollapsible.stories.tsx
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import Body from '../../components/Body/index.js';
-import Button from '../../components/Button/index.js';
+import { Body } from '../../components/Body/index.js';
+import { Button } from '../../components/Button/index.js';
 
 import { useCollapsible, type CollapsibleOptions } from './useCollapsible.js';
 

--- a/packages/circuit-ui/hooks/useEscapeKey/useEscapeKey.stories.tsx
+++ b/packages/circuit-ui/hooks/useEscapeKey/useEscapeKey.stories.tsx
@@ -15,8 +15,8 @@
 
 import { useState } from 'react';
 
-import Body from '../../components/Body/index.js';
-import Button from '../../components/Button/index.js';
+import { Body } from '../../components/Body/index.js';
+import { Button } from '../../components/Button/index.js';
 
 import { useEscapeKey } from './useEscapeKey.js';
 

--- a/packages/circuit-ui/hooks/useFocusList/useFocusList.stories.tsx
+++ b/packages/circuit-ui/hooks/useFocusList/useFocusList.stories.tsx
@@ -17,7 +17,7 @@
 import { action } from '@storybook/addon-actions';
 import { userEvent } from '@storybook/test';
 
-import sharedClasses from '../../styles/shared.js';
+import { sharedClasses } from '../../styles/shared.js';
 
 import { useFocusList } from './useFocusList.js';
 

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -15,82 +15,82 @@
 
 import './styles/base.css';
 
-export { default as utilClasses } from './styles/utility.js';
+export { utilClasses } from './styles/utility.js';
 export { clsx } from './styles/clsx.js';
 
 // Typography
-export { default as Headline } from './components/Headline/index.js';
+export { Headline } from './components/Headline/index.js';
 export type { HeadlineProps } from './components/Headline/index.js';
-export { default as Title } from './components/Title/index.js';
+export { Title } from './components/Title/index.js';
 export type { TitleProps } from './components/Title/index.js';
-export { default as SubHeadline } from './components/SubHeadline/index.js';
+export { SubHeadline } from './components/SubHeadline/index.js';
 export type { SubHeadlineProps } from './components/SubHeadline/index.js';
-export { default as Body } from './components/Body/index.js';
+export { Body } from './components/Body/index.js';
 export type { BodyProps } from './components/Body/index.js';
-export { default as BodyLarge } from './components/BodyLarge/index.js';
+export { BodyLarge } from './components/BodyLarge/index.js';
 export type { BodyLargeProps } from './components/BodyLarge/index.js';
-export { default as Anchor } from './components/Anchor/index.js';
+export { Anchor } from './components/Anchor/index.js';
 export type { AnchorProps } from './components/Anchor/index.js';
-export { default as List } from './components/List/index.js';
+export { List } from './components/List/index.js';
 export type { ListProps } from './components/List/index.js';
 
 // Forms
-export { default as Checkbox } from './components/Checkbox/index.js';
+export { Checkbox } from './components/Checkbox/index.js';
 export type { CheckboxProps } from './components/Checkbox/index.js';
-export { default as CheckboxGroup } from './components/CheckboxGroup/index.js';
+export { CheckboxGroup } from './components/CheckboxGroup/index.js';
 export type { CheckboxGroupProps } from './components/CheckboxGroup/index.js';
-export { default as Input } from './components/Input/index.js';
+export { Input } from './components/Input/index.js';
 export type { InputProps, InputElement } from './components/Input/index.js';
 export type { RadioButtonProps } from './components/RadioButton/index.js';
-export { default as RadioButtonGroup } from './components/RadioButtonGroup/index.js';
+export { RadioButtonGroup } from './components/RadioButtonGroup/index.js';
 export type { RadioButtonGroupProps } from './components/RadioButtonGroup/index.js';
-export { default as SearchInput } from './components/SearchInput/index.js';
+export { SearchInput } from './components/SearchInput/index.js';
 export type { SearchInputProps } from './components/SearchInput/index.js';
-export { default as DateInput } from './components/DateInput/index.js';
+export { DateInput } from './components/DateInput/index.js';
 export type { DateInputProps } from './components/DateInput/index.js';
-export { default as Select } from './components/Select/index.js';
+export { Select } from './components/Select/index.js';
 export type { SelectProps, SelectOption } from './components/Select/index.js';
-export { default as TextArea } from './components/TextArea/index.js';
+export { TextArea } from './components/TextArea/index.js';
 export type { TextAreaProps } from './components/TextArea/index.js';
-export { default as CurrencyInput } from './components/CurrencyInput/index.js';
+export { CurrencyInput } from './components/CurrencyInput/index.js';
 export type { CurrencyInputProps } from './components/CurrencyInput/index.js';
-export { default as PercentageInput } from './components/PercentageInput/index.js';
+export { PercentageInput } from './components/PercentageInput/index.js';
 export type { PercentageInputProps } from './components/PercentageInput/index.js';
-export { default as ImageInput } from './components/ImageInput/index.js';
+export { ImageInput } from './components/ImageInput/index.js';
 export type { ImageInputProps } from './components/ImageInput/index.js';
 
 // Actions
-export { default as Button } from './components/Button/index.js';
+export { Button } from './components/Button/index.js';
 export type { ButtonProps } from './components/Button/index.js';
-export { default as ButtonGroup } from './components/ButtonGroup/index.js';
+export { ButtonGroup } from './components/ButtonGroup/index.js';
 export type { ButtonGroupProps } from './components/ButtonGroup/index.js';
-export { default as CloseButton } from './components/CloseButton/index.js';
+export { CloseButton } from './components/CloseButton/index.js';
 export type { CloseButtonProps } from './components/CloseButton/index.js';
 export { IconButton } from './components/Button/index.js';
 export type { IconButtonProps } from './components/Button/index.js';
-export { default as Toggle } from './components/Toggle/index.js';
+export { Toggle } from './components/Toggle/index.js';
 export type { ToggleProps } from './components/Toggle/index.js';
 export type { SelectorProps } from './components/Selector/index.js';
-export { default as SelectorGroup } from './components/SelectorGroup/index.js';
+export { SelectorGroup } from './components/SelectorGroup/index.js';
 export type { SelectorGroupProps } from './components/SelectorGroup/index.js';
 export type { ClickEvent } from './types/events.js';
 
 // Notifications
-export { default as NotificationBanner } from './components/NotificationBanner/index.js';
+export { NotificationBanner } from './components/NotificationBanner/index.js';
 export type { NotificationBannerProps } from './components/NotificationBanner/index.js';
-export { default as NotificationFullscreen } from './components/NotificationFullscreen/index.js';
+export { NotificationFullscreen } from './components/NotificationFullscreen/index.js';
 export type { NotificationFullscreenProps } from './components/NotificationFullscreen/index.js';
 export { useNotificationToast } from './components/NotificationToast/index.js';
 export type { NotificationToastProps } from './components/NotificationToast/index.js';
 export { ToastProvider } from './components/ToastContext/index.js';
 export type { ToastProviderProps } from './components/ToastContext/index.js';
-export { default as NotificationInline } from './components/NotificationInline/index.js';
+export { NotificationInline } from './components/NotificationInline/index.js';
 export type { NotificationInlineProps } from './components/NotificationInline/index.js';
 
 // Navigation
-export { default as Hamburger } from './components/Hamburger/index.js';
+export { Hamburger } from './components/Hamburger/index.js';
 export type { HamburgerProps } from './components/Hamburger/index.js';
-export { default as Pagination } from './components/Pagination/index.js';
+export { Pagination } from './components/Pagination/index.js';
 export type { PaginationProps } from './components/Pagination/index.js';
 export {
   TopNavigation,
@@ -113,12 +113,12 @@ export type {
 } from './components/Tabs/index.js';
 
 // Miscellaneous
-export { default as Spinner } from './components/Spinner/index.js';
+export { Spinner } from './components/Spinner/index.js';
 export type { SpinnerProps } from './components/Spinner/index.js';
-export { default as Badge } from './components/Badge/index.js';
+export { Badge } from './components/Badge/index.js';
 export type { BadgeProps } from './components/Badge/index.js';
 export {
-  default as Card,
+  Card,
   CardHeader,
   CardFooter,
 } from './components/Card/index.js';
@@ -127,14 +127,14 @@ export type {
   CardHeaderProps,
   CardFooterProps,
 } from './components/Card/index.js';
-export { default as Hr } from './components/Hr/index.js';
-export { default as Image } from './components/Image/index.js';
+export { Hr } from './components/Hr/index.js';
+export { Image } from './components/Image/index.js';
 export type { ImageProps } from './components/Image/index.js';
-export { default as ProgressBar } from './components/ProgressBar/index.js';
+export { ProgressBar } from './components/ProgressBar/index.js';
 export type { ProgressBarProps } from './components/ProgressBar/index.js';
-export { default as Tag } from './components/Tag/index.js';
+export { Tag } from './components/Tag/index.js';
 export type { TagProps } from './components/Tag/index.js';
-export { default as Popover } from './components/Popover/index.js';
+export { Popover } from './components/Popover/index.js';
 export type {
   PopoverProps,
   PopoverItemProps,
@@ -145,9 +145,9 @@ export { useModal } from './components/Modal/index.js';
 export type { ModalProps } from './components/Modal/index.js';
 export { useNotificationModal } from './components/NotificationModal/index.js';
 export type { NotificationModalProps } from './components/NotificationModal/index.js';
-export { default as ListItem } from './components/ListItem/index.js';
+export { ListItem } from './components/ListItem/index.js';
 export type { ListItemProps } from './components/ListItem/index.js';
-export { default as ListItemGroup } from './components/ListItemGroup/index.js';
+export { ListItemGroup } from './components/ListItemGroup/index.js';
 export type { ListItemGroupProps } from './components/ListItemGroup/index.js';
 export {
   SidePanelProvider,
@@ -159,7 +159,7 @@ export type {
   SidePanelHookProps,
 } from './components/SidePanel/index.js';
 
-export { default as Table } from './components/Table/index.js';
+export { Table } from './components/Table/index.js';
 export type {
   TableProps,
   TableSortDirection,
@@ -170,16 +170,16 @@ export type {
   TableRow,
 } from './components/Table/index.js';
 
-export { default as Step, useStep } from './components/Step/index.js';
+export { Step, useStep } from './components/Step/index.js';
 export type { StepProps, StepOptions } from './components/Step/index.js';
-export { default as AspectRatio } from './components/AspectRatio/index.js';
+export { AspectRatio } from './components/AspectRatio/index.js';
 export type { AspectRatioProps } from './components/AspectRatio/index.js';
 export {
-  default as Carousel,
+  Carousel,
   CarouselComposer,
 } from './components/Carousel/index.js';
 export type { CarouselProps } from './components/Carousel/index.js';
-export { default as Avatar } from './components/Avatar/index.js';
+export { Avatar } from './components/Avatar/index.js';
 export type { AvatarProps } from './components/Avatar/index.js';
 
 export {

--- a/packages/circuit-ui/legacy.ts
+++ b/packages/circuit-ui/legacy.ts
@@ -15,11 +15,11 @@
 
 // Forms
 export {
-  default as RadioButton,
+  RadioButton,
   type RadioButtonProps,
 } from './components/RadioButton/index.js';
 export {
-  default as Selector,
+  Selector,
   type SelectorProps,
 } from './components/Selector/index.js';
 export {
@@ -33,19 +33,19 @@ export type {
   RangePickerControllerProps,
   SingleDayPickerProps,
 } from './components/legacy/Calendar/index.js';
-export { default as CalendarTag } from './components/legacy/CalendarTag/index.js';
+export { CalendarTag } from './components/legacy/CalendarTag/index.js';
 export type { CalendarTagProps } from './components/legacy/CalendarTag/index.js';
-export { default as CalendarTagTwoStep } from './components/legacy/CalendarTagTwoStep/index.js';
+export { CalendarTagTwoStep } from './components/legacy/CalendarTagTwoStep/index.js';
 export type { CalendarTagTwoStepProps } from './components/legacy/CalendarTagTwoStep/index.js';
 
 // Layout
 export { Grid, Row, Col } from './components/legacy/Grid/index.js';
 export type { ColProps } from './components/legacy/Grid/index.js';
-export { default as InlineElements } from './components/legacy/InlineElements/index.js';
+export { InlineElements } from './components/legacy/InlineElements/index.js';
 export type { InlineElementsProps } from './components/legacy/InlineElements/index.js';
 
 // Miscellaneous
-export { default as Tooltip } from './components/legacy/Tooltip/index.js';
+export { Tooltip } from './components/legacy/Tooltip/index.js';
 export type { TooltipProps } from './components/legacy/Tooltip/index.js';
 
 export {

--- a/packages/circuit-ui/styles/is-prop-valid.ts
+++ b/packages/circuit-ui/styles/is-prop-valid.ts
@@ -15,4 +15,5 @@
 
 import isPropValid from '@emotion/is-prop-valid';
 
+// biome-ignore lint/style/noDefaultExport: Mirroring Emotion's exports
 export default isPropValid;

--- a/packages/circuit-ui/styles/shared.ts
+++ b/packages/circuit-ui/styles/shared.ts
@@ -16,10 +16,8 @@
 import _classes from './shared.module.css';
 
 // This explicit remapping is needed so TypeScript infers the types correctly
-const classes = {
+export const sharedClasses = {
   listItem: _classes['list-item'],
   listItemDestructive: _classes['list-item-destructive'],
   navigationItem: _classes['navigation-item'],
 };
-
-export default classes;

--- a/packages/circuit-ui/styles/style-mixins.stories.tsx
+++ b/packages/circuit-ui/styles/style-mixins.stories.tsx
@@ -18,7 +18,7 @@
 import { userEvent } from '@storybook/test';
 
 import { Stack } from '../../../.storybook/components/index.js';
-import Button from '../components/Button/index.js';
+import { Button } from '../components/Button/index.js';
 
 import styled from './styled.js';
 import {

--- a/packages/circuit-ui/styles/styled.ts
+++ b/packages/circuit-ui/styles/styled.ts
@@ -16,6 +16,7 @@
 import styled from '@emotion/styled';
 import type { Theme } from '@sumup/design-tokens';
 
+// biome-ignore lint/style/noDefaultExport: Mirroring Emotion's exports
 export default styled;
 
 export interface StyleProps {

--- a/packages/circuit-ui/styles/utility.ts
+++ b/packages/circuit-ui/styles/utility.ts
@@ -16,12 +16,10 @@
 import _classes from './utility.module.css';
 
 // This explicit remapping is needed so TypeScript infers the types correctly
-const classes = {
+export const utilClasses = {
   center: _classes.center,
   hideVisually: _classes['hide-visually'],
   hideScrollbar: _classes['hide-scrollbar'],
   focusVisible: _classes['focus-visible'],
   focusVisibleInset: _classes['focus-visible-inset'],
 };
-
-export default classes;


### PR DESCRIPTION
## Purpose

> Default exports cannot be easily discovered inside an editor: They cannot be suggested by the editor when the user tries to import a name.
> 
> Also, default exports don’t encourage consistency over a code base: the module that imports the default export must choose a name. It is likely that different modules use different names.
> 
> Moreover, default exports encourage exporting an object that acts as a namespace. This is a legacy pattern used to mimic CommonJS modules.

See https://biomejs.dev/linter/rules/no-default-export/

## Approach and changes

- Migrate all default exports to named ones

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
