### PR TITLE
Fix DateSegment width

### DIFF
--- a/.changeset/odd-points-agree.md
+++ b/.changeset/odd-points-agree.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the DateInput component's input segment width when the component isn't immediately rendered to the DOM.

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.spec.tsx
@@ -215,9 +215,13 @@ describe('DateSegment', () => {
 
   describe('layout', () => {
     it('should adjust the width of the input to its content', async () => {
+      vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValueOnce({
+        width: 24,
+      } as DOMRect);
+
       render(<DateSegment {...props} />);
       const input = screen.getByRole('spinbutton');
-      expect(input).toHaveStyle('--width: 1px');
+      expect(input).toHaveStyle('--width: 25px');
     });
   });
 

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
@@ -75,7 +75,10 @@ export function DateSegment({
       const cursorWidth = 1;
       const elementSize = sizeRef.current.getBoundingClientRect();
       const elementWidth = Math.ceil(elementSize.width);
-      setWidth(`${cursorWidth + elementWidth}px`);
+      // The element width can be 0 if a parent element isn't rendered to the DOM (yet)
+      if (elementWidth > 0) {
+        setWidth(`${cursorWidth + elementWidth}px`);
+      }
     }
   }, [props.value]);
 


### PR DESCRIPTION
## Purpose

The DateInput's input segments dynamically resize based on the entered value (or the placeholder when empty) by measuring the actual size of a visually hidden test element.

The measurements can be reported as 0 when the element hasn't been rendered to the DOM, e.g. when a parent element has `display: none`. One such case occurs when the DateInput is rendered inside the new Dialog component that will be introduced in v10.

## Approach and changes

- Avoid updating the DateSegment width if the measured width is 0

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
