### PR TITLE
Fix Button and IconButton RSC compatibility

### DIFF
--- a/.changeset/happy-singers-judge.md
+++ b/.changeset/happy-singers-judge.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the Button and IconButton component's compatibility with React Server Components (RSC) by adding a missing `'use client'` directive.

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import type {
   ForwardRefExoticComponent,
   PropsWithoutRef,

--- a/packages/circuit-ui/components/Button/IconButton.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+'use client';
+
 import {
   Children,
   cloneElement,


### PR DESCRIPTION
## Purpose

We received a report that the Button component throws an error when rendered inside a React Server Component (RSC). I discovered that it and the IconButton component are missing the `'use client'` directive. It should have been added automatically by [`eslint-plugin-react-server-components`](https://github.com/roginfarrer/eslint-plugin-react-server-components), I suspect that didn't happen because the `createButtonComponent` factory function abstracts away the client logic.

## Approach and changes

- Add the `'use client'` directive to the Button and IconButton components

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
