### PR TITLE
Remove empty aria-describedby from Anchor

### DIFF
--- a/.changeset/sour-tomatoes-beg.md
+++ b/.changeset/sour-tomatoes-beg.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed the empty `aria-describedby` attribute from the Anchor component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44327,7 +44327,7 @@
 		},
 		"packages/circuit-ui": {
 			"name": "@sumup-oss/circuit-ui",
-			"version": "9.7.4",
+			"version": "9.9.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@floating-ui/react-dom": "^2.1.2",
@@ -44342,7 +44342,7 @@
 				"@emotion/react": "^11.14.0",
 				"@emotion/styled": "^11.14.0",
 				"@sumup-oss/design-tokens": "^8.2.0",
-				"@sumup-oss/icons": "^5.3.0",
+				"@sumup-oss/icons": "^5.7.0",
 				"@sumup-oss/intl": "^3.1.0",
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/jest-dom": "6.6.3",
@@ -44372,7 +44372,7 @@
 				"@emotion/react": "^11.11.0",
 				"@emotion/styled": "^11.11.0",
 				"@sumup-oss/design-tokens": ">=8.0.0",
-				"@sumup-oss/icons": ">=5.0.0",
+				"@sumup-oss/icons": ">=5.6.0",
 				"@sumup-oss/intl": "^3.1.0",
 				"react": ">=18.0.0 <19.0.0",
 				"react-dom": ">=18.0.0 <19.0.0",
@@ -44437,7 +44437,7 @@
 		},
 		"packages/icons": {
 			"name": "@sumup-oss/icons",
-			"version": "5.4.0",
+			"version": "5.7.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@babel/core": "^7.26.7",

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -97,7 +97,9 @@ export const Anchor = forwardRef(
       return (
         <Body
           {...props}
-          aria-describedby={descriptionIds}
+          {...(descriptionIds && {
+            'aria-describedby': descriptionIds,
+          })}
           className={clsx(classes.base, utilClasses.focusVisible, className)}
           as={Link}
           ref={ref}
@@ -120,7 +122,9 @@ export const Anchor = forwardRef(
       <Body
         as="button"
         {...props}
-        aria-describedby={descriptionIds}
+        {...(descriptionIds && {
+          'aria-describedby': descriptionIds,
+        })}
         className={clsx(classes.base, utilClasses.focusVisible, className)}
         ref={ref}
       >


### PR DESCRIPTION
## Purpose

#2988 added a description to the Anchor component when it points to an external link. Unfortunately, React renders the `aria-describedby` even when it's empty, which is superfluous and incorrect.

## Approach and changes

- Conditionally add the `aria-describedby` attribute to the Anchor component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
