### PR TITLE
Fix regression for `:focus-visible` matcher in unit tests

### DIFF
--- a/.changeset/strong-mayflies-kneel.md
+++ b/.changeset/strong-mayflies-kneel.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': patch
+---
+
+Fixed a regression that [breaks Jest and Vitest tests](https://github.com/dperini/nwsapi/issues?q=sort%3Aupdated-desc+is%3Aissue+focus-visible+) when [matching elements](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches) using the `:focus-visible` selector.

--- a/packages/circuit-ui/components/Tooltip/Tooltip.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.tsx
@@ -137,13 +137,13 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     const handleFocus: FocusEventHandler = useCallback(
       (event) => {
         if (
-          event.currentTarget.matches(':focus-visible') ||
           // Vitest and Jest use nwsapi to mock the `Element.matches` API.
           // It has a bug where `:focus-visible` is not matched unless
           // the element has the `autofocus` property set.
           // https://github.com/dperini/nwsapi/issues/122
-          (process.env.NODE_ENV === 'test' &&
-            event.currentTarget.matches(':focus'))
+          process.env.NODE_ENV === 'test'
+            ? event.currentTarget.matches(':focus')
+            : event.currentTarget.matches(':focus-visible')
         ) {
           handleOpen();
         }


### PR DESCRIPTION
## Purpose

When upgrading dependencies in #2821, I modified a workaround for [bugs in the `nwsapi` package](https://github.com/dperini/nwsapi/issues?q=sort%3Aupdated-desc+is%3Aissue+focus-visible+) related to the `:focus-visible` element matcher. While some of the workarounds aren't necessary in the design system anymore, I didn't consider that the workaround is still needed for projects that still use an older version of `nwsapi`.

## Approach and changes

- Re-instate the workaround for the `:focus-visible` selector in test environments

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
