### PR TITLE
Improve sticky behaviour of ComparisonTable headers

### DIFF
--- a/.changeset/chilled-buttons-care.md
+++ b/.changeset/chilled-buttons-care.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the sticky positioning of the comparison table headers in the absence of a plan picker. Added support for positioning relative to a navigation element by providing a `--top-navigation-height` custom property.

--- a/packages/circuit-ui/components/ComparisonTable/ComparisonTable.mdx
+++ b/packages/circuit-ui/components/ComparisonTable/ComparisonTable.mdx
@@ -16,6 +16,7 @@ Allows users to quickly compare different plans side by side by highlighting key
 
 - This component was designed for the specific case of comparing pricing tiers offered by Sumup. It may not be suitable for other use cases.
 - Limit the number of plans to compare to a maximum of 4.
+- When used with a sticky top navigation component, the table's stickiness can be adjusted to match the navigation's height. This can be achieved by providing a `--top-navigation-height` custom property in component's scope.
 
 ## Content guidelines
 

--- a/packages/circuit-ui/components/ComparisonTable/ComparisonTable.module.css
+++ b/packages/circuit-ui/components/ComparisonTable/ComparisonTable.module.css
@@ -5,7 +5,7 @@
 
 .picker {
   position: sticky;
-  top: 0;
+  top: var(--top-navigation-height, 0);
   z-index: 2;
 }
 

--- a/packages/circuit-ui/components/ComparisonTable/ComparisonTable.stories.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/ComparisonTable.stories.tsx
@@ -13,7 +13,14 @@
  * limitations under the License.
  */
 
+import { Shop, SumUpLogo } from '@sumup-oss/icons';
+import { action } from '@storybook/addon-actions';
+
 import { modes } from '../../../../.storybook/modes.js';
+import {
+  TopNavigation,
+  type TopNavigationProps,
+} from '../TopNavigation/index.js';
 
 import {
   ComparisonTable,
@@ -45,7 +52,7 @@ export default {
 
 const baseProps: ComparisonTableProps = {
   caption: 'Compare plans',
-  headers: [basicPlan, standardPlan, premiumPlan],
+  headers: [basicPlan, standardPlan],
   sections: [essentialFeaturesSection],
   showAllFeaturesLabel: 'Show all features',
   selectSecondPlanLabel: 'Select a second plan',
@@ -62,10 +69,69 @@ export const Collapsed = (args: ComparisonTableProps) => (
 
 Collapsed.args = {
   ...baseProps,
-  sections: [
-    ...baseProps.sections,
-    customizationSection,
-    supportSection,
-    analyticsSection,
+  headers: [basicPlan, standardPlan, premiumPlan],
+  sections: [customizationSection, supportSection, analyticsSection],
+};
+
+const topNavigationProps: TopNavigationProps = {
+  isLoading: false,
+  logo: (
+    <a
+      href="https://sumup.com"
+      aria-label="Visit SumUp's website"
+      target="_blank"
+      rel="noreferrer"
+    >
+      <SumUpLogo />
+    </a>
+  ),
+  user: {
+    name: 'Jane Doe',
+    id: 'ID: AC3YULT8',
+  },
+  profileMenu: {
+    label: 'Open profile menu',
+    actions: [
+      {
+        href: '/profile',
+        onClick: action('View profile'),
+        children: 'View profile',
+      },
+      {
+        href: '/settings',
+        onClick: action('Settings'),
+        children: 'Settings',
+      },
+      { type: 'divider' },
+      {
+        onClick: action('Logout'),
+        children: 'Logout',
+        destructive: true,
+      },
+    ],
+    className: 'custom-class-name',
+  },
+  links: [
+    {
+      icon: Shop,
+      label: 'Shop',
+      href: '/shop',
+      onClick: action('Shop'),
+    },
   ],
+  skipNavigationHref: '#main-content',
+  skipNavigationLabel: 'Skip navigation',
+};
+
+export const WithTopNavigation = (args: ComparisonTableProps) => (
+  <>
+    <TopNavigation {...topNavigationProps} />
+    <ComparisonTable {...args} />
+  </>
+);
+
+WithTopNavigation.args = {
+  ...baseProps,
+  headers: [basicPlan, standardPlan, premiumPlan],
+  sections: [customizationSection, supportSection, analyticsSection],
 };

--- a/packages/circuit-ui/components/ComparisonTable/ComparisonTable.stories.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/ComparisonTable.stories.tsx
@@ -13,14 +13,9 @@
  * limitations under the License.
  */
 
-import { Shop, SumUpLogo } from '@sumup-oss/icons';
-import { action } from '@storybook/addon-actions';
-
 import { modes } from '../../../../.storybook/modes.js';
-import {
-  TopNavigation,
-  type TopNavigationProps,
-} from '../TopNavigation/index.js';
+import { TopNavigation } from '../TopNavigation/index.js';
+import { baseArgs as topNavigationProps } from '../TopNavigation/TopNavigation.stories.js';
 
 import {
   ComparisonTable,
@@ -71,56 +66,6 @@ Collapsed.args = {
   ...baseProps,
   headers: [basicPlan, standardPlan, premiumPlan],
   sections: [customizationSection, supportSection, analyticsSection],
-};
-
-const topNavigationProps: TopNavigationProps = {
-  isLoading: false,
-  logo: (
-    <a
-      href="https://sumup.com"
-      aria-label="Visit SumUp's website"
-      target="_blank"
-      rel="noreferrer"
-    >
-      <SumUpLogo />
-    </a>
-  ),
-  user: {
-    name: 'Jane Doe',
-    id: 'ID: AC3YULT8',
-  },
-  profileMenu: {
-    label: 'Open profile menu',
-    actions: [
-      {
-        href: '/profile',
-        onClick: action('View profile'),
-        children: 'View profile',
-      },
-      {
-        href: '/settings',
-        onClick: action('Settings'),
-        children: 'Settings',
-      },
-      { type: 'divider' },
-      {
-        onClick: action('Logout'),
-        children: 'Logout',
-        destructive: true,
-      },
-    ],
-    className: 'custom-class-name',
-  },
-  links: [
-    {
-      icon: Shop,
-      label: 'Shop',
-      href: '/shop',
-      onClick: action('Shop'),
-    },
-  ],
-  skipNavigationHref: '#main-content',
-  skipNavigationLabel: 'Skip navigation',
 };
 
 export const WithTopNavigation = (args: ComparisonTableProps) => (

--- a/packages/circuit-ui/components/ComparisonTable/ComparisonTable.stories.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/ComparisonTable.stories.tsx
@@ -69,12 +69,24 @@ Collapsed.args = {
 };
 
 export const WithTopNavigation = (args: ComparisonTableProps) => (
-  <>
-    <TopNavigation {...topNavigationProps} />
-    <ComparisonTable {...args} />
-  </>
+  <div style={{ position: 'relative' }}>
+    <TopNavigation
+      {...topNavigationProps}
+      style={{
+        position: 'sticky',
+        top: '0',
+        zIndex: 'calc(var(--cui-z-index-navigation) + 1)',
+      }}
+    />
+    <div style={{ padding: 'var(--cui-spacings-giga)' }}>
+      <ComparisonTable {...args} />
+    </div>
+  </div>
 );
 
+WithTopNavigation.parameters = {
+  layout: 'fullscreen',
+};
 WithTopNavigation.args = {
   ...baseProps,
   headers: [basicPlan, standardPlan, premiumPlan],

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.module.css
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.module.css
@@ -13,7 +13,7 @@
 .table thead th,
 .table thead td {
   position: sticky;
-  top: 0;
+  top: calc(var(--top-navigation-height, 0));
   z-index: 1;
   padding-top: var(--cui-spacings-giga);
   background-color: var(--cui-bg-normal);
@@ -61,9 +61,11 @@
     table-layout: fixed;
   }
 
-  .table thead td,
-  .table thead th {
-    top: 80px; /* height of the sticky plan picker on mobile */
+  .offset {
+    top: calc(
+      var(--top-navigation-height, 0) + 80px
+    ); /* height of the sticky plan picker on mobile */
+
     padding-top: 0;
   }
 
@@ -82,9 +84,11 @@
 }
 
 @media (min-width: 480px) and (max-width: 767px) {
-  .table thead td,
-  .table thead th {
-    top: 96px; /* height of the sticky plan picker on tablet */
+  .offset {
+    top: calc(
+      var(--top-navigation-height, 0) + 96px
+    ); /* height of the sticky plan picker on tablet */
+
     padding-top: 0;
   }
 }

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.module.css
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.module.css
@@ -61,9 +61,9 @@
     table-layout: fixed;
   }
 
-  .offset {
+  .table thead .offset {
     top: calc(
-      var(--top-navigation-height, 0) + 80px
+      var(--top-navigation-height, 0px) + 80px
     ); /* height of the sticky plan picker on mobile */
 
     padding-top: 0;
@@ -84,9 +84,9 @@
 }
 
 @media (min-width: 480px) and (max-width: 767px) {
-  .offset {
+  .table thead .offset {
     top: calc(
-      var(--top-navigation-height, 0) + 96px
+      var(--top-navigation-height, 0px) + 96px
     ); /* height of the sticky plan picker on tablet */
 
     padding-top: 0;

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.module.css
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.module.css
@@ -13,7 +13,7 @@
 .table thead th,
 .table thead td {
   position: sticky;
-  top: calc(var(--top-navigation-height, 0));
+  top: var(--top-navigation-height, 0);
   z-index: 1;
   padding-top: var(--cui-spacings-giga);
   background-color: var(--cui-bg-normal);

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.spec.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.spec.tsx
@@ -23,7 +23,6 @@ import {
   customizationSection,
   basicPlan,
   standardPlan,
-  premiumPlan,
 } from '../../fixtures.js';
 
 import { PlanTable, type PlanTableProps } from './PlanTable.js';
@@ -34,7 +33,7 @@ const baseProps: PlanTableProps = {
   caption: 'Plan comparison',
   showAllFeaturesLabel: 'Show all features',
   sections: [essentialFeaturesSection],
-  headers: [basicPlan, standardPlan, premiumPlan],
+  headers: [basicPlan, standardPlan],
   activePlans: [0, 1],
 };
 
@@ -55,7 +54,7 @@ describe('PlanTable', () => {
     expect(
       screen.getAllByRole('table', { name: baseProps.caption }),
     ).toHaveLength(1);
-    expect(screen.getAllByRole('columnheader')).toHaveLength(3);
+    expect(screen.getAllByRole('columnheader')).toHaveLength(2);
     expect(screen.getAllByRole('rowgroup')).toHaveLength(2);
     expect(screen.getAllByRole('row')).toHaveLength(7);
 
@@ -63,7 +62,7 @@ describe('PlanTable', () => {
       screen.getAllByRole('rowheader', { name: 'Essential Features' }),
     ).toHaveLength(1);
     expect(screen.getAllByRole('rowheader')).toHaveLength(6);
-    expect(screen.getAllByRole('cell', { name: 'included' })).toHaveLength(12);
+    expect(screen.getAllByRole('cell', { name: 'included' })).toHaveLength(7);
     expect(screen.getAllByRole('cell', { name: 'not included' })).toHaveLength(
       3,
     );

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
@@ -173,7 +173,7 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
           </colgroup>
           <thead ref={theadRef}>
             <tr>
-              <td />
+              <td className={clsx(isPlanPickerVisible && classes.offset)} />
               {headersToDisplay.map((plan, index) => (
                 <TableHeader
                   {...plan}
@@ -201,7 +201,7 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
                   colSpan={headers.length + 1}
                   /* account for sticky plan picker on mobile */
                   style={{
-                    top: `calc(var(--top-navigation-height, 0) + ${offset}px)`,
+                    top: `calc(var(--top-navigation-height, 0px) + ${offset}px)`,
                   }}
                 >
                   <Body className={classes.title} size="m" weight="semibold">

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
@@ -109,6 +109,10 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
       ) > COLLAPSE_THRESHOLD,
     );
     const [headerHeight, setHeaderHeight] = useState(0);
+    const isPlanPickerVisible = headers.length > 2;
+    const offset =
+      headerHeight +
+      (isPlanPickerVisible ? (isMobile ? 80 : 0) + (isTablet ? 16 : 0) : 0);
 
     const updateHeaderHeight = useCallback(() => {
       throttle(() => {
@@ -175,7 +179,10 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
                   {...plan}
                   key={`cui-ct-headers-${plan.id}`}
                   id={`cui-ct-headers-${plan.id}`}
-                  className={clsx(index > 0 && classes.border)}
+                  className={clsx(
+                    index > 0 && classes.border,
+                    isPlanPickerVisible && classes.offset,
+                  )}
                 />
               ))}
             </tr>
@@ -194,7 +201,7 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
                   colSpan={headers.length + 1}
                   /* account for sticky plan picker on mobile */
                   style={{
-                    top: `${(isMobile ? 80 : 0) + (isTablet ? 16 : 0) + headerHeight}px`,
+                    top: `calc(var(--top-navigation-height, 0) + ${offset}px)`,
                   }}
                 >
                   <Body className={classes.title} size="m" weight="semibold">

--- a/packages/circuit-ui/components/ComparisonTable/fixtures.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/fixtures.tsx
@@ -73,7 +73,6 @@ export const coreFeature: Feature = {
   values: [
     { value: true, label: 'included' },
     { value: true, label: 'included' },
-    { value: true, label: 'included' },
   ],
 };
 
@@ -82,7 +81,6 @@ export const advancedFeature: Feature = {
     label: 'Advanced features',
   },
   values: [
-    { value: true, label: 'included' },
     { value: true, label: 'included' },
     { value: true, label: 'included' },
   ],
@@ -95,7 +93,6 @@ export const premiumFeature: Feature = {
   values: [
     { value: true, label: 'included' },
     { value: true, label: 'included' },
-    { value: true, label: 'included' },
   ],
 };
 
@@ -105,7 +102,6 @@ export const limitedFeature: Feature = {
   },
   values: [
     { value: false, label: 'not included' },
-    { value: true, label: 'included' },
     { value: true, label: 'included' },
   ],
 };
@@ -117,7 +113,6 @@ export const exclusiveFeature: Feature = {
   values: [
     { value: false, label: 'not included' },
     { value: false, label: 'not included' },
-    { value: true, label: 'included' },
   ],
 };
 


### PR DESCRIPTION
Addresses [DSYS-1023](https://sumupteam.atlassian.net/browse/DSYS-1023)

## Purpose

The table accounts to the plan picker elements height when computing the sticky offset, even when it is not present ( <= 2 plans to compare). This PR also improves the sticky behaviour by allowing the headers to stick relative to a navigation element when a `--top-navigation-height` custom property exists.

## Approach and changes

* Only account for picker height when shown
* add `--top-navigation-height` offset when computing the top position of sticky elements

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
