### PR TITLE
Simplify the styling of overlay components and their content

### DIFF
--- a/.changeset/sad-points-stand.md
+++ b/.changeset/sad-points-stand.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Simplified the styling of overlay components and their content.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29294,7 +29294,7 @@
     },
     "packages/circuit-ui": {
       "name": "@sumup-oss/circuit-ui",
-      "version": "9.9.1",
+      "version": "10.0.0-next.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.2",
@@ -29307,7 +29307,7 @@
         "@emotion/jest": "^11.13.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@sumup-oss/design-tokens": "^8.2.0",
+        "@sumup-oss/design-tokens": "^9.0.0-next.0",
         "@sumup-oss/icons": "^5.7.0",
         "@sumup-oss/intl": "^3.1.0",
         "@testing-library/dom": "^10.4.0",
@@ -29337,7 +29337,7 @@
         "@emotion/is-prop-valid": "^1.2.1",
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
-        "@sumup-oss/design-tokens": ">=8.0.0",
+        "@sumup-oss/design-tokens": ">=9.0.0-next.0",
         "@sumup-oss/icons": ">=5.6.0",
         "@sumup-oss/intl": "^3.1.0",
         "react": ">=18.0.0 <19.0.0",
@@ -29504,7 +29504,7 @@
     },
     "packages/design-tokens": {
       "name": "@sumup-oss/design-tokens",
-      "version": "8.2.0",
+      "version": "9.0.0-next.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.13.11",
@@ -29516,20 +29516,20 @@
     },
     "packages/eslint-plugin-circuit-ui": {
       "name": "@sumup-oss/eslint-plugin-circuit-ui",
-      "version": "5.1.1",
+      "version": "6.0.0-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript-eslint/utils": "^7.16.1"
       },
       "devDependencies": {
-        "@sumup-oss/design-tokens": "^8.0.0",
+        "@sumup-oss/design-tokens": "^9.0.0-next.0",
         "@tsconfig/node18": "^18.2.4",
         "@typescript-eslint/rule-tester": "^7.16.1",
         "typescript": "^5.8.2"
       },
       "peerDependencies": {
-        "@sumup-oss/circuit-ui": ">=9.0.0",
-        "@sumup-oss/design-tokens": ">=8.0.0"
+        "@sumup-oss/circuit-ui": ">=10.0.0-next.0",
+        "@sumup-oss/design-tokens": ">=9.0.0-next.0"
       }
     },
     "packages/eslint-plugin-circuit-ui/node_modules/@typescript-eslint/utils": {
@@ -29577,26 +29577,26 @@
     },
     "packages/stylelint-plugin-circuit-ui": {
       "name": "@sumup-oss/stylelint-plugin-circuit-ui",
-      "version": "3.0.0",
+      "version": "4.0.0-next.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@sumup-oss/design-tokens": "^8.0.0",
+        "@sumup-oss/design-tokens": "^9.0.0-next.0",
         "@tsconfig/node18": "^18.2.4",
         "jest-preset-stylelint": "^7.2.0",
         "typescript": "^5.8.2"
       },
       "peerDependencies": {
-        "@sumup-oss/design-tokens": ">=8.0.0",
+        "@sumup-oss/design-tokens": ">=9.0.0-next.0",
         "stylelint": "^16.16.0"
       }
     },
     "templates/astro": {
       "name": "@sumup-oss/astro-template-circuit-ui",
-      "version": "4.0.0",
+      "version": "4.0.1-next.0",
       "dependencies": {
         "@astrojs/react": "^4.2.1",
-        "@sumup-oss/circuit-ui": "^9.0.0",
-        "@sumup-oss/design-tokens": "^8.0.0",
+        "@sumup-oss/circuit-ui": "^10.0.0-next.0",
+        "@sumup-oss/design-tokens": "^9.0.0-next.0",
         "@sumup-oss/icons": "^5.0.0",
         "@sumup-oss/intl": "^3.1.0",
         "@types/react": "^18.3.3",
@@ -29607,9 +29607,9 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
-        "@sumup-oss/eslint-plugin-circuit-ui": "^5.0.0",
+        "@sumup-oss/eslint-plugin-circuit-ui": "^6.0.0-next.0",
         "@sumup-oss/foundry": "^8.4.1",
-        "@sumup-oss/stylelint-plugin-circuit-ui": "^3.0.0",
+        "@sumup-oss/stylelint-plugin-circuit-ui": "^4.0.0-next.0",
         "prettier-plugin-astro": "^0.14.1",
         "typescript": "^5.8.2"
       }
@@ -29677,11 +29677,11 @@
     },
     "templates/nextjs/template": {
       "name": "next-app",
-      "version": "2.0.0",
+      "version": "2.0.1-next.0",
       "dependencies": {
         "@next/bundle-analyzer": "^15.1.6",
-        "@sumup-oss/circuit-ui": "^9.0.0",
-        "@sumup-oss/design-tokens": "^8.0.0",
+        "@sumup-oss/circuit-ui": "^10.0.0-next.0",
+        "@sumup-oss/design-tokens": "^9.0.0-next.0",
         "@sumup-oss/icons": "^5.0.0",
         "@sumup-oss/intl": "^3.1.0",
         "next": "^15.1.6",
@@ -29689,9 +29689,9 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@sumup-oss/eslint-plugin-circuit-ui": "^5.0.0",
+        "@sumup-oss/eslint-plugin-circuit-ui": "^6.0.0-next.0",
         "@sumup-oss/foundry": "^8.4.1",
-        "@sumup-oss/stylelint-plugin-circuit-ui": "^3.0.0",
+        "@sumup-oss/stylelint-plugin-circuit-ui": "^4.0.0-next.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.6.1",

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.module.css
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.module.css
@@ -1,10 +1,9 @@
-.base > div {
+.base {
   box-sizing: border-box;
   padding: var(--cui-spacings-byte) 0;
   overflow-y: auto;
   background-color: var(--cui-bg-elevated);
   border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
-  border-radius: inherit;
 }
 
 .divider {

--- a/packages/circuit-ui/components/Dialog/Dialog.module.css
+++ b/packages/circuit-ui/components/Dialog/Dialog.module.css
@@ -1,6 +1,6 @@
 .base {
   z-index: var(--cui-z-index-modal);
-  padding: 0 !important;
+  padding: 0;
   pointer-events: none;
   outline: none;
   background-color: var(--cui-bg-elevated);

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -4,12 +4,6 @@
   background-color: var(--cui-bg-elevated);
 }
 
-.content {
-  position: relative;
-  max-height: 90vh;
-  overflow-y: auto;
-}
-
 @media (min-width: 480px) {
   .base {
     top: 0;
@@ -18,14 +12,11 @@
     left: 0;
     min-width: 480px;
     max-width: 50vw;
-    border-radius: var(--cui-border-radius-mega);
-  }
-
-  .base .content {
     padding: var(--cui-spacings-giga);
     padding-bottom: calc(
       env(safe-area-inset-bottom) + var(--cui-spacings-giga)
     );
+    border-radius: var(--cui-border-radius-mega);
   }
 }
 
@@ -37,8 +28,13 @@
     left: 0;
     width: 100%;
     max-width: 100%;
+    padding: var(--cui-spacings-mega);
+    padding-bottom: calc(
+      env(safe-area-inset-bottom) + var(--cui-spacings-mega)
+    );
     border-radius: var(--cui-border-radius-mega) var(--cui-border-radius-mega) 0
       0;
+    -webkit-overflow-scrolling: touch;
   }
 
   .immersive {
@@ -46,13 +42,5 @@
     max-height: unset;
     border: none;
     border-radius: unset;
-  }
-
-  .base .content {
-    padding: var(--cui-spacings-mega);
-    padding-bottom: calc(
-      env(safe-area-inset-bottom) + var(--cui-spacings-mega)
-    );
-    -webkit-overflow-scrolling: touch;
   }
 }

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -111,9 +111,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
       hideCloseButton={preventClose}
       {...rest}
     >
-      <div className={classes.content}>
-        {typeof children === 'function' ? children?.({ onClose }) : children}
-      </div>
+      {typeof children === 'function' ? children?.({ onClose }) : children}
     </Dialog>
   );
 });

--- a/packages/circuit-ui/components/NotificationModal/NotificationModal.module.css
+++ b/packages/circuit-ui/components/NotificationModal/NotificationModal.module.css
@@ -8,10 +8,6 @@
   text-align: center;
 }
 
-.base > div {
-  padding: var(--cui-spacings-giga);
-}
-
 @media (max-width: 479px) {
   .base {
     -webkit-overflow-scrolling: touch;

--- a/packages/circuit-ui/components/Popover/Popover.module.css
+++ b/packages/circuit-ui/components/Popover/Popover.module.css
@@ -2,12 +2,8 @@
   box-sizing: border-box;
   max-height: var(--popover-max-height);
   margin: 0;
-  border-radius: var(--cui-border-radius-byte);
-}
-
-.content {
-  max-height: inherit;
   overflow-y: auto;
+  border-radius: var(--cui-border-radius-byte);
 }
 
 .trigger {
@@ -16,11 +12,8 @@
 
 @media (min-width: 480px) {
   .base {
-    box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);
-  }
-
-  .content {
     padding: var(--cui-spacings-mega);
+    box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);
   }
 }
 
@@ -33,11 +26,8 @@
     width: auto;
     max-width: 100%;
     max-height: 90vh;
+    padding: var(--cui-spacings-kilo);
     border-radius: var(--cui-border-radius-byte) var(--cui-border-radius-byte) 0
       0;
-  }
-
-  .content {
-    padding: var(--cui-spacings-kilo);
   }
 }

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -233,7 +233,7 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
           }
           preventOutsideClickRefs={refs.reference}
         >
-          <div id={contentId} className={classes.content}>
+          <div id={contentId}>
             {typeof children === 'function'
               ? children?.({ onClose: handleCloseEnd })
               : children}


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

This change aims to simplify the styles of the Dialog component and its derived components. By removing the content's wrapper className, it becomes easier to style and override default styles if necessary through the className prop.

## Approach and changes

- Remove content wrapper in Modal and Popover components
- simplify styles of the ActionMenu and NotificationModal components

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
