### PR TITLE
fix(server-components): add missing use client directive

### DIFF
--- a/.changeset/odd-insects-destroy.md
+++ b/.changeset/odd-insects-destroy.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Added the missing "use client" directive to a number of components.

--- a/packages/circuit-ui/components/ComponentsContext/ComponentsContext.ts
+++ b/packages/circuit-ui/components/ComponentsContext/ComponentsContext.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { createContext, type ComponentType } from 'react';
 
 import { Link, type LinkProps } from './components/Link/index.js';

--- a/packages/circuit-ui/components/ComponentsContext/useComponents.ts
+++ b/packages/circuit-ui/components/ComponentsContext/useComponents.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { useContext } from 'react';
 
 import {

--- a/packages/circuit-ui/components/ModalContext/createUseModal.ts
+++ b/packages/circuit-ui/components/ModalContext/createUseModal.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import { useContext, useCallback, useRef, useId } from 'react';
 
 import { ModalContext } from './ModalContext.js';

--- a/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   useContext,
   useCallback,


### PR DESCRIPTION
Addresses [DSYS-849](https://sumupteam.atlassian.net/browse/DSYS-849)

Addresses [DSYS-849](https://sumupteam.atlassian.net/browse/DSYS-849)

##Scope

We had feedback from a team attempting to update to CUI v9 that they encountered issues using CUI components in server components. It turns out that some files did not the "use client"
 directive.

##Task
add "use client" directive to the following files:

- ComponentsContext.js
- useComponents.js
- createUseModal.js
- useSidePanel.js

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
