### PR TITLE
mark the Timestamp component as stable

### DIFF
--- a/.changeset/breezy-suns-impress.md
+++ b/.changeset/breezy-suns-impress.md
@@ -1,0 +1,10 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Marked the Timestamp component as stable.
+
+```diff
+-import { Timestamp } from '@sumup-oss/circuit-ui/experimental';
++import { Timestamp } from '@sumup-oss/circuit-ui';
+```

--- a/.changeset/large-shirts-peel.md
+++ b/.changeset/large-shirts-peel.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/eslint-plugin-circuit-ui": patch
+---
+
+Updated the `component-lifecycle-imports` ESlint rule to flag imports of the now stable Timestamp component from `@sumup-oss/circuit-ui/experimental`

--- a/packages/circuit-ui/components/Timestamp/Timestamp.mdx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.mdx
@@ -5,7 +5,7 @@ import * as Stories from './Timestamp.stories';
 
 # Timestamp
 
-<Status variant="experimental" />
+<Status variant="stable" />
 
 The Timestamp component displays a human readable date time.
 

--- a/packages/circuit-ui/experimental.ts
+++ b/packages/circuit-ui/experimental.ts
@@ -13,7 +13,3 @@
  * limitations under the License.
  */
 
-export {
-  Timestamp,
-  type TimestampProps,
-} from './components/Timestamp/index.js';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -214,6 +214,10 @@ export {
   Toggletip,
   type ToggletipProps,
 } from './components/Toggletip/index.js';
+export {
+  Timestamp,
+  type TimestampProps,
+} from './components/Timestamp/index.js';
 
 // Hooks
 export { useClickOutside } from './hooks/useClickOutside/index.js';

--- a/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.ts
+++ b/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.ts
@@ -85,6 +85,8 @@ const mappings = [
       'TooltipReferenceProps',
       'Toggletip',
       'ToggletipProps',
+      'Timestamp',
+      'TimestampProps',
     ],
   },
 ];


### PR DESCRIPTION

## Purpose

The Timestamp component has been available for a while in CUI v9 and is fully tested and can be marked as stable.

## Approach and changes

- Update docs status variant 
- Update cui package exports
- Update `component-lifecycle-imports` rule

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
