### PR TITLE
chore(docs): change freemium references to generic payment plans

### DIFF
--- a/.changeset/four-states-open.md
+++ b/.changeset/four-states-open.md
@@ -1,5 +1,0 @@
----
-"@sumup-oss/circuit-ui": patch
----
-
-Updated the examples in the ComparisonTable documentation to be more generic.

--- a/.changeset/four-states-open.md
+++ b/.changeset/four-states-open.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Change plan details on ComparisonTable docs

--- a/.changeset/four-states-open.md
+++ b/.changeset/four-states-open.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Change plan details on ComparisonTable docs
+Updated the examples in the ComparisonTable documentation to be more generic.

--- a/packages/circuit-ui/components/ComparisonTable/ComparisonTable.spec.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/ComparisonTable.spec.tsx
@@ -32,27 +32,18 @@ import {
   type ComparisonTableProps,
 } from './ComparisonTable.js';
 import {
-  bankingBasicsSection,
-  moneyManagement,
-  invoicingSection,
-  posPlan,
-  posPlusPlan,
-  posProPlan,
-  productCatalogSection,
+  standardPlan,
+  essentialFeaturesSection,
+  basicPlan,
+  premiumPlan,
 } from './fixtures.js';
 
 vi.mock('../../hooks/useMedia/index.js');
 
 const baseProps: ComparisonTableProps = {
   caption: 'Compare plans',
-  headers: [posPlan, posPlusPlan, posProPlan],
-
-  sections: [
-    bankingBasicsSection,
-    productCatalogSection,
-    moneyManagement,
-    invoicingSection,
-  ],
+  headers: [basicPlan, standardPlan, premiumPlan],
+  sections: [essentialFeaturesSection],
   showAllFeaturesLabel: 'Show all features',
   selectFirstPlanLabel: 'Select a first plan',
   selectSecondPlanLabel: 'Select a second plan',
@@ -98,7 +89,7 @@ describe('ComparisonTable', () => {
 
     it('should not render the plan picker on mobile if only given two plans', () => {
       render(
-        <ComparisonTable {...baseProps} headers={[posPlan, posPlusPlan]} />,
+        <ComparisonTable {...baseProps} headers={[basicPlan, standardPlan]} />,
       );
       expect(
         screen.queryByText(baseProps.selectFirstPlanLabel),
@@ -113,11 +104,11 @@ describe('ComparisonTable', () => {
 
       await userEvent.selectOptions(
         screen.getByLabelText(baseProps.selectFirstPlanLabel),
-        'POS Pro',
+        'Premium',
       );
       expect(
         screen.getByRole('columnheader', {
-          name: 'POS plus $15/month Join now',
+          name: 'Premium Full feature set Get started',
         }),
       ).toBeVisible();
     });

--- a/packages/circuit-ui/components/ComparisonTable/ComparisonTable.stories.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/ComparisonTable.stories.tsx
@@ -20,13 +20,13 @@ import {
   type ComparisonTableProps,
 } from './ComparisonTable.js';
 import {
-  bankingBasicsSection,
-  moneyManagement,
-  invoicingSection,
-  posPlan,
-  posPlusPlan,
-  posProPlan,
-  productCatalogSection,
+  basicPlan,
+  standardPlan,
+  premiumPlan,
+  essentialFeaturesSection,
+  customizationSection,
+  supportSection,
+  analyticsSection
 } from './fixtures.js';
 
 export default {
@@ -45,8 +45,8 @@ export default {
 
 const baseProps: ComparisonTableProps = {
   caption: 'Compare plans',
-  headers: [posPlan, posPlusPlan, posProPlan],
-  sections: [bankingBasicsSection],
+  headers: [basicPlan, standardPlan, premiumPlan],
+  sections: [essentialFeaturesSection],
   showAllFeaturesLabel: 'Show all features',
   selectSecondPlanLabel: 'Select a second plan',
   selectFirstPlanLabel: 'Select a first plan',
@@ -64,8 +64,8 @@ Collapsed.args = {
   ...baseProps,
   sections: [
     ...baseProps.sections,
-    productCatalogSection,
-    moneyManagement,
-    invoicingSection,
+    customizationSection,
+    supportSection,
+    analyticsSection
   ],
 };

--- a/packages/circuit-ui/components/ComparisonTable/ComparisonTable.stories.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/ComparisonTable.stories.tsx
@@ -26,7 +26,7 @@ import {
   essentialFeaturesSection,
   customizationSection,
   supportSection,
-  analyticsSection
+  analyticsSection,
 } from './fixtures.js';
 
 export default {
@@ -66,6 +66,6 @@ Collapsed.args = {
     ...baseProps.sections,
     customizationSection,
     supportSection,
-    analyticsSection
+    analyticsSection,
   ],
 };

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.spec.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.spec.tsx
@@ -19,11 +19,11 @@ import { createRef } from 'react';
 import { axe, render, screen, userEvent } from '../../../../util/test-utils.js';
 import { useMedia } from '../../../../hooks/useMedia/index.js';
 import {
-  bankingBasicsSection,
-  posPlan,
-  posPlusPlan,
-  posProPlan,
-  productCatalogSection,
+  essentialFeaturesSection,
+  customizationSection,
+  basicPlan,
+  standardPlan,
+  premiumPlan,
 } from '../../fixtures.js';
 
 import { PlanTable, type PlanTableProps } from './PlanTable.js';
@@ -33,19 +33,22 @@ vi.mock('../../../../hooks/useMedia/index.js');
 const baseProps: PlanTableProps = {
   caption: 'Plan comparison',
   showAllFeaturesLabel: 'Show all features',
-  sections: [bankingBasicsSection],
-  headers: [posPlan, posPlusPlan, posProPlan],
+  sections: [essentialFeaturesSection],
+  headers: [basicPlan, standardPlan, premiumPlan],
   activePlans: [0, 1],
 };
+
 describe('PlanTable', () => {
   beforeEach(() => {
     (useMedia as Mock).mockReturnValue(false);
   });
+
   it('should forward the ref to the table element', () => {
     const ref = createRef<HTMLTableElement>();
     render(<PlanTable {...baseProps} ref={ref} />);
     expect(screen.getByRole('table')).toBe(ref.current);
   });
+
   it('should render all plan information', () => {
     render(<PlanTable {...baseProps} />);
     expect(screen.getByText(baseProps.caption)).toBeInTheDocument();
@@ -57,19 +60,20 @@ describe('PlanTable', () => {
     expect(screen.getAllByRole('row')).toHaveLength(7);
 
     expect(
-      screen.getAllByRole('rowheader', { name: 'Banking basics' }),
+      screen.getAllByRole('rowheader', { name: 'Essential Features' }),
     ).toHaveLength(1);
     expect(screen.getAllByRole('rowheader')).toHaveLength(6);
-    expect(screen.getAllByRole('cell', { name: 'available' })).toHaveLength(13);
-    expect(screen.getAllByRole('cell', { name: 'unavailable' })).toHaveLength(
-      2,
+    expect(screen.getAllByRole('cell', { name: 'included' })).toHaveLength(12);
+    expect(screen.getAllByRole('cell', { name: 'not included' })).toHaveLength(
+      3,
     );
   });
+
   it('should render as collapsed when content is large', async () => {
     render(
       <PlanTable
         {...baseProps}
-        sections={[...baseProps.sections, productCatalogSection]}
+        sections={[...baseProps.sections, customizationSection]}
       />,
     );
     const showAllFeaturesButton = screen.getByText(
@@ -78,15 +82,16 @@ describe('PlanTable', () => {
     expect(showAllFeaturesButton).toBeVisible();
     expect(screen.getAllByRole('row')).toHaveLength(9);
     await userEvent.click(showAllFeaturesButton);
-    expect(screen.getAllByRole('row')).toHaveLength(13);
+    expect(screen.getAllByRole('row')).toHaveLength(11);
   });
+
   it('should only render two columns on mobile', () => {
     (useMedia as Mock).mockReturnValue(true);
     render(<PlanTable {...baseProps} />);
     expect(screen.getAllByRole('columnheader')).toHaveLength(2);
     expect(
       screen.queryByRole('columnheader', {
-        name: 'POS Pro plus 25$ /month Join now',
+        name: 'Premium Full feature set Get started',
       }),
     ).not.toBeInTheDocument();
   });

--- a/packages/circuit-ui/components/ComparisonTable/components/TableHeader/TableHeader.spec.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/TableHeader/TableHeader.spec.tsx
@@ -16,12 +16,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { render, screen } from '../../../../util/test-utils.js';
-import { posPlusPlan } from '../../fixtures.js';
+import { standardPlan } from '../../fixtures.js';
 
 import { TableHeader, type TableHeaderProps } from './TableHeader.js';
 
 describe('TableHeader', () => {
-  const baseProps: TableHeaderProps = posPlusPlan;
+  const baseProps: TableHeaderProps = standardPlan;
 
   it('should render all plan information', () => {
     render(<TableHeader {...baseProps} tier={{ variant: 'plus' }} />);

--- a/packages/circuit-ui/components/ComparisonTable/fixtures.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/fixtures.tsx
@@ -32,7 +32,6 @@ export const basicPlan: TableHeaderProps = {
 export const standardPlan: TableHeaderProps = {
   title: 'Standard',
   id: 'standard',
-  tier: { variant: 'plus' },
   description: 'Most popular',
   action: {
     children: 'Get started',

--- a/packages/circuit-ui/components/ComparisonTable/fixtures.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/fixtures.tsx
@@ -104,7 +104,7 @@ export const limitedFeature: Feature = {
     label: 'Limited access',
   },
   values: [
-    { value: false, label: 'not available' },
+    { value: false, label: 'not included' },
     { value: true, label: 'included' },
     { value: true, label: 'included' },
   ],
@@ -115,8 +115,8 @@ export const exclusiveFeature: Feature = {
     label: 'Exclusive access',
   },
   values: [
-    { value: false, label: 'not available' },
-    { value: false, label: 'not available' },
+    { value: false, label: 'not included' },
+    { value: false, label: 'not included' },
     { value: true, label: 'included' },
   ],
 };
@@ -167,7 +167,7 @@ export const customizationSection: FeatureSection = {
         },
       },
       values: [
-        { value: false, label: 'not available' },
+        { value: false, label: 'not included' },
         { value: true, label: 'included' },
         { value: true, label: 'included' },
       ],
@@ -177,8 +177,8 @@ export const customizationSection: FeatureSection = {
         label: 'Full customization',
       },
       values: [
-        { value: false, label: 'not available' },
-        { value: false, label: 'not available' },
+        { value: false, label: 'not included' },
+        { value: false, label: 'not included' },
         { value: true, label: 'included' },
       ],
     },
@@ -204,7 +204,7 @@ export const supportSection: FeatureSection = {
         description: '24/7 availability',
       },
       values: [
-        { value: false, label: 'not available' },
+        { value: false, label: 'not included' },
         { value: true, label: 'included' },
         { value: true, label: 'included' },
       ],
@@ -214,8 +214,8 @@ export const supportSection: FeatureSection = {
         label: 'Dedicated support',
       },
       values: [
-        { value: false, label: 'not available' },
-        { value: false, label: 'not available' },
+        { value: false, label: 'not included' },
+        { value: false, label: 'not included' },
         { value: true, label: 'included' },
       ],
     },
@@ -241,7 +241,7 @@ export const analyticsSection: FeatureSection = {
         description: 'Detailed insights and custom reports',
       },
       values: [
-        { value: false, label: 'not available' },
+        { value: false, label: 'not included' },
         { value: true, label: 'included' },
         { value: true, label: 'included' },
       ],
@@ -251,8 +251,8 @@ export const analyticsSection: FeatureSection = {
         label: 'Custom dashboards',
       },
       values: [
-        { value: false, label: 'not available' },
-        { value: false, label: 'not available' },
+        { value: false, label: 'not included' },
+        { value: false, label: 'not included' },
         { value: true, label: 'included' },
       ],
     },

--- a/packages/circuit-ui/components/ComparisonTable/fixtures.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/fixtures.tsx
@@ -23,266 +23,238 @@ import type {
   FeatureSection,
 } from './components/PlanTable/PlanTable.js';
 
-export const posPlan: TableHeaderProps = {
-  title: 'Free',
-  id: 'free',
-  description: '$0 / month',
+export const basicPlan: TableHeaderProps = {
+  title: 'Basic',
+  id: 'basic',
+  description: 'Essential features',
 };
 
-export const posPlusPlan: TableHeaderProps = {
-  title: 'POS',
-  id: 'pos_plus',
+export const standardPlan: TableHeaderProps = {
+  title: 'Standard',
+  id: 'standard',
   tier: { variant: 'plus' },
-  description: '$15/month',
+  description: 'Most popular',
   action: {
-    children: 'Join now',
-    href: 'https://sumup.com',
+    children: 'Get started',
+    href: '#',
   },
 };
 
-export const posProPlan: TableHeaderProps = {
-  title: 'POS Pro',
-  id: 'pos_pro',
-  description: '$25/month',
+export const premiumPlan: TableHeaderProps = {
+  title: 'Premium',
+  id: 'premium',
+  description: 'Full feature set',
   action: {
-    children: 'Join now',
-    href: 'https://sumup.com',
+    children: 'Get started',
+    href: '#',
   },
 };
 
-export const freeBusinessAccountFeature: Feature = {
+export const coreFeature: Feature = {
   featureDescription: {
-    label: 'Free business account',
-    description: 'get started right away',
+    label: 'Core functionality',
+    description: 'essential features included',
     toggletip: {
       component: (props) => (
         <IconButton {...props} icon={Help} variant="tertiary" size="s">
-          View details for Free business account
+          View details for Core functionality
         </IconButton>
       ),
-      headline: 'Some additional information',
-      body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ',
+      headline: 'Additional information',
+      body: 'This feature provides essential functionality for all users.',
       action: {
         children: 'Learn more',
         navigationIcon: ArrowSlanted,
-        href: 'https://help.sumup.com/',
+        href: '#',
         target: '_blank',
       },
       offset: 8,
     },
   },
   values: [
-    { value: true, label: 'available' },
-    { value: true, label: 'available' },
-    { value: true, label: 'available' },
+    { value: true, label: 'included' },
+    { value: true, label: 'included' },
+    { value: true, label: 'included' },
   ],
 };
 
-export const freePhysicalCardFeature: Feature = {
+export const advancedFeature: Feature = {
   featureDescription: {
-    label: 'Free physical or virtual Mastercard',
+    label: 'Advanced features',
   },
   values: [
-    { value: true, label: 'available' },
-    { value: true, label: 'available' },
-    { value: true, label: 'available' },
+    { value: true, label: 'included' },
+    { value: true, label: 'included' },
+    { value: true, label: 'included' },
   ],
 };
 
-export const freeInstantTransfersFeature: Feature = {
+export const premiumFeature: Feature = {
   featureDescription: {
-    label: 'Free instant transfers',
+    label: 'Premium features',
   },
   values: [
-    { value: true, label: 'available' },
-    { value: true, label: 'available' },
-    { value: true, label: 'available' },
+    { value: true, label: 'included' },
+    { value: true, label: 'included' },
+    { value: true, label: 'included' },
   ],
 };
 
-export const scheduledPaymentsFeature: Feature = {
+export const limitedFeature: Feature = {
   featureDescription: {
-    label: 'Scheduled payments',
+    label: 'Limited access',
   },
   values: [
-    { value: false, label: 'unavailable' },
-    { value: true, label: 'available' },
-    { value: true, label: 'available' },
+    { value: false, label: 'not available' },
+    { value: true, label: 'included' },
+    { value: true, label: 'included' },
   ],
 };
 
-export const paymentRemindersFeature: Feature = {
+export const exclusiveFeature: Feature = {
   featureDescription: {
-    label: 'Payment reminders',
+    label: 'Exclusive access',
   },
   values: [
-    { value: false, label: 'unavailable' },
-    { value: false, label: 'available' },
-    { value: true, label: 'available' },
+    { value: false, label: 'not available' },
+    { value: false, label: 'not available' },
+    { value: true, label: 'included' },
   ],
 };
 
-export const bankingBasicsSection: FeatureSection = {
-  title: 'Banking basics',
+export const essentialFeaturesSection: FeatureSection = {
+  title: 'Essential Features',
   features: [
-    freeBusinessAccountFeature,
-    freePhysicalCardFeature,
-    freeInstantTransfersFeature,
-    scheduledPaymentsFeature,
-    paymentRemindersFeature,
+    coreFeature,
+    advancedFeature,
+    premiumFeature,
+    limitedFeature,
+    exclusiveFeature,
   ],
 };
 
-export const productCatalogSection: FeatureSection = {
-  title: 'Product catalog',
+export const customizationSection: FeatureSection = {
+  title: 'Customization',
   features: [
     {
       featureDescription: {
-        label: 'Catalog with item images',
-        description: 'add variations',
+        label: 'Basic customization',
+        description: 'limited options',
       },
       values: [
-        { value: true, label: 'available' },
-        { value: true, label: 'available' },
-        { value: true, label: 'available' },
+        { value: true, label: 'included' },
+        { value: true, label: 'included' },
+        { value: true, label: 'included' },
       ],
     },
     {
       featureDescription: {
-        label: 'Sell with Variants, modifiers, and units of measure',
+        label: 'Advanced customization',
         toggletip: {
           component: (props) => (
             <IconButton {...props} icon={Help} variant="tertiary" size="s">
-              View details for Modifiers
+              View details for Advanced customization
             </IconButton>
           ),
-          headline: 'Some additional information',
-          body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ',
+          headline: 'Customization options',
+          body: 'Advanced customization provides more flexibility and control over your experience.',
           action: {
             children: 'Learn more',
             navigationIcon: ArrowSlanted,
-            href: 'https://help.sumup.com/',
+            href: '#',
             target: '_blank',
           },
           offset: 8,
         },
       },
-
       values: [
-        { value: true, label: 'available' },
-        { value: true, label: 'available' },
-        { value: true, label: 'available' },
+        { value: false, label: 'not available' },
+        { value: true, label: 'included' },
+        { value: true, label: 'included' },
       ],
     },
     {
       featureDescription: {
-        label: 'Eat-in/takeaway prices',
+        label: 'Full customization',
       },
       values: [
-        { value: false, label: 'unavailable' },
-        { value: true, label: 'available' },
-        { value: true, label: 'available' },
-      ],
-    },
-    {
-      featureDescription: {
-        label: 'Import/export items',
-      },
-      values: [
-        { value: false, label: 'unavailable' },
-        { value: true, label: 'available' },
-        { value: true, label: 'available' },
-      ],
-    },
-    {
-      featureDescription: {
-        label: 'Item creation by taking a photo',
-      },
-      values: [
-        { value: false, label: 'unavailable' },
-        { value: false, label: 'unavailable' },
-        { value: true, label: 'available' },
+        { value: false, label: 'not available' },
+        { value: false, label: 'not available' },
+        { value: true, label: 'included' },
       ],
     },
   ],
 };
 
-export const moneyManagement: FeatureSection = {
-  title: 'Money Management',
+export const supportSection: FeatureSection = {
+  title: 'Support',
   features: [
     {
       featureDescription: {
-        label: 'Expense cards',
+        label: 'Email support',
       },
       values: [
-        { value: false, label: 'available' },
-        '3 included',
-        '5 included',
+        { value: true, label: 'included' },
+        { value: true, label: 'included' },
+        { value: true, label: 'included' },
       ],
     },
     {
       featureDescription: {
-        label: 'Additional balances',
-        description: 'Emails, SMS, and push notifications',
+        label: 'Priority support',
+        description: '24/7 availability',
       },
-
       values: [
-        { value: false, label: 'available' },
-        '3 included',
-        '5 included',
+        { value: false, label: 'not available' },
+        { value: true, label: 'included' },
+        { value: true, label: 'included' },
       ],
     },
     {
       featureDescription: {
-        label: 'Bulk transfers',
+        label: 'Dedicated support',
       },
-
       values: [
-        { value: false, label: 'available' },
-        { value: true, label: 'available' },
-        { value: true, label: 'available' },
+        { value: false, label: 'not available' },
+        { value: false, label: 'not available' },
+        { value: true, label: 'included' },
       ],
     },
   ],
 };
 
-export const invoicingSection: FeatureSection = {
-  title: 'Invoicing',
+export const analyticsSection: FeatureSection = {
+  title: 'Analytics',
   features: [
     {
       featureDescription: {
-        label: 'Send invoices to get paid',
-        description: 'Includes electronic invoices',
+        label: 'Basic reporting',
       },
-      values: ['4', 'unlimited', 'unlimited'],
-    },
-    {
-      featureDescription: {
-        label: 'Invoices as proof of payment',
-        description: 'Includes electronic invoices',
-      },
-
-      values: ['unlimited', 'unlimited', 'unlimited'],
-    },
-    {
-      featureDescription: {
-        label: 'Get paid via invoices by bank transfer',
-      },
-
       values: [
-        'With the SumUp Business Account',
-        'With any bank account',
-        'With any bank account',
+        { value: true, label: 'included' },
+        { value: true, label: 'included' },
+        { value: true, label: 'included' },
       ],
     },
     {
       featureDescription: {
-        label: 'Create recurring invoices',
+        label: 'Advanced analytics',
+        description: 'Detailed insights and custom reports',
       },
       values: [
-        { value: false, label: 'unavailable' },
-        { value: false, label: 'available' },
-        { value: true, label: 'available' },
+        { value: false, label: 'not available' },
+        { value: true, label: 'included' },
+        { value: true, label: 'included' },
+      ],
+    },
+    {
+      featureDescription: {
+        label: 'Custom dashboards',
+      },
+      values: [
+        { value: false, label: 'not available' },
+        { value: false, label: 'not available' },
+        { value: true, label: 'included' },
       ],
     },
   ],


### PR DESCRIPTION
## Purpose
Change the ComparisonTable docs to refer to more generic plans instead of SumUp-related plans.

## Approach and changes
* Rewrite ComparisonTable fixtures.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
