### PR TITLE
Fix types for internal components

### DIFF
--- a/.changeset/itchy-swans-shout.md
+++ b/.changeset/itchy-swans-shout.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed type generation for the `@sumup-oss/circuit-ui/internal` exports.

--- a/packages/circuit-ui/tsconfig.json
+++ b/packages/circuit-ui/tsconfig.json
@@ -29,7 +29,8 @@
     "util/**/*",
     "index.ts",
     "legacy.ts",
-    "experimental.ts"
+    "experimental.ts",
+    "internal.ts"
   ],
   "exclude": ["node_modules", "dist"],
   "typeRoots": ["./types"]


### PR DESCRIPTION
## Purpose

Type resolution for `@sumup-oss/circuit-ui/internal` is currently broken because the `/dist/internal.d.ts` file is being generated

## Approach and changes

- Add `internal.ts` to the list of included files in `tsconfig.json`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
