### PR TITLE
Remove the Calendar's deprecated calendar prop

### DIFF
--- a/.changeset/lucky-cheetahs-flow.md
+++ b/.changeset/lucky-cheetahs-flow.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': major
+---
+
+Removed the Calendar component's deprecated `calendar` prop. Support for the `gregory` calendar was removed in v9.4 since it never fully worked.

--- a/packages/circuit-ui/components/Calendar/Calendar.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.tsx
@@ -92,14 +92,6 @@ interface SharedProps {
    */
   locale?: Locale;
   /**
-   * @deprecated Support for the `gregory` calendar has been removed since it
-   * never fully worked. The `calendar` prop will be removed in the next major
-   * version.
-   *
-   * The identifier for the used [calendar](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar). Default: `iso8601`.
-   */
-  calendar?: 'iso8601' | 'gregory';
-  /**
    * An integer indicating the first day of the week. Can be either `1` (Monday)
    * or `7` (Sunday). Default: `1`.
    */


### PR DESCRIPTION
## Purpose

Support for the `gregory` calendar was removed in v9.4 since it never fully worked.

## Approach and changes

- Removed the Calendar component's deprecated `calendar` prop

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
