### PR TITLE
Improve accessility of the SideNavigation's primary links

### DIFF
--- a/.changeset/eight-lizards-decide.md
+++ b/.changeset/eight-lizards-decide.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Extended the `badge` prop of the SideNavigation's primary link props to accept an object to set a custom badge color and provide a label for visually impaired users.

--- a/.changeset/eight-lizards-decide.md
+++ b/.changeset/eight-lizards-decide.md
@@ -2,4 +2,4 @@
 '@sumup/circuit-ui': minor
 ---
 
-Extended the `badge` prop of the SideNavigation's primary link props to accept an object to set a custom badge color and provide a label for visually impaired users.
+Extended the `badge` prop of the SideNavigation's primary link props to accept an object with a custom badge color and a label for visually impaired users.

--- a/.changeset/fluffy-ducks-roll.md
+++ b/.changeset/fluffy-ducks-roll.md
@@ -1,0 +1,5 @@
+---
+'@sumup/circuit-ui': minor
+---
+
+Added an `externalLabel` prop to the SideNavigation's primary link props to describe to visually impaired users that the link leads to an external page or opens in a new tab.

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
@@ -57,7 +57,7 @@ export const baseArgs: SideNavigationProps = {
       href: '/shop',
       onClick: action('Shop'),
       isActive: true,
-      badge: true,
+      badge: { variant: 'promo', label: 'New items' },
       secondaryGroups: [
         {
           secondaryLinks: [
@@ -115,6 +115,7 @@ export const baseArgs: SideNavigationProps = {
       href: 'https://support.example.com',
       onClick: action('Support'),
       target: '_blank',
+      externalLabel: 'Opens in a new tab',
     },
   ],
 };

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.module.css
@@ -117,7 +117,7 @@
   }
 }
 
-.icon-badge::after {
+.badge::after {
   position: absolute;
   top: -8px;
   right: -8px;
@@ -125,8 +125,27 @@
   width: 10px;
   height: 10px;
   content: "";
-  background-color: var(--cui-fg-promo);
   border-radius: var(--cui-border-radius-circle);
+}
+
+.success::after {
+  background-color: var(--cui-bg-success-strong);
+}
+
+.warning::after {
+  background-color: var(--cui-bg-warning-strong);
+}
+
+.danger::after {
+  background-color: var(--cui-bg-danger-strong);
+}
+
+.neutral::after {
+  background-color: var(--cui-bg-highlight);
+}
+
+.promo::after {
+  background-color: var(--cui-bg-promo-strong);
 }
 
 .suffix {

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
@@ -51,6 +51,14 @@ describe('PrimaryLink', () => {
     expect(screen.getByRole('link')).toHaveAttribute('aria-current', 'page');
   });
 
+  it('should render with a badge', () => {
+    renderPrimaryLink(render, {
+      ...baseProps,
+      badge: { label: 'New' },
+    });
+    expect(screen.getByRole('link')).toHaveAccessibleDescription('New');
+  });
+
   it('should render with an active icon', () => {
     renderPrimaryLink(render, {
       ...baseProps,
@@ -60,7 +68,16 @@ describe('PrimaryLink', () => {
     expect(screen.getByTestId('active-icon')).toBeVisible();
   });
 
-  it.todo('should render with an external icon');
+  it('should render with an external icon', () => {
+    renderPrimaryLink(render, {
+      ...baseProps,
+      isExternal: true,
+      externalLabel: 'Opens in a new tab',
+    });
+    expect(screen.getByRole('link')).toHaveAccessibleDescription(
+      'Opens in a new tab',
+    );
+  });
 
   it('should render with a suffix icon', () => {
     renderPrimaryLink(render, {

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -42,19 +42,34 @@ export interface PrimaryLinkProps
    */
   isActive?: boolean;
   /**
-   * Whether the link is the currently active page.
+   * Whether the link leads to an external page or opens in a new tab.
    */
   isExternal?: boolean;
+  /**
+   * Short label to describe that the link leads to an external page or opens in a new tab.
+   */
+  externalLabel?: string;
   /**
    * Whether to show a small circular badge to indicate that a nested secondary
    * link has a badge.
    */
-  badge?: boolean;
+  badge?: boolean | PrimaryBadgeProps;
   /**
    * A collection of secondary groups with nested secondary navigation links.
    */
   secondaryGroups?: SecondaryGroupProps[];
 }
+
+export type PrimaryBadgeProps = {
+  /**
+   * Choose the style variant. Default: 'promo'.
+   */
+  variant?: BadgeProps['variant'];
+  /**
+   * A clear and concise description of the badge's meaning.
+   */
+  label: string;
+};
 
 export interface SecondaryGroupProps {
   /**


### PR DESCRIPTION
## Purpose

The SideNavigation's primary links accept an `isExternal` prop to render an arrow icon to indicate that the link leads to an external page or opens in a new tab and a `badge` prop to indicate that new or important content is available at the target page. The icon and badge lack alternative text to make them accessible to visually impaired users.

## Approach and changes

- Added an `externalLabel` prop to describe to visually impaired users that the link leads to an external page or opens in a new tab.
- Extended the `badge` prop to accept an object with a custom badge color and a label for visually impaired users.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
