### PR TITLE
Fix Body's font weight

### DIFF
--- a/.changeset/plenty-radios-try.md
+++ b/.changeset/plenty-radios-try.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': patch
+---
+
+Fixed the Body's font weight when rendered as a `strong` element.

--- a/packages/circuit-ui/components/Body/Body.module.css
+++ b/packages/circuit-ui/components/Body/Body.module.css
@@ -21,15 +21,15 @@
 
 /* Weights */
 
-.base.regular {
+.regular {
   font-weight: var(--cui-font-weight-regular);
 }
 
-.base.semibold {
+.semibold {
   font-weight: var(--cui-font-weight-semibold);
 }
 
-.base.bold {
+.bold {
   font-weight: var(--cui-font-weight-bold);
 }
 
@@ -88,7 +88,6 @@
 /* Variants */
 
 .highlight,
-strong.base,
 .base strong {
   font-weight: var(--cui-font-weight-semibold);
 }

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -89,6 +89,13 @@ function getHTMLElement(variant?: Variant): AsPropType {
   return 'p';
 }
 
+function getDefaultWeight(as?: AsPropType) {
+  if (as === 'strong') {
+    return 'semibold';
+  }
+  return 'regular';
+}
+
 export const deprecatedSizeMap: Record<string, string> = {
   'one': 'm',
   'two': 's',
@@ -104,7 +111,7 @@ export const Body = forwardRef<HTMLParagraphElement, BodyProps>(
       className,
       as,
       size: legacySize = 'm',
-      weight = 'regular',
+      weight = getDefaultWeight(as),
       decoration,
       color = 'normal',
       variant,


### PR DESCRIPTION
## Purpose

When the Body component is rendered as a `strong` element, it should have a semibold font weight. It should be possible to override the font weight using the `weight` prop. In order to ensure the latter, we increased the specificity of the weight styles, thus breaking the former. 

## Approach and changes

- Revert the specificity of the weight styles
- Change the default `weight` value to `semibold` when the component is rendered as a `strong` element

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
