### PR TITLE
Fix Select classname forwarding

### DIFF
--- a/.changeset/metal-avocados-matter.md
+++ b/.changeset/metal-avocados-matter.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed passing a custom `className` to the outermost element of the Select component.

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
@@ -21,7 +21,8 @@
     transform: translateY(-1px);
   }
 
-  .country-code.country-code {
+  .country-code.country-code select,
+  .country-code-input.country-code-input {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
@@ -38,7 +39,8 @@
     transform: translateX(-1px);
   }
 
-  .country-code.country-code {
+  .country-code.country-code select,
+  .country-code-input.country-code-input {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
@@ -46,8 +48,6 @@
   .country-code-input.country-code-input {
     /* Prefix padding + country code (max 4 chars) + padding */
     max-width: calc(var(--cui-spacings-exa) + 4ch + var(--cui-spacings-mega));
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
   }
 
   .subscriber-number.subscriber-number {

--- a/packages/circuit-ui/components/Select/Select.spec.tsx
+++ b/packages/circuit-ui/components/Select/Select.spec.tsx
@@ -39,8 +39,8 @@ describe('Select', () => {
     const { container } = render(
       <Select {...defaultProps} className={className} />,
     );
-    const select = container.querySelector('select');
-    expect(select?.className).toContain(className);
+    const wrapper = container.querySelector('div');
+    expect(wrapper?.className).toContain(className);
   });
 
   it('should forward a ref', () => {
@@ -106,7 +106,7 @@ describe('Select', () => {
         {...defaultProps}
         placeholder={placeholder}
         value={value}
-        onChange={vi.fn}
+        onChange={vi.fn()}
       />,
     );
     const selectEl = screen.getByRole('combobox');

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -173,11 +173,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             required={required}
             disabled={disabled}
             defaultValue={defaultValue}
-            className={clsx(
-              classes.base,
-              hasPrefix && classes['has-prefix'],
-              className,
-            )}
+            className={clsx(classes.base, hasPrefix && classes['has-prefix'])}
             {...props}
           >
             {!value && !defaultValue && (


### PR DESCRIPTION
## Purpose

I noticed that the Select component forwards its `className` to its wrapper _and_ the `select` element. By convention, the class name should only be passed to the outermost element to allow developers to add outer spacing. The `select` element can be targeted using its tag selector.

## Approach and changes

- Only forward the `className` prop to the `select` element

> [!WARNING]  
> This is a potentially breaking change. However, the status quo of passing the class name to _both_ the outermost and `select` elements doesn't allow reliable styling of either. That's why I believe fixing it is worth the risk.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
