### PR TITLE
Migrate the Body's highlight variant to semibold

### DIFF
--- a/packages/circuit-ui/components/Body/Body.module.css
+++ b/packages/circuit-ui/components/Body/Body.module.css
@@ -21,15 +21,15 @@
 
 /* Weights */
 
-.regular {
+.base.regular {
   font-weight: var(--cui-font-weight-regular);
 }
 
-.semibold {
+.base.semibold {
   font-weight: var(--cui-font-weight-semibold);
 }
 
-.bold {
+.base.bold {
   font-weight: var(--cui-font-weight-bold);
 }
 
@@ -90,7 +90,7 @@
 .highlight,
 strong.base,
 .base strong {
-  font-weight: var(--cui-font-weight-bold);
+  font-weight: var(--cui-font-weight-semibold);
 }
 
 .quote,

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.spec.ts
@@ -354,13 +354,13 @@ ruleTester.run('no-renamed-props', noRenamedProps, {
       output: `
         function ComponentA() {
           return (
-            <Body as="strong" weight="bold">Lorem ipsum</Body>
+            <Body as="strong">Lorem ipsum</Body>
           )
         }
 
         function ComponentB() {
           return (
-            <Body as="span" weight="bold">Lorem ipsum</Body>
+            <Body as="span" weight="semibold">Lorem ipsum</Body>
           )
         }
 

--- a/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-props/index.ts
@@ -301,22 +301,16 @@ const configs: (Config & { components: string[] })[] = [
         const current = getAttributeValue(attribute);
 
         if (current === 'highlight') {
-          const replacement = `as="strong" weight="bold"`;
-          const weightAttribute = findAttribute(node, 'weight');
           const asAttribute = findAttribute(node, 'as');
+          const weightAttribute = findAttribute(node, 'weight');
+          const replacement = asAttribute ? 'weight="semibold"' : `as="strong"`;
           context.report({
             node: attribute,
             messageId: 'bodyVariant',
             data: { component, current, replacement },
             fix: weightAttribute
               ? undefined
-              : (fixer) => {
-                  // Don't override an existing `as` attribute
-                  if (asAttribute) {
-                    return fixer.replaceText(attribute, 'weight="bold"');
-                  }
-                  return fixer.replaceText(attribute, replacement);
-                },
+              : (fixer) => fixer.replaceText(attribute, replacement),
           });
           return;
         }


### PR DESCRIPTION
## Purpose

During the design review of the new typography, we noticed that the Body's bold weight has too much visual weight and should be reduced to semibold.

## Approach and changes

- Render `strong` elements and `variant="highlight"` as semibold instead of bold
- Migrate the Body's deprecated `variant="highlight"` prop to `as="strong"`, leaving out the superfluous `weight="semibold"`. 
- Increase the specificity of the weight class names to ensure the weight can be overridden using `weight="bold"`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
