### PR TITLE
Remove invalid HTML attributes from Table component

### DIFF
--- a/.changeset/short-scissors-behave.md
+++ b/.changeset/short-scissors-behave.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": patch
+---
+
+Removed invalid HTML attributes from the Table component.

--- a/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
+++ b/packages/circuit-ui/components/Table/components/TableHead/TableHead.tsx
@@ -102,8 +102,7 @@ export function TableHead({
       {!!headers.length && (
         <TableRow>
           {headers.map((header, i) => {
-            const cellProps = mapCellProps(header);
-            const { sortable, sortLabel } = cellProps;
+            const { sortable, sortLabel, ...cellProps } = mapCellProps(header);
             const sortParams = getSortParams({
               columnIndex: i,
               sortable,


### PR DESCRIPTION
## Purpose

@fernandofleury reported encountering the following error log from React: 

> ```Received `true` for a non-boolean attribute `sortable`.```
> 
> With the following header:
> 
> ```{ children: 'Date', sortable: true },```

## Approach and changes

- Filter out the `sortLabel` and `sortable` props before passing them to the TableHeader component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
