### PR TITLE
Declare support for temporal-polyfill v0.3.0

### DIFF
--- a/.changeset/short-snails-attack.md
+++ b/.changeset/short-snails-attack.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Widened the allowed version range for the `temporal-polyfill` peer dependency which recently added support for the March 2025 version of the Temporal spec.

--- a/package-lock.json
+++ b/package-lock.json
@@ -40404,6 +40404,7 @@
 			"resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.5.tgz",
 			"integrity": "sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"temporal-spec": "^0.2.4"
 			}
@@ -40412,7 +40413,8 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.4.tgz",
 			"integrity": "sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==",
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/term-size": {
 			"version": "2.2.1",
@@ -44327,7 +44329,7 @@
 		},
 		"packages/circuit-ui": {
 			"name": "@sumup-oss/circuit-ui",
-			"version": "9.9.2",
+			"version": "9.9.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@floating-ui/react-dom": "^2.1.2",
@@ -44359,7 +44361,7 @@
 				"react-dom": "^18.3.1",
 				"react-swipeable": "^7.0.2",
 				"rollup-plugin-preserve-directives": "^0.4.0",
-				"temporal-polyfill": "^0.2.5",
+				"temporal-polyfill": "0.3.0-beta",
 				"typescript": "^5.7.3",
 				"typescript-plugin-css-modules": "^5.1.0",
 				"vite": "^5.4.13"
@@ -44376,8 +44378,25 @@
 				"@sumup-oss/intl": "^3.1.0",
 				"react": ">=18.0.0 <19.0.0",
 				"react-dom": ">=18.0.0 <19.0.0",
-				"temporal-polyfill": "0.2.x"
+				"temporal-polyfill": "0.3.x"
 			}
+		},
+		"packages/circuit-ui/node_modules/temporal-polyfill": {
+			"version": "0.3.0-beta",
+			"resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0-beta.tgz",
+			"integrity": "sha512-1NJXDbRjvk2e2NQVEYhdg3hc/66pEUDpO3IygdnrEcPWQra/ZaxLumZvZl3ZPlQbr7+OfoeAI5pFp4N51F0EGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"temporal-spec": "0.3.0-beta"
+			}
+		},
+		"packages/circuit-ui/node_modules/temporal-spec": {
+			"version": "0.3.0-beta",
+			"resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0-beta.tgz",
+			"integrity": "sha512-iZsNNAyOAfHjGJg8SdZD77OD3lhQW3SOh0BhXzVUKCtbxoZ5tzt5npuvbeSZW+tyOZsQCgd1766A3hfwFulOJQ==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"packages/design-tokens": {
 			"name": "@sumup-oss/design-tokens",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44376,7 +44376,7 @@
 				"@sumup-oss/intl": "^3.1.1",
 				"react": ">=18.0.0 <19.0.0",
 				"react-dom": ">=18.0.0 <19.0.0",
-				"temporal-polyfill": "0.3.x"
+				"temporal-polyfill": ">= 0.2.0 < 0.4.0"
 			}
 		},
 		"packages/design-tokens": {
@@ -44484,7 +44484,8 @@
 				"@types/react-dom": "^18.3.1",
 				"astro": "^5.2.4",
 				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
+				"react-dom": "^18.3.1",
+				"temporal-polyfill": "^0.3.0"
 			},
 			"devDependencies": {
 				"@astrojs/check": "^0.9.4",
@@ -44511,7 +44512,8 @@
 				"@sumup-oss/intl": "^3.1.1",
 				"next": "^15.1.6",
 				"react": "^18.3.1",
-				"react-dom": "^18.3.1"
+				"react-dom": "^18.3.1",
+				"temporal-polyfill": "^0.3.0"
 			},
 			"devDependencies": {
 				"@sumup-oss/eslint-plugin-circuit-ui": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10931,15 +10931,15 @@
 			"link": true
 		},
 		"node_modules/@sumup-oss/intl": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@sumup-oss/intl/-/intl-3.1.0.tgz",
-			"integrity": "sha512-ixt1UtRGeTFLdvgiQ9/5JIy4sSdxNyODLRlHd2cNWUXeLl1/O/T5QjwbBv6dY6zCyukIOA3l9+mrsj+TNlY8zA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@sumup-oss/intl/-/intl-3.1.1.tgz",
+			"integrity": "sha512-QKkiHLx7Lh0eAlq5SMiJBlVJzhsCy7UonOtH+gb42h0iwOF3Wvu3YlWhOp5UdXE7EkHSajASwMWnHjVgTFtGKA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"temporal-polyfill": "0.2.x"
+				"temporal-polyfill": ">= 0.2.0 < 0.4.0"
 			}
 		},
 		"node_modules/@sumup-oss/remix-template-circuit-ui": {
@@ -40400,21 +40400,19 @@
 			}
 		},
 		"node_modules/temporal-polyfill": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.5.tgz",
-			"integrity": "sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0.tgz",
+			"integrity": "sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"temporal-spec": "^0.2.4"
+				"temporal-spec": "0.3.0"
 			}
 		},
 		"node_modules/temporal-spec": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.4.tgz",
-			"integrity": "sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==",
-			"license": "ISC",
-			"peer": true
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0.tgz",
+			"integrity": "sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ==",
+			"license": "ISC"
 		},
 		"node_modules/term-size": {
 			"version": "2.2.1",
@@ -44345,7 +44343,7 @@
 				"@emotion/styled": "^11.14.0",
 				"@sumup-oss/design-tokens": "^8.2.0",
 				"@sumup-oss/icons": "^5.7.0",
-				"@sumup-oss/intl": "^3.1.0",
+				"@sumup-oss/intl": "^3.1.1",
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/jest-dom": "6.6.3",
 				"@testing-library/react": "^16.2.0",
@@ -44361,7 +44359,7 @@
 				"react-dom": "^18.3.1",
 				"react-swipeable": "^7.0.2",
 				"rollup-plugin-preserve-directives": "^0.4.0",
-				"temporal-polyfill": "0.3.0-beta",
+				"temporal-polyfill": "^0.3.0",
 				"typescript": "^5.7.3",
 				"typescript-plugin-css-modules": "^5.1.0",
 				"vite": "^5.4.13"
@@ -44375,28 +44373,11 @@
 				"@emotion/styled": "^11.11.0",
 				"@sumup-oss/design-tokens": ">=8.0.0",
 				"@sumup-oss/icons": ">=5.6.0",
-				"@sumup-oss/intl": "^3.1.0",
+				"@sumup-oss/intl": "^3.1.1",
 				"react": ">=18.0.0 <19.0.0",
 				"react-dom": ">=18.0.0 <19.0.0",
 				"temporal-polyfill": "0.3.x"
 			}
-		},
-		"packages/circuit-ui/node_modules/temporal-polyfill": {
-			"version": "0.3.0-beta",
-			"resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0-beta.tgz",
-			"integrity": "sha512-1NJXDbRjvk2e2NQVEYhdg3hc/66pEUDpO3IygdnrEcPWQra/ZaxLumZvZl3ZPlQbr7+OfoeAI5pFp4N51F0EGw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"temporal-spec": "0.3.0-beta"
-			}
-		},
-		"packages/circuit-ui/node_modules/temporal-spec": {
-			"version": "0.3.0-beta",
-			"resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0-beta.tgz",
-			"integrity": "sha512-iZsNNAyOAfHjGJg8SdZD77OD3lhQW3SOh0BhXzVUKCtbxoZ5tzt5npuvbeSZW+tyOZsQCgd1766A3hfwFulOJQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"packages/design-tokens": {
 			"name": "@sumup-oss/design-tokens",
@@ -44498,7 +44479,7 @@
 				"@sumup-oss/circuit-ui": "^9.0.0",
 				"@sumup-oss/design-tokens": "^8.0.0",
 				"@sumup-oss/icons": "^5.0.0",
-				"@sumup-oss/intl": "^3.1.0",
+				"@sumup-oss/intl": "^3.1.1",
 				"@types/react": "^18.3.3",
 				"@types/react-dom": "^18.3.1",
 				"astro": "^5.2.4",
@@ -44527,7 +44508,7 @@
 				"@sumup-oss/circuit-ui": "^9.0.0",
 				"@sumup-oss/design-tokens": "^8.0.0",
 				"@sumup-oss/icons": "^5.0.0",
-				"@sumup-oss/intl": "^3.1.0",
+				"@sumup-oss/intl": "^3.1.1",
 				"next": "^15.1.6",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1"
@@ -44565,7 +44546,7 @@
 				"@sumup-oss/circuit-ui": "^9.0.0",
 				"@sumup-oss/design-tokens": "^8.0.0",
 				"@sumup-oss/icons": "^5.0.0",
-				"@sumup-oss/intl": "^3.1.0",
+				"@sumup-oss/intl": "^3.1.1",
 				"isbot": "^5.1.21",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1"

--- a/package.json
+++ b/package.json
@@ -97,8 +97,5 @@
 		"vite": "^5.4.13",
 		"vitest": "^3.0.2",
 		"vitest-github-actions-reporter": "^0.11.1"
-	},
-	"overrides": {
-    "temporal-polyfill": "0.3.0-beta"
-  }
+	}
 }

--- a/package.json
+++ b/package.json
@@ -97,5 +97,8 @@
 		"vite": "^5.4.13",
 		"vitest": "^3.0.2",
 		"vitest-github-actions-reporter": "^0.11.1"
-	}
+	},
+	"overrides": {
+    "temporal-polyfill": "0.3.0-beta"
+  }
 }

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -72,7 +72,7 @@
     "@emotion/styled": "^11.14.0",
     "@sumup-oss/design-tokens": "^8.2.0",
     "@sumup-oss/icons": "^5.7.0",
-    "@sumup-oss/intl": "^3.1.0",
+    "@sumup-oss/intl": "^3.1.1",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "^16.2.0",
@@ -88,7 +88,7 @@
     "react-dom": "^18.3.1",
     "react-swipeable": "^7.0.2",
     "rollup-plugin-preserve-directives": "^0.4.0",
-    "temporal-polyfill": "0.3.0-beta",
+    "temporal-polyfill": "^0.3.0",
     "typescript": "^5.7.3",
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^5.4.13"
@@ -99,15 +99,10 @@
     "@emotion/styled": "^11.11.0",
     "@sumup-oss/design-tokens": ">=8.0.0",
     "@sumup-oss/icons": ">=5.6.0",
-    "@sumup-oss/intl": "^3.1.0",
+    "@sumup-oss/intl": "^3.1.1",
     "react": ">=18.0.0 <19.0.0",
     "react-dom": ">=18.0.0 <19.0.0",
     "temporal-polyfill": "0.3.x"
-  },
-  "overrides": {
-    "@sumup-oss/intl": {
-      "temporal-polyfill": "$temporal-polyfill"
-    }
   },
   "engines": {
     "node": ">=20"

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -102,7 +102,7 @@
     "@sumup-oss/intl": "^3.1.1",
     "react": ">=18.0.0 <19.0.0",
     "react-dom": ">=18.0.0 <19.0.0",
-    "temporal-polyfill": "0.3.x"
+    "temporal-polyfill": ">= 0.2.0 < 0.4.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -88,7 +88,7 @@
     "react-dom": "^18.3.1",
     "react-swipeable": "^7.0.2",
     "rollup-plugin-preserve-directives": "^0.4.0",
-    "temporal-polyfill": "^0.2.5",
+    "temporal-polyfill": "0.3.0-beta",
     "typescript": "^5.7.3",
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^5.4.13"
@@ -102,7 +102,12 @@
     "@sumup-oss/intl": "^3.1.0",
     "react": ">=18.0.0 <19.0.0",
     "react-dom": ">=18.0.0 <19.0.0",
-    "temporal-polyfill": "0.2.x"
+    "temporal-polyfill": "0.3.x"
+  },
+  "overrides": {
+    "@sumup-oss/intl": {
+      "temporal-polyfill": "$temporal-polyfill"
+    }
   },
   "engines": {
     "node": ">=20"

--- a/packages/circuit-ui/tsconfig.json
+++ b/packages/circuit-ui/tsconfig.json
@@ -17,6 +17,7 @@
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "strict": true,
+    "skipLibCheck": true,
     "target": "es2019",
     "plugins": [{ "name": "typescript-plugin-css-modules" }]
   },

--- a/templates/astro/package.json
+++ b/templates/astro/package.json
@@ -19,7 +19,7 @@
     "@sumup-oss/circuit-ui": "^9.0.0",
     "@sumup-oss/design-tokens": "^8.0.0",
     "@sumup-oss/icons": "^5.0.0",
-    "@sumup-oss/intl": "^3.1.0",
+    "@sumup-oss/intl": "^3.1.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.1",
     "astro": "^5.2.4",

--- a/templates/astro/package.json
+++ b/templates/astro/package.json
@@ -24,7 +24,8 @@
     "@types/react-dom": "^18.3.1",
     "astro": "^5.2.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "temporal-polyfill": "^0.3.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",

--- a/templates/nextjs/template/package.json
+++ b/templates/nextjs/template/package.json
@@ -17,7 +17,7 @@
     "@sumup-oss/circuit-ui": "^9.0.0",
     "@sumup-oss/design-tokens": "^8.0.0",
     "@sumup-oss/icons": "^5.0.0",
-    "@sumup-oss/intl": "^3.1.0",
+    "@sumup-oss/intl": "^3.1.1",
     "next": "^15.1.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/templates/nextjs/template/package.json
+++ b/templates/nextjs/template/package.json
@@ -20,7 +20,8 @@
     "@sumup-oss/intl": "^3.1.1",
     "next": "^15.1.6",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "temporal-polyfill": "^0.3.0"
   },
   "devDependencies": {
     "@sumup-oss/eslint-plugin-circuit-ui": "^5.0.0",

--- a/templates/remix/package.json
+++ b/templates/remix/package.json
@@ -21,7 +21,7 @@
     "@sumup-oss/circuit-ui": "^9.0.0",
     "@sumup-oss/design-tokens": "^8.0.0",
     "@sumup-oss/icons": "^5.0.0",
-    "@sumup-oss/intl": "^3.1.0",
+    "@sumup-oss/intl": "^3.1.1",
     "isbot": "^5.1.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
## Purpose

`temporal-polyfill` v0.3.0 upgrades to the March 2025 version of the Temporal spec.

## Approach and changes

- Widen the allowed version range of the `temporal-polyfill` peer dependency to include v0.3.0
- Install `temporal-polyfill` in the templates since it's a required peer dependency

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
