### PR TITLE
add a fixer method to the `no-deprecated-custom-properties` ESlint rule

### DIFF
--- a/.changeset/tricky-cups-wave.md
+++ b/.changeset/tricky-cups-wave.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/eslint-plugin-circuit-ui": minor
+---
+
+Added a fixer method to the `no-deprecated-custom-properties` ESlint rule.

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-custom-properties/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-custom-properties/index.spec.ts
@@ -75,13 +75,14 @@ ruleTester.run(
         code: `
           const typography = {
             fontSize: "var(--cui-typography-headline-one-font-size)",
-            lineHeight: "var(--cui-typography-headline-one-line-height)",
+          }
+        `,
+        output: `
+          const typography = {
+            fontSize: "var(--cui-headline-l-font-size)",
           }
         `,
         errors: [
-          {
-            messageId: 'deprecated',
-          },
           {
             messageId: 'deprecated',
           },
@@ -92,13 +93,14 @@ ruleTester.run(
         code: `
           const styles = css\`
             font-size: var(--cui-typography-headline-one-font-size);
-            line-height: var(--cui-typography-headline-one-line-height);
+          \`;
+        `,
+        output: `
+          const styles = css\`
+            font-size: var(--cui-headline-l-font-size);
           \`;
         `,
         errors: [
-          {
-            messageId: 'deprecated',
-          },
           {
             messageId: 'deprecated',
           },
@@ -110,7 +112,18 @@ ruleTester.run(
           function Component() {
             return (
               <p
-                style="font-size:var(--cui-typography-headline-one-font-size);line-height:var(--cui-typography-headline-one-line-height);"
+                style="font-size:var(--cui-typography-headline-one-font-size);"
+              >
+                Success
+              </p>
+            );
+          }
+        `,
+        output: `
+          function Component() {
+            return (
+              <p
+                style="font-size:var(--cui-headline-l-font-size);"
               >
                 Success
               </p>
@@ -118,9 +131,6 @@ ruleTester.run(
           }
         `,
         errors: [
-          {
-            messageId: 'deprecated',
-          },
           {
             messageId: 'deprecated',
           },

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
@@ -35,13 +35,14 @@ export const noDeprecatedCustomProperties = createRule({
   meta: {
     type: 'suggestion',
     schema: [],
+    fixable: 'code',
     docs: {
       description: 'Deprecated custom properties should be removed or replaced',
       recommended: 'strict',
     },
     messages: {
       deprecated:
-        'The `{{name}}` custom property has been deprecated. Use the ` {{replacement}}` custom property instead.',
+        'The `{{name}}` custom property has been deprecated. Use the `{{replacement}}` custom property instead.',
     },
   },
   defaultOptions: [],
@@ -74,6 +75,12 @@ export const noDeprecatedCustomProperties = createRule({
               data: {
                 name,
                 replacement,
+              },
+              fix(fixer) {
+                return fixer.replaceText(
+                  node,
+                  context.sourceCode.getText(node).replace(name, replacement),
+                );
               },
             });
           }


### PR DESCRIPTION
Addresses [DSYS-847](https://sumupteam.atlassian.net/browse/DSYS-847)

## Purpose

After the typography revamp for v9, a new ESlint rule `circuit-ui/no-deprecated-custom-properties` was added to flag deprecated custom properties. In order to make the migration to CUI v9 easier, a fixer function would help migrate deprecated custom props automatically.
## Approach and changes

- add `fixable: 'code'` to rule meta
- add a fixer function to the rule to replace the deprecated custom property name with its new equivalent value.
## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
