### PR TITLE
Add letter-spacing to theme docs

### DIFF
--- a/.storybook/components/Theme.tsx
+++ b/.storybook/components/Theme.tsx
@@ -240,8 +240,14 @@ export function FontStack({ name }: PreviewProps) {
 
 export function FontWeight({ name }: PreviewProps) {
   return (
-    // @ts-expect-error A CSS custom property is a valid font weight
     <p style={{ fontWeight: `var(${name})`, whiteSpace: 'nowrap' }}>
+      Lorem ipsum
+    </p>
+  );
+}
+export function LetterSpacing({ name }: PreviewProps) {
+  return (
+    <p style={{ letterSpacing: `var(${name})`, whiteSpace: 'nowrap' }}>
       Lorem ipsum
     </p>
   );
@@ -255,9 +261,6 @@ export function Typography({ name }: PreviewProps) {
   }
   if (name.includes('line-height')) {
     return <p style={{ lineHeight: `var(${name})` }}>Lorem ipsum</p>;
-  }
-  if (name.includes('letter-spacing')) {
-    return <p style={{ letterSpacing: `var(${name})` }}>Lorem ipsum</p>;
   }
   return null;
 }

--- a/.storybook/components/index.ts
+++ b/.storybook/components/index.ts
@@ -38,6 +38,7 @@ export {
   BorderWidth,
   FontStack,
   FontWeight,
+  LetterSpacing,
   Typography,
   Transition,
   MediaQueriesTable,

--- a/docs/features/1-theme.mdx
+++ b/docs/features/1-theme.mdx
@@ -10,6 +10,7 @@ import {
   BorderWidth,
   FontStack,
   FontWeight,
+  LetterSpacing,
   Typography,
   Transition,
 } from '../../.storybook/components';
@@ -83,6 +84,10 @@ Avoid using the typography CSS custom properties directly in your styles. Instea
 <CustomPropertiesTable namespace="font-weight" preview={FontWeight} />
 
 Pass the `weight` prop to the `Body` component to adjust its font-weight styling. The font weight of the `Display`, `Headline` and the `Numeral` components is bold by default and should not be overwritten.
+
+## Letter spacing
+
+<CustomPropertiesTable namespace="letter-spacing" preview={LetterSpacing} />
 
 ## Transitions
 


### PR DESCRIPTION
## Purpose

In #2909, I forgot to add docs for the new letter spacing design tokens.

## Approach and changes

- Add a section for the letter-spacing tokens to the theme docs

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
