### PR TITLE
Make `temporal-polyfill` a required peer dependency

### DIFF
--- a/.changeset/late-books-attack.md
+++ b/.changeset/late-books-attack.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': major
+---
+
+Added [`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill) to the list of required peer dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40173,9 +40173,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -42527,8 +42527,7 @@
         "@nanostores/react": "^0.7.2",
         "nanostores": "^0.10.3",
         "react-modal": "^3.16.1",
-        "react-number-format": "5.3.0",
-        "temporal-polyfill": "^0.2.5"
+        "react-number-format": "5.3.0"
       },
       "devDependencies": {
         "@emotion/is-prop-valid": "^1.3.0",
@@ -42555,6 +42554,7 @@
         "react-dom": "^18.3.1",
         "react-swipeable": "^7.0.1",
         "rollup-plugin-preserve-directives": "^0.4.0",
+        "temporal-polyfill": "^0.2.5",
         "typescript": "^5.5.4",
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^5.3.5"
@@ -42574,7 +42574,8 @@
         "@sumup-oss/icons": ">=5.0.0-next.0",
         "@sumup-oss/intl": "2.x",
         "react": ">=18.0.0 <19.0.0",
-        "react-dom": ">=18.0.0 <19.0.0"
+        "react-dom": ">=18.0.0 <19.0.0",
+        "temporal-polyfill": "0.2.x"
       }
     },
     "packages/cna-template": {
@@ -70479,9 +70480,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q=="
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="
     },
     "typescript-plugin-css-modules": {
       "version": "5.1.0",

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -55,8 +55,7 @@
     "@nanostores/react": "^0.7.2",
     "nanostores": "^0.10.3",
     "react-modal": "^3.16.1",
-    "react-number-format": "5.3.0",
-    "temporal-polyfill": "^0.2.5"
+    "react-number-format": "5.3.0"
   },
   "devDependencies": {
     "@emotion/is-prop-valid": "^1.3.0",
@@ -83,6 +82,7 @@
     "react-dom": "^18.3.1",
     "react-swipeable": "^7.0.1",
     "rollup-plugin-preserve-directives": "^0.4.0",
+    "temporal-polyfill": "^0.2.5",
     "typescript": "^5.5.4",
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^5.3.5"
@@ -95,7 +95,8 @@
     "@sumup-oss/icons": ">=5.0.0-next.0",
     "@sumup-oss/intl": "2.x",
     "react": ">=18.0.0 <19.0.0",
-    "react-dom": ">=18.0.0 <19.0.0"
+    "react-dom": ">=18.0.0 <19.0.0",
+    "temporal-polyfill": "0.2.x"
   },
   "optionalDependencies": {
     "moment": ">=2.30",


### PR DESCRIPTION
## Purpose

[`temporal-polyfill`](https://www.npmjs.com/package/temporal-polyfill) was added as a direct dependency in #2494. This isn't ideal since the package will likely also be a direct dependency of the host project, leading to duplicate installations and conflicting versions.

## Approach and changes

- Move `temporal-polyfill` from the direct dependencies to the peer dependencies. Users will have to explicitly install it.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
