### PR TITLE
[AC-3395] Support aria attributes as alternative to label in ListItemGroup

### DIFF
--- a/.changeset/clever-icons-change.md
+++ b/.changeset/clever-icons-change.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Changed the `label` prop of ListItemGroup component to be optional to allow providing context via aria attributes.

--- a/.changeset/clever-icons-change.md
+++ b/.changeset/clever-icons-change.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Changed the `label` prop of ListItemGroup component to be optional to allow providing context via aria attributes.
+Allowed more flexibility on the accessibility requirements of the ListItemGroup component by making the `label` prop optional and accepting `aria-label` or `aria-labelledby` attributes as alternatives to provide context.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44327,7 +44327,7 @@
 		},
 		"packages/circuit-ui": {
 			"name": "@sumup-oss/circuit-ui",
-			"version": "9.9.4",
+			"version": "9.11.2",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@floating-ui/react-dom": "^2.1.2",
@@ -44342,7 +44342,7 @@
 				"@emotion/react": "^11.14.0",
 				"@emotion/styled": "^11.14.0",
 				"@sumup-oss/design-tokens": "^8.2.0",
-				"@sumup-oss/icons": "^5.7.0",
+				"@sumup-oss/icons": "^5.8.0",
 				"@sumup-oss/intl": "^3.1.1",
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/jest-dom": "6.6.3",
@@ -44437,7 +44437,7 @@
 		},
 		"packages/icons": {
 			"name": "@sumup-oss/icons",
-			"version": "5.7.0",
+			"version": "5.8.0",
 			"license": "Apache-2.0",
 			"devDependencies": {
 				"@babel/core": "^7.26.7",

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
@@ -55,7 +55,7 @@ describe('ListItemGroup', () => {
     expect(screen.getByText('Group label')).toBeVisible();
   });
 
-  it('should render a ListItemGroup with aria attribute instead of label', () => {
+  it('should render a ListItemGroup with aria-label', () => {
     renderListItemGroup(render, {
       ...baseProps,
       label: undefined,

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createRef } from 'react';
 
 import { screen, render, axe, type RenderFn } from '../../util/test-utils.js';
@@ -107,6 +107,10 @@ describe('ListItemGroup', () => {
       'aria-hidden': undefined,
     } as unknown as ListItemGroupProps;
     // Silence the console.error output and switch to development mode to throw the error
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    process.env.NODE_ENV = 'development';
     expect(() => render(<ListItemGroup {...props} />)).toThrow();
+    process.env.NODE_ENV = 'test';
+    vi.restoreAllMocks();
   });
 });

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
@@ -103,7 +103,8 @@ describe('ListItemGroup', () => {
       ...baseProps,
       label: undefined,
       'aria-label': undefined,
-    };
+      'aria-labelledby': undefined,
+    } as unknown as ListItemGroupProps;
     // Silence the console.error output and switch to development mode to throw the error
     expect(() => render(<ListItemGroup {...props} />)).toThrow();
   });

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
@@ -104,6 +104,7 @@ describe('ListItemGroup', () => {
       label: undefined,
       'aria-label': undefined,
       'aria-labelledby': undefined,
+      'aria-hidden': undefined,
     } as unknown as ListItemGroupProps;
     // Silence the console.error output and switch to development mode to throw the error
     expect(() => render(<ListItemGroup {...props} />)).toThrow();

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.spec.tsx
@@ -55,6 +55,16 @@ describe('ListItemGroup', () => {
     expect(screen.getByText('Group label')).toBeVisible();
   });
 
+  it('should render a ListItemGroup with aria attribute instead of label', () => {
+    renderListItemGroup(render, {
+      ...baseProps,
+      label: undefined,
+      'aria-label': 'Group label',
+    });
+    expect(screen.queryByRole('label')).not.toBeInTheDocument();
+    expect(screen.getByRole('list')).toBeInTheDocument();
+  });
+
   it('should render a ListItemGroup with a details line', () => {
     renderListItemGroup(render, {
       ...baseProps,
@@ -86,5 +96,15 @@ describe('ListItemGroup', () => {
     });
     const actual = await axe(container);
     expect(actual).toHaveNoViolations();
+  });
+
+  it('should throw accessibility error when there is no aria attribute or label', () => {
+    const props = {
+      ...baseProps,
+      label: undefined,
+      'aria-label': undefined,
+    };
+    // Silence the console.error output and switch to development mode to throw the error
+    expect(() => render(<ListItemGroup {...props} />)).toThrow();
   });
 });

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
@@ -22,7 +22,10 @@ import {
   type ReactNode,
 } from 'react';
 
-import { AccessibilityError } from '../../util/errors.js';
+import {
+  AccessibilityError,
+  isSufficientlyLabelled,
+} from '../../util/errors.js';
 import { Body } from '../Body/index.js';
 import { ListItem, type ListItemProps } from '../ListItem/index.js';
 import { isString } from '../../util/type-check.js';
@@ -48,8 +51,9 @@ export interface BaseProps {
   items: ItemProps[];
   /**
    * Display a main label/headline describing the group.
+   * `aria-label` or `aria-labelledby` can alternatively be used to provide accessibility information.
    */
-  label: ReactNode;
+  label?: ReactNode;
   /**
    * Visually hide the label. This should only be used in rare cases and only
    * if the purpose of the field can be inferred from other context.
@@ -89,11 +93,11 @@ export const ListItemGroup = forwardRef<HTMLDivElement, ListItemGroupProps>(
     if (
       process.env.NODE_ENV !== 'production' &&
       process.env.NODE_ENV !== 'test' &&
-      !label
+      !isSufficientlyLabelled(label, props)
     ) {
       throw new AccessibilityError(
         'ListItemGroup',
-        'The `label` prop is missing. This is an accessibility requirement. Pass `hideLabel` if you intend to hide the label visually.',
+        'The `label` prop, `aria-label` or `aria-labelledby` is missing. This is an accessibility requirement. Pass `hideLabel` if you intend to hide the label visually.',
       );
     }
 
@@ -104,20 +108,22 @@ export const ListItemGroup = forwardRef<HTMLDivElement, ListItemGroupProps>(
         ref={ref}
       >
         <div className={classes.header}>
-          <div
-            className={clsx(
-              classes.label,
-              hideLabel && utilClasses.hideVisually,
-            )}
-          >
-            {isString(label) ? (
-              <Body as="h4" size="s">
-                {label}
-              </Body>
-            ) : (
-              label
-            )}
-          </div>
+          {label && (
+            <div
+              className={clsx(
+                classes.label,
+                hideLabel && utilClasses.hideVisually,
+              )}
+            >
+              {isString(label) ? (
+                <Body as="h4" size="s">
+                  {label}
+                </Body>
+              ) : (
+                label
+              )}
+            </div>
+          )}
           {details && (
             <div className={classes.details}>
               {isString(details) ? <Body size="s">{details}</Body> : details}


### PR DESCRIPTION
Addresses [AC-3395](https://sumupteam.atlassian.net/browse/AC-3395)

## Purpose
- Support aria attributes as alternative to the `label`prop in `ListItemGroup` component.
- OBS.: This implementation was previously discussed in [this Slack thread](https://sumup.slack.com/archives/CURHLN94K/p1744713684922149) as a way to fix an existing accessibility issue on the Onboarding domain (within `ze-dashboard` application).

## Approach and changes
- Change the `label` prop of `ListItemGroup` component to be optional
- When throwing `AccessibilityError`, check if the component `isSufficientlyLabelled` (taking into account not only if there is a label, but attributes as well)
- Update `ListItemGroup` component logic to conditionally render the label only if passed as props
- Add unit tests to cover two more uses cases: 
  - (1) Ensure we still render the list if there is no label (but with some aria attribute)
  - (2) Throw an accessibility error if there is no aria attribute or label 
- Generate `changeset` (patch)
- Update `package-lock.json` file

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
