### PR TITLE
Add Timestamp component

### DIFF
--- a/.changeset/poor-wombats-return.md
+++ b/.changeset/poor-wombats-return.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added an experimental Timestamp component to display a human-readable date time to users.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8476,9 +8476,9 @@
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.3.tgz",
-			"integrity": "sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==",
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
+			"integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0",
@@ -8785,54 +8785,72 @@
 			}
 		},
 		"node_modules/@shikijs/core": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.24.0.tgz",
-			"integrity": "sha512-6pvdH0KoahMzr6689yh0QJ3rCgF4j1XsXRHNEeEN6M4xJTfQ6QPWrmHzIddotg+xPJUPEPzYzYCKzpYyhTI6Gw==",
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.27.2.tgz",
+			"integrity": "sha512-ns1dokDr0KE1lQ9mWd4rqaBkhSApk0qGCK1+lOqwnkQSkVZ08UGqXj1Ef8dAcTMZNFkN6PSNjkL5TYNX7pyPbQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/engine-javascript": "1.24.0",
-				"@shikijs/engine-oniguruma": "1.24.0",
-				"@shikijs/types": "1.24.0",
-				"@shikijs/vscode-textmate": "^9.3.0",
+				"@shikijs/engine-javascript": "1.27.2",
+				"@shikijs/engine-oniguruma": "1.27.2",
+				"@shikijs/types": "1.27.2",
+				"@shikijs/vscode-textmate": "^10.0.1",
 				"@types/hast": "^3.0.4",
-				"hast-util-to-html": "^9.0.3"
+				"hast-util-to-html": "^9.0.4"
 			}
 		},
 		"node_modules/@shikijs/engine-javascript": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.24.0.tgz",
-			"integrity": "sha512-ZA6sCeSsF3Mnlxxr+4wGEJ9Tto4RHmfIS7ox8KIAbH0MTVUkw3roHPHZN+LlJMOHJJOVupe6tvuAzRpN8qK1vA==",
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.27.2.tgz",
+			"integrity": "sha512-0JB7U5vJc16NShBdxv9hSSJYSKX79+32O7F4oXIxJLdYfomyFvx4B982ackUI9ftO9T3WwagkiiD3nOxOOLiGA==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "1.24.0",
-				"@shikijs/vscode-textmate": "^9.3.0",
-				"oniguruma-to-es": "0.7.0"
+				"@shikijs/types": "1.27.2",
+				"@shikijs/vscode-textmate": "^10.0.1",
+				"oniguruma-to-es": "^2.0.0"
 			}
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.0.tgz",
-			"integrity": "sha512-Eua0qNOL73Y82lGA4GF5P+G2+VXX9XnuUxkiUuwcxQPH4wom+tE39kZpBFXfUuwNYxHSkrSxpB1p4kyRW0moSg==",
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.27.2.tgz",
+			"integrity": "sha512-FZYKD1KN7srvpkz4lbGLOYWlyDU4Rd+2RtuKfABTkafAPOFr+J6umfIwY/TzOQqfNtWjL7SAwPAO0dcOraRLaQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "1.24.0",
-				"@shikijs/vscode-textmate": "^9.3.0"
+				"@shikijs/types": "1.27.2",
+				"@shikijs/vscode-textmate": "^10.0.1"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.27.2.tgz",
+			"integrity": "sha512-MSrknKL0DbeXvhtSigMLIzjPOOQfvK7fsbcRv2NUUB0EvuTTomY8/U+lAkczYrXY2+dygKOapJKk8ScFYbtoNw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "1.27.2"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.27.2.tgz",
+			"integrity": "sha512-Yw/uV7EijjWavIIZLoWneTAohcbBqEKj6XMX1bfMqO3llqTKsyXukPp1evf8qPqzUHY7ibauqEaQchhfi857mg==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "1.27.2"
 			}
 		},
 		"node_modules/@shikijs/types": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.0.tgz",
-			"integrity": "sha512-aptbEuq1Pk88DMlCe+FzXNnBZ17LCiLIGWAeCWhoFDzia5Q5Krx3DgnULLiouSdd6+LUM39XwXGppqYE0Ghtug==",
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.27.2.tgz",
+			"integrity": "sha512-DM9OWUyjmdYdnKDpaGB/GEn9XkToyK1tqxuqbmc5PV+5K8WjjwfygL3+cIvbkSw2v1ySwHDgqATq/+98pJ4Kyg==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/vscode-textmate": "^9.3.0",
+				"@shikijs/vscode-textmate": "^10.0.1",
 				"@types/hast": "^3.0.4"
 			}
 		},
 		"node_modules/@shikijs/vscode-textmate": {
-			"version": "9.3.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz",
-			"integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.1.tgz",
+			"integrity": "sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==",
 			"license": "MIT"
 		},
 		"node_modules/@sigstore/bundle": {
@@ -15459,9 +15477,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
-			"integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+			"integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
 			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
@@ -17597,16 +17615,16 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/fast-glob": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
 				"glob-parent": "^5.1.2",
 				"merge2": "^1.3.0",
-				"micromatch": "^4.0.4"
+				"micromatch": "^4.0.8"
 			},
 			"engines": {
 				"node": ">=8.6.0"
@@ -19085,9 +19103,9 @@
 			"license": "MIT"
 		},
 		"node_modules/hast-util-to-html": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.3.tgz",
-			"integrity": "sha512-M17uBDzMJ9RPCqLMO92gNNUDuBSq10a25SDBI08iCCxmorf4Yy6sYHK57n9WAbRAAaU+DuR4W6GN9K4DFZesYg==",
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.4.tgz",
+			"integrity": "sha512-wxQzXtdbhiwGAUKrnQJXlOPmHnEehzphwkK7aluUPQ+lEc1xefC8pblMgpp2w5ldBTEfveRIrADcrhGIWrlTDA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/hast": "^3.0.0",
@@ -25180,9 +25198,9 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.14",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.14.tgz",
-			"integrity": "sha512-5c99P1WKTed11ZC0HMJOj6CDIue6F8ySu+bJL+85q1zBEIY8IklrJ1eiKC2NDRh3Ct3FcvmJPyQHb9erXMTJNw==",
+			"version": "0.30.17",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
@@ -32119,14 +32137,14 @@
 			}
 		},
 		"node_modules/oniguruma-to-es": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-0.7.0.tgz",
-			"integrity": "sha512-HRaRh09cE0gRS3+wi2zxekB+I5L8C/gN60S+vb11eADHUaB/q4u8wGGOX3GvwvitG8ixaeycZfeoyruKQzUgNg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.0.0.tgz",
+			"integrity": "sha512-pE7+9jQgomy10aK6BJKRNHj1Nth0YLOzb3iRuhlz4gRzNSBSd7hga6U8BE6o0SoSuSkqv+PPtt511Msd1Hkl0w==",
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex-xs": "^1.0.0",
-				"regex": "^5.0.2",
-				"regex-recursion": "^4.3.0"
+				"regex": "^5.1.1",
+				"regex-recursion": "^5.1.1"
 			}
 		},
 		"node_modules/open": {
@@ -34508,20 +34526,21 @@
 			}
 		},
 		"node_modules/regex": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/regex/-/regex-5.0.2.tgz",
-			"integrity": "sha512-/pczGbKIQgfTMRV0XjABvc5RzLqQmwqxLHdQao2RTXPk+pmTXB2P0IaUHYdYyk412YLwUIkaeMd5T+RzVgTqnQ==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
+			"integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
 			"license": "MIT",
 			"dependencies": {
 				"regex-utilities": "^2.3.0"
 			}
 		},
 		"node_modules/regex-recursion": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-4.3.0.tgz",
-			"integrity": "sha512-5LcLnizwjcQ2ALfOj95MjcatxyqF5RPySx9yT+PaXu3Gox2vyAtLDjHB8NTJLtMGkvyau6nI3CfpwFCjPUIs/A==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
+			"integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
 			"license": "MIT",
 			"dependencies": {
+				"regex": "^5.1.1",
 				"regex-utilities": "^2.3.0"
 			}
 		},
@@ -36873,16 +36892,18 @@
 			}
 		},
 		"node_modules/shiki": {
-			"version": "1.24.0",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-1.24.0.tgz",
-			"integrity": "sha512-qIneep7QRwxRd5oiHb8jaRzH15V/S8F3saCXOdjwRLgozZJr5x2yeBhQtqkO3FSzQDwYEFAYuifg4oHjpDghrg==",
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-1.27.2.tgz",
+			"integrity": "sha512-QtA1C41oEVixKog+V8I3ia7jjGls7oCZ8Yul8vdHrVBga5uPoyTtMvFF4lMMXIyAZo5A5QbXq91bot2vA6Q+eQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/core": "1.24.0",
-				"@shikijs/engine-javascript": "1.24.0",
-				"@shikijs/engine-oniguruma": "1.24.0",
-				"@shikijs/types": "1.24.0",
-				"@shikijs/vscode-textmate": "^9.3.0",
+				"@shikijs/core": "1.27.2",
+				"@shikijs/engine-javascript": "1.27.2",
+				"@shikijs/engine-oniguruma": "1.27.2",
+				"@shikijs/langs": "1.27.2",
+				"@shikijs/themes": "1.27.2",
+				"@shikijs/types": "1.27.2",
+				"@shikijs/vscode-textmate": "^10.0.1",
 				"@types/hast": "^3.0.4"
 			}
 		},
@@ -38694,9 +38715,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
-			"integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
 			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
@@ -40989,9 +41010,9 @@
 			}
 		},
 		"node_modules/vitefu": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.4.tgz",
-			"integrity": "sha512-y6zEE3PQf6uu/Mt6DTJ9ih+kyJLr4XcSgHR2zUkM8SWDhuixEJxfJ6CZGMHh1Ec3vPLoEA0IHU5oWzVqw8ulow==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.0.5.tgz",
+			"integrity": "sha512-h4Vflt9gxODPFNGPwp4zAMZRpZR7eslzwH2c5hn5kNZ5rhnKyRJ50U+yGCdc2IRaBs8O4haIgLNGrV5CrpMsCA==",
 			"license": "MIT",
 			"workspaces": [
 				"tests/deps/*",
@@ -42304,9 +42325,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.23.8",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+			"version": "3.24.1",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+			"integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
@@ -42325,12 +42346,12 @@
 			}
 		},
 		"node_modules/zod-to-json-schema": {
-			"version": "3.23.5",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.5.tgz",
-			"integrity": "sha512-5wlSS0bXfF/BrL4jPAbz9da5hDlDptdEppYfe+x4eIJ7jioqKG9uUxOwPzqof09u/XeVdrgFu29lZi+8XNDJtA==",
+			"version": "3.24.1",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
+			"integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
 			"license": "ISC",
 			"peerDependencies": {
-				"zod": "^3.23.3"
+				"zod": "^3.24.1"
 			}
 		},
 		"node_modules/zod-to-ts": {
@@ -42370,7 +42391,7 @@
 				"@emotion/styled": "^11.14.0",
 				"@sumup-oss/design-tokens": "^8.0.0",
 				"@sumup-oss/icons": "^5.2.0",
-				"@sumup-oss/intl": "^3.0.1",
+				"@sumup-oss/intl": "^3.1.0",
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/jest-dom": "6.6.3",
 				"@testing-library/react": "^16.0.1",
@@ -42400,7 +42421,7 @@
 				"@emotion/styled": "^11.11.0",
 				"@sumup-oss/design-tokens": ">=8.0.0",
 				"@sumup-oss/icons": ">=5.0.0",
-				"@sumup-oss/intl": "3.x",
+				"@sumup-oss/intl": "^3.1.0",
 				"react": ">=18.0.0 <19.0.0",
 				"react-dom": ">=18.0.0 <19.0.0",
 				"temporal-polyfill": "0.2.x"
@@ -42464,7 +42485,7 @@
 		},
 		"packages/icons": {
 			"name": "@sumup-oss/icons",
-			"version": "5.2.0",
+			"version": "5.2.1",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@babel/core": "^7.26.0",
@@ -42506,7 +42527,7 @@
 				"@sumup-oss/circuit-ui": "^9.0.0",
 				"@sumup-oss/design-tokens": "^8.0.0",
 				"@sumup-oss/icons": "^5.0.0",
-				"@sumup-oss/intl": "^3.0.1",
+				"@sumup-oss/intl": "^3.1.0",
 				"@types/react": "^18.3.3",
 				"@types/react-dom": "^18.3.1",
 				"astro": "^5.1.2",
@@ -43659,7 +43680,7 @@
 				"@sumup-oss/circuit-ui": "^9.0.0",
 				"@sumup-oss/design-tokens": "^8.0.0",
 				"@sumup-oss/icons": "^5.0.0",
-				"@sumup-oss/intl": "^3.0.1",
+				"@sumup-oss/intl": "^3.1.0",
 				"next": "^15.1.3",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1"
@@ -43697,7 +43718,7 @@
 				"@sumup-oss/circuit-ui": "^9.0.0",
 				"@sumup-oss/design-tokens": "^8.0.0",
 				"@sumup-oss/icons": "^5.0.0",
-				"@sumup-oss/intl": "^3.0.1",
+				"@sumup-oss/intl": "^3.1.0",
 				"isbot": "^5.1.19",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1"

--- a/packages/circuit-ui/components/Calendar/Calendar.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.tsx
@@ -140,6 +140,11 @@ export interface CalendarProps
   numberOfMonths?: number;
 }
 
+/**
+ * The Calendar component displays a monthly date grid. This is a low-level
+ * component for advanced use cases; you likely want to use the DateInput
+ * component instead.
+ */
 export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
   (props, ref) => {
     const {

--- a/packages/circuit-ui/components/Timestamp/Timestamp.mdx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.mdx
@@ -1,0 +1,43 @@
+import { Meta, Status, Props, Story } from '../../../../.storybook/components';
+import * as Stories from './Timestamp.stories';
+
+<Meta of={Stories} />
+
+# Timestamp
+
+<Status variant="experimental" />
+
+The Timestamp component displays a human readable date time.
+
+<Story of={Stories.Base} />
+<Props />
+
+## Usage
+
+Use the component when displaying a date time to users. The date must adhere to the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format and must include an [IANA time zone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+## Format Styles
+
+Use the `formatStyles` prop to set the verbosity of the displayed datetime value. Keep in mind that longer formats are easier to read for humans.
+
+Use the `includeTime` prop to display the time alongside the date when shown as an [absolute](#absolute) value.
+
+<Story of={Stories.FormatStyles} />
+
+## Variants
+
+### Auto
+
+The _auto_ variant displays a [relative](#relative) value within 1 month of the date time and an [absolute](#absolute) value otherwise.
+
+### Absolute
+
+The _absolute_ variant displays the date time as an absolute value.
+
+<Story of={Stories.Absolute} />
+
+### Relative
+
+The _relative_ variant displays the date time as a relative value and updates it in regular intervals.
+
+<Story of={Stories.Relative} />

--- a/packages/circuit-ui/components/Timestamp/Timestamp.module.css
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.module.css
@@ -1,0 +1,3 @@
+.base {
+  font-variant-numeric: tabular-nums;
+}

--- a/packages/circuit-ui/components/Timestamp/Timestamp.spec.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.spec.tsx
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import MockDate from 'mockdate';
+import { createRef } from 'react';
+
+import { render, screen, axe, act } from '../../util/test-utils.js';
+
+import { Timestamp } from './Timestamp.js';
+
+describe('Calendar', () => {
+  beforeEach(() => {
+    MockDate.set('2020-01-01T01:00+01:00');
+  });
+
+  const baseProps = {
+    datetime: '2020-01-01T00:00+01:00[Europe/Berlin]',
+  };
+
+  it('should merge a custom class name with the default ones', () => {
+    const className = 'foo';
+    render(<Timestamp {...baseProps} className={className} />);
+    const element = screen.getByRole('time');
+    expect(element?.className).toContain(className);
+  });
+
+  it('should forward a ref to the outer element', () => {
+    const ref = createRef<HTMLTimeElement>();
+    render(<Timestamp {...baseProps} ref={ref} />);
+    const element = screen.getByRole('time');
+    expect(ref.current).toBe(element);
+  });
+
+  it('should have a valid `datetime` attribute', () => {
+    render(<Timestamp {...baseProps} />);
+    const element = screen.getByRole('time');
+    expect(element).toHaveAttribute('datetime', '2020-01-01T00:00:00+01:00');
+  });
+
+  describe('absolute variant', () => {
+    it('should display a narrow human-readable date time', () => {
+      render(
+        <Timestamp {...baseProps} variant="absolute" formatStyle="narrow" />,
+      );
+      const element = screen.getByRole('time');
+      expect(element).toHaveTextContent('1/1/20');
+    });
+
+    it('should display a short human-readable date time', () => {
+      render(
+        <Timestamp {...baseProps} variant="absolute" formatStyle="short" />,
+      );
+      const element = screen.getByRole('time');
+      expect(element).toHaveTextContent('Jan 1, 2020');
+    });
+
+    it('should display a long human-readable date time', () => {
+      render(
+        <Timestamp {...baseProps} variant="absolute" formatStyle="long" />,
+      );
+      const element = screen.getByRole('time');
+      expect(element).toHaveTextContent('January 1, 2020 at 12:00 AM');
+    });
+  });
+
+  describe('relative variant', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should display a narrow human-readable date time', () => {
+      render(
+        <Timestamp {...baseProps} variant="relative" formatStyle="narrow" />,
+      );
+      const element = screen.getByRole('time');
+      expect(element).toHaveTextContent('1h ago');
+    });
+
+    it('should display a short human-readable date time', () => {
+      render(
+        <Timestamp {...baseProps} variant="relative" formatStyle="short" />,
+      );
+      const element = screen.getByRole('time');
+      expect(element).toHaveTextContent('1 hr. ago');
+    });
+
+    it('should display a long human-readable date time', () => {
+      render(
+        <Timestamp {...baseProps} variant="relative" formatStyle="long" />,
+      );
+      const element = screen.getByRole('time');
+      expect(element).toHaveTextContent('1 hour ago');
+    });
+
+    it('should update the time after an interval', () => {
+      render(
+        <Timestamp
+          datetime="2020-01-01T01:01+01:00[Europe/Berlin]"
+          variant="relative"
+          formatStyle="narrow"
+        />,
+      );
+
+      const element = screen.getByRole('time');
+      expect(element).toHaveTextContent('in 1m');
+
+      act(() => {
+        vi.advanceTimersByTime(10 * 1000);
+      });
+
+      expect(element).toHaveTextContent('in 50s');
+    });
+  });
+
+  it('should meet accessibility guidelines', async () => {
+    const { container } = render(<Timestamp {...baseProps} />);
+    const actual = await axe(container);
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/packages/circuit-ui/components/Timestamp/Timestamp.spec.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.spec.tsx
@@ -72,7 +72,48 @@ describe('Calendar', () => {
         <Timestamp {...baseProps} variant="absolute" formatStyle="long" />,
       );
       const element = screen.getByRole('time');
-      expect(element).toHaveTextContent('January 1, 2020 at 12:00 AM');
+      expect(element).toHaveTextContent('January 1, 2020');
+    });
+
+    describe('with time', () => {
+      it('should display a narrow human-readable date time', () => {
+        render(
+          <Timestamp
+            {...baseProps}
+            variant="absolute"
+            formatStyle="narrow"
+            includeTime
+          />,
+        );
+        const element = screen.getByRole('time');
+        expect(element).toHaveTextContent('1/1/20, 12:00 AM');
+      });
+
+      it('should display a short human-readable date time', () => {
+        render(
+          <Timestamp
+            {...baseProps}
+            variant="absolute"
+            formatStyle="short"
+            includeTime
+          />,
+        );
+        const element = screen.getByRole('time');
+        expect(element).toHaveTextContent('Jan 1, 2020, 12:00 AM');
+      });
+
+      it('should display a long human-readable date time', () => {
+        render(
+          <Timestamp
+            {...baseProps}
+            variant="absolute"
+            formatStyle="long"
+            includeTime
+          />,
+        );
+        const element = screen.getByRole('time');
+        expect(element).toHaveTextContent('January 1, 2020 at 12:00 AM');
+      });
     });
   });
 

--- a/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
@@ -22,6 +22,7 @@ import { Timestamp, type TimestampProps } from './Timestamp.js';
 export default {
   title: 'Components/Timestamp',
   component: Timestamp,
+  tags: ['status:experimental'],
 };
 
 const datetimes = [
@@ -30,9 +31,10 @@ const datetimes = [
   Temporal.Now.zonedDateTimeISO().subtract({ minutes: 7 }),
   Temporal.Now.zonedDateTimeISO().subtract({ days: 1 }),
   Temporal.Now.zonedDateTimeISO().subtract({ weeks: 5 }),
-];
-
-const locales = ['en-US', 'de-DE', 'pt-BR'];
+] as const;
+const locales = ['en-US', 'de-DE', 'pt-BR'] as const;
+const variants = ['absolute', 'relative'] as const;
+const formatStyles = ['long', 'short', 'narrow'] as const;
 
 export const Base = (args: TimestampProps) => <Timestamp {...args} />;
 
@@ -80,4 +82,26 @@ export const Absolute = (args: TimestampProps) => (
 
 Absolute.args = {
   variant: 'absolute',
+};
+
+export const FormatStyles = (args: TimestampProps) => (
+  <Stack>
+    {variants.map((variant) => (
+      <Stack vertical key={variant}>
+        {formatStyles.map((formatStyle) => (
+          <Timestamp
+            {...args}
+            key={args.datetime.toString()}
+            variant={variant}
+            formatStyle={formatStyle}
+          />
+        ))}
+      </Stack>
+    ))}
+  </Stack>
+);
+
+FormatStyles.args = {
+  datetime: datetimes[2].toString(),
+  includeTime: true,
 };

--- a/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
@@ -85,20 +85,34 @@ Absolute.args = {
 };
 
 export const FormatStyles = (args: TimestampProps) => (
-  <Stack>
-    {variants.map((variant) => (
-      <Stack vertical key={variant}>
-        {formatStyles.map((formatStyle) => (
-          <Timestamp
-            {...args}
-            key={args.datetime}
-            variant={variant}
-            formatStyle={formatStyle}
-          />
+  <table style={{ textAlign: 'center' }}>
+    <thead>
+      <tr>
+        <th />
+        {variants.map((variant) => (
+          <th key={variant} scope="col">
+            {variant}
+          </th>
         ))}
-      </Stack>
-    ))}
-  </Stack>
+      </tr>
+    </thead>
+    <tbody>
+      {formatStyles.map((formatStyle) => (
+        <tr key={formatStyle}>
+          <th scope="row">{formatStyle}</th>
+          {variants.map((variant) => (
+            <td key={formatStyle} style={{ padding: '8px' }}>
+              <Timestamp
+                {...args}
+                variant={variant}
+                formatStyle={formatStyle}
+              />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  </table>
 );
 
 FormatStyles.args = {

--- a/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Temporal } from 'temporal-polyfill';
+
+import { Stack } from '../../../../.storybook/components/Stack.js';
+
+import { Timestamp, type TimestampProps } from './Timestamp.js';
+
+export default {
+  title: 'Components/Timestamp',
+  component: Timestamp,
+};
+
+const datetimes = [
+  Temporal.Now.zonedDateTimeISO().add({ months: 4 }),
+  Temporal.Now.zonedDateTimeISO().add({ seconds: 64 }),
+  Temporal.Now.zonedDateTimeISO().subtract({ minutes: 7 }),
+  Temporal.Now.zonedDateTimeISO().subtract({ days: 1 }),
+  Temporal.Now.zonedDateTimeISO().subtract({ weeks: 5 }),
+];
+
+const locales = ['en-US', 'de-DE', 'pt-BR'];
+
+export const Base = (args: TimestampProps) => <Timestamp {...args} />;
+
+Base.args = {
+  datetime: datetimes[2].toString(),
+};
+
+export const Relative = (args: TimestampProps) => (
+  <Stack>
+    {locales.map((locale) => (
+      <Stack vertical key={locale}>
+        {datetimes.map((datetime) => (
+          <Timestamp
+            {...args}
+            key={datetime.toString()}
+            datetime={datetime.toString()}
+            locale={locale}
+          />
+        ))}
+      </Stack>
+    ))}
+  </Stack>
+);
+
+Relative.args = {
+  variant: 'relative',
+};
+
+export const Absolute = (args: TimestampProps) => (
+  <Stack>
+    {locales.map((locale) => (
+      <Stack vertical key={locale}>
+        {datetimes.map((datetime) => (
+          <Timestamp
+            {...args}
+            key={datetime.toString()}
+            datetime={datetime.toString()}
+            locale={locale}
+          />
+        ))}
+      </Stack>
+    ))}
+  </Stack>
+);
+
+Absolute.args = {
+  variant: 'absolute',
+};

--- a/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
@@ -14,6 +14,7 @@
  */
 
 import { Temporal } from 'temporal-polyfill';
+import isChromatic from 'chromatic/isChromatic';
 
 import { Stack } from '../../../../.storybook/components/Stack.js';
 
@@ -25,12 +26,16 @@ export default {
   tags: ['status:experimental'],
 };
 
+const now = isChromatic()
+  ? Temporal.ZonedDateTime.from('2020-03-15T10:00:00+01:00[Europe/Berlin]')
+  : Temporal.Now.zonedDateTimeISO();
+
 const datetimes = [
-  Temporal.Now.zonedDateTimeISO().add({ months: 4 }),
-  Temporal.Now.zonedDateTimeISO().add({ seconds: 64 }),
-  Temporal.Now.zonedDateTimeISO().subtract({ minutes: 7 }),
-  Temporal.Now.zonedDateTimeISO().subtract({ days: 1 }),
-  Temporal.Now.zonedDateTimeISO().subtract({ weeks: 5 }),
+  now.add({ months: 4 }),
+  now.add({ seconds: 64 }),
+  now.subtract({ minutes: 7 }),
+  now.subtract({ days: 1 }),
+  now.subtract({ weeks: 5 }),
 ] as const;
 const locales = ['en-US', 'de-DE', 'pt-BR'] as const;
 const variants = ['absolute', 'relative'] as const;

--- a/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
@@ -91,7 +91,7 @@ export const FormatStyles = (args: TimestampProps) => (
         {formatStyles.map((formatStyle) => (
           <Timestamp
             {...args}
-            key={args.datetime.toString()}
+            key={args.datetime}
             variant={variant}
             formatStyle={formatStyle}
           />

--- a/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
@@ -26,17 +26,20 @@ export default {
   tags: ['status:experimental'],
 };
 
-const now = isChromatic()
-  ? Temporal.ZonedDateTime.from('2020-03-15T10:00:00+01:00[Europe/Berlin]')
-  : Temporal.Now.zonedDateTimeISO();
+function getDatetimes(variant: TimestampProps['variant']) {
+  const now =
+    variant === 'absolute' && isChromatic()
+      ? Temporal.ZonedDateTime.from('2020-03-15T10:00:00+01:00[Europe/Berlin]')
+      : Temporal.Now.zonedDateTimeISO();
 
-const datetimes = [
-  now.add({ months: 4 }),
-  now.add({ seconds: 64 }),
-  now.subtract({ minutes: 7 }),
-  now.subtract({ days: 1 }),
-  now.subtract({ weeks: 5 }),
-] as const;
+  return [
+    now.add({ months: 4 }),
+    now.add({ seconds: 64 }),
+    now.subtract({ minutes: 7 }),
+    now.subtract({ days: 1 }),
+    now.subtract({ weeks: 5 }),
+  ];
+}
 const locales = ['en-US', 'de-DE', 'pt-BR'] as const;
 const variants = ['absolute', 'relative'] as const;
 const formatStyles = ['long', 'short', 'narrow'] as const;
@@ -44,14 +47,14 @@ const formatStyles = ['long', 'short', 'narrow'] as const;
 export const Base = (args: TimestampProps) => <Timestamp {...args} />;
 
 Base.args = {
-  datetime: datetimes[2].toString(),
+  datetime: getDatetimes('relative')[2].toString(),
 };
 
 export const Relative = (args: TimestampProps) => (
   <Stack>
     {locales.map((locale) => (
       <Stack vertical key={locale}>
-        {datetimes.map((datetime) => (
+        {getDatetimes('relative').map((datetime) => (
           <Timestamp
             {...args}
             key={datetime.toString()}
@@ -72,7 +75,7 @@ export const Absolute = (args: TimestampProps) => (
   <Stack>
     {locales.map((locale) => (
       <Stack vertical key={locale}>
-        {datetimes.map((datetime) => (
+        {getDatetimes('absolute').map((datetime) => (
           <Timestamp
             {...args}
             key={datetime.toString()}
@@ -121,6 +124,6 @@ export const FormatStyles = (args: TimestampProps) => (
 );
 
 FormatStyles.args = {
-  datetime: datetimes[2].toString(),
+  datetime: getDatetimes('absolute')[2].toString(),
   includeTime: true,
 };

--- a/packages/circuit-ui/components/Timestamp/Timestamp.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.tsx
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use client';
+
+import { forwardRef, useEffect, useState, type HTMLAttributes } from 'react';
+import { Temporal } from 'temporal-polyfill';
+
+import type { Locale } from '../../util/i18n.js';
+import { clsx } from '../../styles/clsx.js';
+
+import { getInitialState, getState } from './TimestampService.js';
+import classes from './Timestamp.module.css';
+
+export interface TimestampProps extends HTMLAttributes<HTMLTimeElement> {
+  /**
+   * TODO: Write description
+   */
+  datetime: string;
+  /**
+   * TODO: Write description
+   *
+   * @default 'auto'
+   */
+  variant?: 'auto' | 'relative' | 'absolute';
+  /**
+   * TODO: Write description
+   *
+   * @default 'P1M' // 1 month
+   */
+  threshold?: string;
+  /**
+   * TODO: Write description
+   *
+   * @default 'short'
+   */
+  formatStyle?: 'long' | 'short' | 'narrow';
+  /**
+   * One or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag)
+   * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
+   * When passing an array, the first supported locale is used.
+   * Defaults to `navigator.language` in supported environments.
+   */
+  locale?: Locale;
+}
+
+// TODO: initial, server-rendered label should include timezone and respect format style
+
+/**
+ * TODO:
+ */
+export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
+  (
+    {
+      datetime,
+      variant = 'auto',
+      formatStyle = 'short',
+      threshold = 'P1M',
+      locale,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const zonedDateTime = Temporal.ZonedDateTime.from(datetime);
+    const [state, setState] = useState(
+      getInitialState(datetime, locale, formatStyle),
+    );
+
+    // Update state on props change
+    useEffect(() => {
+      setState(getState(datetime, locale, formatStyle, variant, threshold));
+    }, [datetime, variant, formatStyle, locale, threshold]);
+
+    // Update state in regular intervals for relative times
+    useEffect(() => {
+      if (!state.interval) {
+        return undefined;
+      }
+
+      const timer = setInterval(() => {
+        setState(getState(datetime, locale, formatStyle, variant, threshold));
+      }, state.interval);
+
+      return () => {
+        clearInterval(timer);
+      };
+    }, [state.interval, datetime, variant, formatStyle, locale, threshold]);
+
+    return (
+      <time
+        ref={ref}
+        dateTime={zonedDateTime.toString({ timeZoneName: 'never' })}
+        title={zonedDateTime.toLocaleString(locale, {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+          timeZoneName: 'short',
+        })}
+        className={clsx(className, classes.base)}
+        {...props}
+      >
+        {state.label}
+      </time>
+    );
+  },
+);

--- a/packages/circuit-ui/components/Timestamp/Timestamp.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.tsx
@@ -38,6 +38,12 @@ export interface TimestampProps extends HTMLAttributes<HTMLTimeElement> {
   /**
    * TODO: Write description
    *
+   * @default false
+   */
+  includeTime?: boolean;
+  /**
+   * TODO: Write description
+   *
    * @default 'P1M' // 1 month
    */
   threshold?: string;
@@ -66,7 +72,8 @@ export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
     {
       datetime,
       variant = 'auto',
-      formatStyle = 'short',
+      formatStyle = 'long',
+      includeTime = false,
       threshold = 'P1M',
       locale,
       className,
@@ -76,13 +83,22 @@ export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
   ) => {
     const zonedDateTime = Temporal.ZonedDateTime.from(datetime);
     const [state, setState] = useState(
-      getInitialState(datetime, locale, formatStyle),
+      getInitialState({ datetime, locale, formatStyle, includeTime }),
     );
 
     // Update state on props change
     useEffect(() => {
-      setState(getState(datetime, locale, formatStyle, variant, threshold));
-    }, [datetime, variant, formatStyle, locale, threshold]);
+      setState(
+        getState({
+          datetime,
+          locale,
+          formatStyle,
+          variant,
+          threshold,
+          includeTime,
+        }),
+      );
+    }, [datetime, variant, formatStyle, locale, threshold, includeTime]);
 
     // Update state in regular intervals for relative times
     useEffect(() => {
@@ -91,13 +107,30 @@ export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
       }
 
       const timer = setInterval(() => {
-        setState(getState(datetime, locale, formatStyle, variant, threshold));
+        setState(
+          getState({
+            datetime,
+            locale,
+            formatStyle,
+            variant,
+            threshold,
+            includeTime,
+          }),
+        );
       }, state.interval);
 
       return () => {
         clearInterval(timer);
       };
-    }, [state.interval, datetime, variant, formatStyle, locale, threshold]);
+    }, [
+      state.interval,
+      datetime,
+      variant,
+      formatStyle,
+      locale,
+      threshold,
+      includeTime,
+    ]);
 
     return (
       <time

--- a/packages/circuit-ui/components/Timestamp/Timestamp.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.tsx
@@ -26,33 +26,34 @@ import classes from './Timestamp.module.css';
 
 export interface TimestampProps extends HTMLAttributes<HTMLTimeElement> {
   /**
-   * TODO: Write description
+   * A datetime in the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)
+   * format (`YYYY-MM-DDThh:mm:ss.sss[time-zone-id]`). Must include an
+   * [IANA time zone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
+   * in brackets.
    */
   datetime: string;
   /**
-   * TODO: Write description
-   *
-   * @default 'auto'
-   */
-  variant?: 'auto' | 'relative' | 'absolute';
-  /**
-   * TODO: Write description
+   * Whether to include the time when displaying the datetime as an absolute
+   * value.
    *
    * @default false
    */
   includeTime?: boolean;
   /**
-   * TODO: Write description
-   *
-   * @default 'P1M' // 1 month
-   */
-  threshold?: string;
-  /**
-   * TODO: Write description
+   * The verbosity of the displayed datetime value. Longer formats are easier
+   * to read for humans.
    *
    * @default 'short'
    */
   formatStyle?: 'long' | 'short' | 'narrow';
+  /**
+   * Display the datetime as a relative or absolute value. The auto variant
+   * displays a relative value within 30 days of the datetime and an absolute
+   * value otherwise.
+   *
+   * @default 'auto'
+   */
+  variant?: 'auto' | 'relative' | 'absolute';
   /**
    * One or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag)
    * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
@@ -62,10 +63,8 @@ export interface TimestampProps extends HTMLAttributes<HTMLTimeElement> {
   locale?: Locale;
 }
 
-// TODO: initial, server-rendered label should include timezone and respect format style
-
 /**
- * TODO:
+ * The Timestamp component displays a human readable date time.
  */
 export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
   (
@@ -74,7 +73,6 @@ export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
       variant = 'auto',
       formatStyle = 'long',
       includeTime = false,
-      threshold = 'P1M',
       locale,
       className,
       ...props
@@ -94,11 +92,10 @@ export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
           locale,
           formatStyle,
           variant,
-          threshold,
           includeTime,
         }),
       );
-    }, [datetime, variant, formatStyle, locale, threshold, includeTime]);
+    }, [datetime, variant, formatStyle, locale, includeTime]);
 
     // Update state in regular intervals for relative times
     useEffect(() => {
@@ -113,7 +110,6 @@ export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
             locale,
             formatStyle,
             variant,
-            threshold,
             includeTime,
           }),
         );
@@ -122,15 +118,7 @@ export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
       return () => {
         clearInterval(timer);
       };
-    }, [
-      state.interval,
-      datetime,
-      variant,
-      formatStyle,
-      locale,
-      threshold,
-      includeTime,
-    ]);
+    }, [state.interval, datetime, variant, formatStyle, locale, includeTime]);
 
     return (
       <time

--- a/packages/circuit-ui/components/Timestamp/TimestampService.ts
+++ b/packages/circuit-ui/components/Timestamp/TimestampService.ts
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Temporal } from 'temporal-polyfill';
+import {
+  formatDateTime,
+  formatRelativeTime,
+  isRelativeTimeFormatSupported,
+} from '@sumup-oss/intl';
+
+import type { Locale } from '../../util/i18n.js';
+
+export const DATE_TIME_STYLE_MAP = {
+  long: { dateStyle: 'long', timeStyle: 'short' },
+  short: { dateStyle: 'medium' },
+  narrow: { dateStyle: 'short' },
+} satisfies Record<string, Intl.DateTimeFormatOptions>;
+
+const UNITS = [
+  {
+    name: 'years',
+    duration: Temporal.Duration.from('P1Y'),
+    interval: 300000,
+  },
+  {
+    name: 'months',
+    duration: Temporal.Duration.from('P1M'),
+    interval: 300000,
+  },
+  {
+    name: 'weeks',
+    duration: Temporal.Duration.from('P1W'),
+    interval: 300000,
+  },
+  {
+    name: 'days',
+    duration: Temporal.Duration.from('P1D'),
+    interval: 300000,
+  },
+  {
+    name: 'hours',
+    duration: Temporal.Duration.from('PT1H'),
+    interval: 60000,
+  },
+  {
+    name: 'minutes',
+    duration: Temporal.Duration.from('PT1M'),
+    interval: 5000,
+  },
+  {
+    name: 'seconds',
+    duration: Temporal.Duration.from('PT1S'),
+    interval: 1000,
+  },
+] satisfies {
+  name: Temporal.SmallestUnit<Temporal.DateTimeUnit>;
+  duration: Temporal.Duration;
+  interval: number; // in milliseconds
+}[];
+
+export type State = {
+  label: string;
+  interval: number | null;
+};
+
+export function getInitialState(
+  datetime: string,
+  locale: Locale | undefined,
+  formatStyle: 'long' | 'short' | 'narrow',
+): State {
+  const zonedDateTime = Temporal.ZonedDateTime.from(datetime);
+  const options = DATE_TIME_STYLE_MAP[formatStyle];
+  return {
+    label: formatDateTime(zonedDateTime.toPlainDateTime(), locale, options),
+    interval: null,
+  };
+}
+
+export function getState(
+  datetime: string,
+  locale: Locale | undefined,
+  formatStyle: 'long' | 'short' | 'narrow',
+  variant: 'auto' | 'relative' | 'absolute',
+  threshold: string,
+): State {
+  const zonedDateTime = Temporal.ZonedDateTime.from(datetime);
+  const now = Temporal.Now.zonedDateTimeISO();
+  const duration = zonedDateTime.since(now);
+
+  const isBeyondThreshold =
+    Temporal.Duration.compare(
+      duration.abs(),
+      Temporal.Duration.from(threshold),
+      { relativeTo: now },
+    ) > 0;
+
+  if (
+    variant === 'absolute' ||
+    (variant === 'auto' && isBeyondThreshold) ||
+    !isRelativeTimeFormatSupported
+  ) {
+    const options = DATE_TIME_STYLE_MAP[formatStyle];
+    return {
+      label: formatDateTime(zonedDateTime.toPlainDateTime(), locale, options),
+      interval: null,
+    };
+  }
+
+  const bestUnitIndex = UNITS.findIndex(
+    (unit) =>
+      Temporal.Duration.compare(duration.abs(), unit.duration, {
+        relativeTo: now,
+      }) >= 0,
+  );
+  // Use 'seconds' when no unit was found, i.e. when the duration is less than a second
+  const unitIndex = bestUnitIndex >= 0 ? bestUnitIndex : UNITS.length - 1;
+  const unit = UNITS[unitIndex];
+  const value = duration.round({
+    smallestUnit: unit.name,
+    relativeTo: now,
+  })[unit.name];
+  const options = { style: formatStyle };
+
+  return {
+    label: formatRelativeTime(value, unit.name, locale, options),
+    interval: unit.interval,
+  };
+}

--- a/packages/circuit-ui/components/Timestamp/TimestampService.ts
+++ b/packages/circuit-ui/components/Timestamp/TimestampService.ts
@@ -106,14 +106,12 @@ export function getState({
   locale,
   formatStyle,
   variant,
-  threshold,
   includeTime,
 }: {
   datetime: string;
   locale: Locale | undefined;
   formatStyle: 'long' | 'short' | 'narrow';
   variant: 'auto' | 'relative' | 'absolute';
-  threshold: string;
   includeTime: boolean;
 }): State {
   const zonedDateTime = Temporal.ZonedDateTime.from(datetime);
@@ -121,11 +119,9 @@ export function getState({
   const duration = zonedDateTime.since(now);
 
   const isBeyondThreshold =
-    Temporal.Duration.compare(
-      duration.abs(),
-      Temporal.Duration.from(threshold),
-      { relativeTo: now },
-    ) > 0;
+    Temporal.Duration.compare(duration.abs(), Temporal.Duration.from('P1M'), {
+      relativeTo: now,
+    }) > 0;
 
   if (
     variant === 'absolute' ||
@@ -150,7 +146,7 @@ export function getState({
         relativeTo: now,
       }) >= 0,
   );
-  // Use 'seconds' when no unit was found, i.e. when the duration is less than a second
+  // Use the smallest unit when no unit was found, i.e. when the duration is less than the smallest unit duration
   const unitIndex = bestUnitIndex >= 0 ? bestUnitIndex : UNITS.length - 1;
   const unit = UNITS[unitIndex];
   const value = duration.round({

--- a/packages/circuit-ui/components/Timestamp/index.ts
+++ b/packages/circuit-ui/components/Timestamp/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, SumUp Ltd.
+ * Copyright 2024, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-export {
-  Timestamp,
-  type TimestampProps,
-} from './components/Timestamp/index.js';
+export { Timestamp } from './Timestamp.js';
+
+export type { TimestampProps } from './Timestamp.js';

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -64,7 +64,7 @@
     "@emotion/styled": "^11.14.0",
     "@sumup-oss/design-tokens": "^8.0.0",
     "@sumup-oss/icons": "^5.2.0",
-    "@sumup-oss/intl": "^3.0.1",
+    "@sumup-oss/intl": "^3.1.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "^16.0.1",
@@ -91,7 +91,7 @@
     "@emotion/styled": "^11.11.0",
     "@sumup-oss/design-tokens": ">=8.0.0",
     "@sumup-oss/icons": ">=5.0.0",
-    "@sumup-oss/intl": "3.x",
+    "@sumup-oss/intl": "^3.1.0",
     "react": ">=18.0.0 <19.0.0",
     "react-dom": ">=18.0.0 <19.0.0",
     "temporal-polyfill": "0.2.x"

--- a/templates/astro/package.json
+++ b/templates/astro/package.json
@@ -19,7 +19,7 @@
     "@sumup-oss/circuit-ui": "^9.0.0",
     "@sumup-oss/design-tokens": "^8.0.0",
     "@sumup-oss/icons": "^5.0.0",
-    "@sumup-oss/intl": "^3.0.1",
+    "@sumup-oss/intl": "^3.1.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.1",
     "astro": "^5.1.2",

--- a/templates/nextjs/template/package.json
+++ b/templates/nextjs/template/package.json
@@ -17,7 +17,7 @@
     "@sumup-oss/circuit-ui": "^9.0.0",
     "@sumup-oss/design-tokens": "^8.0.0",
     "@sumup-oss/icons": "^5.0.0",
-    "@sumup-oss/intl": "^3.0.1",
+    "@sumup-oss/intl": "^3.1.0",
     "next": "^15.1.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -21,7 +21,7 @@
     "@sumup-oss/circuit-ui": "^9.0.0",
     "@sumup-oss/design-tokens": "^8.0.0",
     "@sumup-oss/icons": "^5.0.0",
-    "@sumup-oss/intl": "^3.0.1",
+    "@sumup-oss/intl": "^3.1.0",
     "isbot": "^5.1.19",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
Addresses [DSCB-33](https://sumupteam.atlassian.net/browse/DSCB-33).

## Purpose

We often display time stamps to users to communicate when an event took place. New web APIs such as the [`Intl.DateTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) and [`Intl.RelativeTimeFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat) have made it easier to display date times in consistent, humanly-readable formats.

## Approach and changes

- Add an experimental Timestamp component that uses `@sumup-oss/intl` to format the date time and adds additional logic to automatically switch between absolute and relative formats and update the displayed value on regular intervals.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
