### PR TITLE
Optimize Coverage Exclusion

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -17,6 +17,7 @@ import { defineConfig } from 'vite';
 import GithubActionsReporter from 'vitest-github-actions-reporter';
 
 import { css } from './packages/circuit-ui/vite.config.js';
+import { coverageConfigDefaults } from 'vitest/config';
 
 export default defineConfig({
   css,
@@ -27,25 +28,13 @@ export default defineConfig({
     coverage: {
       exclude: [
         // Default
-        'coverage/**',
-        'dist/**',
-        '**/[.]**',
-        'packages/*/test?(s)/**',
-        '**/*.d.ts',
-        '**/virtual:*',
-        '**/__x00__*',
-        '**/\x00*',
-        'cypress/**',
-        'test?(s)/**',
-        'test?(-*).?(c|m)[jt]s?(x)',
-        '**/*{.,-}{test,spec}.?(c|m)[jt]s?(x)',
-        '**/__tests__/**',
-        '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,lint-staged,remix,astro}.config.*',
-        '**/vitest.{workspace,projects}.[jt]s?(on)',
-        '**/.{eslint,mocha,prettier}rc.{?(c|m)js,yml}',
+        ...coverageConfigDefaults.exclude,
         // Custom
         '**/*.stories.*',
         '**/index.*',
+        '**/*.json.js',
+        '**/*.module.css.js',
+        '**/dist/**',
       ],
     },
   },


### PR DESCRIPTION
## Purpose

Following the addition of translations in CUI, translation files should be excluded from vite coverage.

## Approach and changes

Add pattern for excluding translation files to the vite config.
Exclude css modules.
Fix pattern for dist/ folders

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
