### PR TITLE
Add a custom StackingContext for Toggletips inside the ComparisonTable

### DIFF
--- a/.changeset/grumpy-moons-report.md
+++ b/.changeset/grumpy-moons-report.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Improved the stacking of Toggletips inside the ComparisonTable.

--- a/packages/circuit-ui/components/ComparisonTable/components/RowHeader/RowHeader.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/RowHeader/RowHeader.tsx
@@ -52,7 +52,7 @@ export const RowHeader = ({
       </Compact>
       {toggletip && (
         <StackContext.Provider value={'0'}>
-          <Toggletip {...toggletip} style={{ zIndex: 0 }} placement="right" />
+          <Toggletip {...toggletip} placement="right" />
         </StackContext.Provider>
       )}
     </div>

--- a/packages/circuit-ui/components/ComparisonTable/components/RowHeader/RowHeader.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/RowHeader/RowHeader.tsx
@@ -20,6 +20,7 @@ import type { ReactNode, ThHTMLAttributes } from 'react';
 import { Toggletip, type ToggletipProps } from '../../../Toggletip/index.js';
 import { clsx } from '../../../../styles/clsx.js';
 import { Compact } from '../../../Compact/index.js';
+import { StackContext } from '../../../StackContext/index.js';
 
 import classes from './RowHeader.module.css';
 
@@ -49,7 +50,11 @@ export const RowHeader = ({
       <Compact size="s" className={classes.name}>
         {children}
       </Compact>
-      {toggletip && <Toggletip {...toggletip} placement="right" />}
+      {toggletip && (
+        <StackContext.Provider value={'0'}>
+          <Toggletip {...toggletip} style={{ zIndex: 0 }} placement="right" />
+        </StackContext.Provider>
+      )}
     </div>
     {description && (
       <Compact className={classes.description} size="s" color="subtle">


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

When the comparison table is scrolled while a child Toggletip is open, the Toggletip floats on top of content even when it's out of view because of its high `z-index` value. We can improve this behaviour by "flattening" the Toggletip with the rest of the table content

https://github.com/user-attachments/assets/9f14832d-c240-48cb-b5a8-381e22a10ed4


## Approach and changes

Add special stacking context for Toggletips inside the ComparisonTable

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
