### PR TITLE
Remove the deprecated `initialSortedRow` Table prop

### DIFF
--- a/.changeset/late-feet-attack.md
+++ b/.changeset/late-feet-attack.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed the Table component's deprecated `initialSortedRow` prop. Use the `initialSortedColumn` prop instead.

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -167,7 +167,7 @@ export const NotificationBanner = forwardRef<
     ) {
       deprecate(
         'NotificationBanner',
-        "The action's `tertiary` variant has been deprecated. Use the `secondary` variant instead.",
+        "The action's `tertiary` variant has been deprecated. Use the `primary` variant instead.",
       );
     }
 

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -167,7 +167,7 @@ export const NotificationBanner = forwardRef<
     ) {
       deprecate(
         'NotificationBanner',
-        "The action's `tertiary` variant has been deprecated. Use the `primary` size instead.",
+        "The action's `tertiary` variant has been deprecated. Use the `secondary` variant instead.",
       );
     }
 

--- a/packages/circuit-ui/components/Table/Table.spec.tsx
+++ b/packages/circuit-ui/components/Table/Table.spec.tsx
@@ -134,30 +134,6 @@ describe('Table', () => {
       });
     });
 
-    it('should sort a column in ascending order when initial sort direction and initial sorted row is provided and console.warn about it', () => {
-      const warnMock = vi.spyOn(console, 'warn');
-
-      render(
-        <Table
-          rows={rows}
-          headers={headers}
-          rowHeaders={false}
-          initialSortedRow={1}
-          initialSortDirection={'ascending'}
-        />,
-      );
-
-      const cellEls = screen.getAllByRole('cell');
-
-      const sortedRow = ['a', 'c', 'b'];
-
-      rows.forEach((_row, index) => {
-        const cellIndex = rowLength * index;
-        expect(cellEls[cellIndex]).toHaveTextContent(sortedRow[index]);
-      });
-      expect(warnMock).toHaveBeenCalled();
-    });
-
     it('should sort a column in descending order', async () => {
       render(<Table rows={rows} headers={headers} rowHeaders={false} />);
 

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -20,7 +20,6 @@ import { Component, createRef, type HTMLAttributes, type UIEvent } from 'react';
 import { isNil } from '../../util/type-check.js';
 import { throttle } from '../../util/helpers.js';
 import { clsx } from '../../styles/clsx.js';
-import { deprecate } from '../../util/logger.js';
 
 import { TableHead } from './components/TableHead/index.js';
 import { TableBody } from './components/TableBody/index.js';
@@ -69,12 +68,6 @@ export interface TableProps extends HTMLAttributes<HTMLDivElement> {
    */
   initialSortDirection?: 'ascending' | 'descending';
   /**
-   * @deprecated
-   *
-   * Use the `initialSortedColumn` prop instead.
-   */
-  initialSortedRow?: number;
-  /**
    * Specifies the column index which `initialSortDirection` will be applied to
    */
   initialSortedColumn?: number;
@@ -104,19 +97,12 @@ type TableState = {
 export class Table extends Component<TableProps, TableState> {
   constructor(props: TableProps) {
     super(props);
-    if (process.env.NODE_ENV !== 'production' && this.props.initialSortedRow) {
-      deprecate(
-        'Table',
-        'The `initialSortedRow` prop has been deprecated. Use the `initialSortedColumn` prop instead.',
-      );
-    }
     this.state = {
-      sortedColumn:
-        this.props.initialSortedColumn || this.props.initialSortedRow,
+      sortedColumn: this.props.initialSortedColumn,
       rows: this.getInitialRows(
         this.props.rows,
         this.props.initialSortDirection,
-        this.props.initialSortedColumn || this.props.initialSortedRow,
+        this.props.initialSortedColumn,
       ),
       sortHover: undefined,
       sortDirection: this.props.initialSortDirection,


### PR DESCRIPTION
Relates to https://github.com/sumup-oss/circuit-ui/pull/2491.

## Purpose

The `initialSortedRow` was deprecated four months ago, giving developers ample time to migrate.

## Approach and changes

- Remove the deprecated `initialSortedRow` prop from the Table component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
