### PR TITLE
Add new strategy prop to Toggltip and set its value to fixed

### DIFF
--- a/.changeset/silent-ducks-occur.md
+++ b/.changeset/silent-ducks-occur.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added a `strategy` prop to the Toggletip component to allow a more flexible positioning of the floating element. Defaults to `"fixed"`. Read more about strategy in [floating-ui's documentation](https://floating-ui.com/docs/usefloating#strategy).

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -97,7 +97,7 @@ export interface ToggletipProps extends HTMLAttributes<HTMLDialogElement> {
   /**
    * Where to display the toggletip relative to the trigger component. The
    * toggletip will automatically move if there isn't enough space available.
-   * @default top
+   * @default 'top'
    */
   placement?: Placement;
   /**
@@ -119,7 +119,7 @@ export interface ToggletipProps extends HTMLAttributes<HTMLDialogElement> {
   locale?: Locale;
   /**
    * The strategy to use when positioning the floating element.
-   * @default fixed
+   * @default 'fixed'
    */
   strategy?: Strategy;
 }

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -36,6 +36,7 @@ import {
   type Placement,
   type Side,
 } from '@floating-ui/react-dom';
+import type { Strategy } from '@floating-ui/utils';
 
 import dialogPolyfill from '../../vendor/dialog-polyfill/index.js';
 import type { ClickEvent } from '../../types/events.js';
@@ -89,13 +90,14 @@ export interface ToggletipProps extends HTMLAttributes<HTMLDialogElement> {
    */
   closeButtonLabel?: string;
   /**
-   * Whether the toggletip is initially open. Default: 'false'.
+   * Whether the toggletip is initially open.
+   * @default false
    */
   defaultOpen?: boolean;
   /**
    * Where to display the toggletip relative to the trigger component. The
    * toggletip will automatically move if there isn't enough space available.
-   * Default: 'top'.
+   * @default top
    */
   placement?: Placement;
   /**
@@ -104,8 +106,7 @@ export interface ToggletipProps extends HTMLAttributes<HTMLDialogElement> {
    * Pass a number to move the floating element on the main axis, away from (if
    * positive) or towards (if negative) the reference element. Pass an object
    * to displace the floating element on both the main and cross axes.
-   *
-   * Default: 12.
+   * @default 12
    */
   offset?: number | { mainAxis?: number; crossAxis?: number };
   /**
@@ -113,8 +114,14 @@ export interface ToggletipProps extends HTMLAttributes<HTMLDialogElement> {
    * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
    * When passing an array, the first supported locale is used.
    * Defaults to `navigator.language` in supported environments.
+   * @default navigator.language
    */
   locale?: Locale;
+  /**
+   * The strategy to use when positioning the floating element.
+   * @default fixed
+   */
+  strategy?: Strategy;
 }
 
 export const Toggletip = forwardRef<HTMLDialogElement, ToggletipProps>(
@@ -131,6 +138,7 @@ export const Toggletip = forwardRef<HTMLDialogElement, ToggletipProps>(
       className,
       style,
       locale,
+      strategy = 'fixed',
       ...rest
     } = useI18n(props, translations);
     const zIndex = useStackContext();
@@ -167,6 +175,7 @@ export const Toggletip = forwardRef<HTMLDialogElement, ToggletipProps>(
     const { refs, floatingStyles, middlewareData, update, placement } =
       useFloating({
         open,
+        strategy,
         placement: defaultPlacement,
         middleware: [
           offsetMiddleware(offset),


### PR DESCRIPTION
Addresses [DSYS-1022](https://sumupteam.atlassian.net/browse/DSYS-1022)

## Purpose

The Toggletip positioning breaks when the component is rendered inside a relatively positioned parent. One way to fix this is to change its positioning strategy to fixed by default, and exposing a `strategy` prop that accepts `absolute` if needed.

## Approach and changes

- Add a new strategy prop to the Toggletip component.
- Set the default strategy to fixed.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
