### PR TITLE
Refactor Dialog and Popover

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm run build
 
       - name: Publish packages
-        run: npx pkg-pr-new publish './packages/circuit-ui'  './packages/design-tokens'  './packages/icons' --json output.json --comment=off
+        run: npx pkg-pr-new publish './packages/circuit-ui'  './packages/design-tokens'  './packages/icons' './packages/eslint-plugin-circuit-ui' --json output.json --comment=off
 
       - name: Post or update comment
         uses: actions/github-script@v7

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
@@ -67,7 +67,6 @@ export interface ActionMenuReferenceProps {
   'onClick': (event: ClickEvent) => void;
   'onKeyDown': (event: KeyboardEvent) => void;
   'id': string;
-  'aria-haspopup': boolean;
   'aria-controls': string;
   'aria-expanded': boolean;
 }
@@ -275,7 +274,6 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
         <div className={classes.trigger} ref={refs.setReference}>
           <Component
             id={triggerId}
-            aria-haspopup={true}
             aria-controls={menuId}
             aria-expanded={isOpen}
             onClick={handleTriggerClick}

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -461,7 +461,6 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
               className={classes['calendar-button']}
               disabled={disabled || readOnly}
               aria-expanded={open}
-              aria-haspopup="true"
               aria-controls={dialogId}
             >
               {calendarButtonLabel}

--- a/packages/circuit-ui/components/Dialog/Dialog.module.css
+++ b/packages/circuit-ui/components/Dialog/Dialog.module.css
@@ -1,4 +1,5 @@
 .base {
+  z-index: var(--cui-z-index-modal);
   padding: 0 !important;
   pointer-events: none;
   outline: none;

--- a/packages/circuit-ui/components/Dialog/Dialog.spec.tsx
+++ b/packages/circuit-ui/components/Dialog/Dialog.spec.tsx
@@ -23,6 +23,7 @@ import {
   userEvent,
   waitFor,
   act,
+  fireEvent,
 } from '../../util/test-utils.js';
 
 import { Dialog } from './Dialog.js';
@@ -183,7 +184,7 @@ describe('Dialog', () => {
         // eslint-disable-next-line testing-library/no-container
         const dialog = screen.getByRole('dialog', { hidden: true });
         vi.spyOn(dialog, 'close');
-        await userEvent.click(dialog);
+        await userEvent.click(document.body);
         act(() => {
           vi.runAllTimers();
         });
@@ -260,9 +261,18 @@ describe('Dialog', () => {
     });
 
     it('should close the dialog when pressing the backdrop', async () => {
-      render(<Dialog {...props} open />);
+      render(<Dialog {...props} open isModal />);
       const dialog = screen.getByRole('dialog', { hidden: true });
-      await userEvent.click(screen.getByRole('dialog', { hidden: true }));
+
+      // Get the bounding rect of the element
+      const rect = dialog.getBoundingClientRect();
+
+      // Calculate coordinates outside the element's bounding rect
+      const outsideX = rect.right + 10;
+      const outsideY = rect.bottom + 10;
+
+      // Simulate a click event outside the element
+      fireEvent.click(dialog, { clientX: outsideX, clientY: outsideY });
       vi.runAllTimers();
       expect(props.onCloseEnd).toHaveBeenCalledOnce();
       expect(props.onCloseStart).toHaveBeenCalledOnce();

--- a/packages/circuit-ui/components/Dialog/Dialog.spec.tsx
+++ b/packages/circuit-ui/components/Dialog/Dialog.spec.tsx
@@ -263,16 +263,11 @@ describe('Dialog', () => {
     it('should close the dialog when pressing the backdrop', async () => {
       render(<Dialog {...props} open isModal />);
       const dialog = screen.getByRole('dialog', { hidden: true });
+      vi.spyOn(dialog, 'getBoundingClientRect').mockImplementation(
+        () => new DOMRect(100, 100, 500, 500),
+      );
 
-      // Get the bounding rect of the element
-      const rect = dialog.getBoundingClientRect();
-
-      // Calculate coordinates outside the element's bounding rect
-      const outsideX = rect.right + 10;
-      const outsideY = rect.bottom + 10;
-
-      // Simulate a click event outside the element
-      fireEvent.click(dialog, { clientX: outsideX, clientY: outsideY });
+      fireEvent.click(dialog, { clientX: 700, clientY: 700 });
       vi.runAllTimers();
       expect(props.onCloseEnd).toHaveBeenCalledOnce();
       expect(props.onCloseStart).toHaveBeenCalledOnce();

--- a/packages/circuit-ui/components/Popover/Popover.module.css
+++ b/packages/circuit-ui/components/Popover/Popover.module.css
@@ -20,7 +20,7 @@
   }
 
   .content {
-    padding: var(--cui-spacings-giga);
+    padding: var(--cui-spacings-mega);
   }
 }
 
@@ -38,6 +38,6 @@
   }
 
   .content {
-    padding: var(--cui-spacings-mega);
+    padding: var(--cui-spacings-kilo);
   }
 }

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -38,8 +38,8 @@ describe('Popover', () => {
   const baseProps: PopoverProps = {
     component: (triggerProps) => <button {...triggerProps}>Button</button>,
     children: popoverContent,
-    initialOpen: true,
-    onClose: vi.fn(),
+    isOpen: true,
+    onToggle: vi.fn(),
   };
   it('should forward a ref', () => {
     const ref = createRef<HTMLDialogElement>();
@@ -57,14 +57,19 @@ describe('Popover', () => {
   });
 
   describe('when closed', () => {
+    it('should not  render its content', () => {
+      renderPopover({ ...baseProps, isOpen: false });
+
+      expect(screen.queryByText(popoverContent)).not.toBeInTheDocument();
+    });
     it('should open the popover when clicking the trigger element', async () => {
-      renderPopover({ ...baseProps, initialOpen: false });
+      renderPopover({ ...baseProps, isOpen: false });
 
       const popoverTrigger = screen.getByRole('button');
 
       await userEvent.click(popoverTrigger);
 
-      expect(screen.getByText(popoverContent)).toBeVisible();
+      expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
     });
 
     it.each([
@@ -73,37 +78,43 @@ describe('Popover', () => {
     ])(
       'should open the popover when pressing the %s key on the trigger element',
       async (_, key) => {
-        renderPopover({ ...baseProps, initialOpen: false });
+        renderPopover({ ...baseProps, isOpen: false });
 
         const popoverTrigger = screen.getByRole('button');
 
         popoverTrigger.focus();
         await userEvent.keyboard(key);
 
-        expect(screen.getByText(popoverContent)).toBeVisible();
+        expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
       },
     );
   });
 
   describe('when open', () => {
+    it('should render its content', () => {
+      renderPopover(baseProps);
+
+      expect(screen.getByText(popoverContent)).toBeVisible();
+    });
+
     it('should close the popover when clicking outside', async () => {
       renderPopover(baseProps);
 
       await userEvent.click(document.body);
 
       await waitFor(() => {
-        expect(baseProps.onClose).toHaveBeenCalledTimes(1);
+        expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
       });
     });
 
     it('should close the popover when clicking the trigger element', async () => {
       renderPopover(baseProps);
 
-      const popoverTrigger = screen.getByRole('button');
+      const popoverTrigger = screen.getByText('Button');
 
       await userEvent.click(popoverTrigger);
 
-      expect(baseProps.onClose).toHaveBeenCalled();
+      expect(baseProps.onToggle).toHaveBeenCalled();
     });
 
     it.each([
@@ -115,12 +126,12 @@ describe('Popover', () => {
         renderPopover(baseProps);
         vi.runAllTimers();
 
-        const popoverTrigger = screen.getByRole('button');
+        const popoverTrigger = screen.getByText('Button');
 
         popoverTrigger.focus();
         await userEvent.keyboard(key);
 
-        expect(baseProps.onClose).toHaveBeenCalledTimes(1);
+        expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
       },
     );
 
@@ -129,7 +140,15 @@ describe('Popover', () => {
 
       await userEvent.keyboard('{Escape}');
 
-      await waitFor(() => expect(baseProps.onClose).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(baseProps.onToggle).toHaveBeenCalledTimes(1));
+    });
+
+    it('should close the isOpen prop changes ', async () => {
+      const { rerender } = renderPopover(baseProps);
+
+      rerender(<Popover {...baseProps} isOpen={false} />);
+
+      await waitFor(() => expect(baseProps.onToggle).toHaveBeenCalledTimes(1));
     });
   });
 

--- a/packages/circuit-ui/components/Popover/Popover.spec.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.spec.tsx
@@ -57,7 +57,7 @@ describe('Popover', () => {
   });
 
   describe('when closed', () => {
-    it('should not  render its content', () => {
+    it('should not render its content', () => {
       renderPopover({ ...baseProps, isOpen: false });
 
       expect(screen.queryByText(popoverContent)).not.toBeInTheDocument();
@@ -65,7 +65,7 @@ describe('Popover', () => {
     it('should open the popover when clicking the trigger element', async () => {
       renderPopover({ ...baseProps, isOpen: false });
 
-      const popoverTrigger = screen.getByRole('button');
+      const popoverTrigger = screen.getByRole('button', { name: 'Button' });
 
       await userEvent.click(popoverTrigger);
 
@@ -110,7 +110,7 @@ describe('Popover', () => {
     it('should close the popover when clicking the trigger element', async () => {
       renderPopover(baseProps);
 
-      const popoverTrigger = screen.getByText('Button');
+      const popoverTrigger = screen.getByRole('button', { name: 'Button' });
 
       await userEvent.click(popoverTrigger);
 
@@ -126,7 +126,7 @@ describe('Popover', () => {
         renderPopover(baseProps);
         vi.runAllTimers();
 
-        const popoverTrigger = screen.getByText('Button');
+        const popoverTrigger = screen.getByRole('button', { name: 'Button' });
 
         popoverTrigger.focus();
         await userEvent.keyboard(key);
@@ -143,7 +143,7 @@ describe('Popover', () => {
       await waitFor(() => expect(baseProps.onToggle).toHaveBeenCalledTimes(1));
     });
 
-    it('should close the isOpen prop changes ', async () => {
+    it('should close when the isOpen prop changes ', async () => {
       const { rerender } = renderPopover(baseProps);
 
       rerender(<Popover {...baseProps} isOpen={false} />);

--- a/packages/circuit-ui/components/Popover/Popover.stories.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
 import { NotificationCenter } from '@sumup-oss/icons';
 
 import { IconButton } from '../Button/index.js';
@@ -82,47 +82,34 @@ function PopoverWrapper({ children }: { children: ReactNode }) {
     </div>
   );
 }
-export const Base = (args: PopoverProps) => (
-  <PopoverWrapper>
-    <Popover
-      {...args}
-      initialOpen={true}
-      component={(props) => (
-        <IconButton
-          size="s"
-          variant="secondary"
-          icon={NotificationCenter}
-          {...props}
-        >
-          Notifications
-        </IconButton>
-      )}
-    />
-  </PopoverWrapper>
-);
+export const Base = (args: PopoverProps) => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <PopoverWrapper>
+      <Popover
+        {...args}
+        isOpen={isOpen}
+        onToggle={setIsOpen}
+        component={(props) => (
+          <IconButton
+            size="s"
+            variant="secondary"
+            icon={NotificationCenter}
+            {...props}
+          >
+            Notifications
+          </IconButton>
+        )}
+      />
+    </PopoverWrapper>
+  );
+};
 
 Base.args = {
   children: PopoverContent,
 };
 
-export const Offset = (args: PopoverProps) => (
-  <PopoverWrapper>
-    <Popover
-      {...args}
-      initialOpen={true}
-      component={(props) => (
-        <IconButton
-          size="s"
-          variant="secondary"
-          icon={NotificationCenter}
-          {...props}
-        >
-          Notifications
-        </IconButton>
-      )}
-    />
-  </PopoverWrapper>
-);
+export const Offset = (args: PopoverProps) => <Base {...args} />;
 
 Offset.args = {
   children: PopoverContent,

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -53,7 +53,6 @@ export interface PopoverReferenceProps {
   'onClick': (event: ClickEvent) => void;
   'onKeyDown'?: (event: KeyboardEvent) => void;
   'id': string;
-  'aria-haspopup': boolean;
   'aria-controls': string;
   'aria-expanded': boolean;
 }
@@ -195,7 +194,6 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
         <div className={classes.trigger} ref={refs.setReference}>
           <Component
             id={triggerId}
-            aria-haspopup={true}
             aria-controls={contentId}
             aria-expanded={isOpen}
             onClick={handleTriggerClick}

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -59,7 +59,7 @@ export interface PopoverReferenceProps {
 type OnToggle = (open: boolean | ((prevOpen: boolean) => boolean)) => void;
 
 export interface PopoverProps
-  extends PublicDialogProps,
+  extends Omit<PublicDialogProps, 'open'>,
     Pick<DialogProps, 'hideCloseButton'> {
   /**
    * The state of the Popover.

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -220,6 +220,7 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
             className,
           )}
           animationDuration={animationDuration}
+          hideCloseButton
           style={
             isMobile
               ? style

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -35,7 +35,11 @@ import {
   useState,
 } from 'react';
 
-import { Dialog, type DialogProps } from '../Dialog/Dialog.js';
+import {
+  Dialog,
+  type DialogProps,
+  type PublicDialogProps,
+} from '../Dialog/Dialog.js';
 import type { ClickEvent } from '../../types/events.js';
 import { useStackContext } from '../StackContext/index.js';
 import { useMedia } from '../../hooks/useMedia/index.js';
@@ -56,19 +60,8 @@ export interface PopoverReferenceProps {
 type OnToggle = (open: boolean | ((prevOpen: boolean) => boolean)) => void;
 
 export interface PopoverProps
-  extends Omit<
-    DialogProps,
-    | 'open'
-    | 'onCloseEnd'
-    | 'onCloseStart'
-    | 'isModal'
-    | 'animationDuration'
-    | 'preventClose'
-    | 'initialFocusRef'
-    | 'preventOutsideClickRefs'
-    | 'preventEscapeKeyClose'
-    | 'preventOutsideClickClose'
-  > {
+  extends PublicDialogProps,
+    Pick<DialogProps, 'hideCloseButton'> {
   /**
    * The state of the Popover.
    */
@@ -122,7 +115,6 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
       fallbackPlacements = ['top', 'right', 'left'],
       component: Component,
       offset,
-      hideCloseButton,
       className,
       style,
       ...props
@@ -210,6 +202,7 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
           />
         </div>
         <Dialog
+          {...props}
           open={isOpen}
           onCloseStart={handleCloseStart}
           onCloseEnd={handleCloseEnd}
@@ -221,7 +214,6 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
             className,
           )}
           animationDuration={animationDuration}
-          hideCloseButton={hideCloseButton}
           style={
             isMobile
               ? style
@@ -232,7 +224,6 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
                 }
           }
           preventOutsideClickRefs={refs.reference}
-          {...props}
         >
           <div id={contentId} className={classes.content}>
             {typeof children === 'function'

--- a/packages/circuit-ui/components/SidePanel/SidePanel.module.css
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.module.css
@@ -51,12 +51,18 @@
     width: var(--side-panel-width);
     height: calc(100vh - var(--top-navigation-height, 0));
     margin: 0;
+    background-color: var(--cui-bg-normal);
     box-shadow: inset var(--cui-border-width-kilo) 0 0 var(--cui-border-divider);
   }
 
   .base::after {
     /* to account for inset box shadow */
     margin-left: 1px;
+    background: linear-gradient(
+      color-mix(in sRGB, var(--cui-bg-normal) 0%, transparent),
+      color-mix(in sRGB, var(--cui-bg-normal) 66%, transparent),
+      color-mix(in sRGB, var(--cui-bg-normal) 100%, transparent)
+    );
   }
 
   .wrapper {

--- a/packages/circuit-ui/components/SidePanel/SidePanel.module.css
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.module.css
@@ -13,6 +13,10 @@
   transform: translateX(0);
 }
 
+.content {
+  width: 100%;
+}
+
 .wrapper {
   display: flex;
   flex-direction: column;

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.module.css
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.module.css
@@ -5,11 +5,11 @@
   display: flex;
   align-items: center;
   width: 100%;
-  background-color: var(--cui-bg-elevated);
 }
 
 @media (min-width: 768px) {
   .base {
+    background-color: var(--cui-bg-normal);
     box-shadow: inset var(--cui-border-width-kilo) 0 0 var(--cui-border-divider);
   }
 }

--- a/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
+++ b/packages/circuit-ui/components/SidePanel/useSidePanel.tsx
@@ -49,6 +49,11 @@ export type SidePanelHookProps = {
    */
   children: ReactNode | ((props: ChildrenRenderProps) => ReactNode);
   /**
+   * Text label for the close button for screen readers.
+   * Important for accessibility.
+   */
+  closeButtonLabel?: string;
+  /**
    * Callback function that is called when the stacked side panel is closed.
    */
   onBack?: OnBack;

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
@@ -33,18 +33,6 @@ export const useScrollLock = (isActive: boolean): void => {
   useEffect(() => {
     if (isActive) {
       instanceCount += 1;
-    }
-
-    return () => {
-      instanceCount -= 1;
-      if (instanceCount <= 1) {
-        restoreScroll();
-      }
-    };
-  }, [restoreScroll, isActive]);
-
-  useEffect(() => {
-    if (isActive) {
       scrollValue.current = `${window.scrollY}px`;
       const scrollY = scrollValue.current;
       const { body } = document;
@@ -58,5 +46,11 @@ export const useScrollLock = (isActive: boolean): void => {
     } else if (instanceCount === 1) {
       restoreScroll();
     }
+    return () => {
+      instanceCount -= 1;
+      if (instanceCount <= 1) {
+        restoreScroll();
+      }
+    };
   }, [isActive, restoreScroll]);
 };

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
@@ -17,7 +17,7 @@ import { useCallback, useEffect, useRef } from 'react';
 
 let instanceCount = 0;
 
-export const useScrollLock = (isLocked: boolean): void => {
+export const useScrollLock = (isActive: boolean): void => {
   const scrollValue = useRef<string>();
 
   const restoreScroll = useCallback(() => {
@@ -31,18 +31,20 @@ export const useScrollLock = (isLocked: boolean): void => {
   }, []);
 
   useEffect(() => {
-    instanceCount += 1;
+    if (isActive) {
+      instanceCount += 1;
+    }
 
     return () => {
       instanceCount -= 1;
-      if (instanceCount === 0) {
+      if (instanceCount <= 1) {
         restoreScroll();
       }
     };
-  }, [restoreScroll]);
+  }, [restoreScroll, isActive]);
 
   useEffect(() => {
-    if (isLocked) {
+    if (isActive) {
       scrollValue.current = `${window.scrollY}px`;
       const scrollY = scrollValue.current;
       const { body } = document;
@@ -56,5 +58,5 @@ export const useScrollLock = (isLocked: boolean): void => {
     } else if (instanceCount === 1) {
       restoreScroll();
     }
-  }, [isLocked, restoreScroll]);
+  }, [isActive, restoreScroll]);
 };

--- a/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
+++ b/packages/circuit-ui/hooks/useScrollLock/useScrollLock.ts
@@ -19,6 +19,7 @@ let instanceCount = 0;
 
 export const useScrollLock = (isActive: boolean): void => {
   const scrollValue = useRef<string>();
+  const hasBeenActivated = useRef<boolean>(false);
 
   const restoreScroll = useCallback(() => {
     // restore scroll to page
@@ -32,6 +33,7 @@ export const useScrollLock = (isActive: boolean): void => {
 
   useEffect(() => {
     if (isActive) {
+      hasBeenActivated.current = true;
       instanceCount += 1;
       scrollValue.current = `${window.scrollY}px`;
       const scrollY = scrollValue.current;
@@ -43,14 +45,16 @@ export const useScrollLock = (isActive: boolean): void => {
       body.style.position = 'fixed';
       body.style.width = `${bodyWidth}px`;
       body.style.top = `-${scrollY}`;
-    } else if (instanceCount === 1) {
-      restoreScroll();
     }
     return () => {
-      instanceCount -= 1;
-      if (instanceCount <= 1) {
+      if (hasBeenActivated.current) {
+        // only decrease the instance count if the hook has been activated
+        instanceCount -= 1;
+      }
+      if (instanceCount === 0) {
         restoreScroll();
       }
+      hasBeenActivated.current = false;
     };
   }, [isActive, restoreScroll]);
 };

--- a/packages/eslint-plugin-circuit-ui/README.md
+++ b/packages/eslint-plugin-circuit-ui/README.md
@@ -49,3 +49,4 @@ Rules are configured under the rules section:
 - [`no-renamed-props`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-renamed-props)
 - [`prefer-custom-properties`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/prefer-custom-properties)
 - [`renamed-organization-imports`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/renamed-organization-imports)
+- [`no-renamed-components`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-renamed-components)

--- a/packages/eslint-plugin-circuit-ui/index.ts
+++ b/packages/eslint-plugin-circuit-ui/index.ts
@@ -21,6 +21,7 @@ import { noDeprecatedProps } from './no-deprecated-props';
 import { noRenamedProps } from './no-renamed-props';
 import { preferCustomProperties } from './prefer-custom-properties';
 import { renamedPackageScope } from './renamed-package-scope';
+import { noRenamedComponents } from './no-renamed-components';
 
 /* eslint-disable */
 
@@ -33,4 +34,5 @@ export const rules = {
   'no-renamed-props': noRenamedProps,
   'prefer-custom-properties': preferCustomProperties,
   'renamed-package-scope': renamedPackageScope,
+  'no-renamed-components': noRenamedComponents,
 };

--- a/packages/eslint-plugin-circuit-ui/no-renamed-components/index.spec.tsx
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-components/index.spec.tsx
@@ -32,7 +32,7 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-renamed-components', noRenamedComponents, {
   valid: [
     {
-      name: 'similar component from Circuit UI',
+      name: 'different component from Circuit UI',
       code: `
           import {Button} from '@sumup-oss/circuit-ui';
    function Component() {
@@ -64,17 +64,15 @@ ruleTester.run('no-renamed-components', noRenamedComponents, {
       errors: [{ messageId: 'renamed' }, { messageId: 'renamed' }],
     },
     {
-      name: 'matched renamed import from Circuit UI',
-      code: `
-          import {Popover as CircuitPopover} from '@sumup-oss/circuit-ui';
-   function Component() {
-          return <CircuitPopover />
-        }`,
-      output: `
-          import {ActionMenu as CircuitPopover} from '@sumup-oss/circuit-ui';
-   function Component() {
-          return <CircuitPopover />
-        }`,
+      name: 'matched component from Circuit UI',
+      code: `import {PopoverProps} from '@sumup-oss/circuit-ui';`,
+      output: `import {ActionMenuProps} from '@sumup-oss/circuit-ui';`,
+      errors: [{ messageId: 'renamed' }],
+    },
+    {
+      name: 'matched component from Circuit UI',
+      code: `import {PopoverItemProps} from '@sumup-oss/circuit-ui';`,
+      output: `import {ActionMenuItemProps} from '@sumup-oss/circuit-ui';`,
       errors: [{ messageId: 'renamed' }],
     },
   ],

--- a/packages/eslint-plugin-circuit-ui/no-renamed-components/index.spec.tsx
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-components/index.spec.tsx
@@ -75,5 +75,35 @@ ruleTester.run('no-renamed-components', noRenamedComponents, {
       output: `import {ActionMenuItemProps} from '@sumup-oss/circuit-ui';`,
       errors: [{ messageId: 'renamed' }],
     },
+    {
+      name: 'matched renamed import from Circuit UI',
+      code: `
+          import {Popover as CircuitPopover} from '@sumup-oss/circuit-ui';
+   function Component() {
+          return <CircuitPopover />
+        }`,
+      output: `
+          import {ActionMenu as CircuitPopover} from '@sumup-oss/circuit-ui';
+   function Component() {
+          return <CircuitPopover />
+        }`,
+      errors: [{ messageId: 'renamed' }],
+    },
+    {
+      name: 'matched renamed import from Circuit UI',
+      code: `
+          import {PopoverProps as CircuitPopoverProps} from '@sumup-oss/circuit-ui';`,
+      output: `
+          import {ActionMenuProps as CircuitPopoverProps} from '@sumup-oss/circuit-ui';`,
+      errors: [{ messageId: 'renamed' }],
+    },
+    {
+      name: 'matched renamed import from Circuit UI',
+      code: `
+          import {PopoverItemProps as CircuitPopoverItemProps} from '@sumup-oss/circuit-ui';`,
+      output: `
+          import {ActionMenuItemProps as CircuitPopoverItemProps} from '@sumup-oss/circuit-ui';`,
+      errors: [{ messageId: 'renamed' }],
+    },
   ],
 });

--- a/packages/eslint-plugin-circuit-ui/no-renamed-components/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-components/index.ts
@@ -25,6 +25,14 @@ const components = [
     name: 'Popover',
     alternative: 'ActionMenu',
   },
+  {
+    name: 'PopoverProps',
+    alternative: 'ActionMenuProps',
+  },
+  {
+    name: 'PopoverItemProps',
+    alternative: 'ActionMenuItemProps',
+  },
 ];
 
 export const noRenamedComponents = createRule({


### PR DESCRIPTION
## Purpose

Addresses some issues detected after merging https://github.com/sumup-oss/circuit-ui/pull/2903 and testing on ze-dashboard. Also fixes the issue of closing the topmost dialog when pressing the Escape key.

## Approach and changes

- refactor handling outside clicks on the Dialog component
- only close top most dialog on Escape keydown
- export new eslint rule
- Refactor Popover API

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
