### PR TITLE
fix issue with keyboard navigation of the tabs of the Tabs component

### DIFF
--- a/.changeset/soft-jokes-chew.md
+++ b/.changeset/soft-jokes-chew.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed an issue with keyboard navigation in the Tabs component. Tab panels no longer part of the tab order but can be focused with keydown press.

--- a/.changeset/soft-jokes-chew.md
+++ b/.changeset/soft-jokes-chew.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Fixed an issue with keyboard navigation in the Tabs component. Tab panels no longer part of the tab order but can be focused with keydown press.
+Fixed an issue with keyboard navigation in the Tabs component. Tab panels are no longer part of the tab order but can be focused with keydown press.

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.spec.tsx
@@ -50,7 +50,10 @@ describe('TableRow', () => {
     render(<TableRow onClick={onClick}>{children}</TableRow>);
     const rowEl = screen.getByRole('row');
 
-    rowEl.focus();
+    await userEvent.keyboard('{Tab}');
+
+    expect(rowEl).toHaveFocus();
+
     await userEvent.keyboard(key);
 
     expect(onClick).toHaveBeenCalledTimes(1);

--- a/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
@@ -34,19 +34,17 @@ describe('Tabs', () => {
       />,
     );
 
-    const tabEls = screen.getAllByTestId('tab-element');
-    const panelEls = screen.getAllByTestId('tab-panel');
+    const panelA = screen.getByRole('tabpanel');
+    expect(panelA).toHaveAccessibleName('tab-a');
 
-    expect(panelEls[0]).toBeVisible();
-    expect(panelEls[1]).not.toBeVisible();
+    const tabs = screen.getAllByRole('tab');
+    await userEvent.click(tabs[1]);
 
-    await userEvent.click(tabEls[1]);
-
-    expect(panelEls[0]).not.toBeVisible();
-    expect(panelEls[1]).toBeVisible();
+    const panelB = screen.getByRole('tabpanel');
+    expect(panelB).toHaveAccessibleName('tab-b');
   });
 
-  it('should go to the next tab on right press', async () => {
+  it('should go to the next tab on right arrow press', async () => {
     render(
       <Tabs
         items={[
@@ -57,16 +55,68 @@ describe('Tabs', () => {
       />,
     );
 
-    const tabEls = screen.getAllByTestId('tab-element');
-    const panelEls = screen.getAllByTestId('tab-panel');
+    await userEvent.keyboard('{Tab}');
 
-    expect(panelEls[0]).toBeVisible();
-    expect(panelEls[1]).not.toBeVisible();
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).toHaveFocus();
 
-    await userEvent.type(tabEls[0], '{arrowright}');
+    const panelA = screen.getByRole('tabpanel');
+    expect(panelA).toHaveAccessibleName('tab-a');
 
-    expect(panelEls[0]).not.toBeVisible();
-    expect(panelEls[1]).toBeVisible();
+    await userEvent.keyboard('{ArrowRight}');
+
+    const panelB = screen.getByRole('tabpanel');
+    expect(panelB).toHaveAccessibleName('tab-b');
+    expect(tabs[1]).toHaveFocus();
+  });
+
+  it('should go to the previous tab on left arrow press', async () => {
+    render(
+      <Tabs
+        initialSelectedIndex={1}
+        items={[
+          { id: 'a', tab: 'tab-a', panel: 'panel-a' },
+          { id: 'b', tab: 'tab-b', panel: 'panel-b' },
+          { id: 'c', tab: 'tab-c', panel: 'panel-c' },
+        ]}
+      />,
+    );
+
+    await userEvent.keyboard('{Tab}');
+
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[1]).toHaveFocus();
+
+    const panelB = screen.getByRole('tabpanel');
+    expect(panelB).toHaveAccessibleName('tab-b');
+
+    await userEvent.keyboard('{ArrowLeft}');
+
+    const panelA = screen.getByRole('tabpanel');
+    expect(panelA).toHaveAccessibleName('tab-a');
+    expect(tabs[0]).toHaveFocus();
+  });
+
+  it('should focus the current panel on down arrow press', async () => {
+    render(
+      <Tabs
+        items={[
+          { id: 'a', tab: 'tab-a', panel: 'panel-a' },
+          { id: 'b', tab: 'tab-b', panel: 'panel-b' },
+          { id: 'c', tab: 'tab-c', panel: 'panel-c' },
+        ]}
+      />,
+    );
+
+    await userEvent.keyboard('{Tab}');
+
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).toHaveFocus();
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).toHaveFocus();
   });
 
   it('should have no accessibility violations for tablist only', async () => {

--- a/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
@@ -14,6 +14,11 @@
  */
 
 import { useState, Fragment } from 'react';
+import { ArrowLeft, ExternalLink } from '@sumup-oss/icons';
+
+import { Body } from '../Body/index.js';
+import { Headline } from '../Headline/index.js';
+import { Button } from '../Button/index.js';
 
 import type { TabsProps } from './Tabs.js';
 
@@ -29,11 +34,57 @@ export default {
   },
 };
 
+const ContentWithInteractiveElements = ({ index }: { index: number }) => (
+  <div
+    style={{
+      padding: 'var(--cui-spacings-giga',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: 'var(--cui-spacings-kilo)',
+    }}
+  >
+    <Headline as="h2">Content of tab {index}</Headline>
+    <Body>
+      Lorem ipsum dolor amet swag pickled humblebrag retro farm-to-table,
+      shoreditch typewriter deep v single-origin coffee green juice coloring
+      book venmo chambray. Marfa authentic blue bottle mixtape tofu adaptogen.
+      IPhone chia blog palo santo mlkshk tattooed jean shorts yr locavore ennui
+      scenester. Wolf tousled pok pok sartorial scenester man bun salvia quinoa
+      raclette sriracha roof party pour-over venmo hammock. Four dollar toast
+      typewriter 3 wolf moon letterpress disrupt pabst. Neutra irony tousled
+      iPhone banh mi wayfarers hoodie waistcoat.
+    </Body>
+    <Button icon={ArrowLeft} variant="secondary">
+      Home page
+    </Button>
+    <Button variant="primary" navigationIcon={ExternalLink}>
+      Learn more
+    </Button>
+  </div>
+);
+
 const tabs = [
-  { id: 'one', tab: 'Tab 1', panel: 'Content 1' },
-  { id: 'two', tab: 'Tab 2', panel: 'Content 2' },
-  { id: 'three', tab: 'Tab 3', panel: 'Content 3' },
-  { id: 'four', tab: 'Tab 4', panel: 'Content 4' },
+  {
+    id: 'one',
+    tab: 'Tab 1',
+    panel: <ContentWithInteractiveElements index={1} />,
+  },
+  {
+    id: 'two',
+    tab: 'Tab 2',
+    panel: <ContentWithInteractiveElements index={2} />,
+  },
+  {
+    id: 'three',
+    tab: 'Tab 3',
+    panel: <ContentWithInteractiveElements index={3} />,
+  },
+  {
+    id: 'four',
+    tab: 'Tab 4',
+    panel: <ContentWithInteractiveElements index={4} />,
+  },
 ];
 
 export const Base = (args: TabsProps) => <Tabs {...args} />;

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createRef } from 'react';
 
 import { render } from '../../../../util/test-utils.js';
@@ -33,5 +33,14 @@ describe('Tab', () => {
     const { container } = render(<Tab ref={ref} />);
     const button = container.querySelector('button');
     expect(ref.current).toBe(button);
+  });
+
+  it('should be focused when selected', () => {
+    const ref = createRef<HTMLButtonElement>();
+    const { container, rerender } = render(<Tab ref={ref} selected={false} />);
+    const button = container.querySelector('button');
+    vi.spyOn(button, 'focus');
+    rerender(<Tab ref={ref} selected />);
+    expect(button?.focus).toHaveBeenCalledOnce();
   });
 });

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
@@ -13,34 +13,25 @@
  * limitations under the License.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { createRef } from 'react';
 
-import { render } from '../../../../util/test-utils.js';
+import { render, screen } from '../../../../util/test-utils.js';
 
 import { Tab } from './Tab.js';
 
 describe('Tab', () => {
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
-    const { container } = render(<Tab className={className} />);
-    const element = container.querySelector('button');
-    expect(element?.className).toContain(className);
+    render(<Tab className={className} />);
+    const element = screen.getByRole('tab');
+    expect(element.className).toContain(className);
   });
 
   it('should forward a ref', () => {
     const ref = createRef<HTMLButtonElement>();
-    const { container } = render(<Tab ref={ref} />);
-    const button = container.querySelector('button');
-    expect(ref.current).toBe(button);
-  });
-
-  it('should be focused when selected', () => {
-    const ref = createRef<HTMLButtonElement>();
-    const { container, rerender } = render(<Tab ref={ref} selected={false} />);
-    const button = container.querySelector('button');
-    vi.spyOn(button, 'focus');
-    rerender(<Tab ref={ref} selected />);
-    expect(button?.focus).toHaveBeenCalledOnce();
+    render(<Tab ref={ref} />);
+    const tab = screen.getByRole('tab');
+    expect(ref.current).toBe(tab);
   });
 });

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -56,7 +56,7 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>(
 
     useEffect(() => {
       if (selected) {
-        tabRef?.current?.focus();
+        tabRef?.current?.focus({ preventScroll: true });
       }
     }, [selected]);
     return (

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -19,11 +19,14 @@ import {
   forwardRef,
   type AnchorHTMLAttributes,
   type ButtonHTMLAttributes,
+  useEffect,
+  useRef,
 } from 'react';
 
 import { useComponents } from '../../../ComponentsContext/index.js';
 import type { EmotionAsPropType } from '../../../../types/prop-types.js';
 import { clsx } from '../../../../styles/clsx.js';
+import { applyMultipleRefs } from '../../../../util/refs.js';
 
 import classes from './Tab.module.css';
 
@@ -46,12 +49,19 @@ const tabIndex = (selected: boolean) => (selected ? undefined : -1);
  */
 export const Tab = forwardRef<HTMLButtonElement, TabProps>(
   ({ selected = false, className, ...props }, ref) => {
+    const tabRef = useRef<HTMLButtonElement>(null);
     const components = useComponents();
     const Link = components.Link as EmotionAsPropType;
     const Element = props.href ? Link : 'button';
+
+    useEffect(() => {
+      if (selected) {
+        tabRef?.current?.focus();
+      }
+    }, [selected]);
     return (
       <Element
-        ref={ref}
+        ref={applyMultipleRefs(tabRef, ref)}
         role="tab"
         aria-selected={selected}
         tabIndex={tabIndex(selected)}

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -19,14 +19,11 @@ import {
   forwardRef,
   type AnchorHTMLAttributes,
   type ButtonHTMLAttributes,
-  useEffect,
-  useRef,
 } from 'react';
 
 import { useComponents } from '../../../ComponentsContext/index.js';
 import type { EmotionAsPropType } from '../../../../types/prop-types.js';
 import { clsx } from '../../../../styles/clsx.js';
-import { applyMultipleRefs } from '../../../../util/refs.js';
 
 import classes from './Tab.module.css';
 
@@ -49,19 +46,13 @@ const tabIndex = (selected: boolean) => (selected ? undefined : -1);
  */
 export const Tab = forwardRef<HTMLButtonElement, TabProps>(
   ({ selected = false, className, ...props }, ref) => {
-    const tabRef = useRef<HTMLButtonElement>(null);
     const components = useComponents();
     const Link = components.Link as EmotionAsPropType;
     const Element = props.href ? Link : 'button';
 
-    useEffect(() => {
-      if (selected) {
-        tabRef?.current?.focus({ preventScroll: true });
-      }
-    }, [selected]);
     return (
       <Element
-        ref={applyMultipleRefs(tabRef, ref)}
+        ref={ref}
         role="tab"
         aria-selected={selected}
         tabIndex={tabIndex(selected)}

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Children, type HTMLAttributes } from 'react';
+import { Children, forwardRef, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../../../styles/clsx.js';
 import { utilClasses } from '../../../../styles/utility.js';
@@ -29,32 +29,29 @@ const MOBILE_AUTOSTRETCH_ITEMS_MAX = 3;
 /**
  * TabList component that wraps the Tab components
  */
-export function TabList({
-  className,
-  style = {},
-  stretched,
-  children,
-  ...props
-}: TabListProps) {
-  const numberOfTabs = Children.toArray(children).length;
-  const tabWidth = Math.floor(100 / numberOfTabs);
-  const stretchOnMobile = numberOfTabs <= MOBILE_AUTOSTRETCH_ITEMS_MAX;
-  return (
-    <div
-      className={clsx(classes.wrapper, utilClasses.hideScrollbar, className)}
-      style={{ ...style, '--tab-list-width': tabWidth }}
-    >
+export const TabList = forwardRef<HTMLDivElement, TabListProps>(
+  ({ className, style = {}, stretched, children, ...props }, ref) => {
+    const numberOfTabs = Children.toArray(children).length;
+    const tabWidth = Math.floor(100 / numberOfTabs);
+    const stretchOnMobile = numberOfTabs <= MOBILE_AUTOSTRETCH_ITEMS_MAX;
+    return (
       <div
-        className={clsx(
-          classes.base,
-          stretched && classes.stretched,
-          stretchOnMobile && classes['stretched-mobile'],
-        )}
-        {...props}
-        role="tablist"
+        ref={ref}
+        className={clsx(classes.wrapper, utilClasses.hideScrollbar, className)}
+        style={{ ...style, '--tab-list-width': tabWidth }}
       >
-        {children}
+        <div
+          className={clsx(
+            classes.base,
+            stretched && classes.stretched,
+            stretchOnMobile && classes['stretched-mobile'],
+          )}
+          {...props}
+          role="tablist"
+        >
+          {children}
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);

--- a/packages/circuit-ui/components/Tabs/components/TabPanel/TabPanel.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabPanel/TabPanel.tsx
@@ -21,8 +21,7 @@ export type TabPanelProps = HTMLAttributes<HTMLDivElement>;
  * TabPanel wrapping content being showed by tabs
  */
 export const TabPanel = forwardRef<HTMLDivElement, TabPanelProps>(
-  // biome-ignore lint/a11y/noNoninteractiveTabindex: The tabIndex is applicable for role="tabpanel"
-  (props, ref) => <div ref={ref} {...props} role="tabpanel" tabIndex={0} />,
+  (props, ref) => <div ref={ref} {...props} role="tabpanel" tabIndex={-1} />,
 );
 
 TabPanel.displayName = 'TabPanel';


### PR DESCRIPTION
Addresses [DSYS-979](https://sumupteam.atlassian.net/browse/DSYS-979)

## Purpose

There is a tabbed interface on a page identified. When navigating the page using a keyboard, the first tab can receive focus.
However, it is not possible to select the second tab using the Tab or the Arrow keys.
As such, keyboard users may not be able to operate those interactive elements.
Although tabs can be selected using arrow keys, screen reader does not announce tabs change and the active tab does not receive focus, which prevent visually impaired users from navigating the tabs.

## Approach and changes

Set tabIndex of panels to `-1`. Focus tabs upon selection and tab panels upon `keydown` keyboard event.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
