### PR TITLE
Remove empty aria attribute from DateInput

### DIFF
--- a/.changeset/thirty-pugs-crash.md
+++ b/.changeset/thirty-pugs-crash.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed the `aria-valuetext` attribute from the DateInput component when empty.

--- a/packages/circuit-ui/components/DateInput/hooks/usePlainDateState.ts
+++ b/packages/circuit-ui/components/DateInput/hooks/usePlainDateState.ts
@@ -132,7 +132,7 @@ export function usePlainDateState({
       value: values.month,
       'aria-valuetext': values.month
         ? [values.month, getMonthName(values.month, locale)].join(', ')
-        : '',
+        : undefined,
       defaultValue: today.month,
       placeholder: 'mm',
       step: 3,


### PR DESCRIPTION
## Purpose

When upgrading the web dashboard to Circuit UI v9.10, an automated accessibility test complained about the DateInput's empty `aria-valuetext` attribute. Not sure why this only surfaced now.

## Approach and changes

- Set the `aria-valuetext` attribute to `undefined` when empty to fully remove it from the DOM. I've tested this with VoiceOver on Firefox and Safari, there's no difference in screen reader output. 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements