### PR TITLE
Place calendar dialog relative to button in DateInput

### DIFF
--- a/.changeset/hungry-sloths-prove.md
+++ b/.changeset/hungry-sloths-prove.md
@@ -2,4 +2,4 @@
 '@sumup-oss/circuit-ui': patch
 ---
 
-Improved the DateInput component's calendar dialog to be placed relative to the calendar button instead of the whole file. This improves the placement when the DateInput is rendered near the center of the viewport.
+Improved the DateInput component's calendar dialog to be placed relative to the calendar button instead of the whole field. This improves the placement when the DateInput is rendered near the center of the viewport. The default `bottom-end` placement can be customized using the new `placement` prop.

--- a/.changeset/hungry-sloths-prove.md
+++ b/.changeset/hungry-sloths-prove.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': patch
+---
+
+Improved the DateInput component's calendar dialog to be placed relative to the calendar button instead of the whole file. This improves the placement when the DateInput is rendered near the center of the viewport.

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -24,7 +24,14 @@ import {
   type InputHTMLAttributes,
 } from 'react';
 import type { Temporal } from 'temporal-polyfill';
-import { flip, offset, shift, size, useFloating } from '@floating-ui/react-dom';
+import {
+  flip,
+  offset,
+  shift,
+  size,
+  useFloating,
+  type Placement,
+} from '@floating-ui/react-dom';
 import { Calendar as CalendarIcon } from '@sumup-oss/icons';
 
 import type { ClickEvent } from '../../types/events.js';
@@ -134,6 +141,10 @@ export interface DateInputProps
    * A hint to the user agent specifying how to prefill the input.
    */
   autoComplete?: 'bday';
+  /**
+   * One of the accepted placement values. Defaults to `bottom-end`.
+   */
+  placement?: Placement;
 }
 
 /**
@@ -171,6 +182,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
       monthInputLabel,
       dayInputLabel,
       autoComplete,
+      placement = 'bottom-end',
       className,
       style,
       ...props
@@ -208,14 +220,17 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const [open, setOpen] = useState(false);
     const [selection, setSelection] = useState<Temporal.PlainDate>();
 
+    const padding = 16; // px
+
     const { floatingStyles, update } = useFloating({
       open,
-      placement: 'bottom-end',
+      placement,
       middleware: [
         offset(4),
-        flip({ fallbackAxisSideDirection: 'start', crossAxis: false }),
-        shift(),
+        flip({ padding, fallbackAxisSideDirection: 'start' }),
+        shift({ padding }),
         size({
+          padding,
           apply({ availableHeight, elements }) {
             elements.floating.style.maxHeight = `${availableHeight}px`;
           },

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -180,7 +180,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const isMobile = useMedia('(max-width: 479px)');
 
     const inputRef = useRef<HTMLInputElement>(null);
-    const fieldRef = useRef<HTMLDivElement>(null);
+    const calendarButtonRef = useRef<HTMLDivElement>(null);
     const dialogRef = useRef<HTMLDialogElement>(null);
 
     const dialogId = useId();
@@ -210,10 +210,10 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 
     const { floatingStyles, update } = useFloating({
       open,
-      placement: 'bottom-start',
+      placement: 'bottom-end',
       middleware: [
         offset(4),
-        flip({ fallbackAxisSideDirection: 'end', crossAxis: false }),
+        flip({ fallbackAxisSideDirection: 'start', crossAxis: false }),
         shift(),
         size({
           apply({ availableHeight, elements }) {
@@ -222,7 +222,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
         }),
       ],
       elements: {
-        reference: fieldRef.current,
+        reference: calendarButtonRef.current,
         floating: dialogRef.current,
       },
     });
@@ -370,7 +370,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
               optionalLabel={optionalLabel}
             />
           </FieldLegend>
-          <div ref={fieldRef} className={classes.wrapper}>
+          <div className={classes.wrapper}>
             <input
               type="date"
               ref={applyMultipleRefs(ref, inputRef)}
@@ -462,6 +462,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
               })}
             </div>
             <IconButton
+              ref={calendarButtonRef}
               type="button"
               icon={CalendarIcon}
               variant="secondary"


### PR DESCRIPTION
## Purpose

When the DateInput is rendered near the center of the viewport so there's equal space around it, the calendar dialog is placed 

_Before_

![Screenshot 2024-11-13 at 13 55 18](https://github.com/user-attachments/assets/5ffc43c8-1ca5-453f-a9e2-76b8a47cb623)

_After_

![Screenshot 2024-11-14 at 17-57-17 SumUp](https://github.com/user-attachments/assets/4316a58d-f6a0-4efe-a950-e17447d0b8d1)

## Approach and changes

- Position the calendar dialog relative to the calendar button instead of the entire field
- Allow customization of the placement (default is `bottom-end`)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
