### PR TITLE
fix broken aria references

### DIFF
--- a/.changeset/old-keys-walk.md
+++ b/.changeset/old-keys-walk.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed `aria-*` attributes with references to non-existent elements.

--- a/.changeset/silly-crabs-agree.md
+++ b/.changeset/silly-crabs-agree.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': minor
+---
+
+Added a new `idx` helper to concatenate ids for `aria-*` attributes.

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -29,6 +29,7 @@ import type { ClickEvent } from '../../types/events.js';
 import type { AsPropType } from '../../types/prop-types.js';
 import { Body, type BodyProps } from '../Body/Body.js';
 import { useComponents } from '../ComponentsContext/index.js';
+import { idx } from '../../util/idx.js';
 import { clsx } from '../../styles/clsx.js';
 import { utilClasses } from '../../styles/utility.js';
 
@@ -80,9 +81,10 @@ export const Anchor = forwardRef(
     const isExternalLink =
       props.rel === 'external' || props.target === '_blank';
     const externalLabelId = useId();
-    const descriptionIds =
-      clsx(externalLabel && isExternalLink && externalLabelId, descriptionId) ||
-      undefined;
+    const descriptionIds = idx(
+      externalLabel && isExternalLink && externalLabelId,
+      descriptionId,
+    );
 
     if (!props.href && !props.onClick) {
       return (

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -22,7 +22,7 @@ import {
   AccessibilityError,
   isSufficientlyLabelled,
 } from '../../util/errors.js';
-import { clsx } from '../../styles/clsx.js';
+import { idx } from '../../util/idx.js';
 
 import { CheckboxInput, type CheckboxInputProps } from './CheckboxInput.js';
 import classes from './Checkbox.module.css';
@@ -64,8 +64,10 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     ref,
   ) => {
     const validationHintId = useId();
-    const descriptionIds =
-      clsx(descriptionId, validationHint && validationHintId) || undefined;
+    const descriptionIds = idx(
+      descriptionId,
+      validationHint && validationHintId,
+    );
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/Checkbox/Checkbox.tsx
+++ b/packages/circuit-ui/components/Checkbox/Checkbox.tsx
@@ -64,7 +64,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     ref,
   ) => {
     const validationHintId = useId();
-    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
+    const descriptionIds =
+      clsx(descriptionId, validationHint && validationHintId) || undefined;
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
@@ -147,7 +147,8 @@ export const CheckboxGroup = forwardRef(
     ref: CheckboxGroupProps['ref'],
   ) => {
     const validationHintId = useId();
-    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
+    const descriptionIds =
+      clsx(descriptionId, validationHint && validationHintId) || undefined;
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
@@ -35,7 +35,7 @@ import {
   isSufficientlyLabelled,
 } from '../../util/errors.js';
 import { isEmpty } from '../../util/helpers.js';
-import { clsx } from '../../styles/clsx.js';
+import { idx } from '../../util/idx.js';
 
 import classes from './CheckboxGroup.module.css';
 
@@ -147,8 +147,10 @@ export const CheckboxGroup = forwardRef(
     ref: CheckboxGroupProps['ref'],
   ) => {
     const validationHintId = useId();
-    const descriptionIds =
-      clsx(descriptionId, validationHint && validationHintId) || undefined;
+    const descriptionIds = idx(
+      descriptionId,
+      validationHint && validationHintId,
+    );
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/ColorInput/ColorInput.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.tsx
@@ -36,6 +36,7 @@ import {
 } from '../Field/index.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { changeInputValue } from '../../util/input-value.js';
+import { idx } from '../../util/idx.js';
 
 import classes from './ColorInput.module.css';
 import {
@@ -105,9 +106,9 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
     const pickerId = useId();
     const validationHintId = useId();
 
-    const descriptionIds = clsx(
-      validationHint && validationHintId,
+    const descriptionIds = idx(
       descriptionId,
+      validationHint && validationHintId,
     );
 
     const updatePickerValue = useCallback((color: string) => {

--- a/packages/circuit-ui/components/ColorInput/ColorInput.tsx
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.tsx
@@ -105,7 +105,10 @@ export const ColorInput = forwardRef<HTMLInputElement, ColorInputProps>(
     const pickerId = useId();
     const validationHintId = useId();
 
-    const descriptionIds = clsx(validationHintId, descriptionId);
+    const descriptionIds = clsx(
+      validationHint && validationHintId,
+      descriptionId,
+    );
 
     const updatePickerValue = useCallback((color: string) => {
       if (!colorPickerRef.current || !isValidColor(color)) {

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -20,6 +20,7 @@ import { resolveCurrencyFormat } from '@sumup-oss/intl';
 import { NumericFormat, type NumericFormatProps } from 'react-number-format';
 
 import { clsx } from '../../styles/clsx.js';
+import { idx } from '../../util/idx.js';
 import type { Locale } from '../../util/i18n.js';
 import { useLocale } from '../../hooks/useLocale/useLocale.js';
 import { Input, type InputProps } from '../Input/index.js';
@@ -90,7 +91,7 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
   ) => {
     const locale = useLocale(customLocale);
     const currencySymbolId = useId();
-    const descriptionIds = clsx(currencySymbolId, descriptionId);
+    const descriptionIds = idx(currencySymbolId, descriptionId);
 
     const currencyFormat =
       resolveCurrencyFormat(locale, currency) || DEFAULT_FORMAT;

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -198,7 +198,10 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const headlineId = useId();
     const validationHintId = useId();
 
-    const descriptionIds = clsx(descriptionId, validationHintId);
+    const descriptionIds = clsx(
+      descriptionId,
+      validationHint && validationHintId,
+    );
     const minDate = toPlainDate(min);
     const maxDate = toPlainDate(max);
 
@@ -464,7 +467,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
           open={open}
           isModal={isMobile}
           onClose={closeCalendar}
-          aria-labelledby={headlineId}
+          aria-labelledby={clsx(open && headlineId)}
           style={dialogStyles}
         >
           {() => (

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -58,6 +58,7 @@ import {
 import { toPlainDate } from '../../util/date.js';
 import { applyMultipleRefs } from '../../util/refs.js';
 import { changeInputValue } from '../../util/input-value.js';
+import { idx } from '../../util/idx.js';
 
 import { Dialog } from './components/Dialog.js';
 import { DateSegment } from './components/DateSegment.js';
@@ -198,7 +199,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const headlineId = useId();
     const validationHintId = useId();
 
-    const descriptionIds = clsx(
+    const descriptionIds = idx(
       descriptionId,
       validationHint && validationHintId,
     );
@@ -467,7 +468,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
           open={open}
           isModal={isMobile}
           onClose={closeCalendar}
-          aria-labelledby={clsx(open && headlineId)}
+          aria-labelledby={idx(open && headlineId)}
           style={dialogStyles}
         >
           {() => (

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -128,7 +128,8 @@ export const ImageInput = ({
   const id = useId();
   const inputId = customId || id;
   const validationHintId = useId();
-  const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
+  const descriptionIds =
+    clsx(descriptionId, validationHint && validationHintId) || undefined;
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isDragging, setDragging] = useState<boolean>(false);
   const [previewImage, setPreviewImage] = useState<string>('');

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -42,6 +42,7 @@ import {
   isSufficientlyLabelled,
 } from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
+import { idx } from '../../util/idx.js';
 
 import classes from './ImageInput.module.css';
 
@@ -128,8 +129,7 @@ export const ImageInput = ({
   const id = useId();
   const inputId = customId || id;
   const validationHintId = useId();
-  const descriptionIds =
-    clsx(descriptionId, validationHint && validationHintId) || undefined;
+  const descriptionIds = idx(descriptionId, validationHint && validationHintId);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isDragging, setDragging] = useState<boolean>(false);
   const [previewImage, setPreviewImage] = useState<string>('');

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -149,7 +149,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const id = useId();
     const inputId = customId || id;
     const validationHintId = useId();
-    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
+    const descriptionIds =
+      clsx(descriptionId, validationHint && validationHintId) || undefined;
 
     const prefix = RenderPrefix && <RenderPrefix className={classes.prefix} />;
     const suffix = RenderSuffix && <RenderSuffix className={classes.suffix} />;

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -34,6 +34,7 @@ import {
   isSufficientlyLabelled,
 } from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
+import { idx } from '../../util/idx.js';
 
 import classes from './Input.module.css';
 
@@ -149,8 +150,10 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const id = useId();
     const inputId = customId || id;
     const validationHintId = useId();
-    const descriptionIds =
-      clsx(descriptionId, validationHint && validationHintId) || undefined;
+    const descriptionIds = idx(
+      descriptionId,
+      validationHint && validationHintId,
+    );
 
     const prefix = RenderPrefix && <RenderPrefix className={classes.prefix} />;
     const suffix = RenderSuffix && <RenderSuffix className={classes.suffix} />;

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
@@ -20,6 +20,7 @@ import { resolveNumberFormat } from '@sumup-oss/intl';
 import { NumericFormat, type NumericFormatProps } from 'react-number-format';
 
 import { clsx } from '../../styles/clsx.js';
+import { idx } from '../../util/idx.js';
 import { Input, type InputProps } from '../Input/index.js';
 
 import { formatPlaceholder } from './PercentageInputService.js';
@@ -77,7 +78,7 @@ export const PercentageInput = forwardRef<
     ref,
   ) => {
     const percentageSymbolId = useId();
-    const descriptionIds = clsx(percentageSymbolId, descriptionId);
+    const descriptionIds = idx(percentageSymbolId, descriptionId);
 
     const { groupDelimiter, decimalDelimiter } =
       resolveNumberFormat(locale, {

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
@@ -314,7 +314,7 @@ describe('PhoneNumberInput', () => {
   it('should set aria-describedby when there is an error message', () => {
     const props = {
       ...defaultProps,
-      errorMessage: 'This is an error message',
+      validationHint: 'This is an error message',
     };
     render(<PhoneNumberInput {...props} />);
     const fieldset = screen.getByRole('group');

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -225,7 +225,8 @@ export const PhoneNumberInput = forwardRef<
 
     const validationHintId = useId();
 
-    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
+    const descriptionIds =
+      clsx(descriptionId, validationHint && validationHintId) || undefined;
 
     const options = useMemo(
       () => mapCountryCodeOptions(countryCode.options, locale),

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -43,7 +43,7 @@ import {
 import { applyMultipleRefs } from '../../util/refs.js';
 import { eachFn } from '../../util/helpers.js';
 import { changeInputValue } from '../../util/input-value.js';
-import { clsx } from '../../styles/clsx.js';
+import { idx } from '../../util/idx.js';
 
 import {
   mapCountryCodeOptions,
@@ -225,8 +225,10 @@ export const PhoneNumberInput = forwardRef<
 
     const validationHintId = useId();
 
-    const descriptionIds =
-      clsx(descriptionId, validationHint && validationHintId) || undefined;
+    const descriptionIds = idx(
+      descriptionId,
+      validationHint && validationHintId,
+    );
 
     const options = useMemo(
       () => mapCountryCodeOptions(countryCode.options, locale),

--- a/packages/circuit-ui/components/RadioButton/RadioButton.tsx
+++ b/packages/circuit-ui/components/RadioButton/RadioButton.tsx
@@ -21,8 +21,8 @@ import {
   AccessibilityError,
   isSufficientlyLabelled,
 } from '../../util/errors.js';
+import { idx } from '../../util/idx.js';
 import { FieldWrapper, FieldDescription } from '../Field/index.js';
-import { clsx } from '../../styles/clsx.js';
 import { utilClasses } from '../../styles/utility.js';
 import {
   RadioButtonInput,
@@ -64,7 +64,7 @@ export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
     const inputId = customId || id;
     const descriptionId = useId();
 
-    const descriptionIds = clsx(describedBy, description && descriptionId);
+    const descriptionIds = idx(describedBy, description && descriptionId);
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -34,7 +34,7 @@ import {
   isSufficientlyLabelled,
 } from '../../util/errors.js';
 import { isEmpty } from '../../util/helpers.js';
-import { clsx } from '../../styles/clsx.js';
+import { idx } from '../../util/idx.js';
 import {
   RadioButton,
   type RadioButtonProps,
@@ -153,7 +153,7 @@ export const RadioButtonGroup = forwardRef(
     const randomName = useId();
     const name = customName || randomName;
     const validationHintId = useId();
-    const descriptionIds = clsx(
+    const descriptionIds = idx(
       descriptionId,
       validationHint && validationHintId,
     );

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -153,7 +153,10 @@ export const RadioButtonGroup = forwardRef(
     const randomName = useId();
     const name = customName || randomName;
     const validationHintId = useId();
-    const descriptionIds = clsx(descriptionId, validationHintId);
+    const descriptionIds = clsx(
+      descriptionId,
+      validationHint && validationHintId,
+    );
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -132,7 +132,8 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     const id = useId();
     const selectId = customId || id;
     const validationHintId = useId();
-    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
+    const descriptionIds =
+      clsx(descriptionId, validationHint && validationHintId) || undefined;
 
     const prefix = RenderPrefix && (
       <RenderPrefix className={classes.prefix} value={value} />

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -34,6 +34,7 @@ import {
   isSufficientlyLabelled,
 } from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
+import { idx } from '../../util/idx.js';
 
 import classes from './Select.module.css';
 
@@ -132,8 +133,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     const id = useId();
     const selectId = customId || id;
     const validationHintId = useId();
-    const descriptionIds =
-      clsx(descriptionId, validationHint && validationHintId) || undefined;
+    const descriptionIds = idx(
+      descriptionId,
+      validationHint && validationHintId,
+    );
 
     const prefix = RenderPrefix && (
       <RenderPrefix className={classes.prefix} value={value} />

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -35,6 +35,7 @@ import {
 } from '../Field/index.js';
 import { isEmpty } from '../../util/helpers.js';
 import { clsx } from '../../styles/clsx.js';
+import { idx } from '../../util/idx.js';
 
 import classes from './SelectorGroup.module.css';
 
@@ -151,8 +152,10 @@ export const SelectorGroup = forwardRef<
     const randomName = useId();
     const name = customName || randomName;
     const validationHintId = useId();
-    const descriptionIds =
-      clsx(descriptionId, validationHint && validationHintId) || undefined;
+    const descriptionIds = idx(
+      descriptionId,
+      validationHint && validationHintId,
+    );
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -151,7 +151,8 @@ export const SelectorGroup = forwardRef<
     const randomName = useId();
     const name = customName || randomName;
     const validationHintId = useId();
-    const descriptionIds = clsx(descriptionId, validationHintId) || undefined;
+    const descriptionIds =
+      clsx(descriptionId, validationHint && validationHintId) || undefined;
 
     if (
       process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -27,6 +27,7 @@ import type {
   PrimaryBadgeProps,
 } from '../../types.js';
 import { isObject } from '../../../../util/type-check.js';
+import { idx } from '../../../../util/idx.js';
 import { clsx } from '../../../../styles/clsx.js';
 import { utilClasses } from '../../../../styles/utility.js';
 
@@ -56,7 +57,7 @@ export function PrimaryLink({
   const externalLabelId = useId();
 
   const badgeProps = getBadgeProps(badge);
-  const descriptionIds = clsx(
+  const descriptionIds = idx(
     badgeProps?.label && badgeLabelId,
     externalLabel && externalLabelId,
     descriptionId,

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -18,6 +18,7 @@ import './styles/base.css';
 
 export { utilClasses } from './styles/utility.js';
 export { clsx } from './styles/clsx.js';
+export { idx } from './util/idx.js';
 
 // Typography
 export { Headline } from './components/Headline/index.js';

--- a/packages/circuit-ui/util/idx.spec.ts
+++ b/packages/circuit-ui/util/idx.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2025, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { idx } from './idx.js';
+
+describe('idx', () => {
+  it('should concatenate ids', () => {
+    const actual = idx('foo', 'bar');
+    expect(actual).toBe('foo bar');
+  });
+
+  it('should skip falsy ids', () => {
+    const actual = idx('foo', false, null, undefined, 'bar');
+    expect(actual).toBe('foo bar');
+  });
+
+  it('should return undefined when no ids are truthy', () => {
+    const actual = idx(false, null, undefined);
+    expect(actual).toBeUndefined();
+  });
+});

--- a/packages/circuit-ui/util/idx.ts
+++ b/packages/circuit-ui/util/idx.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2025, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type Id = string | false | null | undefined;
+
+export function idx(...ids: Id[]) {
+  return ids.filter((id) => Boolean(id)).join(' ') || undefined;
+}


### PR DESCRIPTION
## Purpose

In a lot of components, we provide the id of the validation hint element to the `aria-describedby` attribute even when a `validationHint` prop isn't provided. This leads to broken aria reference errors.

## Approach and changes

- only reference validation hint elements when `validationHint` is not empty
- add a new `idx` helper, that works similarly to the `clsx` helper, but returns `undefined` when all ids are falsy

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
