### PR TITLE
Export the Dialog as an Internal component

### DIFF
--- a/.changeset/true-adults-end.md
+++ b/.changeset/true-adults-end.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Exported the Dialog component as an internal component.

--- a/packages/circuit-ui/components/Dialog/Dialog.mdx
+++ b/packages/circuit-ui/components/Dialog/Dialog.mdx
@@ -5,7 +5,7 @@ import * as Stories from "./Dialog.stories";
 
 # Dialog
 
-<Status variant="stable" />
+<Status variant="internal" />
 
 The dialog component displays content inside of a `<dialog/>` element while providing all recommended accessibility features needed for a dialog box.
 

--- a/packages/circuit-ui/components/Dialog/Dialog.stories.tsx
+++ b/packages/circuit-ui/components/Dialog/Dialog.stories.tsx
@@ -26,7 +26,7 @@ import { Button } from '../Button/index.js';
 import { Dialog, type DialogProps } from './Dialog.js';
 
 export default {
-  title: 'Components/Dialog',
+  title: 'Components/Modal/Dialog',
   component: Dialog,
   tags: ['status:stable'],
   chromatic: {

--- a/packages/circuit-ui/internal.ts
+++ b/packages/circuit-ui/internal.ts
@@ -18,3 +18,6 @@ export type { CheckboxInputProps } from './components/Checkbox/CheckboxInput.js'
 
 export { RadioButtonInput } from './components/RadioButtonGroup/RadioButtonInput.js';
 export type { RadioButtonInputProps } from './components/RadioButtonGroup/RadioButtonInput.js';
+
+export { Dialog } from './components/Dialog/Dialog.js';
+export type { DialogProps } from './components/Dialog/Dialog.js';


### PR DESCRIPTION
## Purpose

The dialog component being the foundation of many overlay components, it should be exported as part of CUI's internal components.

## Approach and changes

Mark component as internal
Change its storybook location under the Modal component
Export component and prop types in `internal.ts`

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
