### PR TITLE
Prevent DateInput component from triggering form submissions

### DIFF
--- a/.changeset/weak-kings-refuse.md
+++ b/.changeset/weak-kings-refuse.md
@@ -2,4 +2,4 @@
 '@sumup-oss/circuit-ui': patch
 ---
 
-Fixed the DateInput component's calendar button `type` to prevent it from triggering form submissions.
+Added `type="button"` to all `button` elements in the Calendar and DateInput components to prevent them from triggering form submissions.

--- a/.changeset/weak-kings-refuse.md
+++ b/.changeset/weak-kings-refuse.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': patch
+---
+
+Fixed the DateInput component's calendar button `type` to prevent it from triggering form submissions.

--- a/packages/circuit-ui/components/Calendar/Calendar.module.css
+++ b/packages/circuit-ui/components/Calendar/Calendar.module.css
@@ -81,9 +81,6 @@
   align-items: center;
   justify-content: center;
   aspect-ratio: 1 / 1;
-  font-size: var(--cui-body-m-font-size);
-  font-weight: var(--cui-font-weight-bold);
-  line-height: var(--cui-body-m-line-height);
 }
 
 .day {

--- a/packages/circuit-ui/components/Calendar/Calendar.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.tsx
@@ -49,6 +49,7 @@ import {
 import { applyMultipleRefs } from '../../util/refs.js';
 import { useSwipe } from '../../hooks/useSwipe/useSwipe.js';
 import { last } from '../../util/helpers.js';
+import { Body } from '../Body/Body.js';
 
 import {
   CalendarActionType,
@@ -410,9 +411,14 @@ function Month({
             {weekdays.map((weekday) => (
               <th key={weekday.long} scope="col">
                 <span className={utilClasses.hideVisually}>{weekday.long}</span>
-                <span aria-hidden="true" className={classes.weekday}>
+                <Body
+                  as="span"
+                  weight="semibold"
+                  aria-hidden="true"
+                  className={classes.weekday}
+                >
                   {weekday.narrow}
-                </span>
+                </Body>
               </th>
             ))}
           </tr>

--- a/packages/circuit-ui/components/Calendar/Calendar.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.tsx
@@ -288,6 +288,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
         <div className={classes.header}>
           <div className={classes.prev}>
             <IconButton
+              type="button"
               icon={ArrowLeft}
               size="s"
               variant="tertiary"
@@ -301,6 +302,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
           </div>
           <div className={classes.next}>
             <IconButton
+              type="button"
               icon={ArrowRight}
               size="s"
               variant="tertiary"
@@ -472,6 +474,7 @@ function Month({
                 return (
                   <td key={isoDate}>
                     <button
+                      type="button"
                       data-date={isoDate}
                       onClick={handleClick}
                       onMouseEnter={handleMouseEnter}

--- a/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
@@ -348,6 +348,9 @@ describe('DateInput', () => {
       const openCalendarButton = screen.getByRole('button', {
         name: /change date/i,
       });
+
+      expect(openCalendarButton).toHaveAttribute('type', 'button');
+
       await userEvent.click(openCalendarButton);
 
       const calendarDialog = screen.getByRole('dialog');

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -453,6 +453,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
               })}
             </div>
             <IconButton
+              type="button"
               icon={CalendarIcon}
               variant="secondary"
               onClick={openCalendar}
@@ -515,11 +516,16 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
               {(!required || isMobile) && (
                 <div className={classes.buttons}>
                   {!required && (
-                    <Button variant="tertiary" onClick={handleClear}>
+                    <Button
+                      type="button"
+                      variant="tertiary"
+                      onClick={handleClear}
+                    >
                       {clearDateButtonLabel}
                     </Button>
                   )}
                   <Button
+                    type="button"
                     variant="primary"
                     onClick={handleApply}
                     className={classes.apply}


### PR DESCRIPTION
## Purpose

When the DateInput component is rendered inside a `form` element, pressing the button to open the calendar picker erroneously triggers a form submission.

## Approach and changes

- Add `type="button"` attribute to all `button` elements in the Calendar and DateInput components
- Bonus: Improve the visual hierarchy in the Calendar component by reducing the font weight of the weekday headers

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
