### PR TITLE
fix modal context state updates when closing modals

### DIFF
--- a/.changeset/dirty-places-give.md
+++ b/.changeset/dirty-places-give.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Ensured the open property in modal components is always set to true to avoid rendering issues when using the `useModal` hook.

--- a/packages/circuit-ui/components/Modal/ModalContext.tsx
+++ b/packages/circuit-ui/components/Modal/ModalContext.tsx
@@ -74,10 +74,6 @@ export function ModalProvider<T extends ModalProps>({
         modal.onClose();
       }
       dispatch({
-        type: 'update',
-        item: modal,
-      });
-      dispatch({
         type: 'remove',
         id: modal.id,
         transition: {
@@ -105,7 +101,7 @@ export function ModalProvider<T extends ModalProps>({
             {...defaultModalProps}
             {...modalProps}
             key={id}
-            open={!transition}
+            open={true}
             onClose={() => removeModal(modal)}
           />
         );


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

Remove an unnecessary 'update' dispatch during modal closure to prevent redundant state updates. Ensure the `open` property in modal components is always set to `true` to avoid rendering issues.


## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
