### PR TITLE
Address unit test warnings

### DIFF
--- a/packages/circuit-ui/components/DateInput/components/DateSegment.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.spec.tsx
@@ -28,7 +28,6 @@ describe('DateSegment', () => {
     min: 1,
     max: 12,
     step: 3,
-    advanceFocusBoundary: 1,
     onChange: vi.fn(),
     focus: {
       previous: vi.fn(),

--- a/packages/circuit-ui/components/Table/Table.tsx
+++ b/packages/circuit-ui/components/Table/Table.tsx
@@ -222,6 +222,8 @@ export class Table extends Component<TableProps, TableState> {
       scrollable = false,
       onRowClick,
       rows: initialRows,
+      initialSortedColumn,
+      initialSortDirection,
       onSortBy,
       className,
       ...props

--- a/packages/circuit-ui/components/Tabs/Tabs.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.tsx
@@ -85,7 +85,7 @@ export class Tabs extends Component<TabsProps, TabsState> {
   };
 
   render() {
-    const { items, ...props } = this.props;
+    const { items, initialSelectedIndex, ...props } = this.props;
     const { selectedIndex } = this.state;
     const { tabs, panels } = items.reduce(
       (aggr, { id, tab, panel }, index) => {

--- a/packages/circuit-ui/setupTests.ts
+++ b/packages/circuit-ui/setupTests.ts
@@ -47,3 +47,5 @@ global.matchMedia = vi.fn().mockImplementation((query) => ({
   removeEventListener: vi.fn(),
   dispatchEvent: vi.fn(),
 }));
+
+global.scrollTo = vi.fn();

--- a/packages/circuit-ui/vendor/dialog-polyfill/index.js
+++ b/packages/circuit-ui/vendor/dialog-polyfill/index.js
@@ -621,7 +621,7 @@ if (typeof window === 'undefined') {
    * @param {!Element} element to force upgrade
    */
   dialogPolyfill.forceRegisterDialog = function (element) {
-    if (window.HTMLDialogElement || element.showModal) {
+    if ((window.HTMLDialogElement && window.HTMLDialogElement.prototype.showModal) || element.showModal) {
       console.warn(
         'This browser already supports <dialog>, the polyfill ' +
           'may not work correctly',


### PR DESCRIPTION
## Purpose

While running the unit tests, I noticed a number of warnings.

## Approach and changes

- Remove invalid HTML attributes
- Mock `window.scrollTo`
- Silence dialog-polyfill warning in jsdom

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
