### PR TITLE
Removed the irrelevant aria-pressed attribute from Hamburger

### DIFF
--- a/.changeset/early-cows-hide.md
+++ b/.changeset/early-cows-hide.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed the irrelevant `aria-pressed` attribute from the Hamburger component.

--- a/packages/circuit-ui/components/Hamburger/Hamburger.spec.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.spec.tsx
@@ -42,12 +42,6 @@ describe('Hamburger', () => {
     expect(ref.current).toBe(hamburger);
   });
 
-  it('should have the relevant aria attribute when active', () => {
-    render(<Hamburger {...baseProps} isActive />);
-    const button = screen.getByRole('button');
-    expect(button).toHaveAttribute('aria-pressed', 'true');
-  });
-
   it('should call the onClick prop when clicked', async () => {
     const onClick = vi.fn();
     render(

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -112,7 +112,6 @@ export const Hamburger = forwardRef<any, HamburgerProps>(
         className={clsx(classes.button, className)}
         size={size}
         type="button"
-        aria-pressed={isActive}
         ref={ref}
       >
         {isActive ? activeLabel : inactiveLabel}


### PR DESCRIPTION
Addresses [DSYS-990](https://sumupteam.atlassian.net/browse/DSYS-990)

## Purpose

There is a button on the page that is not toggleable. When the button is activated, it triggers a functionality. However, it has
been declared with a toggle state.
The incorrect declaration of the toggle state on a non-toggleable button can confuse screen reader users.

## Approach and changes

Make sure that interactive elements have an appropriate value. In this case, remove the aria-pressed attribute from the button.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
