### PR TITLE
Improve placement of the DateInput dialog

### DIFF
--- a/.changeset/quiet-apples-develop.md
+++ b/.changeset/quiet-apples-develop.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Improved the DateInput component's calendar dialog to be placed on the side with the most available space and to scroll when it overflows the viewport.

--- a/.changeset/silent-lobsters-peel.md
+++ b/.changeset/silent-lobsters-peel.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Stretched the DateInput component to take up the available width.

--- a/packages/circuit-ui/components/DateInput/DateInput.module.css
+++ b/packages/circuit-ui/components/DateInput/DateInput.module.css
@@ -10,6 +10,7 @@
   position: relative;
   z-index: var(--cui-z-index-absolute);
   display: flex;
+  flex-grow: 1;
   gap: 2px;
   min-width: 170px;
   padding: var(--cui-spacings-byte) var(--cui-spacings-mega);

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -24,7 +24,7 @@ import {
   type InputHTMLAttributes,
 } from 'react';
 import type { Temporal } from 'temporal-polyfill';
-import { flip, offset, shift, useFloating } from '@floating-ui/react-dom';
+import { flip, offset, shift, size, useFloating } from '@floating-ui/react-dom';
 import { Calendar as CalendarIcon } from '@sumup-oss/icons';
 
 import type { ClickEvent } from '../../types/events.js';
@@ -215,6 +215,11 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
         offset(4),
         flip({ fallbackAxisSideDirection: 'end', crossAxis: false }),
         shift(),
+        size({
+          apply({ availableHeight, elements }) {
+            elements.floating.style.maxHeight = `${availableHeight}px`;
+          },
+        }),
       ],
       elements: {
         reference: fieldRef.current,

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -211,7 +211,11 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const { floatingStyles, update } = useFloating({
       open,
       placement: 'bottom-start',
-      middleware: [offset(4), flip(), shift()],
+      middleware: [
+        offset(4),
+        flip({ fallbackAxisSideDirection: 'end', crossAxis: false }),
+        shift(),
+      ],
       elements: {
         reference: fieldRef.current,
         floating: dialogRef.current,

--- a/packages/circuit-ui/components/DateInput/components/Dialog.tsx
+++ b/packages/circuit-ui/components/DateInput/components/Dialog.tsx
@@ -94,7 +94,7 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
         dialogElement.removeEventListener('close', onClose);
         dialogElement.removeEventListener('click', onClickListener);
       };
-    }, [onClose]);
+    }, [onClose, onClickListener]);
 
     useEffect(() => {
       const dialogElement = dialogRef.current;


### PR DESCRIPTION
## Purpose

On medium viewports, the DateInput component's calendar modal currently overflows the viewport.

## Approach and changes

- Allow DateInput dialog to be placed on the cross axis
- Scroll the dialog content when it would overflow the viewport
- Stretch the DateInput to take up the available width

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
