### PR TITLE
Enforce primary navigation badge label

### DIFF
--- a/.changeset/silent-pots-rule.md
+++ b/.changeset/silent-pots-rule.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': major
+---
+
+Required an accessible name for the SideNavigation's primary link badge to ensure it can be perceived by visually impaired users. The relevant prop has been renamed from `badge.label` to `badge.children` to match the secondary link's badge.

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.spec.tsx
@@ -51,16 +51,12 @@ describe('SideNavigation', () => {
     return renderFn(<SideNavigation {...props} />);
   }
 
-  const baseProps = {
+  const defaultProps: SideNavigationProps = {
     isOpen: false,
     onClose: vi.fn(),
     closeButtonLabel: 'Close navigation modal',
     primaryNavigationLabel: 'Primary',
     secondaryNavigationLabel: 'Secondary',
-  };
-
-  const defaultProps: SideNavigationProps = {
-    ...baseProps,
     primaryLinks: [
       {
         icon: (iconProps) => <Shop {...iconProps} size="24" />,
@@ -68,6 +64,9 @@ describe('SideNavigation', () => {
         href: '/shop',
         onClick: vi.fn(),
         isActive: true,
+        badge: {
+          children: 'New',
+        },
         secondaryGroups: [
           {
             label: 'For Kids',
@@ -81,6 +80,9 @@ describe('SideNavigation', () => {
                 label: 'Books',
                 href: '/shop/books',
                 onClick: vi.fn(),
+                badge: {
+                  children: 'New',
+                },
               },
             ],
           },

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
@@ -60,7 +60,7 @@ export const baseArgs: SideNavigationProps = {
       href: '/shop',
       onClick: action('Shop'),
       isActive: true,
-      badge: { variant: 'promo', label: 'New items' },
+      badge: { variant: 'promo', children: 'New items' },
       secondaryGroups: [
         {
           secondaryLinks: [

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
@@ -54,7 +54,7 @@ describe('PrimaryLink', () => {
   it('should render with a badge', () => {
     renderPrimaryLink(render, {
       ...baseProps,
-      badge: { label: 'New' },
+      badge: { children: 'New' },
     });
     expect(screen.getByRole('link')).toHaveAccessibleDescription('New');
   });

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -46,30 +46,31 @@ export interface PrimaryLinkProps
    */
   isExternal?: boolean;
   /**
-   * Short label to describe that the link leads to an external page or opens in a new tab.
+   * Short label to describe that the link leads to an external page or opens
+   * in a new tab.
    */
   externalLabel?: string;
   /**
    * Whether to show a small circular badge to indicate that a nested secondary
    * link has a badge.
    */
-  badge?: boolean | PrimaryBadgeProps;
+  badge?: {
+    /**
+     * Choose the style variant.
+     *
+     * @default 'promo'
+     */
+    variant?: BadgeProps['variant'];
+    /**
+     * A clear and concise description of the badge's meaning.
+     */
+    children: string;
+  };
   /**
    * A collection of secondary groups with nested secondary navigation links.
    */
   secondaryGroups?: SecondaryGroupProps[];
 }
-
-export type PrimaryBadgeProps = {
-  /**
-   * Choose the style variant. Default: 'promo'.
-   */
-  variant?: BadgeProps['variant'];
-  /**
-   * A clear and concise description of the badge's meaning.
-   */
-  label: string;
-};
 
 export interface SecondaryGroupProps {
   /**


### PR DESCRIPTION
## Purpose

#2725 added the option to add an accessible name to the badge of the SideNavigation's primary link. It should be required to ensure the badge can be perceived by visually impaired users.

## Approach and changes

- Required an accessible name for the SideNavigation's primary link badge
- Renamed the relevant prop from `badge.label` to `badge.children` to match the secondary link's badge

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
