### PR TITLE
Remove color prop from Anchor component

### DIFF
--- a/.changeset/cyan-buckets-draw.md
+++ b/.changeset/cyan-buckets-draw.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed the `color` prop from the Anchor component's prop types as it's not supported.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -33,7 +33,7 @@ import { utilClasses } from '../../styles/utility.js';
 
 import classes from './Anchor.module.css';
 
-export interface BaseProps extends BodyProps {
+export interface BaseProps extends Omit<BodyProps, 'color'> {
   children: ReactNode;
   /**
    * Function that's called when the button is clicked.
@@ -44,8 +44,14 @@ export interface BaseProps extends BodyProps {
    */
   ref?: Ref<any>;
 }
-type LinkElProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'>;
-type ButtonElProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'>;
+type LinkElProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  'onClick' | 'color'
+>;
+type ButtonElProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'onClick' | 'color'
+>;
 
 export type AnchorProps = BaseProps & LinkElProps & ButtonElProps;
 


### PR DESCRIPTION
## Purpose

The Anchor component extends the Body component, which recently gained support for a `color` prop. The Anchor's color is hard-coded, so customizing its color doesn't work (and isn't supposed to work). 

## Approach and changes

- Remove the `color` prop from the Anchor component's prop types

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
