### PR TITLE
Mimic native input in DateInput and PhoneNumberInput components

### DIFF
--- a/.changeset/two-snakes-tease.md
+++ b/.changeset/two-snakes-tease.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Updated the PhoneNumberInput component to accept `value` and `defaultValue` props. The `onChange` callback is now called with an `Event` object instead of a string to mimic a native input.

--- a/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.spec.tsx
@@ -23,7 +23,6 @@ import {
   fireEvent,
   userEvent,
 } from '../../util/test-utils.js';
-import type { InputElement } from '../Input/index.js';
 
 import { ColorInput } from './ColorInput.js';
 
@@ -39,7 +38,7 @@ describe('ColorInput', () => {
   });
 
   it('should forward a ref', () => {
-    const ref = createRef<InputElement>();
+    const ref = createRef<HTMLInputElement>();
     render(<ColorInput {...baseProps} ref={ref} />);
     const [input] = screen.getAllByLabelText(baseProps.label);
     expect(ref.current).toBe(input);

--- a/packages/circuit-ui/components/ColorInput/ColorInput.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.tsx
@@ -33,6 +33,7 @@ import {
   FieldValidationHint,
 } from '../Field/index.js';
 import { applyMultipleRefs } from '../../util/refs.js';
+import { changeInputValue } from '../../util/input-value.js';
 
 import classes from './ColorInput.module.css';
 
@@ -100,14 +101,14 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
 
     const descriptionIds = clsx(validationHintId, descriptionId);
 
-    const handlePaste: ClipboardEventHandler<HTMLInputElement> = (e) => {
+    const handlePaste: ClipboardEventHandler<HTMLInputElement> = (event) => {
       if (!colorPickerRef.current || !colorInputRef.current || readOnly) {
         return;
       }
 
-      e.preventDefault();
+      event.preventDefault();
 
-      const pastedText = e.clipboardData.getData('text/plain').trim();
+      const pastedText = event.clipboardData.getData('text/plain').trim();
 
       if (!pastedText || !/^#?[0-9A-F]{6}$/i.test(pastedText)) {
         return;
@@ -118,42 +119,34 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
         : `#${pastedText}`;
 
       colorPickerRef.current.value = pastedColor;
-
-      // React overwrites the input.value setter. In order to be able to trigger
-      // a 'change' event on the input, we need to use the native setter.
-      // Adapted from https://stackoverflow.com/a/46012210/4620154
-      Object.getOwnPropertyDescriptor(
-        HTMLInputElement.prototype,
-        'value',
-      )?.set?.call(colorInputRef.current, pastedColor.replace('#', ''));
-
-      colorInputRef.current.dispatchEvent(
-        new Event('change', { bubbles: true }),
-      );
       colorPickerRef.current.dispatchEvent(
         new Event('change', { bubbles: true }),
       );
+
+      changeInputValue(colorInputRef.current, pastedColor.replace('#', ''));
     };
 
-    const onPickerColorChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const onPickerColorChange: ChangeEventHandler<HTMLInputElement> = (
+      event,
+    ) => {
       if (colorInputRef.current) {
-        colorInputRef.current.value = e.target.value.replace('#', '');
+        colorInputRef.current.value = event.target.value.replace('#', '');
       }
       if (onChange) {
-        onChange(e);
+        onChange(event);
       }
     };
 
-    const onInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const onInputChange: ChangeEventHandler<HTMLInputElement> = (event) => {
       if (colorPickerRef.current) {
-        colorPickerRef.current.value = `#${e.target.value}`;
+        colorPickerRef.current.value = `#${event.target.value}`;
       }
       if (onChange) {
         onChange({
-          ...e,
+          ...event,
           target: {
-            ...e.target,
-            value: `#${e.target.value}`,
+            ...event.target,
+            value: `#${event.target.value}`,
           },
         });
       }

--- a/packages/circuit-ui/components/ColorInput/ColorInput.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.tsx
@@ -24,7 +24,7 @@ import {
 } from 'react';
 
 import { classes as inputClasses } from '../Input/index.js';
-import type { InputElement, InputProps } from '../Input/index.js';
+import type { InputProps } from '../Input/index.js';
 import { clsx } from '../../styles/clsx.js';
 import {
   FieldLabelText,
@@ -65,7 +65,7 @@ export interface ColorInputProps
   defaultValue?: string;
 }
 
-export const ColorInput = forwardRef<InputElement, ColorInputProps>(
+export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
   (
     {
       'aria-describedby': descriptionId,
@@ -91,8 +91,8 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
     },
     ref,
   ) => {
-    const colorPickerRef = useRef<InputElement>(null);
-    const colorInputRef = useRef<InputElement>(null);
+    const colorPickerRef = useRef<HTMLInputElement>(null);
+    const colorInputRef = useRef<HTMLInputElement>(null);
 
     const labelId = useId();
     const pickerId = useId();
@@ -100,7 +100,7 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
 
     const descriptionIds = clsx(validationHintId, descriptionId);
 
-    const handlePaste: ClipboardEventHandler<InputElement> = (e) => {
+    const handlePaste: ClipboardEventHandler<HTMLInputElement> = (e) => {
       if (!colorPickerRef.current || !colorInputRef.current || readOnly) {
         return;
       }
@@ -135,7 +135,7 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
       );
     };
 
-    const onPickerColorChange: ChangeEventHandler<InputElement> = (e) => {
+    const onPickerColorChange: ChangeEventHandler<HTMLInputElement> = (e) => {
       if (colorInputRef.current) {
         colorInputRef.current.value = e.target.value.replace('#', '');
       }
@@ -144,7 +144,7 @@ export const ColorInput = forwardRef<InputElement, ColorInputProps>(
       }
     };
 
-    const onInputChange: ChangeEventHandler<InputElement> = (e) => {
+    const onInputChange: ChangeEventHandler<HTMLInputElement> = (e) => {
       if (colorPickerRef.current) {
         colorPickerRef.current.value = `#${e.target.value}`;
       }

--- a/packages/circuit-ui/components/DateInput/DateInput.module.css
+++ b/packages/circuit-ui/components/DateInput/DateInput.module.css
@@ -2,6 +2,10 @@
   display: flex;
 }
 
+.hidden {
+  display: none;
+}
+
 .segments {
   position: relative;
   z-index: var(--cui-z-index-absolute);
@@ -64,7 +68,7 @@
   color: var(--cui-fg-warning);
 }
 
-:global([data-disabled="true"]) .input {
+:global([data-disabled="true"]) .wrapper {
   color: var(--cui-fg-normal-disabled);
   background-color: var(--cui-bg-normal-disabled);
   border-color: var(--cui-border-normal-disabled);

--- a/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
@@ -45,11 +45,11 @@ describe('DateInput', () => {
   });
 
   it('should forward a ref', () => {
-    const ref = createRef<HTMLDivElement>();
+    const ref = createRef<HTMLInputElement>();
     const { container } = render(<DateInput {...props} ref={ref} />);
     // eslint-disable-next-line testing-library/no-container
-    const wrapper = container.querySelectorAll('div')[0];
-    expect(ref.current).toBe(wrapper);
+    const input = container.querySelector('input[type="date"]');
+    expect(ref.current).toBe(input);
   });
 
   it('should merge a custom class name with the default ones', () => {
@@ -222,34 +222,44 @@ describe('DateInput', () => {
 
   describe('state', () => {
     it('should display a default value', () => {
-      render(<DateInput {...props} defaultValue="2000-01-12" />);
+      const ref = createRef<HTMLInputElement>();
+      render(<DateInput {...props} ref={ref} defaultValue="2000-01-12" />);
 
+      expect(ref.current).toHaveValue('2000-01-12');
       expect(screen.getByLabelText(/day/i)).toHaveValue('12');
       expect(screen.getByLabelText(/month/i)).toHaveValue('1');
       expect(screen.getByLabelText(/year/i)).toHaveValue('2000');
     });
 
     it('should display an initial value', () => {
-      render(<DateInput {...props} value="2000-01-12" />);
+      const ref = createRef<HTMLInputElement>();
+      render(<DateInput {...props} ref={ref} value="2000-01-12" />);
 
+      expect(ref.current).toHaveValue('2000-01-12');
       expect(screen.getByLabelText(/day/i)).toHaveValue('12');
       expect(screen.getByLabelText(/month/i)).toHaveValue('1');
       expect(screen.getByLabelText(/year/i)).toHaveValue('2000');
     });
 
     it('should ignore an invalid value', () => {
-      render(<DateInput {...props} value="2000-13-54" />);
+      const ref = createRef<HTMLInputElement>();
+      render(<DateInput {...props} ref={ref} value="2000-13-54" />);
 
+      expect(ref.current).toHaveValue('');
       expect(screen.getByLabelText(/day/i)).toHaveValue('');
       expect(screen.getByLabelText(/month/i)).toHaveValue('');
       expect(screen.getByLabelText(/year/i)).toHaveValue('');
     });
 
     it('should update the displayed value', () => {
-      const { rerender } = render(<DateInput {...props} value="2000-01-12" />);
+      const ref = createRef<HTMLInputElement>();
+      const { rerender } = render(
+        <DateInput {...props} ref={ref} value="2000-01-12" />,
+      );
 
-      rerender(<DateInput {...props} value="2000-01-15" />);
+      rerender(<DateInput {...props} ref={ref} value="2000-01-15" />);
 
+      expect(ref.current).toHaveValue('2000-01-15');
       expect(screen.getByLabelText(/day/i)).toHaveValue('15');
       expect(screen.getByLabelText(/month/i)).toHaveValue('1');
       expect(screen.getByLabelText(/year/i)).toHaveValue('2000');
@@ -266,15 +276,17 @@ describe('DateInput', () => {
     });
 
     it('should allow users to type a date', async () => {
+      const ref = createRef<HTMLInputElement>();
       const onChange = vi.fn();
 
-      render(<DateInput {...props} onChange={onChange} />);
+      render(<DateInput {...props} ref={ref} onChange={onChange} />);
 
       await userEvent.type(screen.getByLabelText('Year'), '2017');
       await userEvent.type(screen.getByLabelText('Month'), '8');
       await userEvent.type(screen.getByLabelText('Day'), '28');
 
-      expect(onChange).toHaveBeenCalledWith('2017-08-28');
+      expect(onChange).toHaveBeenCalled();
+      expect(ref.current).toHaveValue('2017-08-28');
     });
 
     it('should update the minimum and maximum input values as the user types', async () => {
@@ -304,26 +316,34 @@ describe('DateInput', () => {
     });
 
     it('should allow users to delete the date', async () => {
+      const ref = createRef<HTMLInputElement>();
       const onChange = vi.fn();
 
       render(
-        <DateInput {...props} defaultValue="2000-01-12" onChange={onChange} />,
+        <DateInput
+          {...props}
+          ref={ref}
+          defaultValue="2000-01-12"
+          onChange={onChange}
+        />,
       );
 
       await userEvent.click(screen.getByLabelText(/year/i));
       await userEvent.keyboard(Array(9).fill('{backspace}').join(''));
 
+      expect(ref.current).toHaveValue('');
       expect(screen.getByLabelText(/day/i)).toHaveValue('');
       expect(screen.getByLabelText(/month/i)).toHaveValue('');
       expect(screen.getByLabelText(/year/i)).toHaveValue('');
 
-      expect(onChange).toHaveBeenCalledWith('');
+      expect(onChange).toHaveBeenCalled();
     });
 
     it('should allow users to select a date on a calendar', async () => {
+      const ref = createRef<HTMLInputElement>();
       const onChange = vi.fn();
 
-      render(<DateInput {...props} onChange={onChange} />);
+      render(<DateInput {...props} ref={ref} onChange={onChange} />);
 
       const openCalendarButton = screen.getByRole('button', {
         name: /change date/i,
@@ -336,14 +356,21 @@ describe('DateInput', () => {
       const dateButton = screen.getByRole('button', { name: /12/ });
       await userEvent.click(dateButton);
 
-      expect(onChange).toHaveBeenCalledWith('2000-01-12');
+      expect(ref.current).toHaveValue('2000-01-12');
+      expect(onChange).toHaveBeenCalled();
     });
 
     it('should allow users to clear the date', async () => {
+      const ref = createRef<HTMLInputElement>();
       const onChange = vi.fn();
 
       render(
-        <DateInput {...props} defaultValue="2000-01-12" onChange={onChange} />,
+        <DateInput
+          {...props}
+          ref={ref}
+          defaultValue="2000-01-12"
+          onChange={onChange}
+        />,
       );
 
       const openCalendarButton = screen.getByRole('button', {
@@ -357,7 +384,8 @@ describe('DateInput', () => {
       const clearButton = screen.getByRole('button', { name: /clear date/i });
       await userEvent.click(clearButton);
 
-      expect(onChange).toHaveBeenCalledWith('');
+      expect(ref.current).toHaveValue('');
+      expect(onChange).toHaveBeenCalled();
     });
 
     describe('on narrow viewports', () => {
@@ -367,9 +395,10 @@ describe('DateInput', () => {
 
       it('should allow users to select a date on a calendar', async () => {
         (useMedia as Mock).mockReturnValue(true);
+        const ref = createRef<HTMLInputElement>();
         const onChange = vi.fn();
 
-        render(<DateInput {...props} onChange={onChange} />);
+        render(<DateInput {...props} ref={ref} onChange={onChange} />);
 
         const openCalendarButton = screen.getByRole('button', {
           name: /change date/i,
@@ -387,15 +416,18 @@ describe('DateInput', () => {
         const applyButton = screen.getByRole('button', { name: /apply/i });
         await userEvent.click(applyButton);
 
-        expect(onChange).toHaveBeenCalledWith('2000-01-12');
+        expect(ref.current).toHaveValue('2000-01-12');
+        expect(onChange).toHaveBeenCalled();
       });
 
       it('should allow users to clear the date', async () => {
+        const ref = createRef<HTMLInputElement>();
         const onChange = vi.fn();
 
         render(
           <DateInput
             {...props}
+            ref={ref}
             defaultValue="2000-01-12"
             onChange={onChange}
           />,
@@ -412,15 +444,18 @@ describe('DateInput', () => {
         const clearButton = screen.getByRole('button', { name: /clear date/i });
         await userEvent.click(clearButton);
 
-        expect(onChange).toHaveBeenCalledWith('');
+        expect(ref.current).toHaveValue('');
+        expect(onChange).toHaveBeenCalled();
       });
 
       it('should allow users to close the calendar dialog without selecting a date', async () => {
+        const ref = createRef<HTMLInputElement>();
         const onChange = vi.fn();
 
         render(
           <DateInput
             {...props}
+            ref={ref}
             defaultValue="2000-01-12"
             onChange={onChange}
           />,
@@ -438,6 +473,7 @@ describe('DateInput', () => {
         await userEvent.click(closeButton);
 
         expect(calendarDialog).not.toBeVisible();
+        expect(ref.current).toHaveValue('2000-01-12');
         expect(onChange).not.toHaveBeenCalled();
       });
     });

--- a/packages/circuit-ui/components/DateInput/DateInput.stories.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.stories.tsx
@@ -50,7 +50,13 @@ const baseArgs = {
 
 export const Base = (args: DateInputProps) => {
   const [value, setValue] = useState(args.defaultValue || args.value || '');
-  return <DateInput {...args} value={value} onChange={setValue} />;
+  return (
+    <DateInput
+      {...args}
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+    />
+  );
 };
 
 Base.args = baseArgs;

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -50,6 +50,7 @@ import {
 import { getBrowserLocale } from '../../util/i18n.js';
 import { toPlainDate } from '../../util/date.js';
 import { applyMultipleRefs } from '../../util/refs.js';
+import { changeInputValue } from '../../util/input-value.js';
 
 import { Dialog } from './components/Dialog.js';
 import { DateSegment } from './components/DateSegment.js';
@@ -190,17 +191,8 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const minDate = toPlainDate(min);
     const maxDate = toPlainDate(max);
 
-    const handleChange = (tmp: string) => {
-      if (inputRef.current) {
-        // React overwrites the input.value setter. In order to be able to trigger
-        // a 'change' event on the input, we need to use the native setter.
-        // Adapted from https://stackoverflow.com/a/46012210/4620154
-        Object.getOwnPropertyDescriptor(
-          HTMLInputElement.prototype,
-          'value',
-        )?.set?.call(inputRef.current, tmp);
-        inputRef.current.dispatchEvent(new Event('change', { bubbles: true }));
-      }
+    const handleChange = (newValue: string) => {
+      changeInputValue(inputRef.current, newValue);
     };
 
     const focus = useSegmentFocus();

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -48,6 +48,7 @@ import {
   FieldWrapper,
 } from '../Field/Field.js';
 import { getBrowserLocale } from '../../util/i18n.js';
+import { toPlainDate } from '../../util/date.js';
 
 import { Dialog } from './components/Dialog.js';
 import { DateSegment } from './components/DateSegment.js';
@@ -190,14 +191,16 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
     const validationHintId = useId();
 
     const descriptionIds = clsx(descriptionId, validationHintId);
+    const minDate = toPlainDate(min);
+    const maxDate = toPlainDate(max);
 
     const focus = useSegmentFocus();
     const state = usePlainDateState({
       value,
       defaultValue,
       onChange,
-      min,
-      max,
+      minDate,
+      maxDate,
       locale,
     });
 
@@ -482,8 +485,8 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
                 className={classes.calendar}
                 onSelect={handleSelect}
                 selection={selection}
-                minDate={state.minDate}
-                maxDate={state.maxDate}
+                minDate={minDate}
+                maxDate={maxDate}
                 locale={locale}
                 firstDayOfWeek={firstDayOfWeek}
                 modifiers={modifiers}

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -21,7 +21,7 @@ import {
   useId,
   useRef,
   useState,
-  type HTMLAttributes,
+  type InputHTMLAttributes,
 } from 'react';
 import type { Temporal } from 'temporal-polyfill';
 import { flip, offset, shift, useFloating } from '@floating-ui/react-dom';
@@ -49,6 +49,7 @@ import {
 } from '../Field/Field.js';
 import { getBrowserLocale } from '../../util/i18n.js';
 import { toPlainDate } from '../../util/date.js';
+import { applyMultipleRefs } from '../../util/refs.js';
 
 import { Dialog } from './components/Dialog.js';
 import { DateSegment } from './components/DateSegment.js';
@@ -58,7 +59,7 @@ import { getCalendarButtonLabel, getDateSegments } from './DateInputService.js';
 import classes from './DateInput.module.css';
 
 export interface DateInputProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>,
+  extends InputHTMLAttributes<HTMLInputElement>,
     Pick<
       InputProps,
       | 'label'
@@ -119,13 +120,6 @@ export interface DateInputProps
    */
   clearDateButtonLabel: string;
   /**
-   * Callback when the date changes. Called with the date in the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)
-   * format (`YYYY-MM-DD`) or an empty string.
-   *
-   * @example '2024-10-08'
-   */
-  onChange: (date: string) => void;
-  /**
    * The minimum selectable date in the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)
    * format (`YYYY-MM-DD`) (inclusive).
    */
@@ -145,13 +139,12 @@ export interface DateInputProps
  * The DateInput component allows users to type or select a specific date.
  * The input value is always a string in the format `YYYY-MM-DD`.
  */
-export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
+export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
   (
     {
       label,
       value,
       defaultValue,
-      onChange,
       min,
       max,
       locale = getBrowserLocale(),
@@ -177,12 +170,15 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
       monthInputLabel,
       dayInputLabel,
       autoComplete,
+      className,
+      style,
       ...props
     },
     ref,
   ) => {
     const isMobile = useMedia('(max-width: 479px)');
 
+    const inputRef = useRef<HTMLInputElement>(null);
     const fieldRef = useRef<HTMLDivElement>(null);
     const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -194,11 +190,24 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
     const minDate = toPlainDate(min);
     const maxDate = toPlainDate(max);
 
+    const handleChange = (tmp: string) => {
+      if (inputRef.current) {
+        // React overwrites the input.value setter. In order to be able to trigger
+        // a 'change' event on the input, we need to use the native setter.
+        // Adapted from https://stackoverflow.com/a/46012210/4620154
+        Object.getOwnPropertyDescriptor(
+          HTMLInputElement.prototype,
+          'value',
+        )?.set?.call(inputRef.current, tmp);
+        inputRef.current.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    };
+
     const focus = useSegmentFocus();
     const state = usePlainDateState({
       value,
       defaultValue,
-      onChange,
+      onChange: handleChange,
       minDate,
       maxDate,
       locale,
@@ -350,7 +359,7 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
     }
 
     return (
-      <FieldWrapper ref={ref} disabled={disabled} {...props}>
+      <FieldWrapper disabled={disabled} className={className} style={style}>
         <FieldSet aria-describedby={descriptionIds}>
           <FieldLegend onClick={handleClick}>
             <FieldLabelText
@@ -361,6 +370,23 @@ export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
             />
           </FieldLegend>
           <div ref={fieldRef} className={classes.wrapper}>
+            <input
+              type="date"
+              ref={applyMultipleRefs(ref, inputRef)}
+              className={classes.hidden}
+              min={min}
+              max={max}
+              required={required}
+              disabled={disabled}
+              readOnly={readOnly}
+              autoComplete={autoComplete}
+              aria-invalid={invalid}
+              aria-hidden="true"
+              tabIndex={-1}
+              value={value}
+              defaultValue={defaultValue}
+              {...props}
+            />
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: */}
             <div
               onClick={handleClick}

--- a/packages/circuit-ui/components/DateInput/hooks/usePlainDateState.ts
+++ b/packages/circuit-ui/components/DateInput/hooks/usePlainDateState.ts
@@ -38,10 +38,8 @@ type DateValues = {
   day: DateValue;
 };
 
-type PlainDateState = {
+export type PlainDateState = {
   date: Temporal.PlainDate | undefined;
-  minDate: Temporal.PlainDate | undefined;
-  maxDate: Temporal.PlainDate | undefined;
   update: (values: Partial<DateValues>) => void;
   props: {
     year: Omit<DateSegmentProps, 'focus'>;
@@ -54,15 +52,15 @@ export function usePlainDateState({
   value,
   defaultValue,
   onChange,
-  min,
-  max,
+  minDate,
+  maxDate,
   locale,
 }: {
   value: string | undefined;
   defaultValue: string | undefined;
   onChange: ((date: string) => void) | undefined;
-  min: string | undefined;
-  max: string | undefined;
+  minDate: Temporal.PlainDate | undefined;
+  maxDate: Temporal.PlainDate | undefined;
   locale: Locale | undefined;
 }): PlainDateState {
   const [values, setValues] = useState<DateValues>(
@@ -110,8 +108,6 @@ export function usePlainDateState({
 
   const date = safePlainDate(values.year, values.month, values.day);
   const today = getTodaysDate();
-  const minDate = toPlainDate(min);
-  const maxDate = toPlainDate(max);
 
   const sameYearLimit = minDate && maxDate && minDate.year === maxDate.year;
   const sameMonthLimit = sameYearLimit && minDate.month === maxDate.month;
@@ -158,7 +154,7 @@ export function usePlainDateState({
     },
   };
 
-  return { date, minDate, maxDate, update, props };
+  return { date, update, props };
 }
 
 function parseValue(value?: string): DateValues {

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
@@ -2,6 +2,10 @@
   display: flex;
 }
 
+.hidden {
+  display: none;
+}
+
 .country-code.country-code,
 .subscriber-number.subscriber-number {
   flex-grow: 1;

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
@@ -30,6 +30,7 @@ const countryCodeMap: { [key: string]: string } = {
 };
 
 const defaultProps = {
+  ref: createRef<HTMLInputElement>(),
   label: 'Phone number',
   countryCode: {
     label: 'Country code',
@@ -55,14 +56,23 @@ describe('PhoneNumberInput', () => {
     expect(fieldset.className).toContain(props.className);
   });
 
+  it('should forward a ref to the hidden input', () => {
+    const ref = createRef<HTMLInputElement>();
+    const { container } = render(
+      <PhoneNumberInput {...defaultProps} ref={ref} />,
+    );
+    const input = container.querySelectorAll('input')[0];
+    expect(ref.current).toBe(input);
+  });
+
   it('should forward a ref to the country code selector', () => {
     const ref = createRef<HTMLSelectElement>();
     const props = {
       ...defaultProps,
       countryCode: { ...defaultProps.countryCode, ref },
     };
-    const { container } = render(<PhoneNumberInput {...props} />);
-    const select = container.querySelector('select');
+    render(<PhoneNumberInput {...props} />);
+    const select = screen.getByLabelText('Country code');
     expect(ref.current).toBe(select);
   });
 
@@ -72,8 +82,8 @@ describe('PhoneNumberInput', () => {
       ...defaultProps,
       subscriberNumber: { ...defaultProps.subscriberNumber, ref },
     };
-    const { container } = render(<PhoneNumberInput {...props} />);
-    const input = container.querySelector('input');
+    render(<PhoneNumberInput {...props} />);
+    const input = screen.getByLabelText('Subscriber number');
     expect(ref.current).toBe(input);
   });
 
@@ -87,6 +97,47 @@ describe('PhoneNumberInput', () => {
     const select = screen.getByRole('combobox');
     await userEvent.selectOptions(select, 'DE');
     expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it('should display a default value', () => {
+    const props = {
+      ...defaultProps,
+      defaultValue: '+4912345678',
+    };
+    const { container } = render(<PhoneNumberInput {...props} />);
+    const input = container.querySelectorAll('input')[0];
+    const countryCode = screen.getByLabelText('Country code');
+    const subscriberNumber = screen.getByLabelText('Subscriber number');
+    expect(input).toHaveValue('+4912345678');
+    expect(countryCode).toHaveValue('DE');
+    expect(subscriberNumber).toHaveValue('12345678');
+  });
+
+  it('should display an initial value', () => {
+    const props = {
+      ...defaultProps,
+      value: '+4912345678',
+    };
+    const { container } = render(<PhoneNumberInput {...props} />);
+    const input = container.querySelectorAll('input')[0];
+    const countryCode = screen.getByLabelText('Country code');
+    const subscriberNumber = screen.getByLabelText('Subscriber number');
+    expect(input).toHaveValue('+4912345678');
+    expect(countryCode).toHaveValue('DE');
+    expect(subscriberNumber).toHaveValue('12345678');
+  });
+
+  it('should update the displayed value', () => {
+    const { container, rerender } = render(
+      <PhoneNumberInput {...defaultProps} value="+4912345678" />,
+    );
+    rerender(<PhoneNumberInput {...defaultProps} value="+112345678" />);
+    const input = container.querySelectorAll('input')[0];
+    const countryCode = screen.getByLabelText('Country code');
+    const subscriberNumber = screen.getByLabelText('Subscriber number');
+    expect(input).toHaveValue('+112345678');
+    expect(countryCode).toHaveValue('CA');
+    expect(subscriberNumber).toHaveValue('12345678');
   });
 
   it('should call countryCode onChange when there is a change in the country code', async () => {
@@ -114,7 +165,7 @@ describe('PhoneNumberInput', () => {
       },
     };
     render(<PhoneNumberInput {...props} />);
-    const input = screen.getByRole('textbox');
+    const input = screen.getByLabelText('Subscriber number');
     await userEvent.type(input, '1');
     expect(onChange).toHaveBeenCalledOnce();
   });
@@ -135,16 +186,17 @@ describe('PhoneNumberInput', () => {
         },
       };
       render(<PhoneNumberInput {...props} />);
-      const input = screen.getByRole('textbox');
+      const input = screen.getByLabelText('Subscriber number');
       await userEvent.click(input);
       await userEvent.paste(phoneNumber);
-      expect(props.onChange).toHaveBeenCalledWith('+4912345678');
+      expect(props.ref.current).toHaveValue('+4912345678');
+      expect(props.onChange).toHaveBeenCalledTimes(2);
       expect(props.countryCode.onChange).toHaveBeenCalledOnce();
       expect(props.subscriberNumber.onChange).toHaveBeenCalledOnce();
     },
   );
 
-  it('should set only the subscriber number when a phone number without country code', async () => {
+  it('should set only the subscriber number when pasting a phone number without country code', async () => {
     const props = {
       ...defaultProps,
       onChange: vi.fn(),
@@ -158,10 +210,11 @@ describe('PhoneNumberInput', () => {
       },
     };
     render(<PhoneNumberInput {...props} />);
-    const input = screen.getByRole('textbox');
+    const input = screen.getByLabelText('Subscriber number');
     await userEvent.click(input);
     await userEvent.paste('012345678');
-    expect(props.onChange).toHaveBeenCalledWith('+112345678');
+    expect(props.ref.current).toHaveValue('+112345678');
+    expect(props.onChange).toHaveBeenCalledTimes(1);
     expect(props.countryCode.onChange).not.toHaveBeenCalled();
     expect(props.subscriberNumber.onChange).toHaveBeenCalledOnce();
   });
@@ -171,11 +224,11 @@ describe('PhoneNumberInput', () => {
       ...defaultProps,
       subscriberNumber: {
         ...defaultProps.subscriberNumber,
-        value: '123 456789',
+        defaultValue: '123 456789',
       },
     };
     render(<PhoneNumberInput {...props} />);
-    const input = screen.getByRole('textbox');
+    const input = screen.getByLabelText('Subscriber number');
     expect(input).toBeValid();
   });
 
@@ -184,11 +237,11 @@ describe('PhoneNumberInput', () => {
       ...defaultProps,
       subscriberNumber: {
         ...defaultProps.subscriberNumber,
-        value: '1234567891011121314151617',
+        defaultValue: '1234567891011121314151617',
       },
     };
     render(<PhoneNumberInput {...props} />);
-    const input = screen.getByRole('textbox');
+    const input = screen.getByLabelText('Subscriber number');
     expect(input).toBeInvalid();
   });
 

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -88,10 +88,7 @@ export const Validations = (args: PhoneNumberInputProps) => (
     />
     <PhoneNumberInput
       {...args}
-      subscriberNumber={{
-        ...args.subscriberNumber,
-        defaultValue: '202 555 0132',
-      }}
+      defaultValue="+1202 555 0132"
       validationHint="This looks good"
       showValid
     />

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -23,7 +23,7 @@ import {
   type ChangeEvent,
   type ClipboardEvent,
   type ComponentType,
-  type FieldsetHTMLAttributes,
+  type InputHTMLAttributes,
   type ForwardedRef,
   type RefObject,
 } from 'react';
@@ -47,26 +47,29 @@ import { changeInputValue } from '../../util/input-value.js';
 import {
   mapCountryCodeOptions,
   normalizePhoneNumber,
+  parsePhoneNumber,
+  type CountryCodeOption,
 } from './PhoneNumberInputService.js';
 import classes from './PhoneNumberInput.module.css';
 
 export interface PhoneNumberInputProps
-  extends Omit<
-    FieldsetHTMLAttributes<HTMLFieldSetElement>,
-    'onChange' | 'onBlur'
-  > {
+  extends InputHTMLAttributes<HTMLInputElement> {
+  /**
+   * The normalized phone number in the [E.164 format](https://en.wikipedia.org/wiki/E.164).
+   *
+   * @example '+17024181234'
+   */
+  value?: string;
+  /**
+   * The default normalized phone number in the [E.164 format](https://en.wikipedia.org/wiki/E.164).
+   *
+   * @example '+17024181234'
+   */
+  defaultValue?: string;
   /**
    * A clear and concise description of the input purpose.
    */
   label: string;
-  /**
-   * Callback when the country code or subscriber number changes. Called with
-   * the normalized phone number in the [E.164 format](https://en.wikipedia.org/wiki/E.164).
-   *
-   *
-   * @example '+17024181234'
-   */
-  onChange?: (phoneNumber: string) => void;
   /**
    * Label to indicate that the input is optional. Only displayed when the
    * `required` prop is falsy.
@@ -118,16 +121,7 @@ export interface PhoneNumberInputProps
     /**
      * List of country calling codes to be rendered inside the selector
      */
-    options: {
-      /**
-       * Country name in two letter ISO 3166 region code format(https://www.iso.org/iso-3166-country-codes.html)
-       */
-      country: string;
-      /**
-       * Country calling codes, see https://en.wikipedia.org/wiki/List_of_country_calling_codes
-       */
-      code: string;
-    }[];
+    options: CountryCodeOption[];
     /**
      * Triggers error styles on the component. Important for accessibility.
      */
@@ -197,13 +191,15 @@ export interface PhoneNumberInputProps
  * accurate, consistent format including the country code and subscriber number.
  */
 export const PhoneNumberInput = forwardRef<
-  HTMLFieldSetElement,
+  HTMLInputElement,
   PhoneNumberInputProps
 >(
   (
     {
       label,
       hideLabel,
+      value,
+      defaultValue,
       countryCode,
       subscriberNumber,
       optionalLabel,
@@ -213,14 +209,16 @@ export const PhoneNumberInput = forwardRef<
       showValid,
       disabled,
       validationHint,
-      onChange,
       readOnly,
       'aria-describedby': descriptionId,
       locale,
+      className,
+      style,
       ...props
     },
     ref,
   ) => {
+    const hiddenInputRef = useRef<HTMLInputElement>(null);
     const countryCodeRef = useRef<HTMLSelectElement | HTMLInputElement>(null);
     const subscriberNumberRef = useRef<HTMLInputElement>(null);
 
@@ -236,11 +234,7 @@ export const PhoneNumberInput = forwardRef<
     );
 
     const handleChange = () => {
-      if (
-        !onChange ||
-        !countryCodeRef.current ||
-        !subscriberNumberRef.current
-      ) {
+      if (!countryCodeRef.current || !subscriberNumberRef.current) {
         return;
       }
 
@@ -259,7 +253,8 @@ export const PhoneNumberInput = forwardRef<
         code,
         subscriberNumberRef.current.value,
       );
-      onChange(phoneNumber);
+
+      changeInputValue(hiddenInputRef.current, phoneNumber);
     };
 
     const handlePaste = (event: ClipboardEvent) => {
@@ -272,38 +267,29 @@ export const PhoneNumberInput = forwardRef<
         return;
       }
 
-      const pastedText = event.clipboardData
-        .getData('text/plain')
-        .trim()
-        // Normalize the country code prefix
-        .replace(/^00/, '+');
-
-      if (!pastedText) {
-        return;
-      }
-
-      const hasCountryCode = pastedText.startsWith('+');
-
-      if (!hasCountryCode) {
-        return;
-      }
-
-      const pastedOption = countryCode.options
-        // Match longer, more specific country codes first
-        .sort((a, b) => b.code.length - a.code.length)
-        .find(({ code }) => pastedText.startsWith(code));
-
-      if (!pastedOption) {
-        return;
-      }
-
       event.preventDefault();
 
-      const pastedSubscriberNumber = pastedText.split(pastedOption.code)[1];
+      const pastedPhoneNumber = parsePhoneNumber(
+        event.clipboardData.getData('text/plain'),
+        countryCode.options,
+      );
 
-      changeInputValue(countryCodeRef.current, pastedOption.country);
-      changeInputValue(subscriberNumberRef.current, pastedSubscriberNumber);
+      if (pastedPhoneNumber.countryCode) {
+        changeInputValue(countryCodeRef.current, pastedPhoneNumber.countryCode);
+      }
+      if (pastedPhoneNumber.subscriberNumber) {
+        changeInputValue(
+          subscriberNumberRef.current,
+          pastedPhoneNumber.subscriberNumber,
+        );
+      }
     };
+
+    const parsedValue = parsePhoneNumber(value, countryCode.options);
+    const parsedDefaultValue = parsePhoneNumber(
+      defaultValue,
+      countryCode.options,
+    );
 
     if (
       process.env.NODE_ENV !== 'production' &&
@@ -337,8 +323,8 @@ export const PhoneNumberInput = forwardRef<
         aria-invalid={invalid && 'true'}
         aria-required={required && 'true'}
         disabled={disabled}
-        ref={ref}
-        {...props}
+        className={className}
+        style={style}
       >
         <FieldLegend>
           <FieldLabelText
@@ -349,6 +335,20 @@ export const PhoneNumberInput = forwardRef<
           />
         </FieldLegend>
         <div className={classes.wrapper}>
+          <input
+            type="text"
+            ref={applyMultipleRefs(ref, hiddenInputRef)}
+            className={classes.hidden}
+            required={required}
+            disabled={disabled}
+            readOnly={readOnly}
+            aria-invalid={invalid}
+            aria-hidden="true"
+            tabIndex={-1}
+            value={value}
+            defaultValue={defaultValue}
+            {...props}
+          />
           {readOnly || countryCode.readonly ? (
             <Input
               hideLabel
@@ -357,6 +357,10 @@ export const PhoneNumberInput = forwardRef<
               className={classes['country-code']}
               inputClassName={classes['country-code-input']}
               {...countryCode}
+              value={parsedValue.countryCode}
+              defaultValue={
+                parsedDefaultValue.countryCode ?? countryCode.defaultValue
+              }
               invalid={invalid || countryCode.invalid}
               readOnly={true}
               onChange={() => {}}
@@ -373,6 +377,10 @@ export const PhoneNumberInput = forwardRef<
               disabled={disabled}
               className={classes['country-code']}
               {...countryCode}
+              value={parsedValue.countryCode}
+              defaultValue={
+                parsedDefaultValue.countryCode ?? countryCode.defaultValue
+              }
               invalid={invalid || countryCode.invalid}
               aria-readonly={true}
               options={options}
@@ -399,6 +407,11 @@ export const PhoneNumberInput = forwardRef<
             hasWarning={hasWarning}
             showValid={showValid}
             {...subscriberNumber}
+            value={parsedValue.subscriberNumber}
+            defaultValue={
+              parsedDefaultValue.subscriberNumber ??
+              subscriberNumber.defaultValue
+            }
             invalid={invalid || subscriberNumber.invalid}
             readOnly={readOnly || subscriberNumber.readonly}
             onChange={eachFn<[ChangeEvent<HTMLInputElement>]>([

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -42,6 +42,7 @@ import {
 } from '../../util/errors.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { eachFn } from '../../util/helpers.js';
+import { changeInputValue } from '../../util/input-value.js';
 
 import {
   mapCountryCodeOptions,
@@ -300,22 +301,8 @@ export const PhoneNumberInput = forwardRef<
 
       const pastedSubscriberNumber = pastedText.split(pastedOption.code)[1];
 
-      countryCodeRef.current.value = pastedOption.country;
-
-      // React overwrites the input.value setter. In order to be able to trigger
-      // a 'change' event on the input, we need to use the native setter.
-      // Adapted from https://stackoverflow.com/a/46012210/4620154
-      Object.getOwnPropertyDescriptor(
-        HTMLInputElement.prototype,
-        'value',
-      )?.set?.call(subscriberNumberRef.current, pastedSubscriberNumber);
-
-      countryCodeRef.current.dispatchEvent(
-        new Event('change', { bubbles: true }),
-      );
-      subscriberNumberRef.current.dispatchEvent(
-        new Event('change', { bubbles: true }),
-      );
+      changeInputValue(countryCodeRef.current, pastedOption.country);
+      changeInputValue(subscriberNumberRef.current, pastedSubscriberNumber);
     };
 
     if (

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
@@ -15,6 +15,62 @@
 
 import type { SelectProps } from '../Select/Select.js';
 
+export type CountryCodeOption = {
+  /**
+   * Country name in two letter ISO 3166 region code format(https://www.iso.org/iso-3166-country-codes.html)
+   */
+  country: string;
+  /**
+   * Country calling codes, see https://en.wikipedia.org/wiki/List_of_country_calling_codes
+   */
+  code: string;
+};
+
+export function parsePhoneNumber(
+  value: string | undefined,
+  options: CountryCodeOption[],
+): {
+  countryCode?: string;
+  subscriberNumber?: string;
+} {
+  // TODO: Normalize the value further
+  const sanitizedValue = value
+    ?.trim()
+    // Normalize the country code prefix
+    ?.replace(/^00/, '+');
+
+  if (!sanitizedValue) {
+    return {};
+  }
+
+  const hasCountryCode = sanitizedValue.startsWith('+');
+
+  if (!hasCountryCode) {
+    return {
+      subscriberNumber: sanitizedValue,
+    };
+  }
+
+  const matchedOption = options
+    // Match longer, more specific country codes first
+    .sort((a, b) => b.code.length - a.code.length)
+    .find(({ code }) => sanitizedValue.startsWith(code));
+
+  if (!matchedOption) {
+    return {
+      subscriberNumber: sanitizedValue,
+    };
+  }
+
+  // TODO: Handle non-existent subscriber number
+  const subscriberNumber = sanitizedValue.split(matchedOption.code)[1];
+
+  return {
+    countryCode: matchedOption.country,
+    subscriberNumber,
+  };
+}
+
 export function normalizePhoneNumber(
   countryCode: string,
   subscriberNumber: string,

--- a/packages/circuit-ui/util/input-value.spec.tsx
+++ b/packages/circuit-ui/util/input-value.spec.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InputHTMLAttributes } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from './test-utils.js';
+import { changeInputValue } from './input-value.js';
+
+describe('input-value', () => {
+  describe('changeInputValue', () => {
+    function Component(props: InputHTMLAttributes<HTMLInputElement> = {}) {
+      return <input type="text" {...props} />;
+    }
+
+    it('should set the input value', () => {
+      render(<Component />);
+
+      const value = 'foo';
+      const input: HTMLInputElement = screen.getByRole('textbox');
+
+      changeInputValue(input, value);
+
+      expect(input).toHaveValue(value);
+    });
+
+    it('should dispatch a change event', () => {
+      const onChange = vi.fn();
+
+      render(<Component onChange={onChange} />);
+
+      const value = 'foo';
+      const input: HTMLInputElement = screen.getByRole('textbox');
+
+      changeInputValue(input, value);
+
+      expect(onChange).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/circuit-ui/util/input-value.ts
+++ b/packages/circuit-ui/util/input-value.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function changeInputValue<
+  Element extends HTMLInputElement | HTMLSelectElement,
+>(element: Element | null, value: string) {
+  if (element) {
+    const prototype = Object.getPrototypeOf(element) as Element;
+    // React overwrites the input.value setter. In order to be able to trigger
+    // a 'change' event on the input, we need to use the native setter.
+    // Adapted from https://stackoverflow.com/a/46012210/4620154
+    Object.getOwnPropertyDescriptor(prototype, 'value')?.set?.call(
+      element,
+      value,
+    );
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+}


### PR DESCRIPTION
## Purpose

Replacing the native date input with a custom implementation in #2645 meant that the value would no longer be included in native form submissions. Furthermore, the `onChange` value changed from an `Event` object to a simple string which made integration with form libraries more difficult.

The same applies to the PhoneNumberInput component.

## Approach and changes

- Added a hidden `input` element to the DateInput and PhoneNumberInput components that proxies the current value and ensures the value is included in native form submissions

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
