### PR TITLE
remove isExternal prop from SideNavigation

### DIFF
--- a/.changeset/happy-carrots-vanish.md
+++ b/.changeset/happy-carrots-vanish.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Updated the Anchor and the SideNavigation components to throw an accessibility error when external links are not provided with an alternative text.

--- a/.changeset/thick-pianos-fly.md
+++ b/.changeset/thick-pianos-fly.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed the SideNavigation's optional `isExternal` prop to convey when links open externally. Use a combination of the `target` or `rel` props with the `externalLabel` prop to create accessible external links.

--- a/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
@@ -144,4 +144,17 @@ describe('Anchor', () => {
     const actual = await axe(container);
     expect(actual).toHaveNoViolations();
   });
+
+  it('should throw an accessibility error when the externalLabel prop is missing', () => {
+    // Silence the console.error output and switch to development mode to throw the error
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    process.env.NODE_ENV = 'development';
+    expect(() =>
+      render(
+        <Anchor {...baseProps} href="https://sumup.com" target="_blank" />,
+      ),
+    ).toThrow();
+    process.env.NODE_ENV = 'test';
+    vi.restoreAllMocks();
+  });
 });

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -31,6 +31,7 @@ import { Body, type BodyProps } from '../Body/Body.js';
 import { useComponents } from '../ComponentsContext/index.js';
 import { clsx } from '../../styles/clsx.js';
 import { utilClasses } from '../../styles/utility.js';
+import { AccessibilityError } from '../../util/errors.js';
 
 import classes from './Anchor.module.css';
 
@@ -79,6 +80,19 @@ export const Anchor = forwardRef(
     const Link = components.Link as AsPropType;
     const isExternalLink =
       props.rel === 'external' || props.target === '_blank';
+
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      isExternalLink &&
+      !externalLabel
+    ) {
+      throw new AccessibilityError(
+        'Anchor',
+        'An external link is missing an alternative text. Provide an `externalLabel` prop to communicate that the link leads to an external page or opens in a new tab.',
+      );
+    }
+
     const externalLabelId = useId();
     const descriptionIds =
       clsx(externalLabel && isExternalLink && externalLabelId, descriptionId) ||

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.spec.tsx
@@ -71,8 +71,8 @@ describe('PrimaryLink', () => {
   it('should render with an external icon', () => {
     renderPrimaryLink(render, {
       ...baseProps,
-      isExternal: true,
       externalLabel: 'Opens in a new tab',
+      target: '_blank',
     });
     expect(screen.getByRole('link')).toHaveAccessibleDescription(
       'Opens in a new tab',
@@ -105,5 +105,19 @@ describe('PrimaryLink', () => {
     const { container } = renderPrimaryLink(render, baseProps);
     const actual = await axe(container);
     expect(actual).toHaveNoViolations();
+  });
+
+  it('should throw an accessibility error when the externalLabel prop is missing', () => {
+    // Silence the console.error output and switch to development mode to throw the error
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    process.env.NODE_ENV = 'development';
+    expect(() =>
+      renderPrimaryLink(render, {
+        ...baseProps,
+        target: '_blank',
+      }),
+    ).toThrow();
+    process.env.NODE_ENV = 'test';
+    vi.restoreAllMocks();
   });
 });

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -29,6 +29,7 @@ import type {
 import { isObject } from '../../../../util/type-check.js';
 import { clsx } from '../../../../styles/clsx.js';
 import { utilClasses } from '../../../../styles/utility.js';
+import { AccessibilityError } from '../../../../util/errors.js';
 
 import classes from './PrimaryLink.module.css';
 
@@ -42,7 +43,6 @@ export function PrimaryLink({
   activeIcon,
   label,
   isActive,
-  isExternal,
   externalLabel,
   suffix: Suffix,
   badge,
@@ -67,7 +67,19 @@ export function PrimaryLink({
   const suffix = Suffix && (
     <Suffix className={classes.suffix} aria-hidden="true" />
   );
-  const isExternalLink = isExternal || props.target === '_blank';
+  const isExternalLink = props.target === '_blank' || props.rel === 'external';
+
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    isExternalLink &&
+    !externalLabel
+  ) {
+    throw new AccessibilityError(
+      'PrimaryLink',
+      'An external link is missing an alternative text. Provide an `externalLabel` prop to communicate that the link leads to an external page or opens in a new tab.',
+    );
+  }
 
   const Icon = isActive && activeIcon ? activeIcon : icon;
 

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -43,10 +43,6 @@ export interface PrimaryLinkProps
    */
   isActive?: boolean;
   /**
-   * Whether the link leads to an external page or opens in a new tab.
-   */
-  isExternal?: boolean;
-  /**
    * Short label to describe that the link leads to an external page or opens in a new tab.
    */
   externalLabel?: string;


### PR DESCRIPTION
Addresses [DSYS-1002](https://sumupteam.atlassian.net/browse/DSYS-1002)

## Purpose

Simplify the API of PrimaryLinks of the SideNavigation component when handling external links. 

## Approach and changes

- Remove isExternalprop and rely on the externalLabel along with the target/rel properties to handle external links.
- Throw an accessibility error when the externalLabelprop is missing (do the same thing for the Anchor component)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
