### PR TITLE
Chore(circuit-ui): DSYS-817 | mark calendar component as stable

### DIFF
--- a/.changeset/gold-worms-worry.md
+++ b/.changeset/gold-worms-worry.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/eslint-plugin-circuit-ui": minor
+---
+
+Updated the `component-lifecycle-imports` ESLint rule to flag imports of stable entities from `@sumup-oss/circuit-ui/experimental`.

--- a/.changeset/shiny-geckos-hang.md
+++ b/.changeset/shiny-geckos-hang.md
@@ -1,0 +1,11 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Marked the `Calendar` component as stable. Update the related imports:
+
+```diff
+- import { Calendar, CalendarProps, PlainDateRange } from '@sumup-oss/circuit-ui/experimental';
++ import { Calendar, CalendarProps, PlainDateRange } from '@sumup-oss/circuit-ui';
+```
+

--- a/packages/circuit-ui/components/Calendar/Calendar.mdx
+++ b/packages/circuit-ui/components/Calendar/Calendar.mdx
@@ -5,7 +5,7 @@ import * as Stories from './Calendar.stories';
 
 # Calendar
 
-<Status variant="experimental" />
+<Status variant="stable" />
 
 The Calendar component displays a monthly date grid. This is a low-level component for advanced use cases; you likely want to use the [DateInput](Forms/Input/DateInput/Base) component instead.
 

--- a/packages/circuit-ui/experimental.ts
+++ b/packages/circuit-ui/experimental.ts
@@ -22,7 +22,5 @@ export {
   Toggletip,
   type ToggletipProps,
 } from './components/Toggletip/index.js';
-export { Calendar, type CalendarProps } from './components/Calendar/index.js';
-export { type PlainDateRange } from './util/date.js';
 export { PhoneNumberInput } from './components/PhoneNumberInput/index.js';
 export type { PhoneNumberInputProps } from './components/PhoneNumberInput/index.js';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -62,6 +62,9 @@ export { PercentageInput } from './components/PercentageInput/index.js';
 export type { PercentageInputProps } from './components/PercentageInput/index.js';
 export { ImageInput } from './components/ImageInput/index.js';
 export type { ImageInputProps } from './components/ImageInput/index.js';
+export { Calendar } from './components/Calendar/index.js';
+export type { CalendarProps } from './components/Calendar/index.js';
+export type { PlainDateRange } from './util/date.js';
 
 // Actions
 export { Button } from './components/Button/index.js';

--- a/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/README.md
+++ b/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/README.md
@@ -12,12 +12,20 @@ Examples of **incorrect** code for this rule:
 import { RangePicker } from '@sumup-oss/circuit-ui';
 import type { RangePickerProps } from '@sumup-oss/circuit-ui';
 ```
+```tsx
+import { Calendar } from '@sumup-oss/circuit-ui/experimental';
+import type { CalendarProps } from '@sumup-oss/circuit-ui/experimental';
+```
 
 Examples of **correct** code for this rule:
 
 ```tsx
 import { RangePicker } from '@sumup-oss/circuit-ui/legacy';
 import type { RangePickerProps } from '@sumup-oss/circuit-ui/legacy';
+```
+```tsx
+import { Calendar } from '@sumup-oss/circuit-ui';
+import type { CalendarProps } from '@sumup-oss/circuit-ui';
 ```
 
 ### Options

--- a/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.spec.ts
@@ -60,7 +60,7 @@ ruleTester.run('component-lifecycle-imports', componentLifecycleImports, {
   ],
   invalid: [
     {
-      name: 'single import with single match',
+      name: '[Legacy] single import with single match',
       code: `
         import { RangePicker } from '@sumup-oss/circuit-ui';
       `,
@@ -70,7 +70,7 @@ ruleTester.run('component-lifecycle-imports', componentLifecycleImports, {
       errors: [{ messageId: 'refactor' }],
     },
     {
-      name: 'single import with single match with local name',
+      name: '[Legacy] single import with single match with local name',
       code: `
         import { RangePicker as RangeInput } from '@sumup-oss/circuit-ui';
       `,
@@ -80,7 +80,7 @@ ruleTester.run('component-lifecycle-imports', componentLifecycleImports, {
       errors: [{ messageId: 'refactor' }],
     },
     {
-      name: 'multiple imports with single match',
+      name: '[Legacy] multiple imports with single match',
       code: `
         import { RangePicker, Button } from '@sumup-oss/circuit-ui';
       `,
@@ -90,7 +90,7 @@ ruleTester.run('component-lifecycle-imports', componentLifecycleImports, {
       errors: [{ messageId: 'refactor' }],
     },
     {
-      name: 'multiple imports with multiple matches',
+      name: '[Legacy] multiple imports with multiple matches',
       code: `
         import { RangePicker, RangePickerController } from '@sumup-oss/circuit-ui';
       `,
@@ -101,12 +101,22 @@ ruleTester.run('component-lifecycle-imports', componentLifecycleImports, {
       errors: [{ messageId: 'refactor' }, { messageId: 'refactor' }],
     },
     {
-      name: 'single type import with single match',
+      name: '[Legacy] single type import with single match',
       code: `
         import type { RangePickerProps } from '@sumup-oss/circuit-ui';
       `,
       output: `
         import type { RangePickerProps } from '@sumup-oss/circuit-ui/legacy';
+      `,
+      errors: [{ messageId: 'refactor' }],
+    },
+    {
+      name: '[Experimental] single import with single match',
+      code: `
+        import { Calendar } from '@sumup/circuit-ui/experimental';
+      `,
+      output: `
+        import { Calendar } from '@sumup/circuit-ui';
       `,
       errors: [{ messageId: 'refactor' }],
     },

--- a/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.ts
+++ b/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.ts
@@ -71,6 +71,11 @@ const mappings = [
       'center',
     ],
   },
+  {
+    from: '@sumup-oss/circuit-ui/experimental',
+    to: '@sumup-oss/circuit-ui',
+    specifiers: ['Calendar', 'CalendarProps', 'PlainDateRange'],
+  },
 ];
 
 export const componentLifecycleImports = createRule({


### PR DESCRIPTION
Addresses [#DSYS-817](https://sumupteam.atlassian.net/browse/DSYS-817).

## Purpose

The experimental Calendar component was added in [Circuit UI Web v8.8](https://github.com/sumup-oss/circuit-ui/releases/tag/%40sumup%2Fcircuit-ui%408.8.0). It has been used without issue in production for several months and is ready to be marked as stable.

## Approach and changes

Update the component status badge in the Calendar.mdx file 

Move the related exports from experimental.ts to index.ts 

Add a migration for the import path to the component-lifecycle-imports [ESLint rule](https://github.com/sumup-oss/circuit-ui/blob/main/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.ts)
## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [x] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
