### PR TITLE
remove superfluous aria-haspopup attribute from Popover component

### DIFF
--- a/.changeset/five-schools-sit.md
+++ b/.changeset/five-schools-sit.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed the superfluous `aria-haspopup` attribute from the Popover's trigger element.

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -161,7 +161,6 @@ export interface PopoverProps {
     'onClick': (event: ClickEvent) => void;
     'onKeyDown': (event: KeyboardEvent) => void;
     'id': string;
-    'aria-haspopup': boolean;
     'aria-controls': string;
     'aria-expanded': boolean;
   }) => React.JSX.Element;
@@ -322,7 +321,6 @@ export const Popover = ({
       <div className={classes.trigger} ref={refs.setReference}>
         <Component
           id={triggerId}
-          aria-haspopup={true}
           aria-controls={menuId}
           aria-expanded={isOpen}
           onClick={handleTriggerClick}


### PR DESCRIPTION
Addresses [DSYS-980](https://sumupteam.atlassian.net/browse/DSYS-980)

## Purpose

There are disclosure components on the page identified that are incorrectly declared with the aria-haspopup attribute.
The aria-haspopup attribute is used primarily for the menu of web applications (for example, File > Edit > View) such as Office
365.
Disclosure components should not use the aria-haspopup state as it would confuse screen reader users.

## Approach and changes

Remove the aria-haspopup attribute from the Popover component.

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
