### PR TITLE
Fix running puppeteer in Ubuntu 24.04

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -50,4 +50,7 @@ jobs:
 
       - name: Test app
         working-directory: ./test-app
-        run: npx start-server-and-test 'npm run start -- --port=3000' localhost:3000 "node ../scripts/verify-template.js"
+        # We use aa-exec since Ubuntu 24.04's AppArmor profile blocks the use
+        # of puppeteer otherwise, see
+        # https://github.com/puppeteer/puppeteer/issues/12818
+        run: npx start-server-and-test 'npm run start -- --port=3000' localhost:3000 "aa-exec --profile=chrome node ../scripts/verify-template.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,55 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@astrojs/check": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.4.tgz",
+			"integrity": "sha512-IOheHwCtpUfvogHHsvu0AbeRZEnjJg3MopdLddkJE70mULItS/Vh37BHcI00mcOJcH1vhD3odbpvWokpxam7xA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@astrojs/language-server": "^2.15.0",
+				"chokidar": "^4.0.1",
+				"kleur": "^4.1.5",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"astro-check": "dist/bin.js"
+			},
+			"peerDependencies": {
+				"typescript": "^5.0.0"
+			}
+		},
+		"node_modules/@astrojs/check/node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@astrojs/check/node_modules/readdirp": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+			"integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
 		"node_modules/@astrojs/compiler": {
 			"version": "2.10.3",
 			"resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.10.3.tgz",
@@ -152,6 +201,48 @@
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.4.2.tgz",
 			"integrity": "sha512-EdDWkC3JJVcpGpqJAU/5hSk2LKXyG3mNGkzGoAuyK+xoPHbaVdSuIWoN1QTnmK3N/gGfaaAfM8gO2KDCAW7S3w=="
+		},
+		"node_modules/@astrojs/language-server": {
+			"version": "2.15.4",
+			"resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.15.4.tgz",
+			"integrity": "sha512-JivzASqTPR2bao9BWsSc/woPHH7OGSGc9aMxXL4U6egVTqBycB3ZHdBJPuOCVtcGLrzdWTosAqVPz1BVoxE0+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@astrojs/compiler": "^2.10.3",
+				"@astrojs/yaml2ts": "^0.2.2",
+				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"@volar/kit": "~2.4.7",
+				"@volar/language-core": "~2.4.7",
+				"@volar/language-server": "~2.4.7",
+				"@volar/language-service": "~2.4.7",
+				"fast-glob": "^3.2.12",
+				"muggle-string": "^0.4.1",
+				"volar-service-css": "0.0.62",
+				"volar-service-emmet": "0.0.62",
+				"volar-service-html": "0.0.62",
+				"volar-service-prettier": "0.0.62",
+				"volar-service-typescript": "0.0.62",
+				"volar-service-typescript-twoslash-queries": "0.0.62",
+				"volar-service-yaml": "0.0.62",
+				"vscode-html-languageservice": "^5.2.0",
+				"vscode-uri": "^3.0.8"
+			},
+			"bin": {
+				"astro-ls": "bin/nodeServer.js"
+			},
+			"peerDependencies": {
+				"prettier": "^3.0.0",
+				"prettier-plugin-astro": ">=0.11.0"
+			},
+			"peerDependenciesMeta": {
+				"prettier": {
+					"optional": true
+				},
+				"prettier-plugin-astro": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@astrojs/markdown-remark": {
 			"version": "6.0.1",
@@ -802,6 +893,29 @@
 			],
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/@astrojs/yaml2ts": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.2.tgz",
+			"integrity": "sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yaml": "^2.5.0"
+			}
+		},
+		"node_modules/@astrojs/yaml2ts/node_modules/yaml": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -3322,6 +3436,68 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"node_modules/@emmetio/abbreviation": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+			"integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emmetio/scanner": "^1.0.4"
+			}
+		},
+		"node_modules/@emmetio/css-abbreviation": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+			"integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emmetio/scanner": "^1.0.4"
+			}
+		},
+		"node_modules/@emmetio/css-parser": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.0.tgz",
+			"integrity": "sha512-z7wkxRSZgrQHXVzObGkXG+Vmj3uRlpM11oCZ9pbaz0nFejvCDmAiNDpY75+wgXOcffKpj4rzGtwGaZxfJKsJxw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emmetio/stream-reader": "^2.2.0",
+				"@emmetio/stream-reader-utils": "^0.1.0"
+			}
+		},
+		"node_modules/@emmetio/html-matcher": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+			"integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@emmetio/scanner": "^1.0.0"
+			}
+		},
+		"node_modules/@emmetio/scanner": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+			"integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emmetio/stream-reader": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+			"integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@emmetio/stream-reader-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+			"integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@emnapi/core": {
 			"version": "1.3.1",
@@ -11379,6 +11555,111 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@volar/kit": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.11.tgz",
+			"integrity": "sha512-ups5RKbMzMCr6RKafcCqDRnJhJDNWqo2vfekwOAj6psZ15v5TlcQFQAyokQJ3wZxVkzxrQM+TqTRDENfQEXpmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/language-service": "2.4.11",
+				"@volar/typescript": "2.4.11",
+				"typesafe-path": "^0.2.2",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"typescript": "*"
+			}
+		},
+		"node_modules/@volar/language-core": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
+			"integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/source-map": "2.4.11"
+			}
+		},
+		"node_modules/@volar/language-server": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.11.tgz",
+			"integrity": "sha512-W9P8glH1M8LGREJ7yHRCANI5vOvTrRO15EMLdmh5WNF9sZYSEbQxiHKckZhvGIkbeR1WAlTl3ORTrJXUghjk7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/language-core": "2.4.11",
+				"@volar/language-service": "2.4.11",
+				"@volar/typescript": "2.4.11",
+				"path-browserify": "^1.0.1",
+				"request-light": "^0.7.0",
+				"vscode-languageserver": "^9.0.1",
+				"vscode-languageserver-protocol": "^3.17.5",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/@volar/language-service": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.11.tgz",
+			"integrity": "sha512-KIb6g8gjUkS2LzAJ9bJCLIjfsJjeRtmXlu7b2pDFGD3fNqdbC53cCAKzgWDs64xtQVKYBU13DLWbtSNFtGuMLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/language-core": "2.4.11",
+				"vscode-languageserver-protocol": "^3.17.5",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/@volar/source-map": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
+			"integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@volar/typescript": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
+			"integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@volar/language-core": "2.4.11",
+				"path-browserify": "^1.0.1",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/@vscode/emmet-helper": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+			"integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emmet": "^2.4.3",
+				"jsonc-parser": "^2.3.0",
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "^3.15.1",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/@vscode/emmet-helper/node_modules/jsonc-parser": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+			"integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@vscode/l10n": {
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+			"integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@web3-storage/multipart-parser": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz",
@@ -14887,6 +15168,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
+			}
+		},
+		"node_modules/emmet": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+			"integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"./packages/scanner",
+				"./packages/abbreviation",
+				"./packages/css-abbreviation",
+				"./"
+			],
+			"dependencies": {
+				"@emmetio/abbreviation": "^2.3.3",
+				"@emmetio/css-abbreviation": "^2.1.8"
 			}
 		},
 		"node_modules/emoji-regex": {
@@ -30850,6 +31148,13 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
+		"node_modules/muggle-string": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+			"integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/multimatch": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
@@ -32541,6 +32846,13 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/path-browserify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
@@ -35627,6 +35939,13 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
 			}
+		},
+		"node_modules/request-light": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+			"integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -39313,6 +39632,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/typesafe-path": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+			"integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/typescript": {
 			"version": "5.7.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
@@ -39324,6 +39650,16 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/typescript-auto-import-cache": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.5.tgz",
+			"integrity": "sha512-fAIveQKsoYj55CozUiBoj4b/7WpN0i4o74wiGY5JVUEoD0XiqDk1tJqTEjgzL2/AizKQrXxyRosSebyDzBZKjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.3.8"
 			}
 		},
 		"node_modules/typescript-plugin-css-modules": {
@@ -40804,6 +41140,175 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/volar-service-css": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.62.tgz",
+			"integrity": "sha512-JwNyKsH3F8PuzZYuqPf+2e+4CTU8YoyUHEHVnoXNlrLe7wy9U3biomZ56llN69Ris7TTy/+DEX41yVxQpM4qvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-css-languageservice": "^6.3.0",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~2.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-emmet": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.62.tgz",
+			"integrity": "sha512-U4dxWDBWz7Pi4plpbXf4J4Z/ss6kBO3TYrACxWNsE29abu75QzVS0paxDDhI6bhqpbDFXlpsDhZ9aXVFpnfGRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@emmetio/css-parser": "^0.4.0",
+				"@emmetio/html-matcher": "^1.3.0",
+				"@vscode/emmet-helper": "^2.9.3",
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~2.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-html": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.62.tgz",
+			"integrity": "sha512-Zw01aJsZRh4GTGUjveyfEzEqpULQUdQH79KNEiKVYHZyuGtdBRYCHlrus1sueSNMxwwkuF5WnOHfvBzafs8yyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-html-languageservice": "^5.3.0",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~2.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-prettier": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.62.tgz",
+			"integrity": "sha512-h2yk1RqRTE+vkYZaI9KYuwpDfOQRrTEMvoHol0yW4GFKc75wWQRrb5n/5abDrzMPrkQbSip8JH2AXbvrRtYh4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~2.4.0",
+				"prettier": "^2.2 || ^3.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				},
+				"prettier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-typescript": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.62.tgz",
+			"integrity": "sha512-p7MPi71q7KOsH0eAbZwPBiKPp9B2+qrdHAd6VY5oTo9BUXatsOAdakTm9Yf0DUj6uWBAaOT01BSeVOPwucMV1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-browserify": "^1.0.1",
+				"semver": "^7.6.2",
+				"typescript-auto-import-cache": "^0.3.3",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-nls": "^5.2.0",
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~2.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-typescript-twoslash-queries": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.62.tgz",
+			"integrity": "sha512-KxFt4zydyJYYI0kFAcWPTh4u0Ha36TASPZkAnNY784GtgajerUqM80nX/W1d0wVhmcOFfAxkVsf/Ed+tiYU7ng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-uri": "^3.0.8"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~2.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/volar-service-yaml": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.62.tgz",
+			"integrity": "sha512-k7gvv7sk3wa+nGll3MaSKyjwQsJjIGCHFjVkl3wjaSP2nouKyn9aokGmqjrl39mi88Oy49giog2GkZH526wjig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-uri": "^3.0.8",
+				"yaml-language-server": "~1.15.0"
+			},
+			"peerDependencies": {
+				"@volar/language-service": "~2.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@volar/language-service": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vscode-css-languageservice": {
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.2.tgz",
+			"integrity": "sha512-GEpPxrUTAeXWdZWHev1OJU9lz2Q2/PPBxQ2TIRmLGvQiH3WZbqaNoute0n0ewxlgtjzTW3AKZT+NHySk5Rf4Eg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vscode/l10n": "^0.0.18",
+				"vscode-languageserver-textdocument": "^1.0.12",
+				"vscode-languageserver-types": "3.17.5",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"node_modules/vscode-html-languageservice": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.3.1.tgz",
+			"integrity": "sha512-ysUh4hFeW/WOWz/TO9gm08xigiSsV/FOAZ+DolgJfeLftna54YdmZ4A+lIn46RbdO3/Qv5QHTn1ZGqmrXQhZyA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vscode/l10n": "^0.0.18",
+				"vscode-languageserver-textdocument": "^1.0.12",
+				"vscode-languageserver-types": "^3.17.5",
+				"vscode-uri": "^3.0.8"
+			}
+		},
 		"node_modules/vscode-json-languageservice": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.2.1.tgz",
@@ -40816,6 +41321,40 @@
 				"vscode-languageserver-types": "^3.16.0",
 				"vscode-nls": "^5.0.0",
 				"vscode-uri": "^3.0.3"
+			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.17.5"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
 			}
 		},
 		"node_modules/vscode-languageserver-textdocument": {
@@ -41534,6 +42073,147 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/yaml-language-server": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.15.0.tgz",
+			"integrity": "sha512-N47AqBDCMQmh6mBLmI6oqxryHRzi33aPFPsJhYy3VTUGCdLHYjGh4FZzpUjRlphaADBBkDmnkM/++KNIOHi5Rw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.11.0",
+				"lodash": "4.17.21",
+				"request-light": "^0.5.7",
+				"vscode-json-languageservice": "4.1.8",
+				"vscode-languageserver": "^7.0.0",
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "^3.16.0",
+				"vscode-nls": "^5.0.0",
+				"vscode-uri": "^3.0.2",
+				"yaml": "2.2.2"
+			},
+			"bin": {
+				"yaml-language-server": "bin/yaml-language-server"
+			},
+			"optionalDependencies": {
+				"prettier": "2.8.7"
+			}
+		},
+		"node_modules/yaml-language-server/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/yaml-language-server/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/yaml-language-server/node_modules/prettier": {
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+			"integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/yaml-language-server/node_modules/request-light": {
+			"version": "0.5.8",
+			"resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+			"integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/yaml-language-server/node_modules/vscode-json-languageservice": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+			"integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jsonc-parser": "^3.0.0",
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "^3.16.0",
+				"vscode-nls": "^5.0.0",
+				"vscode-uri": "^3.0.2"
+			},
+			"engines": {
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/yaml-language-server/node_modules/vscode-jsonrpc": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+			"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0 || >=10.0.0"
+			}
+		},
+		"node_modules/yaml-language-server/node_modules/vscode-languageserver": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+			"integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.16.0"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/yaml-language-server/node_modules/vscode-languageserver-protocol": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+			"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"vscode-jsonrpc": "6.0.0",
+				"vscode-languageserver-types": "3.16.0"
+			}
+		},
+		"node_modules/yaml-language-server/node_modules/vscode-languageserver-types": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/yaml-language-server/node_modules/yaml": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+			"integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/yargs": {
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -41674,7 +42354,7 @@
 		},
 		"packages/circuit-ui": {
 			"name": "@sumup-oss/circuit-ui",
-			"version": "9.3.2",
+			"version": "9.4.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@floating-ui/react-dom": "^2.1.2",
@@ -41689,7 +42369,7 @@
 				"@emotion/react": "^11.14.0",
 				"@emotion/styled": "^11.14.0",
 				"@sumup-oss/design-tokens": "^8.0.0",
-				"@sumup-oss/icons": "^5.1.0",
+				"@sumup-oss/icons": "^5.2.0",
 				"@sumup-oss/intl": "^3.0.1",
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/jest-dom": "6.6.3",
@@ -41784,7 +42464,7 @@
 		},
 		"packages/icons": {
 			"name": "@sumup-oss/icons",
-			"version": "5.1.0",
+			"version": "5.2.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@babel/core": "^7.26.0",
@@ -41834,6 +42514,7 @@
 				"react-dom": "^18.3.1"
 			},
 			"devDependencies": {
+				"@astrojs/check": "^0.9.4",
 				"@sumup-oss/eslint-plugin-circuit-ui": "^5.0.0",
 				"@sumup-oss/foundry": "^8.4.1",
 				"@sumup-oss/stylelint-plugin-circuit-ui": "^3.0.0",

--- a/templates/astro/package.json
+++ b/templates/astro/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.4",
     "@sumup-oss/eslint-plugin-circuit-ui": "^5.0.0",
     "@sumup-oss/foundry": "^8.4.1",
     "@sumup-oss/stylelint-plugin-circuit-ui": "^3.0.0",


### PR DESCRIPTION
Addresses https://github.com/sumup-oss/circuit-ui/actions/runs/12740043700.

## Purpose

Ubuntu 24.04 has stricter AppArmor policies that prevent Puppeteer from running, with an error like:

> Failed to launch the browser process!
> [0109/235031.343250:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see [chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md](https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md). Otherwise see [chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md](https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md) for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.

We can use [`aa-exec`](https://manpages.ubuntu.com/manpages/noble/man1/aa-exec.1.html) to explicitly set the `chrome` policy and get it working again.

See: https://github.com/mermaid-js/mermaid-cli/issues/730#issuecomment-2408615110
See: https://github.com/actions/runner-images/issues/10015
See: https://github.com/puppeteer/puppeteer/issues/12818

## Approach and changes

- Work around AppArmor protections in Ubuntu 24.04 for puppeteer
- Install `@astrojs/check` to fix the `astro check` script that was silently failing in CI

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
