### PR TITLE
Fix duplicate ImageInput label

### DIFF
--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -278,12 +278,7 @@ export const ImageInput = ({
             isDragging && classes.dragging,
           )}
         >
-          <FieldLabelText
-            label={label}
-            hideLabel={hideLabel}
-            required={required}
-            optionalLabel={optionalLabel}
-          />
+          <span className={utilClasses.hideVisually}>{label}</span>
           <Component src={src || previewImage} aria-hidden="true" />
         </FieldLabel>
         {src ? (


### PR DESCRIPTION
## Purpose

When updating `next` with `main`, I missed a merge conflict between #2684 and #2721 which caused the label to be shown twice.

## Approach and changes

- Remove duplicate visible label

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
