### PR TITLE
Improve accessibility of the Anchor component for external links

### DIFF
--- a/.changeset/gentle-seahorses-press.md
+++ b/.changeset/gentle-seahorses-press.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added two new props `isExternal` and  `externalLabel` to the Anchor component props to describe to visually impaired users that the link leads to an external page or opens in a new tab.

--- a/.changeset/gentle-seahorses-press.md
+++ b/.changeset/gentle-seahorses-press.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": minor
 ---
 
-Added a new props `externalLabel` to the Anchor component to describe to visually impaired users that the link leads to an external page or opens in a new tab.
+Added a new `externalLabel` prop to the Anchor component to describe to visually impaired users that the link leads to an external page or opens in a new tab.

--- a/.changeset/gentle-seahorses-press.md
+++ b/.changeset/gentle-seahorses-press.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": minor
 ---
 
-Added two new props `isExternal` and  `externalLabel` to the Anchor component props to describe to visually impaired users that the link leads to an external page or opens in a new tab.
+Added a new props `externalLabel` to the Anchor component to describe to visually impaired users that the link leads to an external page or opens in a new tab.

--- a/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
@@ -107,6 +107,36 @@ describe('Anchor', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it('should render as link with an description label when it renders an external link', () => {
+    render(
+      <Anchor
+        href="www.external.link.com"
+        {...baseProps}
+        isExternal
+        externalLabel="Opens in a new tab"
+      />,
+    );
+
+    expect(screen.getByRole('link')).toHaveAccessibleDescription(
+      'Opens in a new tab',
+    );
+  });
+
+  it('should render as button with an description label when it renders an external link', () => {
+    render(
+      <Anchor
+        onClick={vi.fn()}
+        {...baseProps}
+        isExternal
+        externalLabel="Opens in a new tab"
+      />,
+    );
+
+    expect(screen.getByRole('button')).toHaveAccessibleDescription(
+      'Opens in a new tab',
+    );
+  });
+
   it('should meet accessibility guidelines', async () => {
     const { container } = render(
       <Anchor {...baseProps} href="https://sumup.com" onClick={vi.fn} />,

--- a/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
@@ -112,7 +112,7 @@ describe('Anchor', () => {
       <Anchor
         href="www.external.link.com"
         {...baseProps}
-        isExternal
+        rel="external"
         externalLabel="Opens in a new tab"
       />,
     );
@@ -127,7 +127,7 @@ describe('Anchor', () => {
       <Anchor
         onClick={vi.fn()}
         {...baseProps}
-        isExternal
+        rel="external"
         externalLabel="Opens in a new tab"
       />,
     );

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -45,10 +45,6 @@ export interface BaseProps extends Omit<BodyProps, 'color'> {
    */
   ref?: Ref<any>;
   /**
-   * Whether the link leads to an external page or opens in a new tab.
-   */
-  isExternal?: boolean;
-  /**
    * Short label to describe that the link leads to an external page or opens in a new tab.
    */
   externalLabel?: string;
@@ -72,7 +68,6 @@ export const Anchor = forwardRef(
   (
     {
       className,
-      isExternal,
       externalLabel,
       'aria-describedby': descriptionId,
       children,
@@ -82,12 +77,13 @@ export const Anchor = forwardRef(
   ): ReturnType => {
     const components = useComponents();
     const Link = components.Link as AsPropType;
+    const isExternalLink =
+      props.rel === 'external' || props.target === '_blank';
     const externalLabelId = useId();
     const descriptionIds = clsx(
-      externalLabel && externalLabelId,
+      externalLabel && isExternalLink && externalLabelId,
       descriptionId,
     );
-    const isExternalLink = isExternal || props.target === '_blank';
 
     if (!props.href && !props.onClick) {
       return (
@@ -108,7 +104,11 @@ export const Anchor = forwardRef(
         >
           {children}
           {isExternalLink && externalLabel && (
-            <span id={externalLabelId} className={utilClasses.hideVisually}>
+            <span
+              aria-hidden={true}
+              id={externalLabelId}
+              className={utilClasses.hideVisually}
+            >
               {externalLabel}
             </span>
           )}
@@ -126,7 +126,11 @@ export const Anchor = forwardRef(
       >
         {children}
         {isExternalLink && externalLabel && (
-          <span id={externalLabelId} className={utilClasses.hideVisually}>
+          <span
+            aria-hidden={true}
+            id={externalLabelId}
+            className={utilClasses.hideVisually}
+          >
             {externalLabel}
           </span>
         )}


### PR DESCRIPTION
Addresses [DSYS-978](https://sumupteam.atlassian.net/browse/DSYS-978)

## Purpose

There are link elements that would open a new browser window on the page. However, the link elements lack a visual cue and
state to communicate the behaviour.
Users may not be aware and may be disoriented when the window context changes unexpectedly. This issue can also confuse
users with cognitive impairment or those using a screen reader.

## Approach and changes

Add optional `externalLabel` and `isExternal` props to the Anchor component to announce when a link opens externally

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
