### PR TITLE
Do not warn on stable Tooltip import

### DIFF
--- a/.changeset/eight-suits-talk.md
+++ b/.changeset/eight-suits-talk.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/eslint-plugin-circuit-ui": patch
+---
+
+Removed warning when importing the stable Tooltip component.

--- a/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.ts
+++ b/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.ts
@@ -54,8 +54,6 @@ const mappings = [
       'SidebarProps',
       'SidebarContextProvider',
       'SidebarContextConsumer',
-      'Tooltip',
-      'TooltipProps',
       'uniqueId',
       'cx',
       'spacing',


### PR DESCRIPTION
## Purpose

The previous experimental Tooltip component is now stable. The component lifecycle warning for the now legacy Tooltip component is therefore obsolete and confusing.

## Approach and changes

- Remove warning when importing the stable Tooltip component.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
