### PR TITLE
Add `hideLabel` prop to ImageInput component

### DIFF
--- a/.changeset/happy-glasses-work.md
+++ b/.changeset/happy-glasses-work.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Added a `hideLabel` prop to the ImageInput component. It defaults to `true` to match the existing behavior.
+Added a `hideLabel` prop to the ImageInput component (defaulting to `true` to match the existing behavior) and added an `optionalLabel` prop to indicate to users whether the input is required.

--- a/.changeset/happy-glasses-work.md
+++ b/.changeset/happy-glasses-work.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added a `hideLabel` prop to the ImageInput component. It defaults to `true` to match the existing behavior.

--- a/packages/circuit-ui/components/Field/Field.module.css
+++ b/packages/circuit-ui/components/Field/Field.module.css
@@ -11,6 +11,7 @@
 }
 
 .label-text {
+  display: block;
   margin-bottom: var(--cui-spacings-bit);
   font-size: var(--cui-typography-body-two-font-size);
   line-height: var(--cui-typography-body-two-line-height);

--- a/packages/circuit-ui/components/Field/Field.module.css
+++ b/packages/circuit-ui/components/Field/Field.module.css
@@ -8,13 +8,12 @@
 .label,
 .legend {
   display: block;
-  font-size: var(--cui-typography-body-two-font-size);
-  line-height: var(--cui-typography-body-two-line-height);
 }
 
 .label-text {
-  display: inline-block;
   margin-bottom: var(--cui-spacings-bit);
+  font-size: var(--cui-typography-body-two-font-size);
+  line-height: var(--cui-typography-body-two-line-height);
 }
 
 [disabled] .label-text,

--- a/packages/circuit-ui/components/Field/Field.tsx
+++ b/packages/circuit-ui/components/Field/Field.tsx
@@ -122,6 +122,7 @@ export function FieldLabelText({
   hideLabel,
   optionalLabel,
   required,
+  ...props
 }: FieldLabelTextProps) {
   return (
     <span
@@ -129,6 +130,7 @@ export function FieldLabelText({
         classes['label-text'],
         hideLabel && utilClasses.hideVisually,
       )}
+      {...props}
     >
       {label}
       {optionalLabel && !required ? (

--- a/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.spec.tsx
@@ -105,7 +105,9 @@ describe('ImageInput', () => {
      */
     it('should support dragging and dropping an image', async () => {
       render(<StatefulInput />);
-      const labelEl = screen.getByText(defaultProps.label);
+      const labelEl = screen.getByText(defaultProps.label, {
+        ignore: '[aria-hidden="true"]',
+      });
 
       fireEvent.drop(labelEl, { dataTransfer: { files: [file] } });
 

--- a/packages/circuit-ui/components/ImageInput/ImageInput.stories.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.stories.tsx
@@ -75,6 +75,7 @@ export const Disabled = (args: ImageInputProps) => (
     disabled
     loadingLabel="Uploading"
     component={(props) => <Avatar {...props} alt="" />}
+    hideLabel={false}
   />
 );
 

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -33,6 +33,7 @@ import {
   FieldWrapper,
   FieldLabel,
   FieldValidationHint,
+  FieldLabelText,
 } from '../Field/index.js';
 import { IconButton } from '../Button/index.js';
 import { Spinner } from '../Spinner/index.js';
@@ -89,6 +90,15 @@ export interface ImageInputProps
    * An information or error message, displayed below the input.
    */
   validationHint?: string;
+  /**
+   * Label to indicate that the input is optional. Only displayed when the
+   * `required` prop is falsy.
+   */
+  optionalLabel?: string;
+  /**
+   * Visually hide the label. Default: `true`.
+   */
+  hideLabel?: boolean;
 }
 
 /**
@@ -104,7 +114,10 @@ export const ImageInput = ({
   disabled,
   validationHint,
   invalid = false,
+  required,
+  optionalLabel,
   loadingLabel,
+  hideLabel = true,
   'component': Component,
   className,
   style,
@@ -231,6 +244,13 @@ export const ImageInput = ({
 
   return (
     <FieldWrapper className={className} style={style} disabled={disabled}>
+      <FieldLabelText
+        label={label}
+        hideLabel={hideLabel}
+        optionalLabel={optionalLabel}
+        required={required}
+        aria-hidden="true"
+      />
       <div onPaste={handlePaste} className={classes.base}>
         <input
           className={clsx(classes.input, utilClasses.hideVisually)}
@@ -240,6 +260,7 @@ export const ImageInput = ({
           accept="image/*"
           onChange={handleInputChange}
           onClick={handleClick}
+          required={required}
           disabled={disabled || isLoading}
           aria-invalid={invalid && 'true'}
           aria-describedby={descriptionIds}


### PR DESCRIPTION
## Purpose

The ImageInput component visually hides its label by default. Currently, there's no way to unhide the label. Thanks @matoous for reporting this 🙌 

## Approach and changes

- Added a `hideLabel` prop to the ImageInput component. Unlike for other input components, `hideLabel` defaults to `true` to match the ImageInput's current behavior. We might change the default in the next major version.

Showing the label wasn't as straightforward as I had initially assumed, due to the unique structure of the ImageInput:

- The `input[type="file"]` element is visually hidden since it cannot be styled. Instead, the `label` element wraps the custom image preview component to proxy interactions to the input.
- The image preview is overlaid with a button to upload or clear the selected image. The button's label must not be part of the input label, so the `button` element must be rendered outside the `label` element. However, the button should be absolutely positioned relative to the image preview _inside_ the `label`. This is achieved with a common parent element.
- Unhiding the label text breaks the layout when the text is wider than the image preview, as it pushes the button to the side.

I solved this by keeping the label text inside the `label` visually hidden and adding a visible label above the image preview & button group. The visible label is hidden from the accessibility tree to avoid duplication. The only limitation of this approach is that pressing the visible label doesn't activate the input.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
