### PR TITLE
Add useLocale hook

### DIFF
--- a/.changeset/ninety-rabbits-vanish.md
+++ b/.changeset/ninety-rabbits-vanish.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': patch
+---
+
+Fixed a hydration error that could occur in the CurrencyInput, Calendar, and DateInput components when no explicit locale was provided.

--- a/packages/circuit-ui/components/Calendar/Calendar.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.tsx
@@ -30,8 +30,8 @@ import {
 import { Temporal } from 'temporal-polyfill';
 import { ArrowLeft, ArrowRight } from '@sumup-oss/icons';
 
+import type { Locale } from '../../util/i18n.js';
 import { utilClasses } from '../../styles/utility.js';
-import { getBrowserLocale, type Locale } from '../../util/i18n.js';
 import { IconButton } from '../Button/IconButton.js';
 import { Headline } from '../Headline/Headline.js';
 import { clsx } from '../../styles/clsx.js';
@@ -48,6 +48,7 @@ import {
 } from '../../util/errors.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { useSwipe } from '../../hooks/useSwipe/useSwipe.js';
+import { useLocale } from '../../hooks/useLocale/useLocale.js';
 import { last } from '../../util/helpers.js';
 import { Body } from '../Body/Body.js';
 
@@ -147,7 +148,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
       minDate,
       maxDate,
       firstDayOfWeek = 1,
-      locale = getBrowserLocale(),
+      locale: customLocale,
       prevMonthButtonLabel,
       nextMonthButtonLabel,
       modifiers,
@@ -157,6 +158,7 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
     },
     ref,
   ) => {
+    const locale = useLocale(customLocale);
     const [{ months, focusedDate, hoveredDate, today }, dispatch] = useReducer(
       calendarReducer,
       { selection, minDate, maxDate, numberOfMonths },

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -20,7 +20,8 @@ import { resolveCurrencyFormat } from '@sumup-oss/intl';
 import { NumericFormat, type NumericFormatProps } from 'react-number-format';
 
 import { clsx } from '../../styles/clsx.js';
-import { getBrowserLocale, type Locale } from '../../util/i18n.js';
+import type { Locale } from '../../util/i18n.js';
+import { useLocale } from '../../hooks/useLocale/useLocale.js';
 import { Input, type InputProps } from '../Input/index.js';
 
 import { formatPlaceholder } from './CurrencyInputService.js';
@@ -79,7 +80,7 @@ const DUMMY_DELIMITER = '?';
 export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
   (
     {
-      locale = getBrowserLocale(),
+      locale: customLocale,
       currency,
       placeholder,
       'aria-describedby': descriptionId,
@@ -87,6 +88,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
     },
     ref,
   ) => {
+    const locale = useLocale(customLocale);
     const currencySymbolId = useId();
     const descriptionIds = clsx(currencySymbolId, descriptionId);
 

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -54,10 +54,10 @@ import {
   FieldValidationHint,
   FieldWrapper,
 } from '../Field/Field.js';
-import { getBrowserLocale } from '../../util/i18n.js';
 import { toPlainDate } from '../../util/date.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { changeInputValue } from '../../util/input-value.js';
+import { useLocale } from '../../hooks/useLocale/useLocale.js';
 
 import { Dialog } from './components/Dialog.js';
 import { DateSegment } from './components/DateSegment.js';
@@ -159,7 +159,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
       defaultValue,
       min,
       max,
-      locale = getBrowserLocale(),
+      locale: customLocale,
       firstDayOfWeek,
       modifiers,
       hideLabel,
@@ -189,6 +189,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     },
     ref,
   ) => {
+    const locale = useLocale(customLocale);
     const isMobile = useMedia('(max-width: 479px)');
 
     const inputRef = useRef<HTMLInputElement>(null);

--- a/packages/circuit-ui/hooks/useLocale/useLocale.spec.ts
+++ b/packages/circuit-ui/hooks/useLocale/useLocale.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { act, renderHook } from '../../util/test-utils.js';
+
+import { useLocale } from './useLocale.js';
+
+describe('useLocale', () => {
+  const navigatorLanguages = ['de-DE', 'de'];
+
+  beforeAll(() => {
+    vi.spyOn(window.navigator, 'languages', 'get').mockReturnValue(
+      navigatorLanguages,
+    );
+  });
+
+  it('should prioritize the custom locale over the browser locale', () => {
+    const locale = 'fr-FR';
+    const { result } = renderHook(() => useLocale(locale));
+    expect(result.current).toBe(locale);
+  });
+
+  it('should return the browser locale', () => {
+    const { result } = renderHook(() => useLocale());
+    expect(result.current).toBe(navigatorLanguages);
+  });
+
+  it('should register only a single "languagechange" event listener', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+
+    renderHook(() => useLocale());
+    renderHook(() => useLocale());
+    renderHook(() => useLocale());
+
+    expect(addEventListener).toHaveBeenCalledOnce();
+    expect(addEventListener).toHaveBeenCalledWith(
+      'languagechange',
+      expect.any(Function),
+    );
+  });
+
+  it('should update the locale in response to the "languagechange" event', () => {
+    const results = [
+      renderHook(() => useLocale()),
+      renderHook(() => useLocale()),
+      renderHook(() => useLocale()),
+    ];
+
+    const updatedLocale = ['pt-BR'];
+
+    act(() => {
+      vi.spyOn(window.navigator, 'languages', 'get').mockReturnValueOnce(
+        updatedLocale,
+      );
+      window.dispatchEvent(new Event('languagechange'));
+    });
+
+    results.forEach(({ result }) => {
+      expect(result.current).toBe(updatedLocale);
+    });
+  });
+});

--- a/packages/circuit-ui/hooks/useLocale/useLocale.ts
+++ b/packages/circuit-ui/hooks/useLocale/useLocale.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from 'react';
+
+import { getDefaultLocale, type Locale } from '../../util/i18n.js';
+
+const listeners = new Set<(locale: Locale) => void>();
+
+function updateLocale() {
+  const currentLocale = getDefaultLocale();
+  // eslint-disable-next-line no-restricted-syntax
+  for (const listener of listeners) {
+    listener(currentLocale);
+  }
+}
+
+/**
+ * Returns the current browser/system language, and updates when it changes.
+ */
+export function useLocale(customLocale?: Locale): Locale {
+  const [locale, setLocale] = useState<Locale>(getDefaultLocale());
+
+  useEffect(() => {
+    if (customLocale) {
+      return undefined;
+    }
+
+    // Update the locale after hydration on the client
+    setLocale(getDefaultLocale());
+
+    // Share a single listener between hook instances to optimize performance
+    if (listeners.size === 0) {
+      window.addEventListener('languagechange', updateLocale);
+    }
+
+    listeners.add(setLocale);
+
+    return () => {
+      listeners.delete(setLocale);
+      if (listeners.size === 0) {
+        window.removeEventListener('languagechange', updateLocale);
+      }
+    };
+  }, [customLocale]);
+
+  return customLocale || locale;
+}

--- a/packages/circuit-ui/hooks/useLocale/useLocale.ts
+++ b/packages/circuit-ui/hooks/useLocale/useLocale.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/circuit-ui/util/i18n.spec.ts
+++ b/packages/circuit-ui/util/i18n.spec.ts
@@ -22,10 +22,10 @@ import {
   type MockInstance,
 } from 'vitest';
 
-import { DEFAULT_LOCALE, getBrowserLocale } from './i18n.js';
+import { FALLBACK_LOCALE, getDefaultLocale } from './i18n.js';
 
 describe('i18n', () => {
-  describe('getBrowserLocale', () => {
+  describe('getDefaultLocale', () => {
     const originalWindow = window;
     let languagesGetter: MockInstance;
     let languageGetter: MockInstance;
@@ -39,14 +39,14 @@ describe('i18n', () => {
     it('should return the default locale in server environments', () => {
       // @ts-expect-error The window object is undefined in server environments
       window = undefined;
-      const actual = getBrowserLocale();
-      expect(actual).toBe(DEFAULT_LOCALE);
+      const actual = getDefaultLocale();
+      expect(actual).toBe(FALLBACK_LOCALE);
     });
 
     it('should return the preferred locales', () => {
       const languages = ['de-DE', 'en'];
       languagesGetter.mockReturnValue(languages);
-      const actual = getBrowserLocale();
+      const actual = getDefaultLocale();
       expect(actual).toEqual(languages);
     });
 
@@ -54,15 +54,15 @@ describe('i18n', () => {
       const language = 'de-DE';
       languagesGetter.mockReturnValue(undefined);
       languageGetter.mockReturnValue(language);
-      const actual = getBrowserLocale();
+      const actual = getDefaultLocale();
       expect(actual).toEqual(language);
     });
 
     it('should fall back to the default locale', () => {
       languagesGetter.mockReturnValue(undefined);
       languageGetter.mockReturnValue(undefined);
-      const actual = getBrowserLocale();
-      expect(actual).toEqual(DEFAULT_LOCALE);
+      const actual = getDefaultLocale();
+      expect(actual).toEqual(FALLBACK_LOCALE);
     });
   });
 });

--- a/packages/circuit-ui/util/i18n.ts
+++ b/packages/circuit-ui/util/i18n.ts
@@ -15,16 +15,16 @@
 
 export type Locale = string | string[];
 
-export const DEFAULT_LOCALE = 'en-US';
+export const FALLBACK_LOCALE = 'en-US';
 
 /**
  * Returns the user's preferred locale(s) in browser-like environments.
  */
-export function getBrowserLocale(): Locale {
+export function getDefaultLocale(): Locale {
   if (typeof window === 'undefined') {
-    return DEFAULT_LOCALE;
+    return FALLBACK_LOCALE;
   }
   return (navigator.languages ||
     navigator.language ||
-    DEFAULT_LOCALE) as Locale;
+    FALLBACK_LOCALE) as Locale;
 }


### PR DESCRIPTION
## Purpose

While investigating #2786, I realized that the current usage of the browser locale can lead to hydration errors. During server side rendering, the `getBrowserLocale` function returns the default locale (`en-US`). During hydration on the client, `getBrowserLocale` returns the user's preferred locale, causing the hydration mismatch.

## Approach and changes

- Add a new `useLocale` hook that returns the default locale during server side rendering and the initial client hydration, and updates it on the next render, thus avoiding the mismatch. Additionally, it listens to the `languagechange` event. If a custom locale is passed, it is given priority.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
