### PR TITLE
Remove accidental default attribute

### DIFF
--- a/.changeset/proud-pigs-yell.md
+++ b/.changeset/proud-pigs-yell.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed the `default` attribute that was accidentally added to components with default translations.

--- a/packages/circuit-ui/util/i18n.ts
+++ b/packages/circuit-ui/util/i18n.ts
@@ -110,7 +110,8 @@ export function transformModulesToTranslations<
   Key extends string | number | symbol = keyof T,
 >(modules: Record<string, T>): Translations<Key> {
   const translations = Object.entries(modules).reduce(
-    (acc, [importPath, strings]) => {
+    (acc, [importPath, exports]) => {
+      const { default: unused, ...strings } = exports;
       const matches = importPath.match(/[a-z]{2}-[A-Z]{2}/);
 
       // @ts-expect-error This environment variable is set by Vite.
@@ -128,7 +129,7 @@ export function transformModulesToTranslations<
         throw new Error(`Unsupported locale: ${importPath}`);
       }
 
-      acc[locale] = strings as Record<Key, string>;
+      acc[locale] = strings as unknown as Record<Key, string>;
       return acc;
     },
     {} as Translations<Key>,


### PR DESCRIPTION
## Purpose

In #2786, I overlooked the fact that Vite returns named and default exports when glob importing JSON files. The `default` export ended up being forward as an attribute to the components.

## Approach and changes

- Filter out the `default` export from the loaded translations

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
