### PR TITLE
Increase the SidePanel's root z-index

### DIFF
--- a/.changeset/wild-tools-dress.md
+++ b/.changeset/wild-tools-dress.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the z-index of the DateInput component when used inside a SidePanel alongside the Select component.

--- a/.changeset/wild-tools-dress.md
+++ b/.changeset/wild-tools-dress.md
@@ -1,5 +1,5 @@
 ---
-"@sumup-oss/circuit-ui": patch
+'@sumup-oss/circuit-ui': patch
 ---
 
-Fixed the z-index of the DateInput component when used inside a SidePanel alongside the Select component.
+Increased the SidePanel component's root z-index value to ensure nested, absolutely-positioned components stack properly.

--- a/packages/circuit-ui/components/SidePanel/components/DesktopSidePanel/DesktopSidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/DesktopSidePanel/DesktopSidePanel.tsx
@@ -43,7 +43,7 @@ export function DesktopSidePanel({
   };
 
   return (
-    <StackContext.Provider value={'var(--cui-z-index-absolute)'}>
+    <StackContext.Provider value={'var(--cui-z-index-navigation)'}>
       <ReactModal {...reactModalProps}>{children}</ReactModal>
     </StackContext.Provider>
   );


### PR DESCRIPTION
Addresses 

## Purpose

The DateInput is overlapped by other absolutely positioned elements such as the Select component when rendered inside the SidePanel component:

![](https://github.com/user-attachments/assets/dcbbe477-76a5-40b0-9745-d0c35d5d7f7c)

That's because the SidePanel's StackContext value is set to `var(--cui-z-index-absolute)` (equal to `1`). 

## Approach and changes

- Increase the SidePanel's root z-index 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
