### PR TITLE
Fix useScrollLock instances issue

### DIFF
--- a/.changeset/poor-ads-hunt.md
+++ b/.changeset/poor-ads-hunt.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed an issue with simultaneous instances of the `useScrollLock` hook.

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
@@ -15,6 +15,8 @@
 
 import { useCallback, useEffect, useRef } from 'react';
 
+let instanceCount = 0;
+
 export const useScrollLock = (isLocked: boolean): void => {
   const scrollValue = useRef<string>();
 
@@ -27,6 +29,18 @@ export const useScrollLock = (isLocked: boolean): void => {
     body.style.width = '';
     window.scrollTo(0, Number.parseInt(scrollY || '0', 10) * -1);
   }, []);
+
+  useEffect(() => {
+    instanceCount += 1;
+
+    return () => {
+      instanceCount -= 1;
+      if (instanceCount === 0) {
+        restoreScroll();
+      }
+    };
+  }, [restoreScroll]);
+
   useEffect(() => {
     if (isLocked) {
       scrollValue.current = `${window.scrollY}px`;
@@ -39,11 +53,8 @@ export const useScrollLock = (isLocked: boolean): void => {
       body.style.position = 'fixed';
       body.style.width = `${bodyWidth}px`;
       body.style.top = `-${scrollY}`;
-    } else {
+    } else if (instanceCount === 1) {
       restoreScroll();
     }
-    return () => {
-      restoreScroll();
-    };
   }, [isLocked, restoreScroll]);
 };


### PR DESCRIPTION
Addresses [#DSYS-883](https://sumupteam.atlassian.net/browse/DSYS-883)

## Purpose

When testing nested modals, I noticed that two different instances of the `useScrollLock` collided and scroll lock no longer functioned as expected.  On a single web page, we only need to disable scroll on the body element once. If a second instance of the hook is introduced by a second component, its cleanup fn will restore the scroll thus canceling the effect of the first instance.


## Approach and changes

Keep track of the number instances of the  `useScrollLock` hook and only  execute cleanup fn for the first instance.


## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
