### PR TITLE
Improve focus management for the date input component

### DIFF
--- a/.changeset/beige-readers-burn.md
+++ b/.changeset/beige-readers-burn.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Improved the accessibility of the DateInput component by restoring focus to the opening element.

--- a/.changeset/beige-readers-burn.md
+++ b/.changeset/beige-readers-burn.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Improved the accessibility of the DateInput component by restoring focus to the opening element.
+Improved the accessibility of the DateInput component by restoring focus to the opening element when closing the calendar dialog.

--- a/.changeset/fluffy-pants-sin.md
+++ b/.changeset/fluffy-pants-sin.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed unclickable previous/next month buttons on the Calendar component.

--- a/packages/circuit-ui/components/Calendar/Calendar.module.css
+++ b/packages/circuit-ui/components/Calendar/Calendar.module.css
@@ -7,6 +7,7 @@
 .next {
   position: absolute;
   top: 0;
+  z-index: 1;
 }
 
 .prev {

--- a/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
@@ -358,6 +358,7 @@ describe('DateInput', () => {
 
       expect(ref.current).toHaveValue('2000-01-12');
       expect(onChange).toHaveBeenCalled();
+      expect(openCalendarButton).toHaveFocus();
     });
 
     it('should allow users to clear the date', async () => {
@@ -386,6 +387,25 @@ describe('DateInput', () => {
 
       expect(ref.current).toHaveValue('');
       expect(onChange).toHaveBeenCalled();
+      expect(openCalendarButton).toHaveFocus();
+    });
+
+    it('should close calendar on outside click', async () => {
+      const ref = createRef<HTMLInputElement>();
+
+      render(<DateInput {...props} ref={ref} defaultValue="2000-01-12" />);
+
+      const openCalendarButton = screen.getByRole('button', {
+        name: /change date/i,
+      });
+      await userEvent.click(openCalendarButton);
+
+      const calendarDialog = screen.getByRole('dialog');
+      expect(calendarDialog).toBeVisible();
+
+      await userEvent.click(screen.getByLabelText('Year'));
+      expect(calendarDialog).not.toBeVisible();
+      expect(openCalendarButton).not.toHaveFocus();
     });
 
     describe('on narrow viewports', () => {

--- a/packages/circuit-ui/components/DateInput/components/Dialog.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/components/Dialog.spec.tsx
@@ -134,6 +134,12 @@ describe('Dialog', () => {
       await userEvent.click(container);
       expect(props.onClose).toHaveBeenCalledOnce();
     });
+
+    it('should close the dialog when modal and pressing the backdrop', async () => {
+      render(<Dialog {...props} isModal open />);
+      await userEvent.click(screen.getByRole('dialog', { hidden: true }));
+      expect(props.onClose).toHaveBeenCalledOnce();
+    });
   });
 
   it('should have no accessibility violations', async () => {

--- a/packages/circuit-ui/components/DateInput/components/Dialog.tsx
+++ b/packages/circuit-ui/components/DateInput/components/Dialog.tsx
@@ -50,7 +50,11 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
     const lastFocusedElementRef = useRef<Element | null>(null);
 
     const handleClickOutside = useCallback(
-      // store it as the last focused element
+      // When the dialog first opens, we store the document's active element as the last active
+      // element to restore focus to it when the dialog closes.
+      // however, if the dialog is closed by clicking outside of it in non-modal mode,
+      // we don't want to restore focus to the last active element, so we override it
+      // with the element triggering the useClickOutside hook.
       (event: Event) => {
         if (event.target instanceof HTMLElement) {
           lastFocusedElementRef.current = event.target;

--- a/packages/circuit-ui/components/DateInput/components/Dialog.tsx
+++ b/packages/circuit-ui/components/DateInput/components/Dialog.tsx
@@ -63,6 +63,15 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
     useClickOutside(dialogRef, handleClickOutside, open);
     useEscapeKey(onClose, open);
 
+    const onClickListener = useCallback(
+      (e: MouseEvent) => {
+        if (isModal && e.target === dialogRef.current) {
+          dialogRef.current?.close();
+        }
+      },
+      [isModal],
+    );
+
     useEffect(() => {
       const dialogElement = dialogRef.current;
 
@@ -75,9 +84,11 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
       dialogPolyfill.registerDialog(dialogElement);
 
       dialogElement.addEventListener('close', onClose);
+      dialogElement.addEventListener('click', onClickListener);
 
       return () => {
         dialogElement.removeEventListener('close', onClose);
+        dialogElement.removeEventListener('click', onClickListener);
       };
     }, [onClose]);
 


### PR DESCRIPTION
Addresses [DSYS-851](https://sumupteam.atlassian.net/browse/DSYS-851)

## Purpose

The Calendar dialog in the DateInput component does not shift back focus to the last focused element, making the component not compliant with accessibility [recommendations](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal).

## Approach and changes

Handle focus management by resetting focus back to the calendar button when: 
- user selects a value
- user clears field value 
- use clicks ‘Esc’ key.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
