### PR TITLE
add aria-label to the IconButton component

### DIFF
--- a/.changeset/wet-avocados-draw.md
+++ b/.changeset/wet-avocados-draw.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Provided an accessible name to the IconButton component.

--- a/packages/circuit-ui/components/Button/IconButton.spec.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.spec.tsx
@@ -50,4 +50,10 @@ describe('IconButton', () => {
     const label = screen.getByText('Close');
     expect(label).toBeInTheDocument();
   });
+
+  it('should render with an accessible name', () => {
+    render(<IconButton icon={Close}>Close</IconButton>);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAccessibleName('Close');
+  });
 });

--- a/packages/circuit-ui/components/Button/IconButton.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.tsx
@@ -125,6 +125,7 @@ export const IconButton: ForwardRefExoticComponent<
       size,
       children: isString(children) ? children : label,
       title: isString(children) ? children : label,
+      'aria-label': isString(children) ? children : label,
       ...props,
     };
   },


### PR DESCRIPTION
Addresses [DSYS-991](https://sumupteam.atlassian.net/browse/DSYS-991)

## Purpose

The title attribute alone is not sufficient to communicate the accessible name for the IconButton component by all AT. Reinforce accessibility by using the `aria-label` attribute.

## Approach and changes

Add an aria-label attribute to IconButton’s component.

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
