### PR TITLE
Adapt Calendar component for Node v22.12+

### DIFF
--- a/.changeset/shaggy-coins-enjoy.md
+++ b/.changeset/shaggy-coins-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Deprecated the Calendar component's `calendar` prop since support for the `gregory` calendar system wasn't fully tested and is partially broken. Use the default `iso8601` calendar system instead. The prop will be removed in the next major version.

--- a/.changeset/sour-llamas-check.md
+++ b/.changeset/sour-llamas-check.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the display order of the Calendar component's month headline on Node 22.12 and above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22.11]
+        node: [20, 22]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
       matrix:
-        node: [20, 22.11]
+        node: [20, 22]
         template: [astro, nextjs, remix]
         include:
           - template: astro

--- a/packages/circuit-ui/components/Calendar/Calendar.mdx
+++ b/packages/circuit-ui/components/Calendar/Calendar.mdx
@@ -28,7 +28,7 @@ Dates are formatted using the [`Intl.DateTimeFormat` API](https://developer.mozi
 
 Use the `firstDayOfWeek` prop to set the first day of the week for the locale, either `1` (Monday) or `7` (Sunday). This information can be obtained using the [`Intl.Locale.prototype.getWeekInfo()` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo#firstday) in supported browsers.
 
-Only `iso8601` and `gregory` [calendars](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCalendars#supported_calendar_types) and the left-to-right [writing direction](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) are currently supported.
+Only the `iso8601` [calendar](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCalendars#supported_calendar_types) and the left-to-right [writing direction](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) are currently supported.
 
 <Story of={Stories.Localized} />
 

--- a/packages/circuit-ui/components/Calendar/Calendar.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.tsx
@@ -92,6 +92,10 @@ interface SharedProps {
    */
   locale?: Locale;
   /**
+   * @deprecated Support for the `gregory` calendar has been removed since it
+   * never fully worked. The `calendar` prop will be removed in the next major
+   * version.
+   *
    * The identifier for the used [calendar](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar). Default: `iso8601`.
    */
   calendar?: 'iso8601' | 'gregory';
@@ -150,7 +154,6 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
       nextMonthButtonLabel,
       modifiers,
       numberOfMonths = 1,
-      calendar = 'iso8601',
       ...rest
     } = useI18n(props, translations);
     const [{ months, focusedDate, hoveredDate, today }, dispatch] = useReducer(
@@ -311,7 +314,6 @@ export const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
               firstDayOfWeek={firstDayOfWeek}
               daysInWeek={daysInWeek}
               locale={locale}
-              calendar={calendar}
               modifiers={modifiers}
               onFocus={handleFocusDate}
               onSelect={onSelect}
@@ -358,17 +360,16 @@ function Month({
   firstDayOfWeek = 1,
   daysInWeek,
   locale,
-  calendar,
 }: MonthProps) {
   const descriptionIds = useId();
   const headlineId = useId();
   const headline = useMemo(
-    () => getMonthHeadline(yearMonth, locale, calendar),
-    [yearMonth, locale, calendar],
+    () => getMonthHeadline(yearMonth, locale),
+    [yearMonth, locale],
   );
   const weekdays = useMemo(
-    () => getWeekdays(firstDayOfWeek, daysInWeek, locale, calendar),
-    [firstDayOfWeek, daysInWeek, locale, calendar],
+    () => getWeekdays(firstDayOfWeek, daysInWeek, locale),
+    [firstDayOfWeek, daysInWeek, locale],
   );
   const weeks = useMemo(
     () => getViewOfMonth(yearMonth, firstDayOfWeek, daysInWeek),

--- a/packages/circuit-ui/components/Calendar/CalendarService.ts
+++ b/packages/circuit-ui/components/Calendar/CalendarService.ts
@@ -143,7 +143,6 @@ export function getWeekdays(
   firstDayOfWeek: FirstDayOfWeek = 1,
   daysInWeek: DaysInWeek = 7,
   locale?: Locale,
-  calendar?: string,
 ) {
   return Array.from(Array(daysInWeek)).map((_, index) => {
     // 1973 started with a Monday
@@ -151,11 +150,11 @@ export function getWeekdays(
     return {
       narrow: formatDateTime(date, locale, {
         weekday: 'narrow',
-        calendar,
+        calendar: date.calendarId,
       }),
       long: formatDateTime(date, locale, {
         weekday: 'long',
-        calendar,
+        calendar: date.calendarId,
       }),
     };
   }) as Weekdays;
@@ -164,12 +163,17 @@ export function getWeekdays(
 export function getMonthHeadline(
   yearMonth: Temporal.PlainYearMonth,
   locale?: Locale,
-  calendar = 'iso8601',
 ) {
-  return formatDateTime(yearMonth, locale, {
+  // Temporal objects use the `iso8601` calendar system by default, which
+  // (incorrectly?) renders the year before the month since Node 22.12
+  // (e.g. "2020 March" instead of "March 2020").
+  // A `PlainYearMonth` has to be converted to a `PlainDate` to be able to
+  // change its calendar system.
+  const date = yearMonth.toPlainDate({ day: 1 }).withCalendar('gregory');
+  return formatDateTime(date, locale, {
     year: 'numeric',
     month: 'long',
-    calendar,
+    calendar: date.calendarId,
   });
 }
 


### PR DESCRIPTION
## Purpose

Node v22.12 broke the Calendar component's unit tests because the month headline changed from e.g. "March 2020" to "2020 March". Node v22.12 [updated the ICU data](https://github.com/nodejs/node/pull/55551) to v76.1 which included the [Common Locale Data Repository (CLDR) v46](https://cldr.unicode.org/downloads/cldr-46#data-changes). We were impacted by this specific change:

> Added a new calendar type, `iso8601`. This is not the same as the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) standard format, which is designed just for data interchange: it is all ASCII, does not have all the options for fields (like “Sunday”, “BC”, or “AM”), and does not contain spaces. The CLDR `iso8601` calendar uses patterns in the order: era, year, month, day, day-of-week, hour, minute, second, day-period, timezone.

The Temporal API uses the `iso8601` calendar by default since it covers dates before 1582 and "is the system most often used in computing, on the modern Internet" ([ref](https://tc39.es/proposal-temporal/docs/calendars.html)). I believe we should stick with this default since migrating from the `iso8601` to the `gregory` calendar would be a breaking change and increase boilerplate code for developers.

## Approach and changes

- Fixed the display order of the Calendar component's month headline on Node 22.12+ by selectively using the `gregory` calendar for formatting.
- Deprecated the Calendar component's `calendar` prop since support for the `gregory` calendar system wasn't fully tested and is partially broken. The prop should be removed in the next major version.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
