### PR TITLE
Fix dialog overflow

### DIFF
--- a/.changeset/slimy-cars-clean.md
+++ b/.changeset/slimy-cars-clean.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the overflow behaviour of the Modal component's content.

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -7,7 +7,7 @@
 .content {
   position: relative;
   max-height: 90vh;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 @media (min-width: 480px) {


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

When users have their system settings set to always show scrollbars, Modal components are shown with scrollbars even when content is not scrollable. This is because the Modal content's overflow property is set to `scroll`

## Approach and changes

Replace overflow property value `scroll` with `auto` for modal content.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
