### PR TITLE
Deprecate Toggle label props

### DIFF
--- a/.changeset/orange-tigers-fetch.md
+++ b/.changeset/orange-tigers-fetch.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": minor
+---
+
+Deprecated the Toggle component's `checkedLabel` and `uncheckedLabel` props since they are no longer needed.

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.module.css
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.module.css
@@ -1,5 +1,6 @@
 .wrapper {
   display: flex;
+  gap: var(--cui-spacings-byte);
   align-items: center;
 }
 
@@ -89,7 +90,6 @@
 
 .label {
   flex-shrink: 0;
-  margin-left: var(--cui-spacings-byte);
   font-size: var(--cui-typography-body-two-font-size);
   line-height: var(--cui-typography-body-two-line-height);
 }

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.stories.tsx
@@ -25,8 +25,8 @@ export default {
 const sizes = ['s', 'm', 'l'] as const;
 
 const progressBarStyles = {
-  width: '90%',
-  minWidth: '500px',
+  width: '500px',
+  maxWidth: '90vw',
 };
 
 export const Steps = (args: ProgressBarProps) => (

--- a/packages/circuit-ui/components/Toggle/Toggle.module.css
+++ b/packages/circuit-ui/components/Toggle/Toggle.module.css
@@ -95,7 +95,7 @@
 
 .label {
   display: block;
-  margin-left: var(--cui-spacings-kilo);
+  padding-left: var(--cui-spacings-kilo);
   font-size: var(--cui-typography-body-one-font-size);
   font-weight: var(--cui-font-weight-regular);
   line-height: var(--cui-typography-body-one-line-height);
@@ -104,8 +104,8 @@
 
 @media (max-width: 479px) {
   .label {
-    margin-right: var(--cui-spacings-kilo);
-    margin-left: 0;
+    padding-right: var(--cui-spacings-kilo);
+    padding-left: 0;
   }
 }
 

--- a/packages/circuit-ui/components/Toggle/Toggle.spec.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.spec.tsx
@@ -23,8 +23,6 @@ import { Toggle } from './Toggle.js';
 const defaultProps = {
   label: 'Label',
   description: 'A longer explanation',
-  checkedLabel: 'on',
-  uncheckedLabel: 'off',
 };
 
 describe('Toggle', () => {

--- a/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
@@ -26,8 +26,6 @@ export default {
 
 const baseArgs = {
   label: 'Short label',
-  checkedLabel: 'on',
-  uncheckedLabel: 'off',
   disabled: false,
 };
 

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -41,13 +41,13 @@ export interface ToggleProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    */
   checked?: boolean;
   /**
-   * Label for the 'on' state. Important for accessibility.
+   * @deprecated This prop is no longer needed.
    */
-  checkedLabel: string;
+  checkedLabel?: string;
   /**
-   * Label for the 'off' state. Important for accessibility.
+   * @deprecated This prop is no longer needed.
    */
-  uncheckedLabel: string;
+  uncheckedLabel?: string;
 }
 
 /**
@@ -79,19 +79,6 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
           'The `label` prop is missing or invalid.',
         );
       }
-
-      if (!isSufficientlyLabelled(checkedLabel)) {
-        throw new AccessibilityError(
-          'Toggle',
-          'The `checkedLabel` prop is missing or invalid.',
-        );
-      }
-      if (!isSufficientlyLabelled(uncheckedLabel)) {
-        throw new AccessibilityError(
-          'Toggle',
-          'The `checkedLabel` prop is missing or invalid.',
-        );
-      }
     }
 
     const switchId = useId();
@@ -121,9 +108,6 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
           ref={ref}
         >
           <span className={classes.knob} />
-          <span className={utilClasses.hideVisually}>
-            {checked ? checkedLabel : uncheckedLabel}
-          </span>
         </button>
         <label className={classes.label} id={labelId} htmlFor={switchId}>
           {label}
@@ -134,9 +118,9 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
           )}
         </label>
         {description && (
-          <p id={descriptionId} className={utilClasses.hideVisually}>
+          <span id={descriptionId} className={utilClasses.hideVisually}>
             {description}
-          </p>
+          </span>
         )}
       </FieldWrapper>
     );

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -24,6 +24,7 @@ import {
 import { FieldDescription, FieldWrapper } from '../Field/index.js';
 import { clsx } from '../../styles/clsx.js';
 import { utilClasses } from '../../styles/utility.js';
+import { deprecate } from '../../util/logger.js';
 
 import classes from './Toggle.module.css';
 
@@ -71,12 +72,29 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
   ) => {
     if (
       process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      !isSufficientlyLabelled(label)
+    ) {
+      throw new AccessibilityError(
+        'Toggle',
+        'The `label` prop is missing or invalid.',
+      );
+    }
+
+    if (
+      process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test'
     ) {
-      if (!isSufficientlyLabelled(label)) {
-        throw new AccessibilityError(
+      if (checkedLabel) {
+        deprecate(
           'Toggle',
-          'The `label` prop is missing or invalid.',
+          'The `checkedLabel` prop is deprecated and can be removed.',
+        );
+      }
+      if (uncheckedLabel) {
+        deprecate(
+          'Toggle',
+          'The `uncheckedLabel` prop is deprecated and can be removed.',
         );
       }
     }


### PR DESCRIPTION
## Purpose

The Toggle's `checkedLabel` and `uncheckedLabel` props were meant to communicate the component's state. They were rendered inside the `button`. However, users could never perceive them: they're visually hidden and are overridden by the `aria-labelledby` attribute on the `button`.

## Approach and changes

- Deprecate the Toggle component's `checkedLabel` and `uncheckedLabel` props since they are no longer needed. They will be removed in the next major.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
