### PR TITLE
Simply linear-gradient value for ComparisonTable's expand button

### DIFF
--- a/.changeset/forty-bottles-train.md
+++ b/.changeset/forty-bottles-train.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Replaced the `color-mix` usage with a straightforward linear gradient value for the ComparisonTable's expand button.

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.module.css
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.module.css
@@ -46,9 +46,9 @@
   min-height: 96px;
   content: "";
   background: linear-gradient(
-    color-mix(in sRGB, var(--cui-bg-normal) 0%, transparent),
-    color-mix(in sRGB, var(--cui-bg-normal) 90%, transparent),
-    color-mix(in sRGB, var(--cui-bg-normal) 100%, transparent)
+    180deg,
+    transparent 10%,
+    var(--cui-bg-normal) 90%
   );
 }
 


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

The background styles of the expand button in the ComparisonTable are broken when used Next.js apps who don't process the `color-mix` css function correctly. For now we can work around this by simplifying the gradient, until we could address the PostCSS config in the Next.js apps that consume Circuit-UI.
[
![Screenshot 2025-04-28 at 16 25 37](https://github.com/user-attachments/assets/362189ca-f5e8-46e2-943c-bccbab9fe15d)
](url)
## Approach and changes

Replace the `color-mix` function in the linear-gradient with a simpler colour combination.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
