### PR TITLE
Guard against similar package names in renamed-package-scope ESLint rule

### DIFF
--- a/.changeset/shaggy-tomatoes-protect.md
+++ b/.changeset/shaggy-tomatoes-protect.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/eslint-plugin-circuit-ui": patch
+---
+
+Guarded against similar names package names in the `renamed-package-scope` ESLint rule.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
         run: npm run lint:css
 
       - name: Run unit tests
-        run: npm run test:ci
+        # For some reason, the global script doesn't run tests in packages/eslint-plugin-circuit-ui
+        # I suspect it's because it's not an ES module.
+        run: npm run test:ci && cd packages/eslint-plugin-circuit-ui && npm run test:ci
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v4

--- a/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.spec.ts
@@ -113,10 +113,10 @@ ruleTester.run('component-lifecycle-imports', componentLifecycleImports, {
     {
       name: '[Experimental] single import with single match',
       code: `
-        import { Calendar } from '@sumup/circuit-ui/experimental';
+        import { Calendar } from '@sumup-oss/circuit-ui/experimental';
       `,
       output: `
-        import { Calendar } from '@sumup/circuit-ui';
+        import { Calendar } from '@sumup-oss/circuit-ui';
       `,
       errors: [{ messageId: 'refactor' }],
     },

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
@@ -73,6 +73,7 @@ const configs: (Config & { components: string[] })[] = [
   {
     type: 'values',
     components: ['Badge', 'NotificationInline', 'NotificationToast'],
+    hook: 'setToast',
     prop: 'variant',
     values: {
       confirm: 'success',

--- a/packages/eslint-plugin-circuit-ui/package.json
+++ b/packages/eslint-plugin-circuit-ui/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/README.md",
   "scripts": {
     "build": "tsc",
-    "test": "vitest"
+    "test": "vitest",
+    "test:ci": "vitest --coverage"
   },
   "dependencies": {
     "@typescript-eslint/utils": "^7.16.1"

--- a/packages/eslint-plugin-circuit-ui/renamed-package-scope/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/renamed-package-scope/index.spec.ts
@@ -37,6 +37,7 @@ ruleTester.run('renamed-package-scope', renamedPackageScope, {
       name: 'import from an unaffected @sumup package',
       code: `
         import { OIDCClient } from '@sumup/nanoauth';
+        import { FormDataType } from '@sumup/circuit-ui-form';
       `,
     },
     {

--- a/packages/eslint-plugin-circuit-ui/renamed-package-scope/index.ts
+++ b/packages/eslint-plugin-circuit-ui/renamed-package-scope/index.ts
@@ -67,7 +67,7 @@ export const renamedPackageScope = createRule({
       const escapedFrom = from.replace('/', '\\u002F');
 
       return Object.assign(visitors, {
-        [`ImportDeclaration:has(Literal[value=/${escapedFrom}.*/])`]: (
+        [`ImportDeclaration:has(Literal[value=/${escapedFrom}(?!-).*/])`]: (
           node: TSESTree.ImportDeclaration,
         ) => {
           context.report({


### PR DESCRIPTION
## Purpose

While upgrading the dashboard to Circuit UI v9, I discovered that the `renamed-package-scope` ESLint rule matches unrelated package imports for `@sumup/circuit-ui-form`. 

While fixing this issue, I found two broken unit tests. They slipped through because the the global test script doesn't run tests in `packages/eslint-plugin-circuit-ui` for some reason.

## Approach and changes

- Guard against similar package names in the `renamed-package-scope` ESLint rule
- Re-add a `no-renamed-props` migration that got lost in the refactor of #2728
- Run the ESLint plugin tests in CI

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
