### PR TITLE
Improve accessibility of the DateInput component

### DIFF
--- a/.changeset/great-seas-fetch.md
+++ b/.changeset/great-seas-fetch.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Improved the DateInput component's accessibility when empty.

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
@@ -178,7 +178,7 @@ export function DateSegment({
         enterKeyHint="next"
         spellCheck="false"
         role="spinbutton"
-        aria-valuenow={props.value as number}
+        aria-valuenow={props.value || undefined}
         aria-valuemin={min}
         aria-valuemax={max}
         aria-invalid={invalid}


### PR DESCRIPTION
## Purpose

[`jest-axe`](https://github.com/nickcolley/jest-axe/) complains about the existence of the `aria-valuenow` attribute when it's empty.

## Approach and changes

- Remove the `aria-valuenow` attribute when empty

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
