### PR TITLE
Improve ESLint migrations for v9

### DIFF
--- a/.changeset/metal-games-knock.md
+++ b/.changeset/metal-games-knock.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/eslint-plugin-circuit-ui': minor
+---
+
+Expanded the `renamed-package-scope` ESLint rule to cover additional occurrences of package names, for example in Jest module mocks.

--- a/.changeset/metal-games-knock.md
+++ b/.changeset/metal-games-knock.md
@@ -2,4 +2,4 @@
 '@sumup-oss/eslint-plugin-circuit-ui': minor
 ---
 
-Expanded the `renamed-package-scope` ESLint rule to cover additional occurrences of package names, for example in Jest module mocks.
+Expanded the `renamed-package-scope` ESLint rule to cover additional occurrences of package names such as in Jest module mocks.

--- a/.changeset/quick-books-train.md
+++ b/.changeset/quick-books-train.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/eslint-plugin-circuit-ui': patch
+---
+
+Fixed the `no-renamed-props` ESLint rule to add the `as="strong"` prop when migrating the Body's `variant="highlight"` prop to match the previous semantics.

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.spec.ts
@@ -341,6 +341,12 @@ ruleTester.run('no-renamed-props', noRenamedProps, {
 
         function ComponentB() {
           return (
+            <Body as="span" variant="highlight">Lorem ipsum</Body>
+          )
+        }
+
+        function ComponentC() {
+          return (
             <Body variant="alert">Lorem ipsum</Body>
           )
         }
@@ -348,17 +354,27 @@ ruleTester.run('no-renamed-props', noRenamedProps, {
       output: `
         function ComponentA() {
           return (
-            <Body weight="bold">Lorem ipsum</Body>
+            <Body as="strong" weight="bold">Lorem ipsum</Body>
           )
         }
 
         function ComponentB() {
           return (
+            <Body as="span" weight="bold">Lorem ipsum</Body>
+          )
+        }
+
+        function ComponentC() {
+          return (
             <Body color="danger">Lorem ipsum</Body>
           )
         }
       `,
-      errors: [{ messageId: 'bodyVariant' }, { messageId: 'bodyVariant' }],
+      errors: [
+        { messageId: 'bodyVariant' },
+        { messageId: 'bodyVariant' },
+        { messageId: 'bodyVariant' },
+      ],
     },
   ],
 });

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
@@ -290,8 +290,9 @@ const configs: (Config & { components: string[] })[] = [
         const current = getAttributeValue(attribute);
 
         if (current === 'highlight') {
-          const replacement = `weight="bold"`;
+          const replacement = `as="strong" weight="bold"`;
           const weightAttribute = findAttribute(node, 'weight');
+          const asAttribute = findAttribute(node, 'as');
           context.report({
             node: attribute,
             messageId: 'bodyVariant',
@@ -299,6 +300,10 @@ const configs: (Config & { components: string[] })[] = [
             fix: weightAttribute
               ? undefined
               : (fixer) => {
+                  // Don't override an existing `as` attribute
+                  if (asAttribute) {
+                    return fixer.replaceText(attribute, 'weight="bold"');
+                  }
                   return fixer.replaceText(attribute, replacement);
                 },
           });

--- a/packages/eslint-plugin-circuit-ui/renamed-package-scope/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/renamed-package-scope/index.spec.ts
@@ -78,5 +78,63 @@ ruleTester.run('renamed-package-scope', renamedPackageScope, {
       `,
       errors: [{ messageId: 'refactor' }],
     },
+    {
+      name: 'dynamic import from the old package scope',
+      code: `
+        const components = await import('@sumup/circuit-ui');
+      `,
+      output: `
+        const components = await import('@sumup-oss/circuit-ui');
+      `,
+      errors: [{ messageId: 'refactor' }],
+    },
+    {
+      name: 'module mock of the old package scope',
+      code: `
+        jest.mock('@sumup/circuit-ui');
+
+        jest.mock('@sumup/intl', () => ({
+          ...jest.requireActual('@sumup/intl'),
+          formatNumber: jest.fn(),
+        }));
+      `,
+      output: `
+        jest.mock('@sumup-oss/circuit-ui');
+
+        jest.mock('@sumup-oss/intl', () => ({
+          ...jest.requireActual('@sumup-oss/intl'),
+          formatNumber: jest.fn(),
+        }));
+      `,
+      errors: [
+        { messageId: 'refactor' },
+        { messageId: 'refactor' },
+        { messageId: 'refactor' },
+      ],
+    },
+    {
+      name: 'module mock of the old package scope with type annotations',
+      code: `
+        vi.mock('@sumup/circuit-ui', () => ({
+          ...vi.importActual<typeof import('@sumup/circuit-ui')>(
+            '@sumup/circuit-ui',
+          ),
+          useCollapsible: vi.fn(),
+        }));
+      `,
+      output: `
+        vi.mock('@sumup-oss/circuit-ui', () => ({
+          ...vi.importActual<typeof import('@sumup-oss/circuit-ui')>(
+            '@sumup-oss/circuit-ui',
+          ),
+          useCollapsible: vi.fn(),
+        }));
+      `,
+      errors: [
+        { messageId: 'refactor' },
+        { messageId: 'refactor' },
+        { messageId: 'refactor' },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## Purpose

While testing the upgrade to Circuit UI v9 on a real application, we discovered a couple of shortcomings in the ESLint migration rules.

## Approach and changes

- Fixed the `no-renamed-props` ESLint rule to add the `as="strong"` prop when migrating the Body's highlight variant to match the previous semantics
- Expanded the `renamed-package-scope` rule to cover additional occurrences of package names such as in Jest module mocks.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements