### PR TITLE
Fix missing effect hook dependencies

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -42,6 +42,9 @@
         "noRedundantRoles": "warn",
         "useSemanticElements": "warn"
       },
+      "correctness": {
+        "useExhaustiveDependencies": "error"
+      },
       "style": {
         "noDefaultExport": "error",
         "useFilenamingConvention": {

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
@@ -102,6 +102,8 @@ export function SideNavigation({
     closeButtonLabel,
     primaryNavigationLabel,
     UNSAFE_components,
+    skipNavigationLabel,
+    skipNavigationHref,
   ]);
 
   // Close the modal when the user resizes the window.


### PR DESCRIPTION
## Approach and changes

- Add missing effect hook dependencies in the SideNavigation component
- Increase Biome's `useExhaustiveDependencies` rule severity to error (it's `warn` in Foundry)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
