### PR TITLE
feat(circuit-ui): Add experimental ColorInput component

### DIFF
--- a/.changeset/violet-seahorses-study.md
+++ b/.changeset/violet-seahorses-study.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": minor
+---
+
+Added an experimental ColorInput component that enables users to type or select a color.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:fix": "biome check --write && foundry run eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "lint:ci": "biome ci && foundry run eslint . --ext .js,.jsx,.ts,.tsx --quiet ",
     "lint:css": "foundry run stylelint '**/*.css'",
+    "lint:css:fix": "foundry run stylelint '**/*.css' --fix",
     "dev": "npm run docs:start",
     "docs": "npm run docs:start",
     "docs:start": "storybook dev -p 6006",

--- a/packages/circuit-ui/components/ColorInput/ColorInput.mdx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.mdx
@@ -1,0 +1,13 @@
+import { Meta, Status, Props, Story } from '../../../../.storybook/components';
+import * as Stories from './ColorInput.stories';
+
+<Meta of={Stories} />
+
+# ColorInput
+
+<Status variant="experimental" />
+
+The ColorInput component enables users to submit or select a color.
+
+<Story of={Stories.Base} />
+<Props />

--- a/packages/circuit-ui/components/ColorInput/ColorInput.mdx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.mdx
@@ -7,7 +7,7 @@ import * as Stories from './ColorInput.stories';
 
 <Status variant="experimental" />
 
-The ColorInput component enables users to submit or select a color.
+The ColorInput component enables users to type or select a color.
 
 <Story of={Stories.Base} />
 <Props />

--- a/packages/circuit-ui/components/ColorInput/ColorInput.module.css
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.module.css
@@ -4,21 +4,26 @@
 }
 
 .picker {
+  position: relative;
   width: var(--cui-spacings-exa);
   height: var(--cui-spacings-exa);
+  margin-right: 1px;
+  cursor: pointer;
   border-top-left-radius: var(--cui-border-radius-byte);
   border-bottom-left-radius: var(--cui-border-radius-byte);
   box-shadow: 0 0 0 1px var(--cui-border-normal);
 }
 
 .picker:hover {
+  z-index: var(--cui-z-index-absolute);
   background: var(--cui-bg-normal-hovered);
   box-shadow: 0 0 0 1px var(--cui-border-normal-hovered);
 }
 
 .picker:focus-within {
+  z-index: var(--cui-z-index-absolute);
   background: var(--cui-bg-normal-pressed);
-  box-shadow: 0 0 0 1px var(--cui-border-normal-pressed);
+  box-shadow: 0 0 0 2px var(--cui-border-focus);
 }
 
 .color-input {
@@ -27,6 +32,7 @@
   padding: 0;
   margin: var(--cui-spacings-kilo);
   appearance: none;
+  cursor: pointer;
   border: none;
   border-radius: 6px;
   outline: none;
@@ -46,18 +52,11 @@
   border: none;
 }
 
-.picker:hover .color-input {
-  box-shadow: 0 0 0 1px var(--cui-border-normal-hovered);
-}
-
-.picker:focus-within .color-input {
-  box-shadow: 0 0 0 1px var(--cui-border-normal-pressed);
-}
-
 .symbol {
   position: absolute;
   top: 0;
   left: var(--cui-spacings-exa);
+  z-index: calc(var(--cui-z-index-absolute) + 1);
   display: grid;
   place-items: center center;
   width: var(--cui-spacings-giga);
@@ -67,16 +66,18 @@
 }
 
 .input {
+  position: relative;
   padding-left: var(--cui-spacings-giga);
   font-family: var(--cui-font-stack-mono);
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
 
-.input::placeholder {
-  font-family: var(--cui-font-stack-mono);
+.input:hover,
+.input:focus {
+  z-index: var(--cui-z-index-absolute);
 }
 
-.colorpick {
-  display: inline-block;
+.input::placeholder {
+  font-family: var(--cui-font-stack-mono);
 }

--- a/packages/circuit-ui/components/ColorInput/ColorInput.module.css
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.module.css
@@ -1,0 +1,46 @@
+.suffix {
+  overflow: hidden;
+  border-top-right-radius: var(--cui-border-radius-byte);
+  border-bottom-right-radius: var(--cui-border-radius-byte);
+  pointer-events: auto !important;
+  border: none;
+  border-left: 1px solid var(--cui-border-normal);
+  width: var(--cui-spacings-exa);
+  height: var(--cui-spacings-exa);
+  position: absolute;
+  top: 0;
+  right: 0;
+  box-shadow: none;
+}
+
+.prefix {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: var(--cui-spacings-mega);
+}
+
+.colorInput {
+  opacity: 0;
+  width: var(--cui-spacings-exa);
+  height: var(--cui-spacings-exa);
+  border: none;
+  box-shadow: none;
+  padding: 0;
+}
+
+.input {
+  font-family: var(--cui-font-stack-mono);
+}
+
+.input::placeholder {
+  font-family: var(--cui-font-stack-mono);
+}
+
+.colorpick {
+  display: inline-block;
+}
+
+.colorpick:focus-within input {
+  box-shadow: 0 0 0 2px var(--cui-border-accent);
+}

--- a/packages/circuit-ui/components/ColorInput/ColorInput.module.css
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.module.css
@@ -1,36 +1,76 @@
-.suffix {
-  overflow: hidden;
-  border-top-right-radius: var(--cui-border-radius-byte);
-  border-bottom-right-radius: var(--cui-border-radius-byte);
-  pointer-events: auto !important;
-  border: none;
-  border-left: 1px solid var(--cui-border-normal);
+.wrapper {
+  position: relative;
+  display: flex;
+}
+
+.picker {
   width: var(--cui-spacings-exa);
   height: var(--cui-spacings-exa);
+  border-top-left-radius: var(--cui-border-radius-byte);
+  border-bottom-left-radius: var(--cui-border-radius-byte);
+  box-shadow: 0 0 0 1px var(--cui-border-normal);
+}
+
+.picker:hover {
+  background: var(--cui-bg-normal-hovered);
+  box-shadow: 0 0 0 1px var(--cui-border-normal-hovered);
+}
+
+.picker:focus-within {
+  background: var(--cui-bg-normal-pressed);
+  box-shadow: 0 0 0 1px var(--cui-border-normal-pressed);
+}
+
+.color-input {
+  width: var(--cui-spacings-giga);
+  height: var(--cui-spacings-giga);
+  padding: 0;
+  margin: var(--cui-spacings-kilo);
+  appearance: none;
+  border: none;
+  border-radius: 6px;
+  outline: none;
+  box-shadow: 0 0 0 1px var(--cui-border-normal);
+}
+
+.color-input::-moz-color-swatch {
+  border: none;
+}
+
+.color-input::-webkit-color-swatch-wrapper {
+  padding: 0;
+  border-radius: 0;
+}
+
+.color-input::-webkit-color-swatch {
+  border: none;
+}
+
+.picker:hover .color-input {
+  box-shadow: 0 0 0 1px var(--cui-border-normal-hovered);
+}
+
+.picker:focus-within .color-input {
+  box-shadow: 0 0 0 1px var(--cui-border-normal-pressed);
+}
+
+.symbol {
   position: absolute;
   top: 0;
-  right: 0;
-  box-shadow: none;
-}
-
-.prefix {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  line-height: var(--cui-spacings-mega);
-}
-
-.colorInput {
-  opacity: 0;
-  width: var(--cui-spacings-exa);
+  left: var(--cui-spacings-exa);
+  display: grid;
+  place-items: center center;
+  width: var(--cui-spacings-giga);
   height: var(--cui-spacings-exa);
-  border: none;
-  box-shadow: none;
-  padding: 0;
+  font-family: var(--cui-font-stack-mono);
+  color: var(--cui-fg-subtle);
 }
 
 .input {
+  padding-left: var(--cui-spacings-giga);
   font-family: var(--cui-font-stack-mono);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 .input::placeholder {
@@ -39,8 +79,4 @@
 
 .colorpick {
   display: inline-block;
-}
-
-.colorpick:focus-within input {
-  box-shadow: 0 0 0 2px var(--cui-border-accent);
 }

--- a/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
@@ -24,6 +24,15 @@ import { ColorInput } from './ColorInput.js';
 describe('ColorInput', () => {
   const baseProps = { label: 'Car color', pickerLabel: 'Pick car color' };
 
+  it('should merge a custom class name with the default ones', () => {
+    const className = 'foo';
+    const { container } = render(
+      <ColorInput {...baseProps} inputClassName={className} />,
+    );
+    const input = container.querySelector('input[type="text"]');
+    expect(input?.className).toContain(className);
+  });
+
   it('should forward a ref', () => {
     const ref = createRef<InputElement>();
     const { container } = render(<ColorInput {...baseProps} ref={ref} />);
@@ -38,15 +47,6 @@ describe('ColorInput', () => {
   });
 
   describe('Labeling', () => {
-    const HEX_SYMBOL = '#';
-
-    it('should have the hex symbol as part of its accessible description', () => {
-      render(<ColorInput {...baseProps} />);
-      expect(screen.getByRole('textbox')).toHaveAccessibleDescription(
-        HEX_SYMBOL,
-      );
-    });
-
     it('should accept a custom description via aria-describedby', () => {
       const customDescription = 'Custom description';
       const customDescriptionId = 'customDescriptionId';
@@ -57,7 +57,7 @@ describe('ColorInput', () => {
         </>,
       );
       expect(screen.getByRole('textbox')).toHaveAccessibleDescription(
-        `${HEX_SYMBOL} ${customDescription}`,
+        customDescription,
       );
     });
   });

--- a/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
@@ -16,7 +16,7 @@
 import { describe, expect, it } from 'vitest';
 import { createRef } from 'react';
 
-import { render, axe } from '../../util/test-utils.js';
+import { render, axe, screen } from '../../util/test-utils.js';
 import type { InputElement } from '../Input/index.js';
 
 import { ColorInput } from './ColorInput.js';
@@ -35,5 +35,30 @@ describe('ColorInput', () => {
     const { container } = render(<ColorInput {...baseProps} />);
     const actual = await axe(container);
     expect(actual).toHaveNoViolations();
+  });
+
+  describe('Labeling', () => {
+    const HEX_SYMBOL = '#';
+
+    it('should have the currency symbol as part of its accessible description', () => {
+      render(<ColorInput {...baseProps} />);
+      expect(screen.getByRole('textbox')).toHaveAccessibleDescription(
+        HEX_SYMBOL,
+      );
+    });
+
+    it('should accept a custom description via aria-describedby', () => {
+      const customDescription = 'Custom description';
+      const customDescriptionId = 'customDescriptionId';
+      render(
+        <>
+          <span id={customDescriptionId}>{customDescription}</span>
+          <ColorInput {...baseProps} aria-describedby={customDescriptionId} />
+        </>,
+      );
+      expect(screen.getByRole('textbox')).toHaveAccessibleDescription(
+        `${HEX_SYMBOL} ${customDescription}`,
+      );
+    });
   });
 });

--- a/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createRef } from 'react';
+
+import { render, axe } from '../../util/test-utils.js';
+import type { InputElement } from '../Input/index.js';
+
+import { ColorInput } from './ColorInput.js';
+
+describe('SearchInput', () => {
+  const baseProps = { label: 'Car color', pickerLabel: 'Pick car color' };
+
+  it('should forward a ref', () => {
+    const ref = createRef<InputElement>();
+    const { container } = render(<ColorInput {...baseProps} ref={ref} />);
+    const input = container.querySelector("input[type='color']");
+    expect(ref.current).toBe(input);
+  });
+
+  it('should have no accessibility violations', async () => {
+    const { container } = render(<ColorInput {...baseProps} />);
+    const actual = await axe(container);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -21,7 +21,7 @@ import type { InputElement } from '../Input/index.js';
 
 import { ColorInput } from './ColorInput.js';
 
-describe('SearchInput', () => {
+describe('ColorInput', () => {
   const baseProps = { label: 'Car color', pickerLabel: 'Pick car color' };
 
   it('should forward a ref', () => {

--- a/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
@@ -40,7 +40,7 @@ describe('ColorInput', () => {
   describe('Labeling', () => {
     const HEX_SYMBOL = '#';
 
-    it('should have the currency symbol as part of its accessible description', () => {
+    it('should have the hex symbol as part of its accessible description', () => {
       render(<ColorInput {...baseProps} />);
       expect(screen.getByRole('textbox')).toHaveAccessibleDescription(
         HEX_SYMBOL,

--- a/packages/circuit-ui/components/ColorInput/ColorInput.stories.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.stories.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/circuit-ui/components/ColorInput/ColorInput.stories.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.stories.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ColorInput, type ColorInputProps } from './ColorInput.js';
+
+export default {
+  title: 'Forms/Input/ColorInput',
+  component: ColorInput,
+};
+
+const baseArgs = {
+  label: 'Color',
+  pickerLabel: 'Pick color',
+  placeholder: '99ffbb',
+};
+
+export const Base = (args: ColorInputProps) => (
+  <ColorInput {...args} style={{ maxWidth: '250px' }} />
+);
+
+Base.args = baseArgs;

--- a/packages/circuit-ui/components/ColorInput/ColorInput.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.tsx
@@ -82,6 +82,7 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
       validationHint,
       readOnly,
       required,
+      inputClassName,
       style,
       value,
       ...props
@@ -120,12 +121,7 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
     };
 
     return (
-      <FieldSet
-        className={className}
-        style={style}
-        disabled={disabled}
-        aria-orientation="horizontal"
-      >
+      <FieldSet className={className} style={style} disabled={disabled}>
         <FieldLegend id={labelId}>
           <FieldLabelText
             label={label}
@@ -150,6 +146,7 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
           <span className={classes.symbol}>#</span>
           <input
             id={id}
+            type="text"
             aria-labelledby={labelId}
             aria-describedby={descriptionIds}
             className={clsx(
@@ -157,6 +154,7 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
               !disabled && hasWarning && inputClasses.warning,
               hasSuffix && inputClasses['has-suffix'],
               classes.input,
+              inputClassName,
             )}
             aria-invalid={invalid && 'true'}
             required={required}

--- a/packages/circuit-ui/components/ColorInput/ColorInput.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.tsx
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use client';
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ChangeEventHandler,
+} from 'react';
+
+import { Input, type InputElement, type InputProps } from '../Input/index.js';
+import { clsx } from '../../styles/clsx.js';
+import { FieldLabel, FieldLabelText } from '../Field/index.js';
+import { applyMultipleRefs } from '../../util/refs.js';
+
+import styles from './ColorInput.module.css';
+
+export interface ColorInputProps
+  extends Omit<
+    InputProps,
+    | 'ref'
+    | 'type'
+    | 'defaultValue'
+    | 'value'
+    | 'placeholder'
+    | 'maxLength'
+    | 'pattern'
+    | 'renderPrefix'
+    | 'renderSuffix'
+    | 'as'
+  > {
+  /**
+   * A short string that is shown inside the empty input.
+   */
+  placeholder?: string;
+  /**
+   * The value of the input element.
+   */
+  value?: string;
+  /**
+   * The default value of the input element.
+   */
+  defaultValue?: string;
+  /*
+   * Picker label describes the color picker which serves as an alternative
+   * to the hex color input.
+   */
+  pickerLabel: string;
+}
+
+export const ColorInput = forwardRef<InputElement, ColorInputProps>(
+  (
+    { onChange, className, value, defaultValue, pickerLabel, ...props },
+    ref,
+  ) => {
+    const [currentColor, setCurrentColor] = useState<string | undefined>(
+      defaultValue,
+    );
+    const colorDisplayRef = useRef<HTMLDivElement>(null);
+    const colorPickerRef = useRef<InputElement>(null);
+    const pickerId = useId();
+
+    const onPickerColorChange: ChangeEventHandler<InputElement> = (e) => {
+      setCurrentColor(e.target.value);
+      if (onChange) {
+        onChange(e);
+      }
+    };
+
+    const onInputChange: ChangeEventHandler<InputElement> = (e) => {
+      if (colorPickerRef.current) {
+        colorPickerRef.current.value = `#${e.target.value}`;
+      }
+      setCurrentColor(`#${e.target.value}`);
+    };
+
+    useEffect(() => {
+      if (colorDisplayRef.current && currentColor) {
+        colorDisplayRef.current.style.backgroundColor = currentColor;
+      }
+    }, [currentColor]);
+
+    const renderSuffix = useCallback(
+      () => (
+        <div
+          className={clsx(styles.suffix)}
+          ref={colorDisplayRef}
+          style={{ backgroundColor: currentColor }}
+        >
+          <FieldLabel htmlFor={pickerId}>
+            <FieldLabelText label={pickerLabel} hideLabel />
+          </FieldLabel>
+          <input
+            type="color"
+            id={pickerId}
+            className={styles.colorInput}
+            onChange={onPickerColorChange}
+            ref={applyMultipleRefs(colorPickerRef, ref)}
+          />
+        </div>
+      ),
+      [],
+    );
+
+    return (
+      <Input
+        className={styles.colorpick}
+        renderPrefix={({ className: cn }) => (
+          <div className={clsx(cn, styles.prefix)}>
+            <span>#</span>
+          </div>
+        )}
+        renderSuffix={renderSuffix}
+        value={currentColor ? currentColor.replace('#', '') : undefined}
+        inputClassName={styles.input}
+        maxLength={6}
+        pattern="[0-9a-f]{3,6}"
+        onChange={onInputChange}
+        {...props}
+      />
+    );
+  },
+);
+
+ColorInput.displayName = 'ColorInput';

--- a/packages/circuit-ui/components/ColorInput/ColorInput.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.tsx
@@ -26,7 +26,12 @@ import {
 import { classes as inputClasses } from '../Input/index.js';
 import type { InputElement, InputProps } from '../Input/index.js';
 import { clsx } from '../../styles/clsx.js';
-import { FieldLabel, FieldLabelText, FieldWrapper } from '../Field/index.js';
+import {
+  FieldLabelText,
+  FieldLegend,
+  FieldSet,
+  FieldValidationHint,
+} from '../Field/index.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 
 import classes from './ColorInput.module.css';
@@ -56,11 +61,6 @@ export interface ColorInputProps
    * The default value of the input element.
    */
   defaultValue?: string;
-  /*
-   * Picker label describes the color picker which serves as an alternative
-   * to the hex color input.
-   */
-  pickerLabel: string;
 }
 
 export const ColorInput = forwardRef<InputElement, ColorInputProps>(
@@ -72,13 +72,14 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
       defaultValue,
       disabled,
       hasWarning,
+      showValid,
       hideLabel,
       id,
       invalid,
       label,
       onChange,
       optionalLabel,
-      pickerLabel,
+      validationHint,
       readOnly,
       required,
       style,
@@ -92,12 +93,11 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
     );
     const colorPickerRef = useRef<InputElement>(null);
 
+    const labelId = useId();
     const pickerId = useId();
-    const hexSymbolId = useId();
-    const inputFallbackId = useId();
-    const inputId = id || inputFallbackId;
+    const validationHintId = useId();
 
-    const descriptionIds = clsx(hexSymbolId, descriptionId);
+    const descriptionIds = clsx(validationHintId, descriptionId);
 
     const suffix = RenderSuffix && (
       <RenderSuffix className={inputClasses.suffix} />
@@ -120,32 +120,37 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
     };
 
     return (
-      <FieldWrapper className={className} style={style} disabled={disabled}>
-        <FieldLabel htmlFor={inputId}>
+      <FieldSet
+        className={className}
+        style={style}
+        disabled={disabled}
+        aria-orientation="horizontal"
+      >
+        <FieldLegend id={labelId}>
           <FieldLabelText
             label={label}
             hideLabel={hideLabel}
             optionalLabel={optionalLabel}
             required={required}
           />
-        </FieldLabel>
+        </FieldLegend>
         <div className={classes.wrapper}>
-          <FieldLabel htmlFor={pickerId} className={classes.picker}>
-            <FieldLabelText label={pickerLabel} hideLabel />
+          <label htmlFor={pickerId} className={classes.picker}>
             <input
-              type="color"
               id={pickerId}
+              type="color"
+              aria-labelledby={labelId}
+              aria-describedby={descriptionIds}
               className={classes['color-input']}
               onChange={onPickerColorChange}
               ref={applyMultipleRefs(colorPickerRef, ref)}
               readOnly={readOnly}
             />
-          </FieldLabel>
-          <span className={classes.symbol} id={hexSymbolId}>
-            #
-          </span>
+          </label>
+          <span className={classes.symbol}>#</span>
           <input
-            id={inputId}
+            id={id}
+            aria-labelledby={labelId}
             aria-describedby={descriptionIds}
             className={clsx(
               inputClasses.base,
@@ -164,7 +169,15 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
             {...props}
           />
         </div>
-      </FieldWrapper>
+        <FieldValidationHint
+          id={validationHintId}
+          disabled={disabled}
+          invalid={invalid}
+          hasWarning={hasWarning}
+          showValid={showValid}
+          validationHint={validationHint}
+        />
+      </FieldSet>
     );
   },
 );

--- a/packages/circuit-ui/components/ColorInput/ColorInput.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.tsx
@@ -23,13 +23,13 @@ import {
   type ChangeEventHandler,
 } from 'react';
 
+import { classes as inputClasses } from '../Input/index.js';
 import type { InputElement, InputProps } from '../Input/index.js';
 import { clsx } from '../../styles/clsx.js';
 import { FieldLabel, FieldLabelText, FieldWrapper } from '../Field/index.js';
 import { applyMultipleRefs } from '../../util/refs.js';
-import classes from '../Input/Input.module.css';
 
-import styles from './ColorInput.module.css';
+import classes from './ColorInput.module.css';
 
 export interface ColorInputProps
   extends Omit<
@@ -99,7 +99,9 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
 
     const descriptionIds = clsx(hexSymbolId, descriptionId);
 
-    const suffix = RenderSuffix && <RenderSuffix className={classes.suffix} />;
+    const suffix = RenderSuffix && (
+      <RenderSuffix className={inputClasses.suffix} />
+    );
 
     const hasSuffix = Boolean(suffix);
 
@@ -127,29 +129,29 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
             required={required}
           />
         </FieldLabel>
-        <div className={styles.wrapper}>
-          <FieldLabel htmlFor={pickerId} className={styles.picker}>
+        <div className={classes.wrapper}>
+          <FieldLabel htmlFor={pickerId} className={classes.picker}>
             <FieldLabelText label={pickerLabel} hideLabel />
             <input
               type="color"
               id={pickerId}
-              className={styles['color-input']}
+              className={classes['color-input']}
               onChange={onPickerColorChange}
               ref={applyMultipleRefs(colorPickerRef, ref)}
               readOnly={readOnly}
             />
           </FieldLabel>
-          <span className={styles.symbol} id={hexSymbolId}>
+          <span className={classes.symbol} id={hexSymbolId}>
             #
           </span>
           <input
             id={inputId}
             aria-describedby={descriptionIds}
             className={clsx(
-              classes.base,
-              !disabled && hasWarning && classes.warning,
-              hasSuffix && classes['has-suffix'],
-              styles.input,
+              inputClasses.base,
+              !disabled && hasWarning && inputClasses.warning,
+              hasSuffix && inputClasses['has-suffix'],
+              classes.input,
             )}
             aria-invalid={invalid && 'true'}
             required={required}

--- a/packages/circuit-ui/components/ColorInput/index.ts
+++ b/packages/circuit-ui/components/ColorInput/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { ColorInput } from './ColorInput.js';
+
+export type { ColorInputProps } from './ColorInput.js';

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -38,6 +38,8 @@ import { clsx } from '../../styles/clsx.js';
 
 import classes from './Input.module.css';
 
+export { classes };
+
 export type InputElement = HTMLInputElement & HTMLTextAreaElement;
 type CircuitInputHTMLAttributes = InputHTMLAttributes<HTMLInputElement> &
   TextareaHTMLAttributes<HTMLTextAreaElement>;

--- a/packages/circuit-ui/components/Input/index.ts
+++ b/packages/circuit-ui/components/Input/index.ts
@@ -13,6 +13,6 @@
  * limitations under the License.
  */
 
-export { Input } from './Input.js';
+export { Input, classes } from './Input.js';
 
 export type { InputProps, InputElement } from './Input.js';


### PR DESCRIPTION
[Work in progress]

Add experimental `ColorInput` component.

<img width="333" alt="Screenshot 2024-08-23 at 09 33 54" src="https://github.com/user-attachments/assets/27d64aa5-4bf9-4c25-a629-d9ed642cf581">

<img width="295" alt="Screenshot 2024-08-23 at 09 34 10" src="https://github.com/user-attachments/assets/4eabd7f8-ed02-4c84-8d48-087a7d9fff4d">

## Purpose

_Describe what you are trying to accomplish_

## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
