### PR TITLE
Add missing export for the SkipLink component

### DIFF
--- a/.changeset/quick-brooms-guess.md
+++ b/.changeset/quick-brooms-guess.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Added missing export of the SkipLink component.

--- a/packages/circuit-ui/components/SkipLink/SkipLink.tsx
+++ b/packages/circuit-ui/components/SkipLink/SkipLink.tsx
@@ -17,6 +17,8 @@ import { Anchor, type AnchorProps } from '../Anchor/index.js';
 
 import classes from './SkipLink.module.css';
 
-export const SkipLink = (props: AnchorProps) => (
+export type SkipLinkProps = AnchorProps;
+
+export const SkipLink = (props: SkipLinkProps) => (
   <Anchor className={classes['skip-link']} {...props} />
 );

--- a/packages/circuit-ui/components/SkipLink/index.ts
+++ b/packages/circuit-ui/components/SkipLink/index.ts
@@ -14,3 +14,4 @@
  */
 
 export { SkipLink } from './SkipLink.js';
+export type { SkipLinkProps } from './SkipLink.js';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -126,7 +126,8 @@ export type {
   TabPanelProps,
   TabProps,
 } from './components/Tabs/index.js';
-
+export { SkipLink } from './components/SkipLink/index.js';
+export type { SkipLinkProps } from './components/SkipLink/index.js';
 // Miscellaneous
 export { Spinner } from './components/Spinner/index.js';
 export type { SpinnerProps } from './components/Spinner/index.js';


### PR DESCRIPTION
## Purpose

SkipLink component was added to cui in https://github.com/sumup-oss/circuit-ui/pull/2780 but not exported.

## Approach and changes

Add missing export of the SkipLink component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
