### PR TITLE
Update fg-placeholder color tokens

### DIFF
--- a/.changeset/red-berries-beam.md
+++ b/.changeset/red-berries-beam.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/design-tokens': minor
+---
+
+Updated the `--cui-fg-placeholder-*` color tokens to meet contrast requirements.

--- a/package-lock.json
+++ b/package-lock.json
@@ -42375,7 +42375,7 @@
 		},
 		"packages/circuit-ui": {
 			"name": "@sumup-oss/circuit-ui",
-			"version": "9.4.0",
+			"version": "9.5.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@floating-ui/react-dom": "^2.1.2",
@@ -42390,7 +42390,7 @@
 				"@emotion/react": "^11.14.0",
 				"@emotion/styled": "^11.14.0",
 				"@sumup-oss/design-tokens": "^8.0.0",
-				"@sumup-oss/icons": "^5.2.0",
+				"@sumup-oss/icons": "^5.3.0",
 				"@sumup-oss/intl": "^3.1.0",
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/jest-dom": "6.6.3",
@@ -42485,7 +42485,7 @@
 		},
 		"packages/icons": {
 			"name": "@sumup-oss/icons",
-			"version": "5.2.1",
+			"version": "5.3.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@babel/core": "^7.26.0",

--- a/packages/design-tokens/themes/dark.ts
+++ b/packages/design-tokens/themes/dark.ts
@@ -338,22 +338,22 @@ export const dark = [
   },
   {
     name: '--cui-fg-placeholder',
-    value: 'rgba(223, 232, 241, 0.4000)',
+    value: '#555D62',
     type: 'color',
   },
   {
     name: '--cui-fg-placeholder-hovered',
-    value: 'rgba(223, 232, 241, 0.4000)',
+    value: '#687278',
     type: 'color',
   },
   {
     name: '--cui-fg-placeholder-pressed',
-    value: 'rgba(223, 232, 241, 0.4000)',
+    value: '#7C878D',
     type: 'color',
   },
   {
     name: '--cui-fg-placeholder-disabled',
-    value: 'rgba(216, 232, 248, 0.1500)',
+    value: 'rgba(85, 93, 98, 0.500)',
     type: 'color',
   },
   {

--- a/packages/design-tokens/themes/light.ts
+++ b/packages/design-tokens/themes/light.ts
@@ -338,22 +338,22 @@ export const light = [
   },
   {
     name: '--cui-fg-placeholder',
-    value: '#9da7b1',
+    value: '#929396',
     type: 'color',
   },
   {
     name: '--cui-fg-placeholder-hovered',
-    value: '#9da7b1',
+    value: '#787A7C',
     type: 'color',
   },
   {
     name: '--cui-fg-placeholder-pressed',
-    value: '#9da7b1',
+    value: '#484A51',
     type: 'color',
   },
   {
     name: '--cui-fg-placeholder-disabled',
-    value: 'rgba(157, 167, 177, 0.4000)',
+    value: 'rgba(146, 147, 150, 0.4000)',
     type: 'color',
   },
   {


### PR DESCRIPTION
Fixes #1816.

## Purpose

The `fg-placeholder-*` color tokens currently don't meet minimum color contrast requirements.

## Approach and changes

- Update the `fg-placeholder-*` color tokens in light and dark mode

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
