### PR TITLE
fix(circuit-ui): DSYS-826 | tooltip and toggletip positioning issue

### DIFF
--- a/.changeset/fair-cows-type.md
+++ b/.changeset/fair-cows-type.md
@@ -1,0 +1,5 @@
+---
+"@sumup/circuit-ui": patch
+---
+
+Fixed positioning issue of the Tooltip and the Toggletip components. Improved styling of the Toggletip's backdrop element.

--- a/packages/circuit-ui/components/Toggletip/Toggletip.module.css
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.module.css
@@ -28,8 +28,7 @@
 }
 
 .backdrop {
-  pointer-events: none;
-  visibility: hidden;
+  display: none;
 }
 
 @media (max-width: 479px) {
@@ -39,8 +38,11 @@
     right: 0;
     bottom: 0;
     left: 0;
+    display: block;
     width: 100%;
     height: 100%;
+    pointer-events: none;
+    visibility: hidden;
     background-color: var(--cui-bg-overlay);
   }
 

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -168,10 +168,15 @@ export const Toggletip = forwardRef<HTMLDialogElement, ToggletipProps>(
       });
 
     useEffect(() => {
+      /* Intentionally running useEffect without dependencies
+       * to ensure that the reference element is always up-to-date.
+       * to fix the issue of the tooltip rendering in the wrong position
+       * whenever the reference component re-renders.
+       * */
       const referenceElement = document.getElementById(referenceId);
 
       refs.setReference(referenceElement);
-    }, [referenceId, refs]);
+    });
 
     useEffect(() => {
       /**

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -175,11 +175,16 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       });
 
     useEffect(() => {
+      /* Intentionally running useEffect without dependencies
+       * to ensure that the reference element is always up-to-date.
+       * to fix the issue of the tooltip rendering in the wrong position
+       * whenever the reference component re-renders.
+       * */
       const selector = `[${ariaAttributeName}="${tooltipId}"]`;
       const referenceElement = document.querySelector(selector);
 
       refs.setReference(referenceElement);
-    }, [ariaAttributeName, tooltipId, refs]);
+    });
 
     useEffect(() => {
       /**


### PR DESCRIPTION
Addresses [DSYS-826]( https://sumupteam.atlassian.net/browse/DSYS-826)

## Purpose

The experimental Tooltip and Toggletip components have some significant bugs that need to be fixed before we can mark them as stable.

- Positioning: The floating element becomes detached from the reference element when the parent component is rerendered
- The Toggletip’s backdrop element is completely hidden on larger screens which might cause issues when global styles leak into the component

## Approach and changes

- Update the reference element for floating-ui on every re-render to ensure that the ref is always up-to-date.
- Apply `display: none` to Toggletip's backdrop element on large screens.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
