### PR TITLE
Introduce an optional contentClassName to the Dialog component props

### DIFF
--- a/.changeset/tidy-dragons-argue.md
+++ b/.changeset/tidy-dragons-argue.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Introduced an optional `contentClassName` prop, enabling custom styling for the content of Dialog-based components, including Dialog, ActionMenu, Popover, Modal, and NotificationModal.

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.module.css
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.module.css
@@ -1,10 +1,10 @@
-.base > div {
+.content {
   box-sizing: border-box;
   padding: var(--cui-spacings-byte) 0;
   overflow-y: auto;
   background-color: var(--cui-bg-elevated);
   border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
-  border-radius: inherit;
+  border-radius: var(--cui-border-radius-byte);
 }
 
 .divider {

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
@@ -106,6 +106,7 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
     return (
       <Popover
         className={clsx(className, classes.base)}
+        contentClassName={classes.content}
         ref={ref}
         hideCloseButton={!isMobile}
         onToggle={onToggle}

--- a/packages/circuit-ui/components/Dialog/Dialog.tsx
+++ b/packages/circuit-ui/components/Dialog/Dialog.tsx
@@ -78,6 +78,10 @@ export interface PublicDialogProps
     | ReactNode
     | (({ onClose }: { onClose?: DialogProps['onCloseEnd'] }) => ReactNode);
   [key: DataAttribute]: string | undefined;
+  /**
+   * An optional class name to be applied to the component's content.
+   */
+  contentClassName?: string;
 }
 
 export interface DialogProps extends PublicDialogProps {
@@ -121,6 +125,7 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
       onCloseEnd,
       closeButtonLabel,
       className,
+      contentClassName,
       preventOutsideClickRefs,
       preventOutsideClickClose = false,
       hideCloseButton = false,
@@ -421,10 +426,12 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
           }}
           {...rest}
         >
-          {(open || isClosing) &&
-            (typeof children === 'function'
-              ? children?.({ onClose: onCloseEnd })
-              : children)}
+          <div className={contentClassName}>
+            {(open || isClosing) &&
+              (typeof children === 'function'
+                ? children?.({ onClose: onCloseEnd })
+                : children)}
+          </div>
           {!hideCloseButton && (
             <CloseButton onClick={handleDialogClose} className={classes.close}>
               {closeButtonLabel}

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -59,6 +59,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
     hideCloseButton,
     variant = 'contextual',
     className,
+    contentClassName,
     preventClose = false,
     children,
     onClose,
@@ -105,14 +106,13 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
         variant === 'immersive' && classes.immersive,
         className,
       )}
+      contentClassName={clsx(classes.content, contentClassName)}
       preventEscapeKeyClose={preventClose}
       preventOutsideClickClose={preventClose}
       hideCloseButton={preventClose}
       {...rest}
     >
-      <div className={classes.content}>
-        {typeof children === 'function' ? children?.({ onClose }) : children}
-      </div>
+      {typeof children === 'function' ? children?.({ onClose }) : children}
     </Dialog>
   );
 });

--- a/packages/circuit-ui/components/Modal/ModalContext.tsx
+++ b/packages/circuit-ui/components/Modal/ModalContext.tsx
@@ -74,10 +74,6 @@ export function ModalProvider<T extends ModalProps>({
         modal.onClose();
       }
       dispatch({
-        type: 'update',
-        item: modal,
-      });
-      dispatch({
         type: 'remove',
         id: modal.id,
         transition: {
@@ -105,7 +101,7 @@ export function ModalProvider<T extends ModalProps>({
             {...defaultModalProps}
             {...modalProps}
             key={id}
-            open={!transition}
+            open={true}
             onClose={() => removeModal(modal)}
           />
         );

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -212,6 +212,7 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
         </div>
         <Dialog
           {...props}
+          id={contentId}
           open={isOpen}
           onCloseStart={handleCloseStart}
           onCloseEnd={handleCloseEnd}
@@ -222,6 +223,7 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
             isClosing ? outAnimation : inAnimation,
             className,
           )}
+          contentClassName={clsx(classes.content, contentClassName)}
           animationDuration={animationDuration}
           style={
             isMobile
@@ -234,14 +236,9 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
           }
           preventOutsideClickRefs={refs.reference}
         >
-          <div
-            id={contentId}
-            className={clsx(classes.content, contentClassName)}
-          >
-            {typeof children === 'function'
-              ? children?.({ onClose: handleCloseEnd })
-              : children}
-          </div>
+          {typeof children === 'function'
+            ? children?.({ onClose: handleCloseEnd })
+            : children}
         </Dialog>
       </Fragment>
     );

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -116,6 +116,7 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
       component: Component,
       offset,
       className,
+      contentClassName,
       style,
       ...props
     },
@@ -233,7 +234,10 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
           }
           preventOutsideClickRefs={refs.reference}
         >
-          <div id={contentId} className={classes.content}>
+          <div
+            id={contentId}
+            className={clsx(classes.content, contentClassName)}
+          >
             {typeof children === 'function'
               ? children?.({ onClose: handleCloseEnd })
               : children}


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

While testing the v10 migration branch, it was reported by some teams that the needed more flexibility to style the Popover's content. We could allow this by exposing an optional `contentClassName` prop that will be applied to the Dialog's content and allow overriding default styles or adding more styling if necessary.

## Approach and changes

- Add a new prop to the Dialog's public props.
- Apply the new prop to the Popover's content wrapper

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
