### PR TITLE
Remove empty aria-describedby from all components

### DIFF
--- a/.changeset/lemon-keys-cover.md
+++ b/.changeset/lemon-keys-cover.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': patch
+---
+
+Removed empty `aria-describedby` attributes from all other components.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -80,10 +80,9 @@ export const Anchor = forwardRef(
     const isExternalLink =
       props.rel === 'external' || props.target === '_blank';
     const externalLabelId = useId();
-    const descriptionIds = clsx(
-      externalLabel && isExternalLink && externalLabelId,
-      descriptionId,
-    );
+    const descriptionIds =
+      clsx(externalLabel && isExternalLink && externalLabelId, descriptionId) ||
+      undefined;
 
     if (!props.href && !props.onClick) {
       return (
@@ -97,9 +96,7 @@ export const Anchor = forwardRef(
       return (
         <Body
           {...props}
-          {...(descriptionIds && {
-            'aria-describedby': descriptionIds,
-          })}
+          aria-describedby={descriptionIds}
           className={clsx(classes.base, utilClasses.focusVisible, className)}
           as={Link}
           ref={ref}
@@ -122,9 +119,7 @@ export const Anchor = forwardRef(
       <Body
         as="button"
         {...props}
-        {...(descriptionIds && {
-          'aria-describedby': descriptionIds,
-        })}
+        aria-describedby={descriptionIds}
         className={clsx(classes.base, utilClasses.focusVisible, className)}
         ref={ref}
       >

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -22,6 +22,7 @@ import {
   AccessibilityError,
   isSufficientlyLabelled,
 } from '../../util/errors.js';
+import { clsx } from '../../styles/clsx.js';
 
 import { CheckboxInput, type CheckboxInputProps } from './CheckboxInput.js';
 import classes from './Checkbox.module.css';
@@ -63,9 +64,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     ref,
   ) => {
     const validationHintId = useId();
-    const descriptionIds = `${
-      descriptionId ? `${descriptionId} ` : ''
-    }${validationHintId}`;
+    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
@@ -35,6 +35,7 @@ import {
   isSufficientlyLabelled,
 } from '../../util/errors.js';
 import { isEmpty } from '../../util/helpers.js';
+import { clsx } from '../../styles/clsx.js';
 
 import classes from './CheckboxGroup.module.css';
 
@@ -146,9 +147,7 @@ export const CheckboxGroup = forwardRef(
     ref: CheckboxGroupProps['ref'],
   ) => {
     const validationHintId = useId();
-    const descriptionIds = `${
-      descriptionId ? `${descriptionId} ` : ''
-    }${validationHintId}`;
+    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -128,9 +128,7 @@ export const ImageInput = ({
   const id = useId();
   const inputId = customId || id;
   const validationHintId = useId();
-  const descriptionIds = `${
-    descriptionId ? `${descriptionId} ` : ''
-  }${validationHintId}`;
+  const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isDragging, setDragging] = useState<boolean>(false);
   const [previewImage, setPreviewImage] = useState<string>('');

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -149,9 +149,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const id = useId();
     const inputId = customId || id;
     const validationHintId = useId();
-    const descriptionIds = `${
-      descriptionId ? `${descriptionId} ` : ''
-    }${validationHintId}`;
+    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
 
     const prefix = RenderPrefix && <RenderPrefix className={classes.prefix} />;
     const suffix = RenderSuffix && <RenderSuffix className={classes.suffix} />;

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -43,6 +43,7 @@ import {
 import { applyMultipleRefs } from '../../util/refs.js';
 import { eachFn } from '../../util/helpers.js';
 import { changeInputValue } from '../../util/input-value.js';
+import { clsx } from '../../styles/clsx.js';
 
 import {
   mapCountryCodeOptions,
@@ -224,9 +225,7 @@ export const PhoneNumberInput = forwardRef<
 
     const validationHintId = useId();
 
-    const descriptionIds = `${
-      descriptionId ? `${descriptionId} ` : ''
-    }${validationHintId}`;
+    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
 
     const options = useMemo(
       () => mapCountryCodeOptions(countryCode.options, locale),

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -132,10 +132,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     const id = useId();
     const selectId = customId || id;
     const validationHintId = useId();
-    const descriptionIds = clsx(
-      Boolean(descriptionId) && descriptionId,
-      Boolean(validationHint) && validationHintId,
-    );
+    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
 
     const prefix = RenderPrefix && (
       <RenderPrefix className={classes.prefix} value={value} />

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -151,9 +151,7 @@ export const SelectorGroup = forwardRef<
     const randomName = useId();
     const name = customName || randomName;
     const validationHintId = useId();
-    const descriptionIds = `${
-      descriptionId ? `${descriptionId} ` : ''
-    }${validationHintId}`;
+    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
 
     if (
       process.env.NODE_ENV !== 'production' &&


### PR DESCRIPTION
## Purpose

#3004 removed the `aria-describedby` attribute from the Anchor component but missed all other components.

## Approach and changes

- Remove the superfluous empty `aria-describedby` attribute from _all_ components

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
