### PR TITLE
Add bundle size check

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,0 +1,15 @@
+name: Bundle Size
+
+on: [pull_request]
+
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check compressed bundle sizes
+        uses: preactjs/compressed-size-action@v2
+        with:
+          pattern: 'packages/**/dist/**/*.{js,css,json}'

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -13,3 +13,4 @@ jobs:
         uses: preactjs/compressed-size-action@v2
         with:
           pattern: 'packages/**/dist/**/*.{js,css,json}'
+          exclude: '{**/*.map,**/node_modules/**,**/eslint-plugin-circuit-ui/**,**/stylelint-plugin-circuit-ui/**,**/*.index.*,**/*.module.css.js}'


### PR DESCRIPTION
## Purpose

I want to keep a closer eye on bundle size. https://github.com/preactjs/compressed-size-action reports changes in compressed file sizes on PRs. It doesn't enforce any limits but creates better awareness.

## Approach and changes

- Add https://github.com/preactjs/compressed-size-action 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
