### PR TITLE
Silence TypeScript warning in dialog-polyfill

### DIFF
--- a/packages/circuit-ui/vendor/dialog-polyfill/index.js
+++ b/packages/circuit-ui/vendor/dialog-polyfill/index.js
@@ -1,3 +1,6 @@
+/**
+ * @type {Object}
+ */
 const dialogPolyfill = {};
 
 // This condition assures imports don't break for isomorphic scripts,


### PR DESCRIPTION
## Purpose

After the recent TypeScript upgrade (#2703), TypeScript throws a new error: 

```
✖ tsc -p tsconfig.json --noEmit:
packages/circuit-ui/vendor/dialog-polyfill/index.js(1,1): error TS9005: Declaration emit for this file requires using private name 'dialogPolyfillInfo'. An explicit type annotation may unblock declaration emit.
```

## Approach and changes

- Add a generic type definition for `dialogPolyfill` to silence the warning

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
