### PR TITLE
Align SidePanel z-index value with Dialog

### DIFF
--- a/.changeset/clean-pears-complain.md
+++ b/.changeset/clean-pears-complain.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed legacy z-index value from the SidePanel component styles. The SidePanel now inherits this property from the Dialog component on desktop, and renders as a modal dialog in the top layer on mobile.

--- a/packages/circuit-ui/components/SidePanel/SidePanel.module.css
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.module.css
@@ -3,7 +3,6 @@
   right: 0;
   bottom: 0;
   left: unset;
-  z-index: var(--cui-z-index-absolute);
   box-shadow: none;
   transform: translateX(100%);
   transition: transform var(--dialog-animation-duration) ease-in-out;


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

The SidePanel has a z-index value of 1 which is no longer relevant. On desktop, the SidePanel will inherit the same zIndex value as the Dialog component (1000) and on mobile, we no longer need to set it as it renders in the TopLayer.

## Approach and changes

Remove z-index value from SidePanel.module.css

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
