### PR TITLE
Add button to copy icon URLs

### DIFF
--- a/.storybook/components/Icons.module.css
+++ b/.storybook/components/Icons.module.css
@@ -45,8 +45,8 @@
 .wrapper {
   position: relative;
   width: 7.5rem;
-  margin-top: var(--cui-spacings-giga);
-  margin-bottom: var(--cui-spacings-giga);
+  padding-bottom: var(--cui-spacings-tera);
+  margin-top: var(--cui-spacings-mega);
   text-align: center;
 }
 
@@ -93,4 +93,16 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) rotate(-30deg);
+}
+
+.copy {
+  position: absolute;
+  right: 50%;
+  bottom: 0;
+  display: none;
+  transform: translateX(50%);
+}
+
+.wrapper:hover .copy {
+  display: block;
 }

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -31,11 +31,13 @@ import { SearchInput } from '../../packages/circuit-ui/components/SearchInput/Se
 import { Select } from '../../packages/circuit-ui/components/Select/Select.js';
 import { SelectorGroup } from '../../packages/circuit-ui/components/SelectorGroup/SelectorGroup.js';
 import { Tooltip } from '../../packages/circuit-ui/components/Tooltip/Tooltip.js';
+import { IconButton } from '../../packages/circuit-ui/components/Button/IconButton.js';
+import { ToastProvider } from '../../packages/circuit-ui/components/ToastContext/ToastContext.js';
+import { useNotificationToast } from '../../packages/circuit-ui/components/NotificationToast/NotificationToast.js';
 import { clsx } from '../../packages/circuit-ui/styles/clsx.js';
 import { utilClasses } from '../../packages/circuit-ui/styles/utility.js';
 import { slugify } from '../slugify.js';
 import classes from './Icons.module.css';
-import { IconButton } from '@sumup-oss/circuit-ui';
 
 function groupBy(
   icons: IconsManifest['icons'],
@@ -114,113 +116,144 @@ export function Icons() {
 
   return (
     <Unstyled>
-      <fieldset className={classes.filters}>
-        <legend className={utilClasses.hideVisually}>Icon filters</legend>
-        <SearchInput
-          label="Search by name or keyword"
-          placeholder="Search..."
-          value={search}
-          onChange={handleChange(setSearch)}
-          onClear={() => setSearch('')}
-          clearLabel="Clear"
-        />
-        <Select
-          label="Size"
-          options={sizeOptions}
-          value={size}
-          onChange={handleChange(setSize)}
-        />
-        <Select
-          label="Color"
-          options={colorOptions}
-          value={color}
-          onChange={handleChange(setColor)}
-        />
-        <SelectorGroup
-          label="Scale"
-          options={scaleOptions}
-          value={scale}
-          onChange={handleChange(setScale)}
-        />
-      </fieldset>
+      <ToastProvider>
+        <fieldset className={classes.filters}>
+          <legend className={utilClasses.hideVisually}>Icon filters</legend>
+          <SearchInput
+            label="Search by name or keyword"
+            placeholder="Search..."
+            value={search}
+            onChange={handleChange(setSearch)}
+            onClear={() => setSearch('')}
+            clearLabel="Clear"
+          />
+          <Select
+            label="Size"
+            options={sizeOptions}
+            value={size}
+            onChange={handleChange(setSize)}
+          />
+          <Select
+            label="Color"
+            options={colorOptions}
+            value={color}
+            onChange={handleChange(setColor)}
+          />
+          <SelectorGroup
+            label="Scale"
+            options={scaleOptions}
+            value={scale}
+            onChange={handleChange(setScale)}
+          />
+        </fieldset>
 
-      {activeIcons.length <= 0 ? (
-        <Body>No icons found</Body>
-      ) : (
-        Object.entries<IconsManifest['icons']>(
-          groupBy(activeIcons, 'category'),
-        ).map(([category, items]) => (
-          <section key={category} className={classes.category}>
-            <Headline as="h2" size="m" id={slugify(category)}>
-              {category}
-            </Headline>
-            <div className={classes.list}>
-              {sortBy(items, 'name').map((icon) => {
-                const id = `${icon.name}-${icon.size}`;
-                const componentName = getComponentName(
-                  icon.name,
-                ) as keyof typeof iconComponents;
-                const Icon = iconComponents[componentName] as IconComponentType;
-                const copyIconURL = () => {
-                  const iconURL = `https://circuit.sumup.com/icons/v2/${icon.name}_${icon.size}.svg`;
-                  navigator.clipboard.writeText(iconURL);
-                };
-                return (
-                  <div key={id} className={classes.wrapper}>
-                    <div
-                      className={clsx(classes['icon-wrapper'], classes[scale])}
-                    >
-                      <Icon
-                        aria-labelledby={id}
-                        size={icon.size}
-                        className={classes.icon}
-                        style={{
-                          color,
-                          backgroundColor:
-                            color === 'var(--cui-fg-on-strong)'
-                              ? 'var(--cui-bg-strong)'
-                              : 'var(--cui-bg-normal)',
-                        }}
-                      />
-                    </div>
-                    <span id={id} className={classes.label}>
-                      {componentName}
-                      <span className={classes.size}>{icon.size}</span>
-                    </span>
-                    {icon.deprecation && (
-                      <Tooltip
-                        type="description"
-                        label={icon.deprecation}
-                        component={(props) => (
-                          <Badge
-                            {...props}
-                            tabIndex={0}
-                            variant="warning"
-                            className={classes.badge}
-                          >
-                            Deprecated
-                          </Badge>
-                        )}
-                      />
-                    )}
-                    {navigator.clipboard && (
-                      <IconButton
-                        variant="tertiary"
-                        size="s"
-                        icon={iconComponents.Link}
-                        className={classes.copy}
-                        onClick={copyIconURL}
-                      >
-                        Copy URL
-                      </IconButton>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </section>
-        ))
-      )}
+        {activeIcons.length <= 0 ? (
+          <Body>No icons found</Body>
+        ) : (
+          Object.entries<IconsManifest['icons']>(
+            groupBy(activeIcons, 'category'),
+          ).map(([category, items]) => (
+            <section key={category} className={classes.category}>
+              <Headline as="h2" size="m" id={slugify(category)}>
+                {category}
+              </Headline>
+              <div className={classes.list}>
+                {sortBy(items, 'name').map((icon) => (
+                  <Icon
+                    key={`${icon.name}-${icon.size}`}
+                    icon={icon}
+                    scale={scale}
+                    color={color}
+                  />
+                ))}
+              </div>
+            </section>
+          ))
+        )}
+      </ToastProvider>
     </Unstyled>
+  );
+}
+
+function Icon({
+  icon,
+  scale,
+  color,
+}: { icon: IconsManifest['icons'][number]; scale: string; color: string }) {
+  const { setToast } = useNotificationToast();
+
+  const id = `${icon.name}-${icon.size}`;
+  const componentName = getComponentName(
+    icon.name,
+  ) as keyof typeof iconComponents;
+  const Icon = iconComponents[componentName] as IconComponentType;
+
+  const copyIconURL = () => {
+    const iconURL = `https://circuit.sumup.com/icons/v2/${icon.name}_${icon.size}.svg`;
+    navigator.clipboard
+      .writeText(iconURL)
+      .then(() => {
+        setToast({
+          variant: 'success',
+          body: `Copied the ${componentName} (${icon.size}) icon URL to the clipboard.`,
+        });
+      })
+      .catch((error) => {
+        console.error(error);
+        setToast({
+          variant: 'danger',
+          body: `Failed to copy the ${componentName} (${icon.size}) icon URL to the clipboard.`,
+        });
+      });
+  };
+
+  return (
+    <div className={classes.wrapper}>
+      <div className={clsx(classes['icon-wrapper'], classes[scale])}>
+        <Icon
+          aria-labelledby={id}
+          size={icon.size}
+          className={classes.icon}
+          style={{
+            color,
+            backgroundColor:
+              color === 'var(--cui-fg-on-strong)'
+                ? 'var(--cui-bg-strong)'
+                : 'var(--cui-bg-normal)',
+          }}
+        />
+      </div>
+      <span id={id} className={classes.label}>
+        {componentName}
+        <span className={classes.size}>{icon.size}</span>
+      </span>
+      {icon.deprecation && (
+        <Tooltip
+          type="description"
+          label={icon.deprecation}
+          component={(props) => (
+            <Badge
+              {...props}
+              tabIndex={0}
+              variant="warning"
+              className={classes.badge}
+            >
+              Deprecated
+            </Badge>
+          )}
+        />
+      )}
+      {navigator.clipboard && (
+        <IconButton
+          variant="tertiary"
+          size="s"
+          icon={iconComponents.Link}
+          className={classes.copy}
+          onClick={copyIconURL}
+        >
+          Copy URL
+        </IconButton>
+      )}
+    </div>
   );
 }

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -35,6 +35,7 @@ import { clsx } from '../../packages/circuit-ui/styles/clsx.js';
 import { utilClasses } from '../../packages/circuit-ui/styles/utility.js';
 import { slugify } from '../slugify.js';
 import classes from './Icons.module.css';
+import { IconButton } from '@sumup-oss/circuit-ui';
 
 function groupBy(
   icons: IconsManifest['icons'],
@@ -77,7 +78,7 @@ export function Icons() {
 
   const handleChange =
     (setState: Dispatch<SetStateAction<string>>) =>
-    (event: ChangeEvent<any>) => {
+    (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
       setState(event.target.value);
     };
 
@@ -160,6 +161,10 @@ export function Icons() {
                   icon.name,
                 ) as keyof typeof iconComponents;
                 const Icon = iconComponents[componentName] as IconComponentType;
+                const copyIconURL = () => {
+                  const iconURL = `https://circuit.sumup.com/icons/v2/${icon.name}_${icon.size}.svg`;
+                  navigator.clipboard.writeText(iconURL);
+                };
                 return (
                   <div key={id} className={classes.wrapper}>
                     <div
@@ -180,9 +185,7 @@ export function Icons() {
                     </div>
                     <span id={id} className={classes.label}>
                       {componentName}
-                      {size === 'all' && (
-                        <span className={classes.size}>{icon.size}</span>
-                      )}
+                      <span className={classes.size}>{icon.size}</span>
                     </span>
                     {icon.deprecation && (
                       <Tooltip
@@ -200,6 +203,15 @@ export function Icons() {
                         )}
                       />
                     )}
+                    <IconButton
+                      variant="tertiary"
+                      size="s"
+                      icon={iconComponents.Link}
+                      className={classes.copy}
+                      onClick={copyIconURL}
+                    >
+                      Copy URL
+                    </IconButton>
                   </div>
                 );
               })}

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -203,15 +203,17 @@ export function Icons() {
                         )}
                       />
                     )}
-                    <IconButton
-                      variant="tertiary"
-                      size="s"
-                      icon={iconComponents.Link}
-                      className={classes.copy}
-                      onClick={copyIconURL}
-                    >
-                      Copy URL
-                    </IconButton>
+                    {navigator.clipboard && (
+                      <IconButton
+                        variant="tertiary"
+                        size="s"
+                        icon={iconComponents.Link}
+                        className={classes.copy}
+                        onClick={copyIconURL}
+                      >
+                        Copy URL
+                      </IconButton>
+                    )}
                   </div>
                 );
               })}


### PR DESCRIPTION
## Purpose

Icons are hosted at `https://circuit.sumup.com/icons/v2/<icon_name>_<size>.svg`. We've received a suggestion to add a button the icon overview page to copy this URL to the clipboard.

## Approach and changes

- Add buttons to copy icon URLs to the clipboard

⚠️  The copy button is only shown when the icon is hovered to reduce visual clutter in the UI. This means the button isn't accessible on touch screen devices. I'm open to alternative suggestions.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
