### PR TITLE
Fix: Hide button when hidden attribute is passed

### DIFF
--- a/.changeset/tidy-bananas-warn.md
+++ b/.changeset/tidy-bananas-warn.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Hide button when hidden attribute is passed
+Added support for the `hidden` attribute to the Button component.

--- a/.changeset/tidy-bananas-warn.md
+++ b/.changeset/tidy-bananas-warn.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Hide button when hidden attribute is passed

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -20,6 +20,10 @@
     border-color var(--cui-transitions-default);
 }
 
+.base[hidden] {
+  display: none;
+}
+
 .base[aria-busy="true"] {
   position: relative;
   overflow: hidden;

--- a/packages/circuit-ui/components/Button/base.spec.tsx
+++ b/packages/circuit-ui/components/Button/base.spec.tsx
@@ -124,6 +124,12 @@ describe('Button', () => {
       const anchor = container.querySelector('a');
       expect(ref.current).toBe(anchor);
     });
+
+    it('should render button with display: none when hidden attribute is set', () => {
+      const { container } = render(<Button hidden />);
+      const button = container.querySelector('button');
+      expect(button).toHaveStyle({ display: 'none' });
+    });
   });
 
   describe('accessibility', () => {


### PR DESCRIPTION
## Purpose

`hidden` HTML attribute had no effect on `Button`. This is because we specifically set `display: inline-flex`, and that overrides the default browser behaviour (setting `display: none`)

## Approach and changes

Add specific `display: none` rule when `hidden` attribute is present on buttons.

## Definition of done

* [X] Development completed
* [ ] Reviewers assigned
* [X] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
