### PR TITLE
fix keyboard interaction bug for the rows of the Table component

### DIFF
--- a/.changeset/poor-peas-hunt.md
+++ b/.changeset/poor-peas-hunt.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed a bug on the Table component to allow table rows to be activated using Enter or Space keys.

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.spec.tsx
@@ -42,16 +42,18 @@ describe('TableRow', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('should call the onClick when navigating with the keyboard', async () => {
+  it.each([
+    ['space', '{ }'],
+    ['enter', '{Enter}'],
+  ])('should call onClick when %s key is pressed', async (_, key) => {
     const onClick = vi.fn();
     render(<TableRow onClick={onClick}>{children}</TableRow>);
     const rowEl = screen.getByRole('row');
 
     rowEl.focus();
-    await userEvent.type(rowEl, '{enter}');
-    await userEvent.type(rowEl, ' ');
+    await userEvent.keyboard(key);
 
-    expect(onClick).toHaveBeenCalledTimes(2);
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it('should have no accessibility violations', async () => {

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.tsx
@@ -15,10 +15,11 @@
 
 'use client';
 
-import type { HTMLAttributes } from 'react';
+import { type HTMLAttributes, useCallback, type KeyboardEvent } from 'react';
 
 import type { ClickEvent } from '../../../../types/events.js';
 import { clsx } from '../../../../styles/clsx.js';
+import { isEnter, isSpacebar } from '../../../../util/key-codes.js';
 
 import classes from './TableRow.module.css';
 
@@ -30,9 +31,18 @@ export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
  * TableRow for the Table component. The Table handles rendering it.
  */
 export function TableRow({ onClick, className, ...props }: TableRowProps) {
+  const onRowKeydown = useCallback(
+    (event: KeyboardEvent<HTMLTableRowElement>) => {
+      if (isEnter(event) || isSpacebar(event)) {
+        onClick?.(event);
+      }
+    },
+    [onClick],
+  );
   return (
     <tr
       onClick={onClick}
+      onKeyDown={onClick ? onRowKeydown : undefined}
       tabIndex={onClick ? 0 : undefined}
       className={clsx(classes.base, className)}
       {...props}


### PR DESCRIPTION
Addresses [DSYS-977](https://sumupteam.atlassian.net/browse/DSYS-977)

## Description
There are interactive table rows that receive focus when navigating the page using a keyboard. However, it cannot be
activated using Enter or Space.
As such, keyboard users may not be able to operate those interactive elements.


## Approach and changes

Add a keydown event handler than triggers the onClickcallback when a row receives a Enter or Space key event.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
