### PR TITLE
Export component styles without global reset

### DIFF
--- a/.changeset/ninety-scissors-share.md
+++ b/.changeset/ninety-scissors-share.md
@@ -1,5 +1,5 @@
 ---
-"@sumup-oss/circuit-ui": minor
+'@sumup-oss/circuit-ui': minor
 ---
 
-Exported the component styles without the global style reset under `@sumup-oss/circuit-ui/components.css`.
+Exported the component styles without the global style reset under `@sumup-oss/circuit-ui/experimental/styles.css`. The global style reset will be removed in the next major release.

--- a/.changeset/ninety-scissors-share.md
+++ b/.changeset/ninety-scissors-share.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Exported the component styles without the global style reset under `@sumup-oss/circuit-ui/components.css`.

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -18,7 +18,8 @@
       "types": "./dist/experimental.d.ts",
       "default": "./dist/experimental.js"
     },
-    "./styles.css": "./dist/style.css"
+    "./styles.css": "./dist/style.css",
+    "./components.css": "./dist/components.css"
   },
   "typesVersions": {
     "*": {
@@ -45,7 +46,7 @@
   },
   "homepage": "https://github.com/sumup-oss/circuit-ui/tree/main/packages/circuit-ui/README.md",
   "scripts": {
-    "build": "vite build && tsc -p tsconfig.build.json && rm -rf dist/node_modules",
+    "build": "vite build && tsc -p tsconfig.build.json && rm -rf dist/node_modules && sed '/BEGIN RESET/,/END RESET/d' ./dist/style.css > ./dist/components.css",
     "lint": "foundry run eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "npm run lint -- --fix",
     "test": "vitest"

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -19,7 +19,7 @@
       "default": "./dist/experimental.js"
     },
     "./styles.css": "./dist/style.css",
-    "./components.css": "./dist/components.css"
+    "./experimental/styles.css": "./dist/experimental-styles.css"
   },
   "typesVersions": {
     "*": {
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/sumup-oss/circuit-ui/tree/main/packages/circuit-ui/README.md",
   "scripts": {
-    "build": "vite build && tsc -p tsconfig.build.json && rm -rf dist/node_modules && sed '/BEGIN RESET/,/END RESET/d' ./dist/style.css > ./dist/components.css",
+    "build": "vite build && tsc -p tsconfig.build.json && rm -rf dist/node_modules && sed '/BEGIN RESET/,/END RESET/d' ./dist/style.css > ./dist/experimental-styles.css",
     "lint": "foundry run eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "npm run lint -- --fix",
     "test": "vitest"

--- a/packages/circuit-ui/styles/base.css
+++ b/packages/circuit-ui/styles/base.css
@@ -14,7 +14,7 @@
 
 html {
   box-sizing: border-box;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 [type="button"] {

--- a/packages/circuit-ui/styles/base.css
+++ b/packages/circuit-ui/styles/base.css
@@ -14,7 +14,14 @@
 
 html {
   box-sizing: border-box;
-  overflow-x: clip;
+  overflow-x: hidden;
+}
+
+/* `clip` has the same visual effect as `hidden`, but doesn't interfere with `position: sticky` on child elements */
+@supports (overflow-x: clip) {
+  html {
+    overflow-x: clip;
+  }
 }
 
 [type="button"] {

--- a/packages/circuit-ui/styles/reset.css
+++ b/packages/circuit-ui/styles/reset.css
@@ -1,3 +1,5 @@
+/* BEGIN RESET */
+
 /**
  * reset.css
  * http://meyerweb.com/eric/tools/css/reset/
@@ -129,3 +131,5 @@ table {
   border-spacing: 0;
   border-collapse: collapse;
 }
+
+/* END RESET */


### PR DESCRIPTION
Follow up to #2237.

## Purpose

[CSS resets](https://meyerweb.com/eric/tools/css/reset/) are used to reduce browser inconsistencies in things like default line heights, margins and font sizes of headings, and so on. All browsers have presentation defaults, but no browsers have the same defaults.

Circuit UI’s [global base styles](https://github.com/sumup-oss/circuit-ui/blob/main/packages/circuit-ui/styles/base.css) are pretty opinionated and can clash with other frameworks or styles used on a page. This pull request exports a new CSS bundle without the global style reset to prevent these kinds of conflicts.

## Approach and changes

- Exported the component styles without the global style resets as `@sumup-oss/circuit-ui/experimental/styles.css`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
