### PR TITLE
Refactor Tabs component

### DIFF
--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.spec.tsx
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.spec.tsx
@@ -50,7 +50,10 @@ describe('TableRow', () => {
     render(<TableRow onClick={onClick}>{children}</TableRow>);
     const rowEl = screen.getByRole('row');
 
-    rowEl.focus();
+    await userEvent.keyboard('{Tab}');
+
+    expect(rowEl).toHaveFocus();
+
     await userEvent.keyboard(key);
 
     expect(onClick).toHaveBeenCalledTimes(1);

--- a/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
@@ -73,7 +73,7 @@ describe('Tabs', () => {
   it('should go to the previous tab on left arrow press', async () => {
     render(
       <Tabs
-        initialSelectedId="b"
+        initialSelectedIndex={1}
         items={[
           { id: 'a', tab: 'tab-a', panel: 'panel-a' },
           { id: 'b', tab: 'tab-b', panel: 'panel-b' },

--- a/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
@@ -34,19 +34,17 @@ describe('Tabs', () => {
       />,
     );
 
-    const tabEls = screen.getAllByTestId('tab-element');
-    const panelEls = screen.getAllByTestId('tab-panel');
+    const panelA = screen.getByRole('tabpanel');
+    expect(panelA).toHaveAccessibleName('tab-a');
 
-    expect(panelEls[0]).toBeVisible();
-    expect(panelEls[1]).not.toBeVisible();
+    const tabs = screen.getAllByRole('tab');
+    await userEvent.click(tabs[1]);
 
-    await userEvent.click(tabEls[1]);
-
-    expect(panelEls[0]).not.toBeVisible();
-    expect(panelEls[1]).toBeVisible();
+    const panelB = screen.getByRole('tabpanel');
+    expect(panelB).toHaveAccessibleName('tab-b');
   });
 
-  it('should go to the next tab on right press', async () => {
+  it('should go to the next tab on right arrow press', async () => {
     render(
       <Tabs
         items={[
@@ -57,16 +55,69 @@ describe('Tabs', () => {
       />,
     );
 
-    const tabEls = screen.getAllByTestId('tab-element');
-    const panelEls = screen.getAllByTestId('tab-panel');
+    await userEvent.keyboard('{Tab}');
 
-    expect(panelEls[0]).toBeVisible();
-    expect(panelEls[1]).not.toBeVisible();
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).toHaveFocus();
 
-    await userEvent.type(tabEls[0], '{arrowright}');
+    const panelA = screen.getByRole('tabpanel');
+    expect(panelA).toHaveAccessibleName('tab-a');
 
-    expect(panelEls[0]).not.toBeVisible();
-    expect(panelEls[1]).toBeVisible();
+    await userEvent.keyboard('{ArrowRight}');
+
+    const panelB = screen.getByRole('tabpanel');
+    expect(panelB).toHaveAccessibleName('tab-b');
+    expect(tabs[1]).toHaveFocus();
+  });
+
+  it('should go to the previous tab on left arrow press', async () => {
+    render(
+      <Tabs
+        initialSelectedIndex={1}
+        items={[
+          { id: 'a', tab: 'tab-a', panel: 'panel-a' },
+          { id: 'b', tab: 'tab-b', panel: 'panel-b' },
+          { id: 'c', tab: 'tab-c', panel: 'panel-c' },
+        ]}
+      />,
+    );
+
+    await userEvent.keyboard('{Tab}');
+
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).toHaveFocus();
+
+    const panelB = screen.getByRole('tabpanel');
+    expect(panelB).toHaveAccessibleName('tab-b');
+
+    await userEvent.keyboard('{ArrowLeft}');
+
+    const panelA = screen.getByRole('tabpanel');
+    expect(panelA).toHaveAccessibleName('tab-a');
+    expect(tabs[0]).toHaveFocus();
+  });
+
+  it('should focus the current panel on down arrow press', async () => {
+    render(
+      <Tabs
+        initialSelectedIndex={1}
+        items={[
+          { id: 'a', tab: 'tab-a', panel: 'panel-a' },
+          { id: 'b', tab: 'tab-b', panel: 'panel-b' },
+          { id: 'c', tab: 'tab-c', panel: 'panel-c' },
+        ]}
+      />,
+    );
+
+    await userEvent.keyboard('{Tab}');
+
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0]).toHaveFocus();
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).toHaveFocus();
   });
 
   it('should have no accessibility violations for tablist only', async () => {

--- a/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
@@ -73,7 +73,7 @@ describe('Tabs', () => {
   it('should go to the previous tab on left arrow press', async () => {
     render(
       <Tabs
-        initialSelectedIndex={1}
+        initialSelectedId="b"
         items={[
           { id: 'a', tab: 'tab-a', panel: 'panel-a' },
           { id: 'b', tab: 'tab-b', panel: 'panel-b' },
@@ -85,7 +85,7 @@ describe('Tabs', () => {
     await userEvent.keyboard('{Tab}');
 
     const tabs = screen.getAllByRole('tab');
-    expect(tabs[0]).toHaveFocus();
+    expect(tabs[1]).toHaveFocus();
 
     const panelB = screen.getByRole('tabpanel');
     expect(panelB).toHaveAccessibleName('tab-b');
@@ -100,7 +100,6 @@ describe('Tabs', () => {
   it('should focus the current panel on down arrow press', async () => {
     render(
       <Tabs
-        initialSelectedIndex={1}
         items={[
           { id: 'a', tab: 'tab-a', panel: 'panel-a' },
           { id: 'b', tab: 'tab-b', panel: 'panel-b' },

--- a/packages/circuit-ui/components/Tabs/Tabs.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.tsx
@@ -29,11 +29,11 @@ import { TabPanel } from './components/TabPanel/index.js';
 
 export interface TabsProps extends TabListProps {
   /**
-   * The id of the initially selected tab.
+   * The index of the initially selected tab.
    *
-   * @default items[0].id
+   * @default 0
    */
-  initialSelectedId?: string;
+  initialSelectedIndex?: number;
   /**
    * A collection of tabs with an id, the tab label, and panel content.
    */
@@ -44,12 +44,8 @@ export interface TabsProps extends TabListProps {
   }[];
 }
 
-export function Tabs({
-  items,
-  initialSelectedId = items[0].id,
-  ...props
-}: TabsProps) {
-  const [selectedId, setSelectedId] = useState(initialSelectedId);
+export function Tabs({ items, initialSelectedIndex = 0, ...props }: TabsProps) {
+  const [selectedId, setSelectedId] = useState(items[initialSelectedIndex]?.id);
 
   const handleTabKeyDown = (event: KeyboardEvent) => {
     const selectedIndex = items.findIndex((item) => item.id === selectedId);

--- a/packages/circuit-ui/components/Tabs/Tabs.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.tsx
@@ -74,7 +74,6 @@ export function Tabs({ initialSelectedIndex = 0, items, ...props }: TabsProps) {
         {items.map(({ id, tab }, index) => (
           <Tab
             key={id}
-            data-testid="tab-element"
             selected={selectedIndex === index}
             onClick={() => setSelectedIndex(index)}
             id={`tab-${id}`}
@@ -88,7 +87,6 @@ export function Tabs({ initialSelectedIndex = 0, items, ...props }: TabsProps) {
       {items.map(({ id, panel }, index) => (
         <TabPanel
           key={id}
-          data-testid="tab-panel"
           id={`panel-${id}`}
           aria-labelledby={`tab-${id}`}
           hidden={selectedIndex !== index}

--- a/packages/circuit-ui/components/Tabs/Tabs.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.tsx
@@ -39,7 +39,7 @@ export interface TabsProps extends TabListProps {
    */
   items: {
     id: string;
-    tab: ReactNode;
+    tab: string;
     panel: ReactNode;
   }[];
 }

--- a/packages/circuit-ui/components/Tabs/Tabs.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.tsx
@@ -39,7 +39,7 @@ export interface TabsProps extends TabListProps {
    */
   items: {
     id: string;
-    tab: string;
+    tab: ReactNode;
     panel: ReactNode;
   }[];
 }
@@ -75,6 +75,7 @@ export function Tabs({ items, initialSelectedIndex = 0, ...props }: TabsProps) {
         {items.map(({ id, tab }) => (
           <Tab
             key={id}
+            data-testid="tab-element"
             selected={selectedId === id}
             onClick={() => setSelectedId(id)}
             id={`tab-${id}`}
@@ -88,6 +89,7 @@ export function Tabs({ items, initialSelectedIndex = 0, ...props }: TabsProps) {
       {items.map(({ id, panel }) => (
         <TabPanel
           key={id}
+          data-testid="tab-panel"
           id={`panel-${id}`}
           aria-labelledby={`tab-${id}`}
           hidden={selectedId !== id}

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
@@ -13,34 +13,25 @@
  * limitations under the License.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { createRef } from 'react';
 
-import { render } from '../../../../util/test-utils.js';
+import { render, screen } from '../../../../util/test-utils.js';
 
 import { Tab } from './Tab.js';
 
 describe('Tab', () => {
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
-    const { container } = render(<Tab className={className} />);
-    const element = container.querySelector('button');
-    expect(element?.className).toContain(className);
+    render(<Tab className={className} />);
+    const element = screen.getByRole('tab');
+    expect(element.className).toContain(className);
   });
 
   it('should forward a ref', () => {
     const ref = createRef<HTMLButtonElement>();
-    const { container } = render(<Tab ref={ref} />);
-    const button = container.querySelector('button');
-    expect(ref.current).toBe(button);
-  });
-
-  it('should be focused when selected', () => {
-    const ref = createRef<HTMLButtonElement>();
-    const { container, rerender } = render(<Tab ref={ref} selected={false} />);
-    const button = container.querySelector('button');
-    vi.spyOn(button, 'focus');
-    rerender(<Tab ref={ref} selected />);
-    expect(button?.focus).toHaveBeenCalledOnce();
+    render(<Tab ref={ref} />);
+    const tab = screen.getByRole('tab');
+    expect(ref.current).toBe(tab);
   });
 });

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -19,14 +19,11 @@ import {
   forwardRef,
   type AnchorHTMLAttributes,
   type ButtonHTMLAttributes,
-  useEffect,
-  useRef,
 } from 'react';
 
 import { useComponents } from '../../../ComponentsContext/index.js';
 import type { EmotionAsPropType } from '../../../../types/prop-types.js';
 import { clsx } from '../../../../styles/clsx.js';
-import { applyMultipleRefs } from '../../../../util/refs.js';
 
 import classes from './Tab.module.css';
 
@@ -49,19 +46,13 @@ const tabIndex = (selected: boolean) => (selected ? undefined : -1);
  */
 export const Tab = forwardRef<HTMLButtonElement, TabProps>(
   ({ selected = false, className, ...props }, ref) => {
-    const tabRef = useRef<HTMLButtonElement>(null);
     const components = useComponents();
     const Link = components.Link as EmotionAsPropType;
     const Element = props.href ? Link : 'button';
 
-    useEffect(() => {
-      if (selected) {
-        tabRef?.current?.focus({ preventScroll: true });
-      }
-    }, [selected]);
     return (
       <Element
-        ref={applyMultipleRefs(tabRef, ref)}
+        ref={ref}
         role="tab"
         aria-selected={selected}
         tabIndex={tabIndex(selected)}

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Children, type HTMLAttributes } from 'react';
+import { Children, forwardRef, type HTMLAttributes } from 'react';
 
 import { clsx } from '../../../../styles/clsx.js';
 import { utilClasses } from '../../../../styles/utility.js';
@@ -29,32 +29,29 @@ const MOBILE_AUTOSTRETCH_ITEMS_MAX = 3;
 /**
  * TabList component that wraps the Tab components
  */
-export function TabList({
-  className,
-  style = {},
-  stretched,
-  children,
-  ...props
-}: TabListProps) {
-  const numberOfTabs = Children.toArray(children).length;
-  const tabWidth = Math.floor(100 / numberOfTabs);
-  const stretchOnMobile = numberOfTabs <= MOBILE_AUTOSTRETCH_ITEMS_MAX;
-  return (
-    <div
-      className={clsx(classes.wrapper, utilClasses.hideScrollbar, className)}
-      style={{ ...style, '--tab-list-width': tabWidth }}
-    >
+export const TabList = forwardRef<HTMLDivElement, TabListProps>(
+  ({ className, style = {}, stretched, children, ...props }, ref) => {
+    const numberOfTabs = Children.toArray(children).length;
+    const tabWidth = Math.floor(100 / numberOfTabs);
+    const stretchOnMobile = numberOfTabs <= MOBILE_AUTOSTRETCH_ITEMS_MAX;
+    return (
       <div
-        className={clsx(
-          classes.base,
-          stretched && classes.stretched,
-          stretchOnMobile && classes['stretched-mobile'],
-        )}
-        {...props}
-        role="tablist"
+        ref={ref}
+        className={clsx(classes.wrapper, utilClasses.hideScrollbar, className)}
+        style={{ ...style, '--tab-list-width': tabWidth }}
       >
-        {children}
+        <div
+          className={clsx(
+            classes.base,
+            stretched && classes.stretched,
+            stretchOnMobile && classes['stretched-mobile'],
+          )}
+          {...props}
+          role="tablist"
+        >
+          {children}
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);


### PR DESCRIPTION
Addresses [DSYS-979](https://sumupteam.atlassian.net/browse/DSYS-979).

## Purpose

#2987 attempts to improve the focus management of the Tabs component, however, its approach using a `useEffect` captures focus on page load and programmatic changes of the selected tab. 

This pull request uses a different approach to set focus on user interaction. 

## Approach and changes

- Migrate the Tabs component from a class to a functional component
- Improve unit tests, add additional ones and ~~remove `data-testid`s~~
- Refactor the logic to set focus to the previous/next tab using the arrow keys

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
