### PR TITLE
remove redundant element roles

### DIFF
--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -116,7 +116,6 @@ export const Pagination = ({
 
   return (
     <nav
-      role="navigation"
       aria-label={label}
       className={clsx(classes.base, className)}
       {...props}

--- a/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
@@ -39,7 +39,7 @@ export const PageList: FC<PageListProps> = ({
   ...props
 }: PageListProps) => (
   // eslint-disable-next-line jsx-a11y/no-redundant-roles
-  <ol role="list" className={clsx(classes.base, className)} {...props}>
+  <ol className={clsx(classes.base, className)} {...props}>
     {pages.map((page) => {
       const isCurrent = currentPage === page;
       const label = pageLabel(page);

--- a/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
+++ b/packages/circuit-ui/components/Pagination/components/PageList/PageList.tsx
@@ -38,7 +38,6 @@ export const PageList: FC<PageListProps> = ({
   className,
   ...props
 }: PageListProps) => (
-  // eslint-disable-next-line jsx-a11y/no-redundant-roles
   <ol className={clsx(classes.base, className)} {...props}>
     {pages.map((page) => {
       const isCurrent = currentPage === page;

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -85,7 +85,7 @@ export function DesktopNavigation({
         {skipNavigationHref && skipNavigationLabel && (
           <SkipLink href={skipNavigationHref}>{skipNavigationLabel}</SkipLink>
         )}
-        <ul role="list" className={classes.list}>
+        <ul className={classes.list}>
           {primaryLinks.map((link) => (
             <li key={link.label}>
               <PrimaryLink {...link} {...focusProps} />

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.tsx
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable jsx-a11y/no-redundant-roles */
-
 'use client';
 
 import { utilClasses } from '../../../../styles/utility.js';

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable jsx-a11y/no-redundant-roles */
-
 'use client';
 
 import { forwardRef } from 'react';

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -98,7 +98,7 @@ function SecondaryGroup({
           </Body>
         </Skeleton>
       )}
-      <ul role="list" className={classes.list}>
+      <ul className={classes.list}>
         {secondaryLinks.map((link) => (
           <SecondaryLink key={link.label} {...link} {...focusProps} />
         ))}
@@ -116,12 +116,7 @@ export const SecondaryLinks = forwardRef<HTMLUListElement, SecondaryLinksProps>(
   ({ secondaryGroups, className, ...props }, ref) => {
     const focusProps = useFocusList();
     return (
-      <ul
-        role="list"
-        ref={ref}
-        className={clsx(classes.list, className)}
-        {...props}
-      >
+      <ul ref={ref} className={clsx(classes.list, className)} {...props}>
         {secondaryGroups.map((group) => (
           <SecondaryGroup
             key={group.label}

--- a/packages/circuit-ui/hooks/useFocusList/useFocusList.stories.tsx
+++ b/packages/circuit-ui/hooks/useFocusList/useFocusList.stories.tsx
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable jsx-a11y/no-redundant-roles */
 import { action } from '@storybook/addon-actions';
 import { userEvent } from '@storybook/test';
 

--- a/packages/circuit-ui/hooks/useFocusList/useFocusList.stories.tsx
+++ b/packages/circuit-ui/hooks/useFocusList/useFocusList.stories.tsx
@@ -32,7 +32,7 @@ export const Example = () => {
   const focusProps = useFocusList();
 
   return (
-    <ul role="list" style={{ listStyle: 'none', margin: 0, padding: 0 }}>
+    <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
       {fruits.map((fruit) => (
         <li key={fruit}>
           <button


### PR DESCRIPTION
## Purpose

Fixes some Biome warnings about redundant role attributes on semantic elements.


## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
