### PR TITLE
Refactor action menu with popover

### DIFF
--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.module.css
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.module.css
@@ -1,43 +1,10 @@
-.base {
+.base > div {
   box-sizing: border-box;
-  max-height: var(--popover-max-height);
-  padding: 0;
-  margin: 0;
-  border-radius: var(--cui-border-radius-byte);
-}
-
-.trigger {
-  display: inline-block;
-}
-
-.menu {
-  box-sizing: border-box;
-  max-height: var(--popover-max-height);
   padding: var(--cui-spacings-byte) 0;
   overflow-y: auto;
   background-color: var(--cui-bg-elevated);
   border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
   border-radius: inherit;
-  box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);
-}
-
-@media (max-width: 479px) {
-  .base {
-    top: unset;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: auto;
-    max-width: 100%;
-    max-height: 90vh;
-    border-radius: var(--cui-border-radius-byte) var(--cui-border-radius-byte) 0
-      0;
-  }
-
-  .menu {
-    max-height: 90vh;
-    padding: var(--cui-spacings-byte) 0;
-  }
 }
 
 .divider {

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.spec.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.spec.tsx
@@ -56,7 +56,9 @@ describe('ActionMenu', () => {
   }
 
   const baseProps: ActionMenuProps = {
-    component: (triggerProps) => <button {...triggerProps}>Button</button>,
+    component: (triggerProps) => (
+      <button {...triggerProps}>Trigger Button</button>
+    ),
     actions: [
       {
         onClick: vi.fn(),
@@ -127,7 +129,7 @@ describe('ActionMenu', () => {
   it('should close the action menu when clicking the trigger element', async () => {
     renderActionMenu(baseProps);
 
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('button', { name: 'Trigger Button' });
 
     await userEvent.click(trigger);
 
@@ -145,7 +147,7 @@ describe('ActionMenu', () => {
       renderActionMenu(baseProps);
       vi.runAllTimers();
 
-      const trigger = screen.getByRole('button');
+      const trigger = screen.getByRole('button', { name: 'Trigger Button' });
 
       trigger.focus();
       await userEvent.keyboard(key);

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
@@ -16,43 +16,26 @@
 'use client';
 
 import {
-  Fragment,
-  useCallback,
-  useEffect,
   useId,
   useRef,
-  type KeyboardEvent,
   forwardRef,
-  type ComponentType,
-  useState,
+  useCallback,
+  type KeyboardEvent,
 } from 'react';
-import {
-  useFloating,
-  flip,
-  offset as offsetMiddleware,
-  size,
-  type Placement,
-  type SizeOptions,
-} from '@floating-ui/react-dom';
 
 import type { ClickEvent } from '../../types/events.js';
-import { isArrowDown, isArrowUp } from '../../util/key-codes.js';
-import { isFunction } from '../../util/type-check.js';
-import { clsx } from '../../styles/clsx.js';
-import { useMedia } from '../../hooks/useMedia/index.js';
-import { applyMultipleRefs } from '../../util/refs.js';
 import { Hr } from '../Hr/index.js';
 import { useFocusList } from '../../hooks/useFocusList/index.js';
-import { usePrevious } from '../../hooks/usePrevious/index.js';
-import { useStackContext } from '../StackContext/index.js';
-import { Dialog, type PublicDialogProps } from '../Dialog/Dialog.js';
-import { sharedClasses } from '../../styles/shared.js';
+import { Popover, type PopoverProps } from '../Popover/Popover.js';
+import { isArrowDown, isArrowUp } from '../../util/key-codes.js';
+import { useMedia } from '../../hooks/useMedia/index.js';
+import { clsx } from '../../styles/clsx.js';
 
-import classes from './ActionMenu.module.css';
 import {
   ActionMenuItem,
   type ActionMenuItemProps,
 } from './components/ActionMenuItem.js';
+import classes from './ActionMenu.module.css';
 
 type Divider = { type: 'divider' };
 type Action = ActionMenuItemProps | Divider;
@@ -61,54 +44,11 @@ function isDivider(action: Action): action is Divider {
   return 'type' in action && action.type === 'divider';
 }
 
-type OnToggle = (open: boolean | ((prevOpen: boolean) => boolean)) => void;
-
-export interface ActionMenuReferenceProps {
-  'onClick': (event: ClickEvent) => void;
-  'onKeyDown': (event: KeyboardEvent) => void;
-  'id': string;
-  'aria-controls': string;
-  'aria-expanded': boolean;
-}
-
-export interface ActionMenuProps
-  extends Omit<PublicDialogProps, 'open' | 'role'> {
-  /**
-   * Determines whether the ActionMenu is open or closed.
-   */
-  isOpen: boolean;
-  /**
-   * Function that is called when opening and closing the ActionMenu.
-   */
-  onToggle: OnToggle;
+export interface ActionMenuProps extends Omit<PopoverProps, 'role'> {
   /**
    * An array of ActionMenuItem or Divider.
    */
   actions: Action[];
-  /**
-   * One of the accepted placement values.
-   * @default `bottom`.
-   */
-  placement?: Placement;
-  /**
-   * The placements to fallback to when there is not enough space for the
-   * ActionMenu.
-   * @default `['top', 'right', 'left']`.
-   */
-  fallbackPlacements?: Placement[];
-  /**
-   * Displaces the floating element from its `placement` along specified axes.
-   *
-   * Pass a number to move the floating element on the main axis, away from (if
-   * positive) or towards (if negative) the reference element. Pass an object
-   * to displace the floating element on both the main and cross axes.
-   */
-  offset?: number | { mainAxis?: number; crossAxis?: number };
-  /**
-   * The component that toggles the ActionMenu when clicked. Also referred to as
-   * reference element.
-   */
-  component: ComponentType<ActionMenuReferenceProps>;
   /**
    * Remove the [`menu` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/roles/menu_role)
    * when its semantics aren't appropriate for the use case, for example when
@@ -119,215 +59,85 @@ export interface ActionMenuProps
    */
   role?: 'menu' | null;
 }
-
 type TriggerKey = 'ArrowUp' | 'ArrowDown';
-
-const sizeOptions: SizeOptions = {
-  apply({ availableHeight, elements }) {
-    elements.floating.style.setProperty(
-      '--popover-max-height',
-      `${availableHeight}px`,
-    );
-  },
-};
 
 export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
   (
     {
-      isOpen = false,
-      onToggle,
       actions,
-      placement = 'bottom',
-      fallbackPlacements = ['top', 'right', 'left'],
-      component: Component,
-      offset,
-      className,
       role = 'menu',
-      style,
+      className,
+      onToggle,
+      component: Component,
       ...props
     },
     ref,
   ) => {
-    const zIndex = useStackContext();
-    const triggerKey = useRef<TriggerKey | null>(null);
     const menuEl = useRef<HTMLDivElement>(null);
-    const dialogRef = useRef<HTMLDialogElement>(null);
+    const triggerKey = useRef<TriggerKey | null>(null);
     const triggerId = useId();
     const menuId = useId();
-    const [isClosing, setClosing] = useState(false);
     const isMobile = useMedia('(max-width: 479px)');
-    const animationDuration = isMobile ? 300 : 0;
-
-    const { floatingStyles, refs, update } = useFloating<HTMLElement>({
-      open: isOpen,
-      placement,
-      strategy: 'fixed',
-      middleware: offset
-        ? [
-            offsetMiddleware(offset),
-            flip({ fallbackPlacements }),
-            size(sizeOptions),
-          ]
-        : [flip({ fallbackPlacements }), size(sizeOptions)],
-    });
 
     const focusProps = useFocusList();
-    const prevOpen = usePrevious(isOpen);
-
-    const handleToggle: OnToggle = useCallback(
-      (state) => {
-        onToggle((prev) => (isFunction(state) ? state(prev) : state));
-      },
-      [onToggle],
-    );
-
-    const handleTriggerClick = useCallback(() => {
-      handleToggle((prev) => !prev);
-    }, [handleToggle]);
 
     const handleTriggerKeyDown = useCallback(
       (event: KeyboardEvent) => {
         if (isArrowDown(event)) {
           triggerKey.current = 'ArrowDown';
-          handleToggle(true);
+          onToggle(true);
         }
         if (isArrowUp(event)) {
           triggerKey.current = 'ArrowUp';
-          handleToggle((prev) => !prev);
+          onToggle((prev) => !prev);
         }
       },
-      [handleToggle],
+      [onToggle],
     );
 
     const handleActionMenuItemClick =
       (onClick: ActionMenuItemProps['onClick']) => (event: ClickEvent) => {
         onClick?.(event);
-        handleToggle(false);
+        onToggle(false);
       };
-
-    useEffect(() => {
-      /**
-       * When we support `ResizeObserver` (https://caniuse.com/resizeobserver),
-       * we can look into using Floating UI's `autoUpdate` (but we can't use
-       * `whileElementIsMounted` because our implementation hides the floating
-       * element using CSS instead of using conditional rendering.
-       * See https://floating-ui.com/docs/react-dom#updating
-       */
-      if (isOpen) {
-        update();
-        window.addEventListener('resize', update);
-        window.addEventListener('scroll', update);
-      } else {
-        window.removeEventListener('resize', update);
-        window.removeEventListener('scroll', update);
-      }
-
-      return () => {
-        window.removeEventListener('resize', update);
-        window.removeEventListener('scroll', update);
-      };
-    }, [isOpen, update]);
-
-    useEffect(() => {
-      // Focus the first or last action menu item after opening
-      if (!prevOpen && isOpen) {
-        const element = (
-          triggerKey.current && triggerKey.current === 'ArrowUp'
-            ? menuEl.current?.lastElementChild
-            : menuEl.current?.firstElementChild
-        ) as HTMLElement;
-        if (element) {
-          setTimeout(() => {
-            element.focus();
-          }, animationDuration);
-        }
-      }
-
-      // Focus the reference element after closing
-      if (prevOpen && !isOpen) {
-        const triggerButton = refs.reference.current
-          ?.firstElementChild as HTMLElement;
-        triggerButton.focus();
-      }
-
-      triggerKey.current = null;
-    }, [isOpen, prevOpen, refs.reference, animationDuration]);
 
     const isMenu = role === 'menu';
 
-    const handleCloseEnd = useCallback(() => {
-      setClosing(false);
-      handleToggle(false);
-    }, [handleToggle]);
-
-    const handleCloseStart = useCallback(() => {
-      setClosing(true);
-    }, []);
-
-    const outAnimation = isMobile
-      ? sharedClasses.animationSlideUpOut
-      : undefined;
-    const inAnimation = isMobile ? sharedClasses.animationSlideUpIn : undefined;
-
     return (
-      <Fragment>
-        <div className={classes.trigger} ref={refs.setReference}>
-          <Component
-            id={triggerId}
-            aria-controls={menuId}
-            aria-expanded={isOpen}
-            onClick={handleTriggerClick}
-            onKeyDown={handleTriggerKeyDown}
-          />
-        </div>
-        <Dialog
-          open={isOpen}
-          onCloseStart={handleCloseStart}
-          onCloseEnd={handleCloseEnd}
-          isModal={isMobile}
-          hideCloseButton={!isMobile}
-          ref={applyMultipleRefs(ref, refs.setFloating, dialogRef)}
-          className={clsx(
-            classes.base,
-            isClosing ? outAnimation : inAnimation,
-            className,
-          )}
-          animationDuration={animationDuration}
-          style={
-            isMobile
-              ? style
-              : {
-                  ...style,
-                  ...floatingStyles,
-                  zIndex: zIndex || 'var(--cui-z-index-popover)',
-                }
-          }
-          preventOutsideClickRefs={refs.reference}
-          {...props}
+      <Popover
+        className={clsx(className, classes.base)}
+        ref={ref}
+        hideCloseButton={!isMobile}
+        onToggle={onToggle}
+        component={(refProps) => (
+          <Component {...refProps} onKeyDown={handleTriggerKeyDown} />
+        )}
+        {...props}
+      >
+        <div
+          id={menuId}
+          ref={menuEl}
+          aria-labelledby={isMenu ? triggerId : undefined}
+          role={isMenu ? 'menu' : undefined}
         >
-          <div
-            id={menuId}
-            ref={menuEl}
-            aria-labelledby={isMenu ? triggerId : undefined}
-            role={isMenu ? 'menu' : undefined}
-            className={classes.menu}
-          >
-            {actions.map((action, index) =>
-              isDivider(action) ? (
-                <Hr className={classes.divider} key={index} />
-              ) : (
-                <ActionMenuItem
-                  key={index}
-                  {...action}
-                  {...focusProps}
-                  role={isMenu ? 'menuitem' : undefined}
-                  onClick={handleActionMenuItemClick(action.onClick)}
-                />
-              ),
-            )}
-          </div>
-        </Dialog>
-      </Fragment>
+          {actions.map((action, index) =>
+            isDivider(action) ? (
+              <Hr
+                className={classes.divider}
+                key={`cui-action-menu-divider-${menuId}-${index}`}
+              />
+            ) : (
+              <ActionMenuItem
+                key={`cui-action-menu-item-${menuId}-${index}`}
+                {...action}
+                {...focusProps}
+                role={isMenu ? 'menuitem' : undefined}
+                onClick={handleActionMenuItemClick(action.onClick)}
+              />
+            ),
+          )}
+        </div>
+      </Popover>
     );
   },
 );

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
@@ -122,13 +122,10 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
         >
           {actions.map((action, index) =>
             isDivider(action) ? (
-              <Hr
-                className={classes.divider}
-                key={`cui-action-menu-divider-${menuId}-${index}`}
-              />
+              <Hr className={classes.divider} key={index} />
             ) : (
               <ActionMenuItem
-                key={`cui-action-menu-item-${menuId}-${index}`}
+                key={index}
                 {...action}
                 {...focusProps}
                 role={isMenu ? 'menuitem' : undefined}

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -46,6 +46,7 @@ import { useMedia } from '../../hooks/useMedia/index.js';
 import { sharedClasses } from '../../styles/shared.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { clsx } from '../../styles/clsx.js';
+import { usePrevious } from '../../hooks/usePrevious/index.js';
 
 import classes from './Popover.module.css';
 
@@ -127,6 +128,7 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
     const [isClosing, setClosing] = useState(false);
     const isMobile = useMedia('(max-width: 479px)');
     const animationDuration = isMobile ? 300 : 0;
+    const prevOpen = usePrevious(isOpen);
 
     const { floatingStyles, refs, update } = useFloating<HTMLElement>({
       open: isOpen,
@@ -189,6 +191,14 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
       : undefined;
     const inAnimation = isMobile ? sharedClasses.animationSlideUpIn : undefined;
 
+    useEffect(() => {
+      // Focus the reference element after closing
+      if (prevOpen && !isOpen) {
+        const triggerButton = refs.reference.current
+          ?.firstElementChild as HTMLElement;
+        triggerButton.focus();
+      }
+    }, [isOpen, prevOpen, refs.reference]);
     return (
       <Fragment>
         <div className={classes.trigger} ref={refs.setReference}>

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -150,7 +150,10 @@ export type {
   ActionMenuItemProps,
 } from './components/ActionMenu/index.js';
 export { Popover } from './components/Popover/Popover.js';
-export type { PopoverProps } from './components/Popover/Popover.js';
+export type {
+  PopoverProps,
+  PopoverReferenceProps,
+} from './components/Popover/Popover.js';
 export { ModalProvider } from './components/Modal/ModalContext.js';
 export type { ModalProviderProps } from './components/Modal/ModalContext.js';
 export { useModal } from './components/Modal/index.js';


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

After aligning Popover API with ActionMenu's API, its now more natural and easy to refacor ActionMenu based with the generic Popover component.
I also noticed that, when a popover opens, its trigger element is rerendered, which caused the focus management to break as the Dialog component isn't able to find the current active element, thus defaulting to the `body`. Ideally the reference component prop should be wrapped inside a `useCallback`. Since we can't always guarantee that, The Popover will explicitly focus the reference element inside the Popover component when the `isOpen` prop becomes falsy.

## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
