### PR TITLE
Improve the sticky behavior of headers with ResizeObserver

### DIFF
--- a/.changeset/gold-bananas-eat.md
+++ b/.changeset/gold-bananas-eat.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Improved the sticky behavior of sticky section names of the ComporisonTable component.

--- a/packages/circuit-ui/components/ComparisonTable/ComparisonTable.spec.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/ComparisonTable.spec.tsx
@@ -51,6 +51,10 @@ const baseProps: ComparisonTableProps = {
 
 describe('ComparisonTable', () => {
   beforeEach(() => {
+    window.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+    }));
     (useMedia as Mock).mockReturnValue(false);
   });
 

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.spec.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.spec.tsx
@@ -39,6 +39,10 @@ const baseProps: PlanTableProps = {
 
 describe('PlanTable', () => {
   beforeEach(() => {
+    window.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+    }));
     (useMedia as Mock).mockReturnValue(false);
   });
 

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
@@ -111,7 +111,7 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
     const isPlanPickerVisible = headers.length > 2;
 
     useEffect(() => {
-      if (!theadRef.current) {
+      if (!theadRef.current || !ResizeObserver) {
         return undefined;
       }
 

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
@@ -112,7 +112,7 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
 
     useEffect(() => {
       const tableHeaderElement = theadRef.current;
-      if (!tableHeaderElement || !ResizeObserver) {
+      if (!tableHeaderElement || typeof ResizeObserver === 'undefined') {
         return undefined;
       }
 

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
@@ -127,9 +127,7 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
 
       headerSizeObserver.observe(tableHeaderElement);
       return () => {
-        if (tableHeaderElement) {
-          headerSizeObserver.unobserve(tableHeaderElement);
-        }
+        headerSizeObserver.unobserve(tableHeaderElement);
       };
     }, [isPlanPickerVisible, isMobile, isTablet]);
 

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
@@ -119,12 +119,10 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
       // opt for progressive enhancement
       // eslint-disable-next-line compat/compat
       const headerSizeObserver = new ResizeObserver((entries) => {
-        setSectionOffset(
-          entries[0].contentRect.height +
-            (isPlanPickerVisible
-              ? (isMobile ? 80 : 0) + (isTablet ? 16 : 0)
-              : 0),
-        );
+        const planPickerHeight = isPlanPickerVisible
+          ? (isMobile ? 80 : 0) + (isTablet ? 16 : 0)
+          : 0;
+        setSectionOffset(entries[0].contentRect.height + planPickerHeight);
       });
 
       headerSizeObserver.observe(tableHeaderElement);

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.tsx
@@ -111,7 +111,8 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
     const isPlanPickerVisible = headers.length > 2;
 
     useEffect(() => {
-      if (!theadRef.current || !ResizeObserver) {
+      const tableHeaderElement = theadRef.current;
+      if (!tableHeaderElement || !ResizeObserver) {
         return undefined;
       }
 
@@ -126,10 +127,10 @@ export const PlanTable = forwardRef<HTMLTableElement, PlanTableProps>(
         );
       });
 
-      headerSizeObserver.observe(theadRef.current);
+      headerSizeObserver.observe(tableHeaderElement);
       return () => {
-        if (theadRef.current) {
-          headerSizeObserver.unobserve(theadRef.current);
+        if (tableHeaderElement) {
+          headerSizeObserver.unobserve(tableHeaderElement);
         }
       };
     }, [isPlanPickerVisible, isMobile, isTablet]);


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

The sticky position of the sections of the comparison table adapt to the height of other elements like the plan picker selects or the main headers of the table. The table header sizes can change not only if the table data is updated or the window size changes, but also if it's placed alongside other content that changes dynamically, which can lead to changing their height. The current implementation does not take into consideration this last factor. To fix this issue, its best to use a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserve) that accounts for all these cases in an optimised manner.

Note: 
The ResizeObserver is [not supported](https://caniuse.com/resizeobserver) for firefox <69 and safari <13.1 but I think the tradeoff is reasonable since it does not impact the logic of the component or render it unusable.

## Approach and changes

Replace the window.resize event listener with a resize observer that observes the table header.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
