### PR TITLE
Modal Component

### DIFF
--- a/.changeset/cyan-knives-drop.md
+++ b/.changeset/cyan-knives-drop.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Set an explicit minimum version for TypeScript of 4.1 or higher. While this is technically a breaking change, v4.1 was released over 4 years ago, so we don't expect this to break anyone's code. Please let us know if this causes you issues.

--- a/.changeset/eight-beers-think.md
+++ b/.changeset/eight-beers-think.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Refactored the NotificationModal component to use the new Modal component under the hood.

--- a/.changeset/gold-lemons-report.md
+++ b/.changeset/gold-lemons-report.md
@@ -1,5 +1,5 @@
 ---
-"@sumup-oss/design-tokens": patch
+"@sumup-oss/design-tokens": minor
 ---
 
 Added "::backdrop" to the list of selectors to apply theme custom properties to. See https://developer.chrome.com/blog/css-backdrop-inheritance.

--- a/.changeset/gold-lemons-report.md
+++ b/.changeset/gold-lemons-report.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/design-tokens": patch
+---
+
+Added "::backdrop" to the list of selectors to apply theme custom properties to. See https://developer.chrome.com/blog/css-backdrop-inheritance.

--- a/.changeset/grumpy-wombats-talk.md
+++ b/.changeset/grumpy-wombats-talk.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added a new hook `useScrollLock` to disable page scroll on demand.

--- a/.changeset/rich-icons-pretend.md
+++ b/.changeset/rich-icons-pretend.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Deprecated the `hideCloseButton` prop in the Modal and NotificationModal components. It had no effect.

--- a/.changeset/sharp-seals-leave.md
+++ b/.changeset/sharp-seals-leave.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added default translations for the Modal and NotificationModal components. The `closeButtonLabel` prop is now optional.

--- a/.changeset/wicked-pants-cough.md
+++ b/.changeset/wicked-pants-cough.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Refactored the Modal component to use the native `dialog` element. The Modal component can now be rendered directly in your JSX (the older `useModal` hook continues to be supported).

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -1,18 +1,17 @@
 name: Continuous Releases
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    types:
+      - labeled
 
 jobs:
   build:
-    if: ${{ github.event.comment.body == '/preview' && github.event.issue.pull_request }}
+    if: ${{ github.event.label.name == 'preview' }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.issue.number }}/head #based on https://github.com/stackblitz-labs/pkg.pr.new/issues/187
 
       - name: Setup Node.js v20
         uses: actions/setup-node@v4

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head #based on https://github.com/stackblitz-labs/pkg.pr.new/issues/187
 
       - name: Setup Node.js v20
         uses: actions/setup-node@v4

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -26,4 +26,78 @@ jobs:
         run: npm run build
 
       - name: Publish packages
-        run: npx pkg-pr-new publish './packages/circuit-ui'  './packages/design-tokens'  './packages/icons'
+        run: npx pkg-pr-new publish './packages/circuit-ui'  './packages/design-tokens'  './packages/icons' --json output.json --comment=off
+
+      - name: Post or update comment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const output = JSON.parse(fs.readFileSync('output.json', 'utf8'));
+            console.log(output);
+      
+            const packages = output.packages
+              .map((p) => `- ${p.name}: ${p.url}`)
+              .join('\n');
+      
+            const sha = context.payload.pull_request.head.sha
+            
+            const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${sha}`;
+      
+            const body = `## 🚀 Your packages were published 
+      
+            ### Published Packages:
+      
+            ${packages}
+      
+            [View Commit](${commitUrl})`;
+      
+            const botCommentIdentifier = '## 🚀 Your packages were published ';
+      
+            async function findBotComment(issueNumber) {
+              if (!issueNumber) return null;
+              const comments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              return comments.data.find((comment) =>
+                comment.body.includes(botCommentIdentifier)
+              );
+            }
+      
+            async function createOrUpdateComment(issueNumber) {
+              if (!issueNumber) {
+                console.log('No issue number provided. Cannot post or update comment.');
+                return;
+              }
+      
+              const existingComment = await findBotComment(issueNumber);
+              if (existingComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existingComment.id,
+                  body: body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: issueNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body,
+                });
+              }
+            }
+            if (context.issue.number) {
+              await createOrUpdateComment(context.issue.number);
+            }
+
+      - name: Delete label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER:
+            ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit $PR_NUMBER --remove-label "preview"

--- a/package-lock.json
+++ b/package-lock.json
@@ -41942,7 +41942,8 @@
 				"vite": "^5.4.11"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=20",
+				"typescript": ">=4.1"
 			},
 			"peerDependencies": {
 				"@emotion/is-prop-valid": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"test:ci": "vitest run --coverage",
 		"lint": "biome check --diagnostic-level=error && foundry run eslint . --ext .js,.jsx,.ts,.tsx",
 		"lint:fix": "biome check --write --diagnostic-level=error && foundry run eslint . --ext .js,.jsx,.ts,.tsx --fix",
-		"lint:ci": "biome ci && foundry run eslint . --ext .js,.jsx,.ts,.tsx --quiet ",
+		"lint:ci": "biome ci --diagnostic-level=error && foundry run eslint . --ext .js,.jsx,.ts,.tsx --quiet ",
 		"lint:css": "foundry run stylelint '**/*.css'",
 		"lint:css:fix": "foundry run stylelint '**/*.css' --fix",
 		"dev": "npm run docs:start",

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -224,6 +224,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const { floatingStyles, update } = useFloating({
       open,
       placement,
+      strategy: 'fixed',
       middleware: [
         offset(4),
         flip({ padding, fallbackAxisSideDirection: 'start' }),

--- a/packages/circuit-ui/components/Modal/Modal.mdx
+++ b/packages/circuit-ui/components/Modal/Modal.mdx
@@ -7,7 +7,7 @@ import * as Stories from './Modal.stories';
 
 <Status variant="stable" />
 
-The dialog component displays self-contained tasks in a modal view, requiring the user to interact with it before returning to the underlying content.
+The modal component displays self-contained tasks in an overlay view, requiring the user to interact with it before returning to the underlying content.
 
 <Story of={Stories.Base} />
 <Props />
@@ -18,46 +18,54 @@ Generally, use the modal dialog component sparingly. Consider displaying more co
 
 A modal dialog is a disruptive pattern that interrupts the user's current task. It should only be used when the task requires immediate attention or when the user needs to make a decision before continuing:
 
-- Confirming a critical action, such as deleting an item or abandoning a task (also see the  [NotificationModal](Notification/NotificationModal/Docs) component).
-- Forms or Inputs: To collect short amounts of input without navigating away from the current page (e.g., login, feedback forms).
-- Focused Actions: For focused tasks like editing an item, uploading files, or reviewing details.
-
+- Confirming a critical action, such as deleting an item or abandoning a task (also see the [NotificationModal](Notification/NotificationModal/Docs) component).
+- Forms or inputs to collect small amounts of data without navigating away from the current page (e.g., login, feedback forms).
+- Focused tasks like editing an item, uploading files, or reviewing details.
 
 ## How to use it
 
-### inline (recommended)
+### Inline (recommended)
+
 Place your dialog content directly in the `Modal` component:
 
 ```tsx
 import { Modal, Body, Button, Heading } from '@sumup-oss/circuit-ui';
-import {useState} from 'react';
+import { useState } from 'react';
 
-const [open, setOpen] = useState(false);
+function Component() {
+  const [open, setOpen] = useState(false);
 
-return (
+  return (
     <>
       <Button onClick={() => setOpen(true)}>Open dialog</Button>
-      <Modal open={open} closeButtonLabel="Close" aria-labelledby="dialog-title" onClose={() => setOpen(false)}>
+      <Modal
+        open={open}
+        aria-labelledby="dialog-title"
+        onClose={() => setOpen(false)}
+      >
         {() => (
-            <>
-            <Heading as="h2" id="dialog-title">Modal title</Heading>
+          <>
+            <Heading as="h2" id="dialog-title">
+              Modal title
+            </Heading>
             <Body>Modal content</Body>
             <Button>Close dialog</Button>
-        </>
+          </>
         )}
       </Modal>
     </>
-);
-
+  );
+}
 ```
-### with the `useModal` hook
+
+### With the `useModal` hook
+
 First, wrap your application in the `ModalProvider`:
 
 ```tsx
-// _app.tsx for Next.js or App.js for CRA
 import { ModalProvider } from '@sumup-oss/circuit-ui';
 
-export default function App() {
+export function App() {
   return <ModalProvider>{/* Your content here... */}</ModalProvider>;
 }
 ```
@@ -72,14 +80,17 @@ export function SayHello({ name }) {
 
   const handleClick = () => {
     setModal({
-      children: <>
-        <Heading as="h2" id="dialog-title">Modal title</Heading>
-        <Body>Modal content</Body>
-        <Button>Close dialog</Button>
-        </>,
-      'aria-labelledby': "dialog-title",
+      children: (
+        <>
+          <Heading as="h2" id="dialog-title">
+            Modal title
+          </Heading>
+          <Body>Modal content</Body>
+          <Button>Close dialog</Button>
+        </>
+      ),
+      'aria-labelledby': 'dialog-title',
       variant: 'immersive',
-      closeButtonLabel: 'Close dialog',
     });
   };
 
@@ -88,17 +99,17 @@ export function SayHello({ name }) {
 ```
 
 ## Immersive
+
 Use the `immersive` variant to focus the user's attention on the dialog content. On small viewports, the dialog component opens up from the bottom as a fullscreen overlay on top of the page content and covers it entirely in favor of an immersive experience.
 
 <Story of={Stories.Immersive} />
-
 
 ## Related components
 
 For cases displaying simple text content but requiring immediate or critical action(s) from the user, consider using the [NotificationModal](Notification/NotificationModal/Docs) component.
 
-
 ## Accessibility
+
 This component is built using the native `dialog` HTML element and follows the [WAI-ARIA Modal Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/). It is fully accessible and supports keyboard navigation and screen readers. In browsers where `dialog` is not supported, it uses [dialog-polyfill](https://github.com/GoogleChrome/dialog-polyfill).
 
 It is important to ensure that the dialog is appropriately labeled and that the user can easily navigate and interact with it using a keyboard or screen reader.
@@ -107,5 +118,3 @@ If your dialog content has a title, make sure to provide an `aria-labelledby` at
 If your dialog displays a complex flow with multiple screens (for example: a complex form with multiple steps), make sure to programmatically set focus to the title upon landing on every step to convey to the user their evolution within your flow.
 
 If your content contains interactive elements, the component will focus the first interactive element when the dialog opens by default. However, if you wish to focus a different element, you can provide the `initialFocusRef` prop with the ref of the element you want to focus. It is generally recommended to focus the least destructive element, such as a close or a cancel button. If the element you want to focus is not interactive, don't forget to give it a tabindex with a negative value to enable its focus.
-
-

--- a/packages/circuit-ui/components/Modal/Modal.mdx
+++ b/packages/circuit-ui/components/Modal/Modal.mdx
@@ -5,32 +5,53 @@ import * as Stories from './Modal.stories';
 
 # Modal
 
-<Status variant="under-review" />
+<Status variant="stable" />
 
-The modal component displays self-contained tasks in a focused window that overlays the page content.
+The dialog component displays self-contained tasks in a modal view, requiring the user to interact with it before returning to the underlying content.
 
 <Story of={Stories.Base} />
 <Props />
 
 ## When to use it
 
-Generally, use the modal component sparingly. Consider displaying more complex tasks and large amounts of information on a separate page instead.
+Generally, use the modal dialog component sparingly. Consider displaying more complex tasks and large amounts of information on a separate page instead.
 
-## Variants
+A modal dialog is a disruptive pattern that interrupts the user's current task. It should only be used when the task requires immediate attention or when the user needs to make a decision before continuing:
 
-<Story of={Stories.Variants} />
+- Confirming a critical action, such as deleting an item or abandoning a task (also see the  [NotificationModal](Notification/NotificationModal/Docs) component).
+- Forms or Inputs: To collect short amounts of input without navigating away from the current page (e.g., login, feedback forms).
+- Focused Actions: For focused tasks like editing an item, uploading files, or reviewing details.
 
-### Contextual
 
-Use this variant when the modal content requires the context of the page underneath to be understood. On small viewports, the modal component opens up from the bottom as a bottom sheet overlay on top of the page content, dimming the uncovered area while giving a visual context of the page underneath. The height of the bottom sheet can be manually adjusted depending on the use case and the amount of content needed to be displayed.
+## How to use it
 
-### Immersive
+### inline (recommended)
+Place your dialog content directly in the `Modal` component:
 
-Use this variant to focus the user's attention on the modal content. On small viewports, the modal component opens up from the bottom as a fullscreen overlay on top of the page content and covers it entirely in favor of an immersive experience.
+```tsx
+import { Modal, Body, Button, Heading } from '@sumup-oss/circuit-ui';
+import {useState} from 'react';
 
-## Usage in code
+const [open, setOpen] = useState(false);
 
-First, wrap your application in the `ModalProvider` which keeps track of the open modals, prevents scrolling of the page when a modal is open, and ensures the accessibility of the modal.
+return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <Modal open={open} closeButtonLabel="Close" aria-labelledby="dialog-title" onClose={() => setOpen(false)}>
+        {() => (
+            <>
+            <Heading as="h2" id="dialog-title">Modal title</Heading>
+            <Body>Modal content</Body>
+            <Button>Close dialog</Button>
+        </>
+        )}
+      </Modal>
+    </>
+);
+
+```
+### with the `useModal` hook
+First, wrap your application in the `ModalProvider`:
 
 ```tsx
 // _app.tsx for Next.js or App.js for CRA
@@ -41,22 +62,50 @@ export default function App() {
 }
 ```
 
-Then, use the `useModal` hook to open a modal from a component:
+Then, use the `useModal` hook to open a dialog from a component:
 
 ```tsx
-import { useModal, Button, Body } from '@sumup-oss/circuit-ui';
+import { useModal, Heading, Button, Body } from '@sumup-oss/circuit-ui';
 
 export function SayHello({ name }) {
   const { setModal } = useModal();
 
   const handleClick = () => {
     setModal({
-      children: <Body>Hello {name}</Body>,
+      children: <>
+        <Heading as="h2" id="dialog-title">Modal title</Heading>
+        <Body>Modal content</Body>
+        <Button>Close dialog</Button>
+        </>,
+      'aria-labelledby': "dialog-title",
       variant: 'immersive',
-      closeButtonLabel: 'Close modal',
+      closeButtonLabel: 'Close dialog',
     });
   };
 
   return <Button onClick={handleClick}>Say hello</Button>;
 }
 ```
+
+## Immersive
+Use the `immersive` variant to focus the user's attention on the dialog content. On small viewports, the dialog component opens up from the bottom as a fullscreen overlay on top of the page content and covers it entirely in favor of an immersive experience.
+
+<Story of={Stories.Immersive} />
+
+
+## Related components
+
+For cases displaying simple text content but requiring immediate or critical action(s) from the user, consider using the [NotificationModal](Notification/NotificationModal/Docs) component.
+
+
+## Accessibility
+This component is built using the native `dialog` HTML element and follows the [WAI-ARIA Modal Authoring Practices](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/). It is fully accessible and supports keyboard navigation and screen readers. In browsers where `dialog` is not supported, it uses [dialog-polyfill](https://github.com/GoogleChrome/dialog-polyfill).
+
+It is important to ensure that the dialog is appropriately labeled and that the user can easily navigate and interact with it using a keyboard or screen reader.
+If your dialog content has a title, make sure to provide an `aria-labelledby` attribute with the ID of the title element to the `Modal` component. Otherwise, provide an `aria-label` attribute with a descriptive label.
+
+If your dialog displays a complex flow with multiple screens (for example: a complex form with multiple steps), make sure to programmatically set focus to the title upon landing on every step to convey to the user their evolution within your flow.
+
+If your content contains interactive elements, the component will focus the first interactive element when the dialog opens by default. However, if you wish to focus a different element, you can provide the `initialFocusRef` prop with the ref of the element you want to focus. It is generally recommended to focus the least destructive element, such as a close or a cancel button. If the element you want to focus is not interactive, don't forget to give it a tabindex with a negative value to enable its focus.
+
+

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -8,6 +8,7 @@
   background-color: var(--cui-bg-elevated);
   border: none;
   outline: none;
+  box-shadow: 0 0 0 100vmax var(--cui-bg-overlay);
   animation: fade-out 0.3s forwards;
 }
 
@@ -20,12 +21,14 @@
   position: relative;
 }
 
-.base::after {
+.scrollable {
   position: sticky;
   right: 0;
   bottom: 0;
   left: 0;
   display: block;
+  height: var(--cui-spacings-giga);
+  pointer-events: none;
   content: "";
   background: linear-gradient(
     color-mix(in sRGB, var(--cui-bg-elevated) 0%, transparent),
@@ -43,15 +46,9 @@
     border-radius: var(--cui-border-radius-mega);
   }
 
-  .base::after {
-    height: var(--cui-spacings-giga);
-  }
-
   .base .content {
-    padding: var(--cui-spacings-giga);
-    padding-bottom: calc(
-      env(safe-area-inset-bottom) + var(--cui-spacings-giga)
-    );
+    padding: var(--cui-spacings-giga) var(--cui-spacings-giga) 0;
+    padding-bottom: env(safe-area-inset-bottom);
   }
 }
 
@@ -63,8 +60,8 @@
     left: 0;
     width: 100%;
     max-width: 100%;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-radius: var(--cui-border-radius-mega) var(--cui-border-radius-mega) 0
+      0;
     animation: slide-out 0.3s forwards;
   }
 
@@ -80,23 +77,15 @@
   }
 
   .base .content {
-    padding: var(--cui-spacings-mega);
-    padding-bottom: calc(
-      env(safe-area-inset-bottom) + var(--cui-spacings-mega)
-    );
+    padding: var(--cui-spacings-mega) var(--cui-spacings-mega) 0;
+    padding-bottom: env(safe-area-inset-bottom);
     -webkit-overflow-scrolling: touch;
   }
 }
 
 /* Native Backdrop */
 .base::backdrop {
-  background-color: var(--cui-bg-overlay);
-  animation: fade-out 0.3s forwards;
-}
-
-.base.show::backdrop {
-  pointer-events: auto;
-  animation: fade-in 0.3s forwards;
+  background: transparent;
 }
 
 /* Polyfill Backdrop */

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -27,7 +27,7 @@
 }
 
 .base::after {
-  position: sticky;
+  position: absolute;
   right: 0;
   bottom: env(safe-area-inset-bottom);
   left: 0;
@@ -81,8 +81,10 @@
   }
 
   .base .content {
-    padding: var(--cui-spacings-giga) var(--cui-spacings-giga) 0;
-    padding-bottom: env(safe-area-inset-bottom);
+    padding: var(--cui-spacings-giga);
+    padding-bottom: calc(
+      env(safe-area-inset-bottom) + var(--cui-spacings-giga)
+    );
   }
 
   .base::after {
@@ -120,8 +122,10 @@
   }
 
   .base .content {
-    padding: var(--cui-spacings-mega) var(--cui-spacings-mega) 0;
-    padding-bottom: env(safe-area-inset-bottom);
+    padding: var(--cui-spacings-mega);
+    padding-bottom: calc(
+      env(safe-area-inset-bottom) + var(--cui-spacings-mega)
+    );
     -webkit-overflow-scrolling: touch;
   }
 

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -60,11 +60,6 @@
   bottom: 0;
   left: 0;
   background: transparent;
-  animation: fade-out var(--dialog-animation-duration) forwards;
-}
-
-.backdrop.backdrop-visible {
-  animation: fade-in var(--dialog-animation-duration) forwards;
 }
 
 @media (min-width: 480px) {

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -1,11 +1,28 @@
-.base {
+.dialog {
   position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  padding: 0;
+  margin: auto;
+  overflow-y: auto;
+  pointer-events: none;
+  visibility: hidden;
   background-color: var(--cui-bg-elevated);
+  border: none;
+  border-radius: var(--cui-border-radius-mega);
   outline: none;
+  animation: fade-out 0.5s forwards;
 }
 
-.base::after {
-  position: fixed;
+.dialog.show {
+  pointer-events: auto;
+  animation: fade-in 0.5s forwards;
+}
+
+.dialog::after {
+  position: absolute;
   right: 0;
   bottom: 0;
   left: 0;
@@ -18,111 +35,75 @@
   );
 }
 
-@media (max-width: 479px) {
-  .base {
-    right: 0;
-    bottom: 0;
-    left: 0;
-    transition: transform var(--cui-transitions-default);
-    transform: translateY(100%);
-  }
-
-  .base::after {
-    height: var(--cui-spacings-mega);
-  }
-}
-
 @media (min-width: 480px) {
-  .base {
-    top: 50%;
-    left: 50%;
-    border-radius: var(--cui-border-radius-mega);
-    opacity: 0;
-    transition: opacity var(--cui-transitions-slow);
-    transform: translate(-50%, -50%);
-  }
-
-  .base::after {
+  .dialog::after {
     height: var(--cui-spacings-giga);
     border-bottom-right-radius: var(--cui-border-radius-mega);
     border-bottom-left-radius: var(--cui-border-radius-mega);
   }
 }
 
-/* Variants */
-
 @media (max-width: 479px) {
-  .contextual {
-    border-top-left-radius: var(--cui-border-radius-mega);
-    border-top-right-radius: var(--cui-border-radius-mega);
+  .dialog {
+    top: unset;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    max-width: 100%;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+    animation: slide-out 0.5s forwards;
   }
 
-  .immersive {
-    top: 0;
-  }
-}
-
-@media (max-width: 479px) {
-  .open {
-    transform: translateY(0);
-  }
-}
-
-@media (min-width: 480px) {
-  .open {
-    opacity: 1;
+  .dialog.show {
+    animation: slide-in 0.5s forwards;
   }
 }
 
-@media (max-width: 479px) {
-  .closed {
-    transform: translateY(100%);
-  }
+/* Native Backdrop */
+.dialog::backdrop {
+  background-color: var(--cui-bg-overlay);
+  animation: fade-out 0.5s forwards;
 }
 
-@media (min-width: 480px) {
-  .closed {
-    opacity: 0;
-  }
+.dialog.show::backdrop {
+  pointer-events: auto;
+  animation: fade-in 0.5s forwards;
 }
 
-/* Overlay */
-
-.overlay {
+/* Polyfill Backdrop */
+.dialog + .backdrop {
   position: fixed;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: var(--cui-z-index-modal);
-  background: var(--cui-bg-overlay);
-  opacity: 0;
-  transition: opacity var(--cui-transitions-default);
+  background-color: var(--cui-bg-overlay);
+  animation: fade-out 0.5s forwards;
 }
 
-@media (min-width: 480px) {
-  .overlay {
-    transition: opacity var(--cui-transitions-slow);
-  }
+.backdrop.backdrop-visible {
+  animation: fade-in 0.5s forwards;
 }
 
-.overlay-open {
-  opacity: 1;
-}
-
-.overlay-closed {
-  opacity: 0;
-}
-
-/* Content */
-
-.content {
-  overflow-y: auto;
+.dialog .close {
+  position: absolute;
+  top: var(--cui-spacings-byte);
+  right: var(--cui-spacings-byte);
+  z-index: var(--cui-z-index-absolute);
 }
 
 @media (max-width: 479px) {
-  .content {
-    width: 100vw;
+  .immersive {
+    height: 100%;
+    max-height: unset;
+    border: none;
+    border-radius: unset;
+  }
+}
+
+@media (max-width: 479px) {
+  .dialog .content {
     padding: var(--cui-spacings-mega);
     padding-bottom: calc(
       env(safe-area-inset-bottom) + var(--cui-spacings-mega)
@@ -132,10 +113,14 @@
 }
 
 @media (min-width: 480px) {
-  .content {
+  .dialog {
+    width: min-content;
     min-width: 480px;
     max-width: 90vw;
     max-height: 90vh;
+  }
+
+  .dialog .content {
     padding: var(--cui-spacings-giga);
     padding-bottom: calc(
       env(safe-area-inset-bottom) + var(--cui-spacings-giga)
@@ -143,32 +128,54 @@
   }
 }
 
-/* Variants */
+@keyframes fade-in {
+  from {
+    visibility: hidden;
+    opacity: 0;
+  }
 
-@media (max-width: 479px) {
-  .contextual .content {
-    max-height: calc(100vh - var(--cui-spacings-giga));
+  to {
+    visibility: visible;
+    opacity: 1;
   }
 }
 
-/* iOS viewport bug fix: https://allthingssmitty.com/2020/05/11/css-fix-for-100vh-in-mobile-webkit/ */
-@supports (max-height: -webkit-fill-available) {
-  @media (max-width: 479px) {
-    .contextual .content {
-      max-height: 80vh;
-    }
+@keyframes fade-out {
+  from {
+    visibility: visible;
+    opacity: 1;
+  }
+
+  to {
+    visibility: hidden;
+    opacity: 0;
   }
 }
 
-@media (max-width: 479px) {
-  .immersive .content {
-    height: 100%;
+@keyframes slide-in {
+  from {
+    visibility: hidden;
+    opacity: 0;
+    transform: translateY(100%);
+  }
+
+  to {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
-.base .close {
-  position: absolute;
-  top: var(--cui-spacings-byte);
-  right: var(--cui-spacings-byte);
-  z-index: var(--cui-z-index-absolute);
+@keyframes slide-out {
+  from {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  to {
+    visibility: hidden;
+    opacity: 0;
+    transform: translateY(100%);
+  }
 }

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -11,6 +11,12 @@
   background-color: var(--cui-bg-elevated);
   border: none;
   outline: none;
+
+  /* Firefox does not support animating the backdrop property.
+   As a workaround, we used the box-shadow on the dialog element as a fake backdrop,
+   which gets animated along with the dialog element itself.
+   https://stackoverflow.com/questions/75313685/animating-dialog-backdrop-in-firefox
+   */
   box-shadow: 0 0 0 100vmax var(--cui-bg-overlay);
   animation: fade-out var(--dialog-animation-duration) forwards;
 }

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -1,4 +1,6 @@
 .base {
+  --dialog-animation-duration: 0.3s;
+
   position: fixed;
   padding: 0;
   margin: auto;
@@ -9,12 +11,12 @@
   border: none;
   outline: none;
   box-shadow: 0 0 0 100vmax var(--cui-bg-overlay);
-  animation: fade-out 0.3s forwards;
+  animation: fade-out var(--dialog-animation-duration) forwards;
 }
 
 .base.show {
   pointer-events: auto;
-  animation: fade-in 0.3s forwards;
+  animation: fade-in var(--dialog-animation-duration) forwards;
 }
 
 .content {
@@ -24,10 +26,9 @@
 .scrollable {
   position: sticky;
   right: 0;
-  bottom: 0;
+  bottom: env(safe-area-inset-bottom);
   left: 0;
   display: block;
-  height: var(--cui-spacings-giga);
   pointer-events: none;
   content: "";
   background: linear-gradient(
@@ -37,50 +38,10 @@
   );
 }
 
-@media (min-width: 480px) {
-  .base {
-    width: min-content;
-    min-width: 480px;
-    max-width: 90vw;
-    max-height: 90vh;
-    border-radius: var(--cui-border-radius-mega);
-  }
-
-  .base .content {
-    padding: var(--cui-spacings-giga) var(--cui-spacings-giga) 0;
-    padding-bottom: env(safe-area-inset-bottom);
-  }
-}
-
-@media (max-width: 479px) {
-  .base {
-    top: unset;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    max-width: 100%;
-    border-radius: var(--cui-border-radius-mega) var(--cui-border-radius-mega) 0
-      0;
-    animation: slide-out 0.3s forwards;
-  }
-
-  .base.show {
-    animation: slide-in 0.3s forwards;
-  }
-
-  .immersive {
-    height: 100%;
-    max-height: unset;
-    border: none;
-    border-radius: unset;
-  }
-
-  .base .content {
-    padding: var(--cui-spacings-mega) var(--cui-spacings-mega) 0;
-    padding-bottom: env(safe-area-inset-bottom);
-    -webkit-overflow-scrolling: touch;
-  }
+/* Close button */
+.base .close {
+  position: absolute;
+  z-index: var(--cui-z-index-absolute);
 }
 
 /* Native Backdrop */
@@ -95,20 +56,80 @@
   right: 0;
   bottom: 0;
   left: 0;
-  background-color: var(--cui-bg-overlay);
-  animation: fade-out 0.3s forwards;
+  background: transparent;
+  animation: fade-out var(--dialog-animation-duration) forwards;
 }
 
 .backdrop.backdrop-visible {
-  animation: fade-in 0.3s forwards;
+  animation: fade-in var(--dialog-animation-duration) forwards;
 }
 
-/* Close button */
-.base .close {
-  position: absolute;
-  top: var(--cui-spacings-byte);
-  right: var(--cui-spacings-byte);
-  z-index: var(--cui-z-index-absolute);
+@media (min-width: 480px) {
+  .base {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: min-content;
+    min-width: 480px;
+    max-width: 90vw;
+    max-height: 90vh;
+    border-radius: var(--cui-border-radius-mega);
+  }
+
+  .base .content {
+    padding: var(--cui-spacings-giga) var(--cui-spacings-giga) 0;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  .scrollable {
+    height: var(--cui-spacings-giga);
+  }
+
+  .base .close {
+    top: var(--cui-spacings-byte);
+    right: var(--cui-spacings-byte);
+  }
+}
+
+@media (max-width: 479px) {
+  .base {
+    top: unset;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    max-width: 100%;
+    border-radius: var(--cui-border-radius-mega) var(--cui-border-radius-mega) 0
+      0;
+    animation: slide-out var(--dialog-animation-duration) forwards;
+  }
+
+  .base.show {
+    animation: slide-in var(--dialog-animation-duration) forwards;
+  }
+
+  .immersive {
+    height: 100%;
+    max-height: unset;
+    border: none;
+    border-radius: unset;
+  }
+
+  .base .content {
+    padding: var(--cui-spacings-mega) var(--cui-spacings-mega) 0;
+    padding-bottom: env(safe-area-inset-bottom);
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .scrollable {
+    height: var(--cui-spacings-mega);
+  }
+
+  .base .close {
+    top: var(--cui-spacings-bit);
+    right: var(--cui-spacings-bit);
+  }
 }
 
 /* Animations */

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -1,9 +1,5 @@
-.dialog {
+.base {
   position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
   padding: 0;
   margin: auto;
   overflow-y: auto;
@@ -11,18 +7,21 @@
   visibility: hidden;
   background-color: var(--cui-bg-elevated);
   border: none;
-  border-radius: var(--cui-border-radius-mega);
   outline: none;
   animation: fade-out 0.3s forwards;
 }
 
-.dialog.show {
+.base.show {
   pointer-events: auto;
   animation: fade-in 0.3s forwards;
 }
 
-.dialog::after {
-  position: absolute;
+.content {
+  position: relative;
+}
+
+.base::after {
+  position: sticky;
   right: 0;
   bottom: 0;
   left: 0;
@@ -36,16 +35,30 @@
 }
 
 @media (min-width: 480px) {
-  .dialog::after {
+  .base {
+    width: min-content;
+    min-width: 480px;
+    max-width: 90vw;
+    max-height: 90vh;
+    border-radius: var(--cui-border-radius-mega);
+  }
+
+  .base::after {
     height: var(--cui-spacings-giga);
-    border-bottom-right-radius: var(--cui-border-radius-mega);
-    border-bottom-left-radius: var(--cui-border-radius-mega);
+  }
+
+  .base .content {
+    padding: var(--cui-spacings-giga);
+    padding-bottom: calc(
+      env(safe-area-inset-bottom) + var(--cui-spacings-giga)
+    );
   }
 }
 
 @media (max-width: 479px) {
-  .dialog {
+  .base {
     top: unset;
+    right: 0;
     bottom: 0;
     left: 0;
     width: 100%;
@@ -55,24 +68,39 @@
     animation: slide-out 0.3s forwards;
   }
 
-  .dialog.show {
+  .base.show {
     animation: slide-in 0.3s forwards;
+  }
+
+  .immersive {
+    height: 100%;
+    max-height: unset;
+    border: none;
+    border-radius: unset;
+  }
+
+  .base .content {
+    padding: var(--cui-spacings-mega);
+    padding-bottom: calc(
+      env(safe-area-inset-bottom) + var(--cui-spacings-mega)
+    );
+    -webkit-overflow-scrolling: touch;
   }
 }
 
 /* Native Backdrop */
-.dialog::backdrop {
+.base::backdrop {
   background-color: var(--cui-bg-overlay);
   animation: fade-out 0.3s forwards;
 }
 
-.dialog.show::backdrop {
+.base.show::backdrop {
   pointer-events: auto;
   animation: fade-in 0.3s forwards;
 }
 
 /* Polyfill Backdrop */
-.dialog + .backdrop {
+.base + .backdrop {
   position: fixed;
   top: 0;
   right: 0;
@@ -86,47 +114,15 @@
   animation: fade-in 0.3s forwards;
 }
 
-.dialog .close {
+/* Close button */
+.base .close {
   position: absolute;
   top: var(--cui-spacings-byte);
   right: var(--cui-spacings-byte);
   z-index: var(--cui-z-index-absolute);
 }
 
-@media (max-width: 479px) {
-  .immersive {
-    height: 100%;
-    max-height: unset;
-    border: none;
-    border-radius: unset;
-  }
-}
-
-@media (max-width: 479px) {
-  .dialog .content {
-    padding: var(--cui-spacings-mega);
-    padding-bottom: calc(
-      env(safe-area-inset-bottom) + var(--cui-spacings-mega)
-    );
-    -webkit-overflow-scrolling: touch;
-  }
-}
-
-@media (min-width: 480px) {
-  .dialog {
-    width: min-content;
-    min-width: 480px;
-    max-width: 90vw;
-    max-height: 90vh;
-  }
-
-  .dialog .content {
-    padding: var(--cui-spacings-giga);
-    padding-bottom: calc(
-      env(safe-area-inset-bottom) + var(--cui-spacings-giga)
-    );
-  }
-}
+/* Animations */
 
 @keyframes fade-in {
   from {

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -2,6 +2,7 @@
   --dialog-animation-duration: 0.3s;
 
   position: fixed;
+  max-height: 90vh;
   padding: 0;
   margin: auto;
   overflow-y: auto;
@@ -21,9 +22,11 @@
 
 .content {
   position: relative;
+  max-height: 90vh;
+  overflow-y: scroll;
 }
 
-.scrollable {
+.base::after {
   position: sticky;
   right: 0;
   bottom: env(safe-area-inset-bottom);
@@ -82,7 +85,7 @@
     padding-bottom: env(safe-area-inset-bottom);
   }
 
-  .scrollable {
+  .base::after {
     height: var(--cui-spacings-giga);
   }
 
@@ -122,7 +125,7 @@
     -webkit-overflow-scrolling: touch;
   }
 
-  .scrollable {
+  .base::after {
     height: var(--cui-spacings-mega);
   }
 

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -13,12 +13,12 @@
   border: none;
   border-radius: var(--cui-border-radius-mega);
   outline: none;
-  animation: fade-out 0.5s forwards;
+  animation: fade-out 0.3s forwards;
 }
 
 .dialog.show {
   pointer-events: auto;
-  animation: fade-in 0.5s forwards;
+  animation: fade-in 0.3s forwards;
 }
 
 .dialog::after {
@@ -52,23 +52,23 @@
     max-width: 100%;
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
-    animation: slide-out 0.5s forwards;
+    animation: slide-out 0.3s forwards;
   }
 
   .dialog.show {
-    animation: slide-in 0.5s forwards;
+    animation: slide-in 0.3s forwards;
   }
 }
 
 /* Native Backdrop */
 .dialog::backdrop {
   background-color: var(--cui-bg-overlay);
-  animation: fade-out 0.5s forwards;
+  animation: fade-out 0.3s forwards;
 }
 
 .dialog.show::backdrop {
   pointer-events: auto;
-  animation: fade-in 0.5s forwards;
+  animation: fade-in 0.3s forwards;
 }
 
 /* Polyfill Backdrop */
@@ -79,11 +79,11 @@
   bottom: 0;
   left: 0;
   background-color: var(--cui-bg-overlay);
-  animation: fade-out 0.5s forwards;
+  animation: fade-out 0.3s forwards;
 }
 
 .backdrop.backdrop-visible {
-  animation: fade-in 0.5s forwards;
+  animation: fade-in 0.3s forwards;
 }
 
 .dialog .close {

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -74,9 +74,8 @@
     right: 0;
     bottom: 0;
     left: 0;
-    width: min-content;
     min-width: 480px;
-    max-width: 90vw;
+    max-width: 50vw;
     max-height: 90vh;
     border-radius: var(--cui-border-radius-mega);
   }

--- a/packages/circuit-ui/components/Modal/Modal.spec.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.spec.tsx
@@ -67,55 +67,64 @@ describe('Modal', () => {
 
   it('should forward a ref', () => {
     const ref = createRef<HTMLDialogElement>();
-    const { container } = render(<Modal {...props} ref={ref} />);
+    render(<Modal {...props} ref={ref} />);
     // eslint-disable-next-line testing-library/no-container
-    const dialog = container.querySelector('dialog');
+    const dialog = screen.getByRole('dialog', { hidden: true });
     expect(ref.current).toBe(dialog);
   });
 
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
-    const { container } = render(<Modal {...props} className={className} />);
+    render(<Modal {...props} className={className} />);
     // eslint-disable-next-line testing-library/no-container
-    const dialog = container.querySelector('dialog');
+    const dialog = screen.getByRole('dialog', { hidden: true });
     expect(dialog?.className).toContain(className);
   });
 
   it('should render in closed state by default', () => {
-    const { container } = render(<Modal {...props} />);
+    render(<Modal {...props} />);
     // eslint-disable-next-line testing-library/no-container
-    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const dialog = screen.getByRole('dialog', { hidden: true });
     expect(dialog).not.toBeVisible();
   });
 
   it('should open the dialog when the open prop becomes truthy', () => {
-    const { container, rerender } = render(<Modal {...props} />);
+    const { rerender } = render(<Modal {...props} />);
     // eslint-disable-next-line testing-library/no-container
-    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const dialog = screen.getByRole('dialog', {
+      hidden: true,
+    });
     vi.spyOn(dialog, 'showModal');
     rerender(<Modal {...props} open />);
     expect(dialog.showModal).toHaveBeenCalledOnce();
+    expect(dialog).toBeVisible();
   });
 
   it('should close the dialog when the open prop becomes falsy', () => {
-    const { container, rerender } = render(<Modal {...props} open />);
+    const { rerender } = render(<Modal {...props} open />);
     // eslint-disable-next-line testing-library/no-container
-    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const dialog = screen.getByRole('dialog', {
+      hidden: true,
+    });
     vi.spyOn(dialog, 'close');
     rerender(<Modal {...props} />);
     act(() => {
       vi.advanceTimersByTime(ANIMATION_DURATION);
     });
     expect(dialog.close).toHaveBeenCalledOnce();
+    expect(dialog).not.toBeVisible();
   });
 
   it('should close the dialog when the component is unmounted', async () => {
-    const { container, unmount } = render(<Modal {...props} open />);
+    const { unmount } = render(<Modal {...props} open />);
     // eslint-disable-next-line testing-library/no-container
-    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const dialog = screen.getByRole('dialog', {
+      hidden: true,
+    });
     vi.spyOn(dialog, 'close');
     unmount();
     expect(dialog.close).toHaveBeenCalledOnce();
+    expect(dialog).not.toBeVisible();
   });
 
   describe('when the dialog is closed', () => {
@@ -142,46 +151,43 @@ describe('Modal', () => {
     });
 
     it('should not close modal on backdrop click if preventClose is true', async () => {
-      const { container } = render(<Modal {...props} open preventClose />);
+      render(<Modal {...props} open preventClose />);
       // eslint-disable-next-line testing-library/no-container
-      const dialog = container.querySelector('dialog') as HTMLDialogElement;
+      const dialog = screen.getByRole('dialog', { hidden: true });
       await userEvent.click(dialog);
       act(() => {
         vi.advanceTimersByTime(ANIMATION_DURATION);
       });
       expect(props.onClose).not.toHaveBeenCalled();
-    });
-
-    it('should open in immersive mode', async () => {
-      const { container } = render(
-        <Modal {...props} open variant="immersive" />,
-      );
-      // eslint-disable-next-line testing-library/no-container
-      const dialog = container.querySelector('dialog') as HTMLDialogElement;
-      expect(dialog.className).toContain('immersive');
+      expect(dialog).toBeVisible();
     });
 
     it('should close the dialog when pressing the backdrop', async () => {
       render(<Modal {...props} open />);
+      const dialog = screen.getByRole('dialog', { hidden: true });
       await userEvent.click(screen.getByRole('dialog', { hidden: true }));
       act(() => {
         vi.advanceTimersByTime(ANIMATION_DURATION);
       });
       expect(props.onClose).toHaveBeenCalledOnce();
+      expect(dialog).not.toBeVisible();
     });
 
     it('should close the dialog when the close button is clicked', async () => {
       render(<Modal {...props} open />);
+      const dialog = screen.getByRole('dialog', { hidden: true });
       await userEvent.click(screen.getByRole('button', { name: 'Close' }));
       act(() => {
         vi.advanceTimersByTime(ANIMATION_DURATION);
       });
       expect(props.onClose).toHaveBeenCalledOnce();
+      expect(dialog).not.toBeVisible();
     });
 
     it('should remove animation classes when closed when polyfill is used', async () => {
       (hasNativeDialogSupport as Mock).mockReturnValue(false);
       render(<Modal {...props} open />);
+      const dialog = screen.getByRole('dialog', { hidden: true });
 
       const backdrop = document.getElementsByClassName('backdrop')[0];
       expect(backdrop.classList.toString()).toContain('backdrop-visible');
@@ -192,6 +198,7 @@ describe('Modal', () => {
       });
 
       expect(props.onClose).toHaveBeenCalledOnce();
+      expect(dialog).not.toBeVisible();
     });
   });
 

--- a/packages/circuit-ui/components/Modal/Modal.spec.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.spec.tsx
@@ -56,7 +56,6 @@ describe('Modal', () => {
   it('should forward a ref', () => {
     const ref = createRef<HTMLDialogElement>();
     render(<Modal {...props} ref={ref} />);
-    // eslint-disable-next-line testing-library/no-container
     const dialog = screen.getByRole('dialog', { hidden: true });
     expect(ref.current).toBe(dialog);
   });

--- a/packages/circuit-ui/components/Modal/Modal.spec.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.spec.tsx
@@ -32,21 +32,20 @@ describe('Modal', () => {
     onClose: vi.fn(),
     open: false,
     closeButtonLabel: 'Close',
-    children: vi.fn(() => (
-      <div data-testid="children">Modal dialog content</div>
-    )),
+    children: 'Modal dialog content',
   };
   let originalHTMLDialogElement: typeof window.HTMLDialogElement;
 
   beforeEach(() => {
     originalHTMLDialogElement = window.HTMLDialogElement;
+    vi.clearAllMocks();
     vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
   afterEach(() => {
     vi.runOnlyPendingTimers();
     vi.useRealTimers();
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     Object.defineProperty(window, 'HTMLDialogElement', {
       writable: true,
       value: originalHTMLDialogElement,
@@ -132,9 +131,10 @@ describe('Modal', () => {
   describe('when the dialog is open', () => {
     it('should render its children', () => {
       render(<Modal {...props} open />);
-      const children = screen.getByText('Modal dialog content');
-      expect(props.children).toHaveBeenCalledOnce();
-      expect(children).toBeVisible();
+      act(() => {
+        vi.advanceTimersByTime(ANIMATION_DURATION);
+      });
+      expect(screen.getByText('Modal dialog content')).toBeVisible();
     });
 
     it('should not close modal on backdrop click if preventClose is true', async () => {

--- a/packages/circuit-ui/components/Modal/Modal.spec.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.spec.tsx
@@ -13,15 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  beforeEach,
-  afterEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type Mock,
-} from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { createRef } from 'react';
 
 import {
@@ -34,15 +26,6 @@ import {
 } from '../../util/test-utils.js';
 
 import { ANIMATION_DURATION, Modal } from './Modal.js';
-import { hasNativeDialogSupport } from './ModalService.js';
-
-vi.mock('./ModalService.js', async (importOriginal) => {
-  const module = await importOriginal<typeof import('./ModalService.js')>();
-  return {
-    ...module,
-    hasNativeDialogSupport: vi.fn().mockReturnValue(true),
-  };
-});
 
 describe('Modal', () => {
   const props = {
@@ -53,16 +36,21 @@ describe('Modal', () => {
       <div data-testid="children">Modal dialog content</div>
     )),
   };
+  let originalHTMLDialogElement: typeof window.HTMLDialogElement;
 
   beforeEach(() => {
+    originalHTMLDialogElement = window.HTMLDialogElement;
     vi.useFakeTimers({ shouldAdvanceTime: true });
-    (hasNativeDialogSupport as Mock).mockReturnValue(true);
   });
 
   afterEach(() => {
     vi.runOnlyPendingTimers();
     vi.useRealTimers();
     vi.clearAllMocks();
+    Object.defineProperty(window, 'HTMLDialogElement', {
+      writable: true,
+      value: originalHTMLDialogElement,
+    });
   });
 
   it('should forward a ref', () => {
@@ -185,7 +173,11 @@ describe('Modal', () => {
     });
 
     it('should remove animation classes when closed when polyfill is used', async () => {
-      (hasNativeDialogSupport as Mock).mockReturnValue(false);
+      Object.defineProperty(window, 'HTMLDialogElement', {
+        writable: true,
+        value: undefined,
+      });
+
       render(<Modal {...props} open />);
       const dialog = screen.getByRole('dialog', { hidden: true });
 

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -32,6 +32,7 @@ export default {
   component: Modal,
   tags: ['status:stable'],
   parameters: {
+    layout: 'padded',
     chromatic: {
       modes: {
         mobile: modes.smallMobile,

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -31,14 +31,15 @@ export default {
   title: 'Components/Modal',
   component: Modal,
   tags: ['status:stable'],
+  chromatic: {
+    modes: {
+      mobile: modes.smallMobile,
+      desktop: modes.desktop,
+    },
+    pauseAnimationAtEnd: true,
+  },
   parameters: {
     layout: 'padded',
-    chromatic: {
-      modes: {
-        mobile: modes.smallMobile,
-        desktop: modes.desktop,
-      },
-    },
   },
   decorators: [
     (Story) => (
@@ -167,11 +168,9 @@ export const Immersive = () => {
     </>
   );
 };
-Immersive.parameters = {
-  chromatic: {
-    modes: {
-      mobile: modes.smallMobile,
-    },
+Immersive.chromatic = {
+  modes: {
+    mobile: modes.smallMobile,
   },
 };
 Immersive.play = openModal;

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024, SumUp Ltd.
+ * Copyright 2019, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/circuit-ui/components/Modal/Modal.stories.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.stories.tsx
@@ -23,15 +23,15 @@ import { Body } from '../Body/index.js';
 import { Button } from '../Button/index.js';
 import { FullViewport } from '../../../../.storybook/components/index.js';
 
-import { Modal, type ModalProps, useModal } from './Modal.js';
 import { ModalProvider } from './ModalContext.js';
+
+import { Modal, type ModalProps, useModal } from './index.js';
 
 export default {
   title: 'Components/Modal',
   component: Modal,
   tags: ['status:stable'],
   parameters: {
-    layout: 'padded',
     chromatic: {
       modes: {
         mobile: modes.smallMobile,

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -40,6 +40,7 @@ import { createUseModal } from './createUseModal.js';
 import {
   getFirstFocusableElement,
   hasNativeDialogSupport,
+  useScrollLock,
 } from './ModalService.js';
 import { translations } from './translations/index.js';
 
@@ -124,6 +125,8 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
 
   const hasNativeDialog = hasNativeDialogSupport();
 
+  useScrollLock(open);
+
   // set initial focus on the modal dialog content
   useEffect(() => {
     const dialogElement = dialogRef.current;
@@ -142,19 +145,6 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
     };
   }, [open, initialFocusRef?.current]);
 
-  useEffect(() => {
-    function setScrollProperty() {
-      document.documentElement.style.setProperty(
-        '--scroll-y',
-        `${window.scrollY}px`,
-      );
-    }
-    window.addEventListener('scroll', setScrollProperty);
-    return () => {
-      window.removeEventListener('scroll', setScrollProperty);
-    };
-  }, []);
-
   const handleDialogClose = useCallback(() => {
     const dialogElement = dialogRef.current;
     if (!dialogElement) {
@@ -167,15 +157,6 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
         ANIMATION_DURATION,
       );
     }
-    // restore scroll to page
-    const { body } = document;
-    const scrollY = body.style.top;
-    body.style.position = '';
-    body.style.top = '';
-    body.style.left = '';
-    body.style.right = '';
-    window.scrollTo(0, Number.parseInt(scrollY || '0', 10) * -1);
-
     // trigger closing animation
     dialogElement.classList.remove(classes.show);
     if (!hasNativeDialog) {
@@ -270,14 +251,6 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
 
         // trigger show animation
         dialogElement.classList.add(classes.show);
-        // disable scroll on page
-        const scrollY =
-          document.documentElement.style.getPropertyValue('--scroll-y');
-        const { body } = document;
-        body.style.position = 'fixed';
-        body.style.left = '0';
-        body.style.right = '0';
-        body.style.top = `-${scrollY}`;
       }
     } else if (dialogElement.open) {
       handleDialogClose();

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -36,7 +36,6 @@ import { deprecate } from '../../util/logger.js';
 import type { Locale } from '../../util/i18n.js';
 
 import classes from './Modal.module.css';
-import { createUseModal } from './createUseModal.js';
 import {
   getFirstFocusableElement,
   hasNativeDialogSupport,
@@ -126,6 +125,15 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
   const hasNativeDialog = hasNativeDialogSupport();
 
   useScrollLock(open);
+
+  useEffect(
+    () => () => {
+      if (dialogRef?.current?.open) {
+        dialogRef?.current?.close();
+      }
+    },
+    [],
+  );
 
   // set initial focus on the modal dialog content
   useEffect(() => {
@@ -228,7 +236,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
     const dialogElement = dialogRef.current;
 
     if (!dialogElement) {
-      return undefined;
+      return;
     }
     if (open) {
       if (document.activeElement instanceof HTMLElement) {
@@ -255,12 +263,6 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
     } else if (dialogElement.open) {
       handleDialogClose();
     }
-
-    return () => {
-      if (dialogElement.open) {
-        dialogElement.close();
-      }
-    };
   }, [open, handleDialogClose, hasNativeDialog, onPolyfillBackdropClick]);
 
   const onDialogClick = (
@@ -304,5 +306,3 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
 });
 
 Modal.displayName = 'Modal';
-
-export const useModal = createUseModal(Modal);

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -37,10 +37,7 @@ import type { Locale } from '../../util/i18n.js';
 import { useScrollLock } from '../../hooks/useScrollLock/useScrollLock.js';
 
 import classes from './Modal.module.css';
-import {
-  getFirstFocusableElement,
-  hasNativeDialogSupport,
-} from './ModalService.js';
+import { getFirstFocusableElement } from './ModalService.js';
 import { translations } from './translations/index.js';
 
 type DataAttribute = `data-${string}`;
@@ -122,7 +119,8 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
     }
   }
 
-  const hasNativeDialog = hasNativeDialogSupport();
+  // eslint-disable-next-line compat/compat
+  const hasNativeDialog = window.HTMLDialogElement !== undefined;
 
   useScrollLock(open);
 

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -300,7 +300,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
         onClick={onDialogClick}
         ref={applyMultipleRefs(ref, dialogRef)}
         className={clsx(
-          classes.dialog,
+          classes.base,
           variant === 'immersive' && classes.immersive,
           className,
         )}

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -296,7 +296,6 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
             {typeof children === 'function'
               ? children?.({ onClose })
               : children}
-            <div className={classes.scrollable} />
           </div>
         )}
       </dialog>

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -34,12 +34,12 @@ import { isEscape } from '../../util/key-codes.js';
 import { useI18n } from '../../hooks/useI18n/useI18n.js';
 import { deprecate } from '../../util/logger.js';
 import type { Locale } from '../../util/i18n.js';
+import { useScrollLock } from '../../hooks/useScrollLock/useScrollLock.js';
 
 import classes from './Modal.module.css';
 import {
   getFirstFocusableElement,
   hasNativeDialogSupport,
-  useScrollLock,
 } from './ModalService.js';
 import { translations } from './translations/index.js';
 

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -166,6 +166,8 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
     const scrollY = body.style.top;
     body.style.position = '';
     body.style.top = '';
+    body.style.left = '';
+    body.style.right = '';
     window.scrollTo(0, Number.parseInt(scrollY || '0', 10) * -1);
 
     // trigger closing animation
@@ -258,6 +260,8 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
           document.documentElement.style.getPropertyValue('--scroll-y');
         const { body } = document;
         body.style.position = 'fixed';
+        body.style.left = '0';
+        body.style.right = '0';
         body.style.top = `-${scrollY}`;
       }
     } else if (dialogElement.open) {

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -290,9 +290,9 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
         onClick={onDialogClick}
         ref={applyMultipleRefs(ref, dialogRef)}
         className={clsx(
-          className,
           classes.dialog,
           variant === 'immersive' && classes.immersive,
+          className,
         )}
         {...rest}
       >

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -22,6 +22,7 @@ import {
   type RefObject,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useRef,
 } from 'react';
 
@@ -124,7 +125,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
 
   useScrollLock(open);
 
-  useEffect(
+  useLayoutEffect(
     () => () => {
       if (dialogRef?.current?.open) {
         dialogRef?.current?.close();

--- a/packages/circuit-ui/components/Modal/ModalContext.spec.tsx
+++ b/packages/circuit-ui/components/Modal/ModalContext.spec.tsx
@@ -61,9 +61,6 @@ describe('ModalContext', () => {
         vi.advanceTimersByTime(ANIMATION_DURATION);
       });
 
-      expect(
-        (screen.getByTestId('dummy-dialog')).open,
-      ).toBe(true);
       expect(screen.getByTestId('dummy-dialog')).toBeVisible();
     });
 

--- a/packages/circuit-ui/components/Modal/ModalContext.spec.tsx
+++ b/packages/circuit-ui/components/Modal/ModalContext.spec.tsx
@@ -43,6 +43,7 @@ describe('ModalContext', () => {
     const onClose = vi.fn();
     const modal = {
       id: 'initial',
+      open: true,
       component: Modal,
       onClose,
       children: () => <p>Modal content</p>,

--- a/packages/circuit-ui/components/Modal/ModalContext.spec.tsx
+++ b/packages/circuit-ui/components/Modal/ModalContext.spec.tsx
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { useContext } from 'react';
+
+import {
+  render,
+  act,
+  userEvent as baseUserEvent,
+  screen,
+} from '../../util/test-utils.js';
+
+import { ModalProvider, ModalContext } from './ModalContext.js';
+import { ANIMATION_DURATION, type ModalProps } from './Modal.js';
+
+const Modal = (props: ModalProps) => <Modal {...props} />;
+
+describe('ModalDialogContext', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+
+    // HACK: Temporary workaround for a bug in @testing-library/react when
+    // using  @testing-library/user-event with fake timers.
+    // https://github.com/testing-library/react-testing-library/issues/1197
+    const originalJest = globalThis.jest;
+
+    globalThis.jest = {
+      ...globalThis.jest,
+      advanceTimersByTime: vi.advanceTimersByTime.bind(vi),
+    };
+
+    return () => {
+      globalThis.jest = originalJest;
+    };
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const userEvent = baseUserEvent.setup({
+    advanceTimers: vi.advanceTimersByTime,
+  });
+
+  describe('ModalProvider', () => {
+    const onClose = vi.fn();
+    const modal = {
+      id: 'initial',
+      component: Modal,
+      onClose,
+      children: () => <p>Modal content</p>,
+      closeButtonLabel: 'Close',
+    };
+    const initialState = [modal];
+
+    it('should render the initial modals', () => {
+      render(
+        <ModalProvider initialState={initialState}>
+          <div />
+        </ModalProvider>,
+      );
+
+      expect(screen.getByRole('dialog')).toBeVisible();
+    });
+
+    it('should open and close a modal when the context functions are called', async () => {
+      const Trigger = () => {
+        const { setModal, removeModal } = useContext(ModalContext);
+        return (
+          <>
+            <button onClick={() => setModal(modal)}>Open modal</button>
+            <button onClick={() => removeModal(modal)}>Close modal</button>
+          </>
+        );
+      };
+
+      render(
+        <ModalProvider>
+          <Trigger />
+        </ModalProvider>,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Open modal' }));
+
+      expect(screen.getByRole('dialog')).toBeVisible();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    it('should close the modal when the user navigates back', () => {
+      const { container, unmount } = render(
+        <ModalProvider initialState={initialState}>
+          <div />
+        </ModalProvider>,
+      );
+      const dialog = container.querySelector('dialog') as HTMLDialogElement;
+      vi.spyOn(dialog, 'close');
+
+      unmount();
+      act(() => {
+        vi.runAllTimers();
+        vi.advanceTimersByTime(ANIMATION_DURATION);
+      });
+
+      expect(screen.queryByRole('dialog')).toBeNull();
+      expect(dialog.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('should close the modal when the onClose method is called', async () => {
+      render(
+        <ModalProvider initialState={initialState}>
+          <div />
+        </ModalProvider>,
+      );
+
+      const closeButton = screen.queryByRole('button') as HTMLButtonElement;
+      await userEvent.click(closeButton);
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(screen.queryByRole('dialog')).toBeNull();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/circuit-ui/components/Modal/ModalContext.tsx
+++ b/packages/circuit-ui/components/Modal/ModalContext.tsx
@@ -57,7 +57,9 @@ export function ModalProvider<T extends ModalProps>({
   initialState,
   ...defaultModalProps
 }: ModalProviderProps<T>) {
-  const [modals, dispatch] = useStack<ModalState<T>>(initialState);
+  const [modals, dispatch] = useStack<ModalState<T>>(
+    initialState?.map((modal) => ({ ...modal, open: true })),
+  );
 
   const setModal = useCallback(
     (modal: ModalState<T>) => {

--- a/packages/circuit-ui/components/Modal/ModalContext.tsx
+++ b/packages/circuit-ui/components/Modal/ModalContext.tsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use client';
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
+
+import type { ModalProps } from './Modal.js';
+import type { ModalDialogComponent } from './createUseModal.js';
+
+export type SetModalArgs<T> = Omit<T, 'open'>;
+
+// keep initial state compatible with the old version of this component
+export type ModalState<T extends ModalProps> = SetModalArgs<T> & {
+  component: ModalDialogComponent<T>;
+  id: string | number;
+};
+
+type ModalContextValue<T extends ModalProps> = {
+  setModal: (modal: ModalState<T>) => void;
+  removeModal: (modal: ModalState<T>) => void;
+};
+export interface ModalProviderProps<T extends ModalProps> {
+  /**
+   * The ModalProvider should wrap your entire application.
+   */
+  children: ReactNode;
+  /**
+   * An array of modals that should be displayed immediately, e.g. on page load.
+   */
+  initialState?: ModalState<T>[];
+}
+
+// TODO replace any
+export const ModalContext = createContext<ModalContextValue<any>>({
+  setModal: () => {},
+  removeModal: () => {},
+});
+
+export function ModalProvider<T extends ModalProps>({
+  children,
+  initialState,
+  ...defaultModalProps
+}: ModalProviderProps<T>) {
+  const [modals, setModals] = useState(initialState ?? []);
+
+  const setModal = useCallback((modal: ModalState<T>) => {
+    setModals((prevValue) => [...prevValue, modal]);
+  }, []);
+
+  const removeModal = useCallback((modal: ModalState<T>) => {
+    if (modal.onClose) {
+      modal.onClose();
+    }
+    setModals((prevValue) => prevValue.filter((m) => m.id !== modal.id));
+  }, []);
+
+  const context = useMemo(
+    () => ({ setModal, removeModal }),
+    [setModal, removeModal],
+  );
+
+  return (
+    <ModalContext.Provider value={context}>
+      {children}
+      {modals.map((modal) => {
+        const { id, component: Component, ...modalProps } = modal;
+        return (
+          // @ts-expect-error type will either be ModalProps or NotificationProps
+          <Component
+            {...defaultModalProps}
+            {...modalProps}
+            key={id}
+            open={true}
+            onClose={() => removeModal(modal)}
+          />
+        );
+      })}
+    </ModalContext.Provider>
+  );
+}

--- a/packages/circuit-ui/components/Modal/ModalService.spec.tsx
+++ b/packages/circuit-ui/components/Modal/ModalService.spec.tsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { getKeyboardFocusableElements } from './ModalService.js';
+
+describe('DialogService', () => {
+  describe('getKeyboardFocusableElements', () => {
+    it('should return empty array if element is empty', () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const result = getKeyboardFocusableElements(document.body);
+      expect(result).toEqual([]);
+    });
+
+    it('should not return an a tag without href', () => {
+      const a = document.createElement('a');
+      document.body.appendChild(a);
+      const result = getKeyboardFocusableElements(document.body);
+      expect(result).toEqual([]);
+    });
+
+    it('should not return a disabled element', () => {
+      const input = document.createElement('input');
+      input.setAttribute('disabled', 'true');
+      document.body.appendChild(input);
+      const result = getKeyboardFocusableElements(document.body);
+      expect(result).toEqual([]);
+    });
+
+    it('should not return an element with aria-hidden', () => {
+      const input = document.createElement('input');
+      input.setAttribute('aria-hidden', 'true');
+      document.body.appendChild(input);
+      const result = getKeyboardFocusableElements(document.body);
+      expect(result).toEqual([]);
+    });
+
+    it('should return an array of focusable elements', () => {
+      const container = document.createElement('div');
+      container.setAttribute('tabindex', '0');
+      const button = document.createElement('button');
+      const input = document.createElement('input');
+      const a = document.createElement('a');
+      a.setAttribute('href', 'showSignature(xyz)');
+      const textarea = document.createElement('textarea');
+      const select = document.createElement('select');
+      const details = document.createElement('details');
+
+      document.body.append(
+        container,
+        button,
+        input,
+        a,
+        textarea,
+        select,
+        details,
+      );
+
+      const result = getKeyboardFocusableElements(document.body);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          button,
+          input,
+          a,
+          textarea,
+          select,
+          details,
+          container,
+        ]),
+      );
+    });
+  });
+});

--- a/packages/circuit-ui/components/Modal/ModalService.spec.tsx
+++ b/packages/circuit-ui/components/Modal/ModalService.spec.tsx
@@ -13,9 +13,11 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getKeyboardFocusableElements } from './ModalService.js';
+import { renderHook, act } from '../../util/test-utils.js';
+
+import { getKeyboardFocusableElements, useScrollLock } from './ModalService.js';
 
 describe('DialogService', () => {
   describe('getKeyboardFocusableElements', () => {
@@ -83,6 +85,71 @@ describe('DialogService', () => {
           container,
         ]),
       );
+    });
+  });
+  describe('useScrollLock', () => {
+    Object.defineProperty(window, 'scrollTo', {
+      value: vi.fn(),
+      writable: true,
+    });
+
+    Object.defineProperty(window, 'scrollY', { value: 1, writable: true });
+
+    beforeEach(() => {
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.documentElement.style.setProperty('--scroll-y', '');
+    });
+
+    it('locks the scroll when `isLocked` is true', () => {
+      document.documentElement.style.setProperty('--scroll-y', '100px');
+
+      const { rerender } = renderHook(
+        ({ isLocked }) => useScrollLock(isLocked),
+        {
+          initialProps: { isLocked: false },
+        },
+      );
+
+      rerender({ isLocked: true });
+
+      expect(document.body.style.position).toBe('fixed');
+      expect(document.body.style.top).toBe('-100px');
+    });
+
+    it('unlocks the scroll when `isLocked` is false', () => {
+      document.body.style.top = '-100px';
+
+      const { rerender } = renderHook(
+        ({ isLocked }) => useScrollLock(isLocked),
+        {
+          initialProps: { isLocked: true },
+        },
+      );
+
+      rerender({ isLocked: false });
+
+      expect(document.body.style.position).toBe('');
+      expect(document.body.style.top).toBe('');
+      expect(window.scrollTo).toHaveBeenCalledWith(0, 100);
+    });
+
+    it('updates `--scroll-y` on scroll', () => {
+      global.requestAnimationFrame = vi
+        .fn()
+        .mockImplementation((callback: () => void) => callback());
+
+      renderHook(() => useScrollLock(false));
+
+      act(() => {
+        window.scrollY = 200;
+        const scrollEvent = new Event('scroll');
+        window.dispatchEvent(scrollEvent);
+      });
+
+      expect(
+        document.documentElement.style.getPropertyValue('--scroll-y'),
+      ).toBe('200px');
     });
   });
 });

--- a/packages/circuit-ui/components/Modal/ModalService.spec.tsx
+++ b/packages/circuit-ui/components/Modal/ModalService.spec.tsx
@@ -13,11 +13,9 @@
  * limitations under the License.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { renderHook, act } from '../../util/test-utils.js';
-
-import { getKeyboardFocusableElements, useScrollLock } from './ModalService.js';
+import { getKeyboardFocusableElements } from './ModalService.js';
 
 describe('DialogService', () => {
   describe('getKeyboardFocusableElements', () => {
@@ -85,71 +83,6 @@ describe('DialogService', () => {
           container,
         ]),
       );
-    });
-  });
-  describe('useScrollLock', () => {
-    Object.defineProperty(window, 'scrollTo', {
-      value: vi.fn(),
-      writable: true,
-    });
-
-    Object.defineProperty(window, 'scrollY', { value: 1, writable: true });
-
-    beforeEach(() => {
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.documentElement.style.setProperty('--scroll-y', '');
-    });
-
-    it('locks the scroll when `isLocked` is true', () => {
-      document.documentElement.style.setProperty('--scroll-y', '100px');
-
-      const { rerender } = renderHook(
-        ({ isLocked }) => useScrollLock(isLocked),
-        {
-          initialProps: { isLocked: false },
-        },
-      );
-
-      rerender({ isLocked: true });
-
-      expect(document.body.style.position).toBe('fixed');
-      expect(document.body.style.top).toBe('-100px');
-    });
-
-    it('unlocks the scroll when `isLocked` is false', () => {
-      document.body.style.top = '-100px';
-
-      const { rerender } = renderHook(
-        ({ isLocked }) => useScrollLock(isLocked),
-        {
-          initialProps: { isLocked: true },
-        },
-      );
-
-      rerender({ isLocked: false });
-
-      expect(document.body.style.position).toBe('');
-      expect(document.body.style.top).toBe('');
-      expect(window.scrollTo).toHaveBeenCalledWith(0, 100);
-    });
-
-    it('updates `--scroll-y` on scroll', () => {
-      global.requestAnimationFrame = vi
-        .fn()
-        .mockImplementation((callback: () => void) => callback());
-
-      renderHook(() => useScrollLock(false));
-
-      act(() => {
-        window.scrollY = 200;
-        const scrollEvent = new Event('scroll');
-        window.dispatchEvent(scrollEvent);
-      });
-
-      expect(
-        document.documentElement.style.getPropertyValue('--scroll-y'),
-      ).toBe('200px');
     });
   });
 });

--- a/packages/circuit-ui/components/Modal/ModalService.ts
+++ b/packages/circuit-ui/components/Modal/ModalService.ts
@@ -13,21 +13,6 @@
  * limitations under the License.
  */
 
-/**
- * Copyright 2024, SumUp Ltd.
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 export function getKeyboardFocusableElements(
   element: HTMLElement,
 ): HTMLElement[] {
@@ -52,6 +37,3 @@ export function getFirstFocusableElement(
     ? focusableElements[0]
     : focusableElements[1];
 }
-
-export const hasNativeDialogSupport = (): boolean =>
-  'HTMLDialogElement' in window;

--- a/packages/circuit-ui/components/Modal/ModalService.ts
+++ b/packages/circuit-ui/components/Modal/ModalService.ts
@@ -13,6 +13,22 @@
  * limitations under the License.
  */
 
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useRef } from 'react';
+
 export function getKeyboardFocusableElements(
   element: HTMLElement,
 ): HTMLElement[] {
@@ -40,3 +56,48 @@ export function getFirstFocusableElement(
 
 export const hasNativeDialogSupport = (): boolean =>
   'HTMLDialogElement' in window;
+
+export const useScrollLock = (isLocked: boolean): void => {
+  const busy = useRef(false);
+
+  useEffect(() => {
+    function setScrollProperty() {
+      if (!busy.current) {
+        requestAnimationFrame(() => {
+          document.documentElement.style.setProperty(
+            '--scroll-y',
+            `${window.scrollY}px`,
+          );
+          busy.current = false;
+        });
+        busy.current = true;
+      }
+    }
+    window.addEventListener('scroll', setScrollProperty);
+
+    return () => {
+      window.removeEventListener('scroll', setScrollProperty);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isLocked) {
+      const scrollY =
+        document.documentElement.style.getPropertyValue('--scroll-y');
+      const { body } = document;
+      body.style.position = 'fixed';
+      body.style.left = '0';
+      body.style.right = '0';
+      body.style.top = `-${scrollY}`;
+    } else {
+      // restore scroll to page
+      const { body } = document;
+      const scrollY = body.style.top;
+      body.style.position = '';
+      body.style.top = '';
+      body.style.left = '';
+      body.style.right = '';
+      window.scrollTo(0, Number.parseInt(scrollY || '0', 10) * -1);
+    }
+  }, [isLocked]);
+};

--- a/packages/circuit-ui/components/Modal/ModalService.ts
+++ b/packages/circuit-ui/components/Modal/ModalService.ts
@@ -27,7 +27,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEffect, useRef } from 'react';
 
 export function getKeyboardFocusableElements(
   element: HTMLElement,
@@ -56,48 +55,3 @@ export function getFirstFocusableElement(
 
 export const hasNativeDialogSupport = (): boolean =>
   'HTMLDialogElement' in window;
-
-export const useScrollLock = (isLocked: boolean): void => {
-  const busy = useRef(false);
-
-  useEffect(() => {
-    function setScrollProperty() {
-      if (!busy.current) {
-        requestAnimationFrame(() => {
-          document.documentElement.style.setProperty(
-            '--scroll-y',
-            `${window.scrollY}px`,
-          );
-          busy.current = false;
-        });
-        busy.current = true;
-      }
-    }
-    window.addEventListener('scroll', setScrollProperty);
-
-    return () => {
-      window.removeEventListener('scroll', setScrollProperty);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (isLocked) {
-      const scrollY =
-        document.documentElement.style.getPropertyValue('--scroll-y');
-      const { body } = document;
-      body.style.position = 'fixed';
-      body.style.left = '0';
-      body.style.right = '0';
-      body.style.top = `-${scrollY}`;
-    } else {
-      // restore scroll to page
-      const { body } = document;
-      const scrollY = body.style.top;
-      body.style.position = '';
-      body.style.top = '';
-      body.style.left = '';
-      body.style.right = '';
-      window.scrollTo(0, Number.parseInt(scrollY || '0', 10) * -1);
-    }
-  }, [isLocked]);
-};

--- a/packages/circuit-ui/components/Modal/ModalService.ts
+++ b/packages/circuit-ui/components/Modal/ModalService.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function getKeyboardFocusableElements(
+  element: HTMLElement,
+): HTMLElement[] {
+  return [
+    ...element.querySelectorAll(
+      'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])',
+    ),
+  ].filter(
+    (el) =>
+      !el.hasAttribute('disabled') &&
+      !el.hasAttribute('aria-disabled') &&
+      !el.getAttribute('aria-hidden'),
+  ) as HTMLElement[];
+}
+
+export function getFirstFocusableElement(
+  dialog: HTMLDialogElement,
+): HTMLElement {
+  const focusableElements = getKeyboardFocusableElements(dialog);
+  // if there is only one focusable element (the close button), focus it
+  return focusableElements.length === 1
+    ? focusableElements[0]
+    : focusableElements[1];
+}
+
+export const hasNativeDialogSupport = (): boolean =>
+  'HTMLDialogElement' in window;

--- a/packages/circuit-ui/components/Modal/createUseModal.spec.tsx
+++ b/packages/circuit-ui/components/Modal/createUseModal.spec.tsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { PropsWithChildren } from 'react';
+
+import { renderHook, act } from '../../util/test-utils.js';
+
+import { createUseModal } from './createUseModal.js';
+import { ModalContext } from './ModalContext.js';
+import { Modal, type ModalProps } from './Modal.js';
+
+const ModalComponent = (props: ModalProps) => <Modal {...props} />;
+
+const props = {
+  onClose: vi.fn(),
+  open: false,
+  closeButtonLabel: 'Close',
+  children: vi.fn(() => <div data-testid="children">Modal dialog content</div>),
+};
+
+describe('createUseModal', () => {
+  const useModal = createUseModal(ModalComponent);
+
+  const setModal = vi.fn();
+  const removeModal = vi.fn();
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <ModalContext.Provider value={{ setModal, removeModal }}>
+      {children}
+    </ModalContext.Provider>
+  );
+
+  it('should add the modal when setModal is called', () => {
+    const { result } = renderHook(() => useModal(), { wrapper });
+
+    act(() => {
+      result.current.setModal(props);
+    });
+
+    const expected = expect.objectContaining({
+      component: expect.any(Function),
+      id: expect.any(String),
+    });
+    expect(setModal).toHaveBeenCalledWith(expected);
+  });
+
+  it('should remove the modal when removeModal is called', () => {
+    const { result } = renderHook(() => useModal(), { wrapper });
+
+    act(() => {
+      result.current.setModal(props);
+    });
+
+    act(() => {
+      result.current.removeModal();
+    });
+
+    const expected = expect.any(Object);
+    expect(removeModal).toHaveBeenCalledWith(expected);
+  });
+});

--- a/packages/circuit-ui/components/Modal/createUseModal.ts
+++ b/packages/circuit-ui/components/Modal/createUseModal.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2021, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use client';
+
+import { useContext, useCallback, useRef, useId, type ReactNode } from 'react';
+
+import { ModalContext, type SetModalArgs } from './ModalContext.js';
+import type { ModalProps } from './Modal.js';
+
+export type ModalDialogComponent<TProps extends ModalProps = ModalProps> = (
+  props: TProps,
+) => ReactNode;
+
+export function createUseModal<T extends ModalProps>(
+  component: ModalDialogComponent<T>,
+) {
+  return (): {
+    setModal: (props: SetModalArgs<T>) => void;
+    removeModal: () => void;
+  } => {
+    const id = useId();
+    const modalRef = useRef<SetModalArgs<T> | null>(null);
+    const context = useContext(ModalContext);
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: The `component` never changes
+    const setModal = useCallback(
+      (props: SetModalArgs<T>): void => {
+        modalRef.current = props;
+        context.setModal({ ...props, id, component });
+      },
+      [context, id],
+    );
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: The `component` never changes
+    const removeModal = useCallback((): void => {
+      if (modalRef.current) {
+        context.removeModal({ ...modalRef.current, id, component });
+        modalRef.current = null;
+      }
+    }, [context, id]);
+
+    return { setModal, removeModal };
+  };
+}

--- a/packages/circuit-ui/components/Modal/createUseModal.ts
+++ b/packages/circuit-ui/components/Modal/createUseModal.ts
@@ -39,7 +39,7 @@ export function createUseModal<T extends ModalProps>(
     const setModal = useCallback(
       (props: SetModalArgs<T>): void => {
         modalRef.current = props;
-        context.setModal({ ...props, id, component });
+        context.setModal({ ...props, id, component, open: true });
       },
       [context, id],
     );
@@ -47,7 +47,12 @@ export function createUseModal<T extends ModalProps>(
     // biome-ignore lint/correctness/useExhaustiveDependencies: The `component` never changes
     const removeModal = useCallback((): void => {
       if (modalRef.current) {
-        context.removeModal({ ...modalRef.current, id, component });
+        context.removeModal({
+          ...modalRef.current,
+          id,
+          component,
+          open: false,
+        });
         modalRef.current = null;
       }
     }, [context, id]);

--- a/packages/circuit-ui/components/Modal/index.ts
+++ b/packages/circuit-ui/components/Modal/index.ts
@@ -13,6 +13,6 @@
  * limitations under the License.
  */
 
+export { Modal } from './Modal.js';
 export { useModal } from './Modal.js';
-
 export type { ModalProps } from './Modal.js';

--- a/packages/circuit-ui/components/Modal/index.ts
+++ b/packages/circuit-ui/components/Modal/index.ts
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+import { createUseModal } from './createUseModal.js';
+import { Modal } from './Modal.js';
+
 export { Modal } from './Modal.js';
-export { useModal } from './Modal.js';
 export type { ModalProps } from './Modal.js';
+export const useModal = createUseModal(Modal);

--- a/packages/circuit-ui/components/Modal/translations/bg-BG.json
+++ b/packages/circuit-ui/components/Modal/translations/bg-BG.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Затвори"
+}

--- a/packages/circuit-ui/components/Modal/translations/cs-CZ.json
+++ b/packages/circuit-ui/components/Modal/translations/cs-CZ.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Zavřít"
+}

--- a/packages/circuit-ui/components/Modal/translations/da-DK.json
+++ b/packages/circuit-ui/components/Modal/translations/da-DK.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Luk"
+}

--- a/packages/circuit-ui/components/Modal/translations/de-AT.json
+++ b/packages/circuit-ui/components/Modal/translations/de-AT.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Schließen"
+}

--- a/packages/circuit-ui/components/Modal/translations/de-CH.json
+++ b/packages/circuit-ui/components/Modal/translations/de-CH.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Schliessen"
+}

--- a/packages/circuit-ui/components/Modal/translations/de-DE.json
+++ b/packages/circuit-ui/components/Modal/translations/de-DE.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Schließen"
+}

--- a/packages/circuit-ui/components/Modal/translations/de-LU.json
+++ b/packages/circuit-ui/components/Modal/translations/de-LU.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Schließen"
+}

--- a/packages/circuit-ui/components/Modal/translations/el-CY.json
+++ b/packages/circuit-ui/components/Modal/translations/el-CY.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Κλείσιμο"
+}

--- a/packages/circuit-ui/components/Modal/translations/el-GR.json
+++ b/packages/circuit-ui/components/Modal/translations/el-GR.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Κλείσιμο"
+}

--- a/packages/circuit-ui/components/Modal/translations/en-AU.json
+++ b/packages/circuit-ui/components/Modal/translations/en-AU.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Close"
+}

--- a/packages/circuit-ui/components/Modal/translations/en-GB.json
+++ b/packages/circuit-ui/components/Modal/translations/en-GB.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Close"
+}

--- a/packages/circuit-ui/components/Modal/translations/en-IE.json
+++ b/packages/circuit-ui/components/Modal/translations/en-IE.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Close"
+}

--- a/packages/circuit-ui/components/Modal/translations/en-MT.json
+++ b/packages/circuit-ui/components/Modal/translations/en-MT.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Close"
+}

--- a/packages/circuit-ui/components/Modal/translations/en-US.json
+++ b/packages/circuit-ui/components/Modal/translations/en-US.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Close"
+}

--- a/packages/circuit-ui/components/Modal/translations/es-CL.json
+++ b/packages/circuit-ui/components/Modal/translations/es-CL.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Cerrar"
+}

--- a/packages/circuit-ui/components/Modal/translations/es-CO.json
+++ b/packages/circuit-ui/components/Modal/translations/es-CO.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Cerrar"
+}

--- a/packages/circuit-ui/components/Modal/translations/es-ES.json
+++ b/packages/circuit-ui/components/Modal/translations/es-ES.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Cerrar"
+}

--- a/packages/circuit-ui/components/Modal/translations/es-MX.json
+++ b/packages/circuit-ui/components/Modal/translations/es-MX.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Cerrar"
+}

--- a/packages/circuit-ui/components/Modal/translations/es-PE.json
+++ b/packages/circuit-ui/components/Modal/translations/es-PE.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Cerrar"
+}

--- a/packages/circuit-ui/components/Modal/translations/es-US.json
+++ b/packages/circuit-ui/components/Modal/translations/es-US.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Cerrar"
+}

--- a/packages/circuit-ui/components/Modal/translations/et-EE.json
+++ b/packages/circuit-ui/components/Modal/translations/et-EE.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Sulge"
+}

--- a/packages/circuit-ui/components/Modal/translations/fi-FI.json
+++ b/packages/circuit-ui/components/Modal/translations/fi-FI.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Sulje"
+}

--- a/packages/circuit-ui/components/Modal/translations/fr-BE.json
+++ b/packages/circuit-ui/components/Modal/translations/fr-BE.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Fermer"
+}

--- a/packages/circuit-ui/components/Modal/translations/fr-CH.json
+++ b/packages/circuit-ui/components/Modal/translations/fr-CH.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Fermer"
+}

--- a/packages/circuit-ui/components/Modal/translations/fr-FR.json
+++ b/packages/circuit-ui/components/Modal/translations/fr-FR.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Fermer"
+}

--- a/packages/circuit-ui/components/Modal/translations/fr-LU.json
+++ b/packages/circuit-ui/components/Modal/translations/fr-LU.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Fermer"
+}

--- a/packages/circuit-ui/components/Modal/translations/hr-HR.json
+++ b/packages/circuit-ui/components/Modal/translations/hr-HR.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Zatvori"
+}

--- a/packages/circuit-ui/components/Modal/translations/hu-HU.json
+++ b/packages/circuit-ui/components/Modal/translations/hu-HU.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Bezárás"
+}

--- a/packages/circuit-ui/components/Modal/translations/index.ts
+++ b/packages/circuit-ui/components/Modal/translations/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { transformModulesToTranslations } from '../../../util/i18n.js';
+
+export const translations = transformModulesToTranslations<
+  typeof import('./en-US.json')
+>(
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore import.meta.glob is supported by Vite
+  import.meta.glob('./*.json', {
+    eager: true,
+  }),
+);

--- a/packages/circuit-ui/components/Modal/translations/it-CH.json
+++ b/packages/circuit-ui/components/Modal/translations/it-CH.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Chiudi"
+}

--- a/packages/circuit-ui/components/Modal/translations/it-IT.json
+++ b/packages/circuit-ui/components/Modal/translations/it-IT.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Chiudi"
+}

--- a/packages/circuit-ui/components/Modal/translations/lt-LT.json
+++ b/packages/circuit-ui/components/Modal/translations/lt-LT.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Uždaryti"
+}

--- a/packages/circuit-ui/components/Modal/translations/lv-LV.json
+++ b/packages/circuit-ui/components/Modal/translations/lv-LV.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Aizvērt"
+}

--- a/packages/circuit-ui/components/Modal/translations/nb-NO.json
+++ b/packages/circuit-ui/components/Modal/translations/nb-NO.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Lukk"
+}

--- a/packages/circuit-ui/components/Modal/translations/nl-BE.json
+++ b/packages/circuit-ui/components/Modal/translations/nl-BE.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Sluit"
+}

--- a/packages/circuit-ui/components/Modal/translations/nl-NL.json
+++ b/packages/circuit-ui/components/Modal/translations/nl-NL.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Sluiten"
+}

--- a/packages/circuit-ui/components/Modal/translations/pl-PL.json
+++ b/packages/circuit-ui/components/Modal/translations/pl-PL.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Zamknij"
+}

--- a/packages/circuit-ui/components/Modal/translations/pt-BR.json
+++ b/packages/circuit-ui/components/Modal/translations/pt-BR.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Fechar"
+}

--- a/packages/circuit-ui/components/Modal/translations/pt-PT.json
+++ b/packages/circuit-ui/components/Modal/translations/pt-PT.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Fechar"
+}

--- a/packages/circuit-ui/components/Modal/translations/ro-RO.json
+++ b/packages/circuit-ui/components/Modal/translations/ro-RO.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Închide"
+}

--- a/packages/circuit-ui/components/Modal/translations/sk-SK.json
+++ b/packages/circuit-ui/components/Modal/translations/sk-SK.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Zatvoriť"
+}

--- a/packages/circuit-ui/components/Modal/translations/sl-SI.json
+++ b/packages/circuit-ui/components/Modal/translations/sl-SI.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Zapri"
+}

--- a/packages/circuit-ui/components/Modal/translations/sv-SE.json
+++ b/packages/circuit-ui/components/Modal/translations/sv-SE.json
@@ -1,0 +1,3 @@
+{
+  "closeButtonLabel": "Stäng"
+}

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.mdx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.mdx
@@ -7,7 +7,7 @@ import * as Stories from './NotificationModal.stories';
 
 <Status variant="stable" />
 
-The notification modal component communicates critical information while blocking everything else on the page, and needs the user's attention or action to proceed.
+The notification modal component communicates critical information while blocking everything else on the page, and needs the user's attention or action to proceed. It is built atop the [Modal](Components/Modal/Docs) component.
 
 <Story of={Stories.Base} />
 <Props />
@@ -16,6 +16,82 @@ The notification modal component communicates critical information while blockin
 
 - For information that needs a user's immediate attention.
 - To request confirmation before performing a destructive action.
+
+## How to use it
+
+### Inline (recommended)
+
+Place your NotificationModal directly in your JSX:
+
+```jsx
+import { NotificationModal, Button } from '@sumup-oss/circuit-ui';
+import {useState} from 'react';
+
+const [open, setOpen] = useState(false);
+
+return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open dialog</Button>
+      <NotificationModal open={open} closeButtonLabel="Close" onClose={() => setOpen(false)} headline="It's time to update your browser" actions={{
+    primary: {
+      children: 'Update now',
+      onClick: update(),
+    },
+    secondary: {
+      children: 'Not now',
+      onClick: () => setOpen(false),
+    },
+  }}>
+
+      </NotificationModal>
+    </>
+);
+```
+
+### with the `useModal` hook
+First, wrap your application in the `ModalProvider`:
+
+```tsx
+import { ModalProvider } from '@sumup-oss/circuit-ui';
+
+export default function App() {
+  return <ModalProvider>{/* Your content here... */}</ModalProvider>;
+}
+```
+
+Then, use the `useNotificationModal` hook to open a NotificationModal from a component:
+
+```tsx
+import { useNotificationModal, Heading, Button } from '@sumup-oss/circuit-ui';
+
+export function SayHello({ name }) {
+  const { setModal, removeModal } = useNotificationModal();
+
+  const handleClick = () => {
+    setModal({
+            image: {
+              src: '/images/illustration-update.svg',
+              alt: '',
+            },
+            headline: "It's time to update your browser",
+            body: "You'll soon need a more up-to-date browser to continue using SumUp.",
+            actions: {
+              primary: {
+                children: 'Update now',
+                onClick: update(),
+              },
+              secondary: {
+                children: 'Not now',
+                onClick: removeModal(),
+              },
+            },
+            closeButtonLabel: 'Close',
+          })
+  };
+
+  return <Button onClick={handleClick}>Say hello</Button>;
+}
+```
 
 ## Usage guidelines
 

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.mdx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.mdx
@@ -1,5 +1,5 @@
-import { Meta, Status, Props, Story } from '../../../../.storybook/components';
-import * as Stories from './NotificationModal.stories';
+import { Meta, Status, Props, Story } from "../../../../.storybook/components";
+import * as Stories from "./NotificationModal.stories";
 
 <Meta of={Stories} />
 
@@ -24,35 +24,40 @@ The notification modal component communicates critical information while blockin
 Place your NotificationModal directly in your JSX:
 
 ```jsx
-import { NotificationModal, Button } from '@sumup-oss/circuit-ui';
-import {useState} from 'react';
+import { NotificationModal, Button } from "@sumup-oss/circuit-ui";
+import { useState } from "react";
 
 const [open, setOpen] = useState(false);
 
 return (
-    <>
-      <Button onClick={() => setOpen(true)}>Open dialog</Button>
-      <NotificationModal open={open} closeButtonLabel="Close" onClose={() => setOpen(false)} headline="It's time to update your browser" actions={{
-    primary: {
-      children: 'Update now',
-      onClick: update(),
-    },
-    secondary: {
-      children: 'Not now',
-      onClick: () => setOpen(false),
-    },
-  }}>
-
-      </NotificationModal>
-    </>
+  <>
+    <Button onClick={() => setOpen(true)}>Open dialog</Button>
+    <NotificationModal
+      open={open}
+      closeButtonLabel="Close"
+      onClose={() => setOpen(false)}
+      headline="It's time to update your browser"
+      actions={{
+        primary: {
+          children: "Update now",
+          onClick: update(),
+        },
+        secondary: {
+          children: "Not now",
+          onClick: () => setOpen(false),
+        },
+      }}
+    ></NotificationModal>
+  </>
 );
 ```
 
 ### with the `useModal` hook
+
 First, wrap your application in the `ModalProvider`:
 
 ```tsx
-import { ModalProvider } from '@sumup-oss/circuit-ui';
+import { ModalProvider } from "@sumup-oss/circuit-ui";
 
 export default function App() {
   return <ModalProvider>{/* Your content here... */}</ModalProvider>;
@@ -62,31 +67,31 @@ export default function App() {
 Then, use the `useNotificationModal` hook to open a NotificationModal from a component:
 
 ```tsx
-import { useNotificationModal, Heading, Button } from '@sumup-oss/circuit-ui';
+import { useNotificationModal, Heading, Button } from "@sumup-oss/circuit-ui";
 
 export function SayHello({ name }) {
   const { setModal, removeModal } = useNotificationModal();
 
   const handleClick = () => {
     setModal({
-            image: {
-              src: '/images/illustration-update.svg',
-              alt: '',
-            },
-            headline: "It's time to update your browser",
-            body: "You'll soon need a more up-to-date browser to continue using SumUp.",
-            actions: {
-              primary: {
-                children: 'Update now',
-                onClick: update(),
-              },
-              secondary: {
-                children: 'Not now',
-                onClick: removeModal(),
-              },
-            },
-            closeButtonLabel: 'Close',
-          })
+      image: {
+        src: "/images/illustration-update.svg",
+        alt: "",
+      },
+      headline: "It's time to update your browser",
+      body: "You'll soon need a more up-to-date browser to continue using SumUp.",
+      actions: {
+        primary: {
+          children: "Update now",
+          onClick: update(),
+        },
+        secondary: {
+          children: "Not now",
+          onClick: removeModal(),
+        },
+      },
+      closeButtonLabel: "Close",
+    });
   };
 
   return <Button onClick={handleClick}>Say hello</Button>;

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.module.css
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.module.css
@@ -1,19 +1,9 @@
 .base {
-  position: fixed;
-  top: 50%;
-  left: 50%;
   width: calc(100vw - var(--cui-spacings-peta) * 2);
+  min-width: unset;
   max-width: 420px;
   max-height: calc(100vh - var(--cui-spacings-mega) * 2);
-  padding: var(--cui-spacings-giga);
-  overflow-y: auto;
   text-align: center;
-  background-color: var(--cui-bg-elevated);
-  border-radius: var(--cui-border-radius-mega);
-  outline: none;
-  opacity: 0;
-  transition: opacity var(--cui-transitions-slow);
-  transform: translate(-50%, -50%);
 }
 
 @media (max-width: 479px) {
@@ -22,49 +12,7 @@
   }
 }
 
-/* Overlay */
-
-.overlay {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: var(--cui-z-index-modal);
-  background: var(--cui-bg-overlay);
-  opacity: 0;
-  transition: opacity var(--cui-transitions-slow);
-}
-
-@media (min-width: 480px) {
-  .overlay {
-    -webkit-overflow-scrolling: touch;
-    overflow-y: auto;
-  }
-}
-
-.open {
-  opacity: 1;
-}
-
-.closed {
-  opacity: 0;
-}
-
 /* Child elements */
-
-.base .close {
-  position: absolute;
-  top: var(--cui-spacings-byte);
-  right: var(--cui-spacings-byte);
-}
-
-@media (min-width: 480px) {
-  .base .close {
-    top: var(--cui-spacings-mega);
-    right: var(--cui-spacings-mega);
-  }
-}
 
 .base .image {
   max-width: 232px;

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.spec.tsx
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.spec.tsx
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Plus } from '@sumup-oss/icons';
 
-import { axe, render, userEvent, screen } from '../../util/test-utils.js';
+import { axe, render, userEvent, screen, act } from '../../util/test-utils.js';
+import { ANIMATION_DURATION } from '../Modal/Modal.js';
 
 import {
   NotificationModal,
@@ -24,11 +25,21 @@ import {
 } from './NotificationModal.js';
 
 describe('NotificationModal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
   const renderNotificationModal = (props: NotificationModalProps) =>
     render(<NotificationModal {...props} />);
 
   const baseNotificationModal = {
-    isOpen: true,
+    open: true,
     closeButtonLabel: 'Close modal',
     onClose: vi.fn(),
     image: {
@@ -47,7 +58,6 @@ describe('NotificationModal', () => {
         onClick: vi.fn(),
       },
     },
-    ariaHideApp: false,
   } as const;
 
   it('should render with an SVG', () => {
@@ -57,6 +67,9 @@ describe('NotificationModal', () => {
       image: { svg: Plus, alt },
     };
     renderNotificationModal(props);
+    act(() => {
+      vi.advanceTimersByTime(ANIMATION_DURATION);
+    });
 
     const svg = screen.getByRole('img');
 
@@ -74,6 +87,10 @@ describe('NotificationModal', () => {
   it('should render the modal', async () => {
     renderNotificationModal(baseNotificationModal);
 
+    act(() => {
+      vi.advanceTimersByTime(ANIMATION_DURATION);
+    });
+
     const modalEl = await screen.findByRole('dialog');
 
     expect(modalEl).toBeVisible();
@@ -82,27 +99,27 @@ describe('NotificationModal', () => {
   describe('business logic', () => {
     it('should close the modal when clicking the close button', async () => {
       renderNotificationModal(baseNotificationModal);
+      act(() => {
+        vi.advanceTimersByTime(ANIMATION_DURATION);
+      });
 
       const closeButton = await screen.findByRole('button', {
         name: baseNotificationModal.closeButtonLabel,
       });
 
       await userEvent.click(closeButton);
-
-      expect(baseNotificationModal.onClose).toHaveBeenCalled();
-    });
-
-    it('should close the modal when clicking outside', async () => {
-      renderNotificationModal(baseNotificationModal);
-
-      await userEvent.click(document.body);
+      act(() => {
+        vi.advanceTimersByTime(ANIMATION_DURATION);
+      });
 
       expect(baseNotificationModal.onClose).toHaveBeenCalled();
     });
 
     it('should perform an action and close the modal when clicking an action button', async () => {
       renderNotificationModal(baseNotificationModal);
-
+      act(() => {
+        vi.advanceTimersByTime(ANIMATION_DURATION);
+      });
       const actionButton = await screen.findByRole('button', {
         name: baseNotificationModal.actions.primary.children,
       });

--- a/packages/circuit-ui/components/NotificationModal/index.ts
+++ b/packages/circuit-ui/components/NotificationModal/index.ts
@@ -16,3 +16,4 @@
 export { useNotificationModal } from './useNotificationModal.js';
 
 export type { NotificationModalProps } from './NotificationModal.js';
+export { NotificationModal } from './NotificationModal.js';

--- a/packages/circuit-ui/components/NotificationModal/useNotificationModal.ts
+++ b/packages/circuit-ui/components/NotificationModal/useNotificationModal.ts
@@ -13,8 +13,12 @@
  * limitations under the License.
  */
 
-import { createUseModal } from '../ModalContext/index.js';
+import { createUseModal } from '../Modal/createUseModal.js';
 
-import { NotificationModal } from './NotificationModal.js';
+import {
+  NotificationModal,
+  type NotificationModalProps,
+} from './NotificationModal.js';
 
-export const useNotificationModal = createUseModal(NotificationModal);
+export const useNotificationModal =
+  createUseModal<NotificationModalProps>(NotificationModal);

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.mdx
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.mdx
@@ -1,0 +1,28 @@
+import { Meta, Status, Story } from "../../../../.storybook/components";
+import * as Stories from "./useScrollLock.stories";
+
+<Meta of={Stories} />
+
+# useScrollLock()
+
+<Status variant="stable" />
+
+Disables scrolling on the body element when the given argument is true.
+
+<div
+  style={{
+    maxHeight: "50vh",
+    overflowY: "scroll",
+  }}
+>
+  <Story of={Stories.ForDocs} />
+</div>
+
+```ts
+function useScrollLock(isLocked: boolean): void;
+```
+
+## Usage
+
+Use this hook to prevent scrolling on the body element when a modal or other overlay is open.
+This pattern prevents users from scrolling the background content while interacting with a modal or other overlay.

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.spec.ts
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.spec.ts
@@ -58,4 +58,19 @@ describe('useScrollLock', () => {
     expect(document.body.style.top).toBe('');
     expect(window.scrollTo).toHaveBeenCalledWith(0, 100);
   });
+
+  it('unlocks the scroll when unmounted', () => {
+    window.scrollY = 100;
+
+    const { unmount } = renderHook(() => useScrollLock(true), {
+      initialProps: { isLocked: true },
+    });
+    expect(document.body.style.position).toBe('fixed');
+
+    unmount();
+
+    expect(document.body.style.position).toBe('');
+    expect(document.body.style.top).toBe('');
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 100);
+  });
 });

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.spec.ts
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { act, renderHook } from '../../util/test-utils.js';
+
+import { useScrollLock } from './useScrollLock.js';
+
+describe('useScrollLock', () => {
+  Object.defineProperty(window, 'scrollTo', {
+    value: vi.fn(),
+    writable: true,
+  });
+
+  Object.defineProperty(window, 'scrollY', { value: 1, writable: true });
+
+  beforeEach(() => {
+    document.body.style.position = '';
+    document.body.style.top = '';
+    document.documentElement.style.setProperty('--scroll-y', '');
+  });
+
+  it('locks the scroll when `isLocked` is true', () => {
+    document.documentElement.style.setProperty('--scroll-y', '100px');
+
+    const { rerender } = renderHook(({ isLocked }) => useScrollLock(isLocked), {
+      initialProps: { isLocked: false },
+    });
+
+    rerender({ isLocked: true });
+
+    expect(document.body.style.position).toBe('fixed');
+    expect(document.body.style.top).toBe('-100px');
+  });
+
+  it('unlocks the scroll when `isLocked` is false', () => {
+    document.body.style.top = '-100px';
+
+    const { rerender } = renderHook(({ isLocked }) => useScrollLock(isLocked), {
+      initialProps: { isLocked: true },
+    });
+
+    rerender({ isLocked: false });
+
+    expect(document.body.style.position).toBe('');
+    expect(document.body.style.top).toBe('');
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 100);
+  });
+
+  it('updates `--scroll-y` on scroll', () => {
+    global.requestAnimationFrame = vi
+      .fn()
+      .mockImplementation((callback: () => void) => callback());
+
+    renderHook(() => useScrollLock(false));
+
+    act(() => {
+      window.scrollY = 200;
+      const scrollEvent = new Event('scroll');
+      window.dispatchEvent(scrollEvent);
+    });
+
+    expect(document.documentElement.style.getPropertyValue('--scroll-y')).toBe(
+      '200px',
+    );
+  });
+});

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.spec.ts
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.spec.ts
@@ -15,7 +15,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { act, renderHook } from '../../util/test-utils.js';
+import { renderHook } from '../../util/test-utils.js';
 
 import { useScrollLock } from './useScrollLock.js';
 
@@ -30,12 +30,11 @@ describe('useScrollLock', () => {
   beforeEach(() => {
     document.body.style.position = '';
     document.body.style.top = '';
-    document.documentElement.style.setProperty('--scroll-y', '');
+    window.scrollY = 1;
   });
 
   it('locks the scroll when `isLocked` is true', () => {
-    document.documentElement.style.setProperty('--scroll-y', '100px');
-
+    window.scrollY = 100;
     const { rerender } = renderHook(({ isLocked }) => useScrollLock(isLocked), {
       initialProps: { isLocked: false },
     });
@@ -47,7 +46,7 @@ describe('useScrollLock', () => {
   });
 
   it('unlocks the scroll when `isLocked` is false', () => {
-    document.body.style.top = '-100px';
+    window.scrollY = 100;
 
     const { rerender } = renderHook(({ isLocked }) => useScrollLock(isLocked), {
       initialProps: { isLocked: true },
@@ -58,23 +57,5 @@ describe('useScrollLock', () => {
     expect(document.body.style.position).toBe('');
     expect(document.body.style.top).toBe('');
     expect(window.scrollTo).toHaveBeenCalledWith(0, 100);
-  });
-
-  it('updates `--scroll-y` on scroll', () => {
-    global.requestAnimationFrame = vi
-      .fn()
-      .mockImplementation((callback: () => void) => callback());
-
-    renderHook(() => useScrollLock(false));
-
-    act(() => {
-      window.scrollY = 200;
-      const scrollEvent = new Event('scroll');
-      window.dispatchEvent(scrollEvent);
-    });
-
-    expect(document.documentElement.style.getPropertyValue('--scroll-y')).toBe(
-      '200px',
-    );
   });
 });

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.stories.tsx
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.stories.tsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState } from 'react';
+
+import { Button } from '../../components/Button/index.js';
+import { Stack } from '../../../../.storybook/components/index.js';
+
+import { useScrollLock } from './useScrollLock.js';
+
+export default {
+  title: 'Hooks/useScrollLock',
+  parameters: {
+    chromatic: {
+      layout: 'padded',
+      disableSnapshot: true,
+    },
+  },
+  tags: ['status:stable'],
+};
+
+export const Base = ({ height = '150vh' }) => {
+  const [disableScroll, setDisableScroll] = useState(false);
+
+  const toggleScroll = () => {
+    setDisableScroll((prev) => !prev);
+  };
+  useScrollLock(disableScroll);
+
+  return (
+    <div
+      style={{
+        height,
+        width: '50vw',
+        backgroundColor: 'lightgray',
+        padding: 'var(--cui-spacings-giga)',
+      }}
+    >
+      <Stack>
+        <Button onClick={toggleScroll}>
+          {disableScroll ? 'Enable scroll' : 'Disable Scroll'} on this page
+        </Button>
+      </Stack>
+    </div>
+  );
+};
+
+export const ForDocs = () => Base({ height: 'unset' });
+ForDocs.tags = ['!dev']; // hide story, used for docs only.

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
@@ -13,11 +13,20 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 export const useScrollLock = (isLocked: boolean): void => {
   const scrollValue = useRef<string>();
 
+  const restoreScroll = useCallback(() => {
+    // restore scroll to page
+    const { body } = document;
+    const scrollY = body.style.top;
+    body.style.position = '';
+    body.style.top = '';
+    body.style.width = '';
+    window.scrollTo(0, Number.parseInt(scrollY || '0', 10) * -1);
+  }, []);
   useEffect(() => {
     if (isLocked) {
       scrollValue.current = `${window.scrollY}px`;
@@ -31,13 +40,10 @@ export const useScrollLock = (isLocked: boolean): void => {
       body.style.width = `${bodyWidth}px`;
       body.style.top = `-${scrollY}`;
     } else {
-      // restore scroll to page
-      const { body } = document;
-      const scrollY = body.style.top;
-      body.style.position = '';
-      body.style.top = '';
-      body.style.width = '';
-      window.scrollTo(0, Number.parseInt(scrollY || '0', 10) * -1);
+      restoreScroll();
     }
-  }, [isLocked]);
+    return () => {
+      restoreScroll();
+    };
+  }, [isLocked, restoreScroll]);
 };

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
@@ -16,32 +16,12 @@
 import { useEffect, useRef } from 'react';
 
 export const useScrollLock = (isLocked: boolean): void => {
-  const busy = useRef(false);
-
-  useEffect(() => {
-    function setScrollProperty() {
-      if (!busy.current) {
-        requestAnimationFrame(() => {
-          document.documentElement.style.setProperty(
-            '--scroll-y',
-            `${window.scrollY}px`,
-          );
-          busy.current = false;
-        });
-        busy.current = true;
-      }
-    }
-    window.addEventListener('scroll', setScrollProperty);
-
-    return () => {
-      window.removeEventListener('scroll', setScrollProperty);
-    };
-  }, []);
+  const scrollValue = useRef<string>();
 
   useEffect(() => {
     if (isLocked) {
-      const scrollY =
-        document.documentElement.style.getPropertyValue('--scroll-y');
+      scrollValue.current = `${window.scrollY}px`;
+      const scrollY = scrollValue.current;
       const { body } = document;
       const bodyWidth = body.offsetWidth;
       // when position is set to fixed, the body element is taken out of

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useRef } from 'react';
+
+export const useScrollLock = (isLocked: boolean): void => {
+  const busy = useRef(false);
+
+  useEffect(() => {
+    function setScrollProperty() {
+      if (!busy.current) {
+        requestAnimationFrame(() => {
+          document.documentElement.style.setProperty(
+            '--scroll-y',
+            `${window.scrollY}px`,
+          );
+          busy.current = false;
+        });
+        busy.current = true;
+      }
+    }
+    window.addEventListener('scroll', setScrollProperty);
+
+    return () => {
+      window.removeEventListener('scroll', setScrollProperty);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isLocked) {
+      const scrollY =
+        document.documentElement.style.getPropertyValue('--scroll-y');
+      const { body } = document;
+      const bodyWidth = body.offsetWidth;
+      // when position is set to fixed, the body element is taken out of
+      // the normal document flow and this may cause it to change size.
+      // To prevent this, we set the width of the body to its current width.
+      body.style.position = 'fixed';
+      body.style.width = `${bodyWidth}px`;
+      body.style.top = `-${scrollY}`;
+    } else {
+      // restore scroll to page
+      const { body } = document;
+      const scrollY = body.style.top;
+      body.style.position = '';
+      body.style.top = '';
+      body.style.width = '';
+      window.scrollTo(0, Number.parseInt(scrollY || '0', 10) * -1);
+    }
+  }, [isLocked]);
+};

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -155,12 +155,14 @@ export type {
   PopoverProps,
   PopoverItemProps,
 } from './components/Popover/index.js';
-export { ModalProvider } from './components/ModalContext/index.js';
-export type { ModalProviderProps } from './components/ModalContext/index.js';
-export { useModal } from './components/Modal/index.js';
-export type { ModalProps } from './components/Modal/index.js';
+export { ModalProvider } from './components/Modal/ModalContext.js';
+export type { ModalProviderProps } from './components/Modal/ModalContext.js';
+export { useModal } from './components/Modal/Modal.js';
+export type { ModalProps } from './components/Modal/Modal.js';
+export { Modal } from './components/Modal/Modal.js';
 export { useNotificationModal } from './components/NotificationModal/index.js';
 export type { NotificationModalProps } from './components/NotificationModal/index.js';
+export { NotificationModal } from './components/NotificationModal/index.js';
 export { ListItem } from './components/ListItem/index.js';
 export type { ListItemProps } from './components/ListItem/index.js';
 export { ListItemGroup } from './components/ListItemGroup/index.js';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -157,9 +157,9 @@ export type {
 } from './components/Popover/index.js';
 export { ModalProvider } from './components/Modal/ModalContext.js';
 export type { ModalProviderProps } from './components/Modal/ModalContext.js';
-export { useModal } from './components/Modal/Modal.js';
-export type { ModalProps } from './components/Modal/Modal.js';
-export { Modal } from './components/Modal/Modal.js';
+export { useModal } from './components/Modal/index.js';
+export type { ModalProps } from './components/Modal/index.js';
+export { Modal } from './components/Modal/index.js';
 export { useNotificationModal } from './components/NotificationModal/index.js';
 export type { NotificationModalProps } from './components/NotificationModal/index.js';
 export { NotificationModal } from './components/NotificationModal/index.js';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -222,3 +222,4 @@ export { useFocusList } from './hooks/useFocusList/index.js';
 export { useCollapsible } from './hooks/useCollapsible/index.js';
 export { useSwipe } from './hooks/useSwipe/index.js';
 export { useMedia } from './hooks/useMedia/index.js';
+export { useScrollLock } from './hooks/useScrollLock/useScrollLock.js';

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -97,6 +97,7 @@
     "temporal-polyfill": "0.2.x"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20",
+    "typescript": ">=4.1"
   }
 }

--- a/packages/design-tokens/scripts/build.ts
+++ b/packages/design-tokens/scripts/build.ts
@@ -48,7 +48,7 @@ function main(): void {
       {
         type: 'tokens',
         tokens: [...light, ...shared],
-        selectors: [':root'],
+        selectors: [':root, ::backdrop'],
         colorScheme: 'light',
       },
     ],
@@ -56,7 +56,7 @@ function main(): void {
       {
         type: 'tokens',
         tokens: [...dark, ...shared],
-        selectors: [':root'],
+        selectors: [':root, ::backdrop'],
         colorScheme: 'dark',
       },
     ],
@@ -80,13 +80,13 @@ function main(): void {
       {
         type: 'tokens',
         tokens: [...light, ...shared],
-        selectors: [':root'],
+        selectors: [':root, ::backdrop'],
         colorScheme: 'light',
       },
       {
         type: 'tokens',
         tokens: dark,
-        selectors: ['@media (prefers-color-scheme: dark)', ':root'],
+        selectors: ['@media (prefers-color-scheme: dark)', ':root, ::backdrop'],
         colorScheme: 'dark',
       },
       {


### PR DESCRIPTION
Addresses [DSYS-860.](https://sumupteam.atlassian.net/browse/DSYS-860)

## Purpose

Rewrite the modal component using the [native HTML `<dialog/>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) element with the [`dialog-polyfill`](https://github.com/GoogleChrome/dialog-polyfill)

## Approach and changes

- remove `react-modal` and use the `<dialog/>` element in the modal component.
- Handle focus management.
- Ensure component API stays compatible with the `useModal` hook.
- Update the NotificationModal component.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
