### PR TITLE
Prevent unnecessary peer dependency version bumps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@1.5.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
   "changelog": [
     "@changesets/changelog-github",
     { "repo": "sumup-oss/circuit-ui" }
@@ -9,5 +9,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }


### PR DESCRIPTION
Addresses #ticket-number.

## Purpose

When `@sumup/circuit-ui` has a minor version bump, changesets unnecessarily bumps the peer dependency ranges in the other packages, causing a major version bump.

## Approach and changes

- Enable changesets' [experimental `onlyUpdatePeerDependentsWhenOutOfRange` option](https://github.com/changesets/changesets/blob/main/docs/experimental-options.md#onlyupdatepeerdependentswhenoutofrange-type-boolean)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
