### PR TITLE
Add remove toast callback

### DIFF
--- a/.changeset/silver-pears-promise.md
+++ b/.changeset/silver-pears-promise.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Add remove toast callback

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.mdx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.mdx
@@ -65,6 +65,39 @@ Change the position of notifications by passing the `position` prop. Supported v
 
 <Story of={Stories.Position} />
 
+### Dismissing toasts programmatically
+
+You can use the function returned from the `setToast` method to dismiss a toast programmatically:
+
+```tsx
+import { useNotificationToast, Button } from '@sumup-oss/circuit-ui';
+
+export function App({}) {
+  const { setToast } = useNotificationToast();
+  const dismissRef = useRef(() => {});
+
+  const handleClick = () => {
+    dismissRef.current = setToast({
+      variant: 'success',
+      body: 'This is a toast message',
+    });
+  };
+
+  const handleDismiss = () => {
+    dismissRef.current();
+  };
+
+  return (
+    <>
+      <Button onClick={handleClick}>Open toast</Button>
+      <Button onClick={handleDismiss}>Dismiss toast</Button>
+    </>
+  );
+}
+```
+
+<Story of={Stories.Dismiss} />
+
 ## Accessibility
 
 By their nature as status messages, toasts are rendered inside a [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) using `role="status"` and `aria-live="polite"`.

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -16,6 +16,7 @@
 
 import { screen, userEvent, within } from '@storybook/test';
 import isChromatic from 'chromatic/isChromatic';
+import { useRef } from 'react';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 import { Button } from '../Button/index.js';
@@ -26,7 +27,6 @@ import {
   NotificationToast,
   type NotificationToastProps,
 } from './NotificationToast.js';
-import { useRef } from 'react';
 
 export default {
   title: 'Notification/NotificationToast',

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.stories.tsx
@@ -26,6 +26,7 @@ import {
   NotificationToast,
   type NotificationToastProps,
 } from './NotificationToast.js';
+import { useRef } from 'react';
 
 export default {
   title: 'Notification/NotificationToast',
@@ -109,6 +110,36 @@ Position.args = {
 };
 
 Position.play = play;
+
+const DismissApp = ({ toast }: { toast: NotificationToastProps }) => {
+  const { setToast } = useNotificationToast();
+  const dismissRef = useRef(() => {});
+  const randomIndex = isChromatic()
+    ? 1
+    : Math.floor(Math.random() * TOASTS.length);
+  return (
+    <>
+      <Button
+        type="button"
+        onClick={() => {
+          dismissRef.current = setToast({ ...toast, ...TOASTS[randomIndex] });
+        }}
+      >
+        Open toast
+      </Button>
+      &nbsp;
+      <Button type="button" onClick={() => dismissRef.current()}>
+        Dismiss toast
+      </Button>
+    </>
+  );
+};
+
+export const Dismiss = (toast: NotificationToastProps) => (
+  <ToastProvider>
+    <DismissApp toast={toast} />
+  </ToastProvider>
+);
 
 const variants = ['info', 'success', 'warning', 'danger'] as const;
 

--- a/packages/circuit-ui/components/ToastContext/createUseToast.spec.tsx
+++ b/packages/circuit-ui/components/ToastContext/createUseToast.spec.tsx
@@ -54,4 +54,17 @@ describe('createUseToast', () => {
     });
     expect(setToast).toHaveBeenCalledWith(expected);
   });
+
+  it('should remove the toast when the returned function is called', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    const remove = result.current.setToast({});
+    remove();
+
+    const expected = expect.objectContaining({
+      component: expect.any(Function),
+      id: expect.any(String),
+    });
+    expect(removeToast).toHaveBeenCalledWith(expected);
+  });
 });

--- a/packages/circuit-ui/components/ToastContext/createUseToast.ts
+++ b/packages/circuit-ui/components/ToastContext/createUseToast.ts
@@ -24,16 +24,20 @@ export function createUseToast<T extends BaseToastProps>(
   component: ToastComponent<T>,
 ) {
   return (): {
-    setToast: (props: Omit<T, 'isVisible'>) => void;
+    setToast: (props: Omit<T, 'isVisible'>) => () => void;
   } => {
     const context = useContext(ToastContext);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: The `component` never changes
     return useMemo(
       () => ({
-        setToast: (props: Omit<T, 'isVisible'>): void => {
+        setToast: (props: Omit<T, 'isVisible'>): (() => void) => {
           const id = uniqueId('toast_');
-          context.setToast({ ...props, id, component });
+          const toast = { ...props, id, component };
+          context.setToast(toast);
+          return () => {
+            context.removeToast(toast);
+          };
         },
       }),
       [context],


### PR DESCRIPTION
## Purpose

Allow users to dismiss a Toast programmatically. Sometimes this can be beneficial to avoid showing too many toasts or dismissing toasts after navigating away.

## Approach and changes

Return a callback function from the `setToast` function that removes the toast from the context.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
