### PR TITLE
Add official support for passing a ref to Modal

### DIFF
--- a/.changeset/big-olives-lie.md
+++ b/.changeset/big-olives-lie.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added support for passing a `ref` to the `setModal` function to get the underlying `dialog` element.

--- a/.changeset/big-olives-lie.md
+++ b/.changeset/big-olives-lie.md
@@ -1,5 +1,5 @@
 ---
-"@sumup-oss/circuit-ui": minor
+"@sumup-oss/circuit-ui": patch
 ---
 
-Added support for passing a `ref` to the `setModal` function to get the underlying `dialog` element.
+Added `ref` to the prop types of the `setModal` function, which makes it possible to get the underlying `dialog` element.

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -15,7 +15,7 @@
 
 'use client';
 
-import { forwardRef, useCallback, useState } from 'react';
+import { forwardRef, useCallback, useState, type Ref } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
 import { deprecate } from '../../util/logger.js';
@@ -50,6 +50,7 @@ export interface ModalProps extends PublicDialogProps {
    * @default false
    */
   preventClose?: boolean;
+  ref?: Ref<HTMLDialogElement>;
 }
 
 export const ANIMATION_DURATION = 300;


### PR DESCRIPTION
## Purpose

In Circuit UI v9, it is possible to get a reference to the modal element using [`react-modal`'s `contentRef` prop ](https://reactcommunity.org/react-modal/#refs). In v10, the same is already possible using the standard `ref` prop, it's just missing from the types.

## Approach and changes

- Declare official support for passing the `ref` prop to the `setModal` function to get the underlying `dialog` element

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
