### PR TITLE
Use the regular color for placeholder text

### DIFF
--- a/.changeset/cuddly-lemons-rhyme.md
+++ b/.changeset/cuddly-lemons-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': patch
+---
+
+Removed the Input component's red or yellow placeholder color when invalid or with a warning. Previously, the placeholder text could be confused for a user entered value.

--- a/packages/circuit-ui/components/Input/Input.module.css
+++ b/packages/circuit-ui/components/Input/Input.module.css
@@ -53,10 +53,6 @@
   box-shadow: inset 0 0 0 1px var(--cui-border-danger);
 }
 
-.base[aria-invalid="true"]:not(:focus):not([disabled])::placeholder {
-  color: var(--cui-fg-danger);
-}
-
 .warning {
   border: 1px solid var(--cui-border-warning);
 }
@@ -68,10 +64,6 @@
 .warning:focus {
   border: 1px solid var(--cui-border-warning);
   box-shadow: inset 0 0 0 1px var(--cui-border-warning);
-}
-
-.warning:not(:focus):not([disabled])::placeholder {
-  color: var(--cui-fg-warning);
 }
 
 /* Disabled */


### PR DESCRIPTION
Addresses [DSYS-912](https://sumupteam.atlassian.net/browse/DSYS-912).

## Purpose

The placeholder text of an invalid Input can be confused for a user entered value.

## Approach and changes

- Removed the Input component's red or yellow placeholder color when invalid or with a warning

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
