### PR TITLE
Display actions in TH of Comparison Table on mobile screens

### DIFF
--- a/.changeset/shy-dingos-double.md
+++ b/.changeset/shy-dingos-double.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Display action item in comparison table header on mobile screens

--- a/.changeset/shy-dingos-double.md
+++ b/.changeset/shy-dingos-double.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": minor
 ---
 
-Display action item in comparison table header on mobile screens
+Display the action button in the ComparisonTable's header on narrow viewports.

--- a/packages/circuit-ui/components/ComparisonTable/components/TableHeader/TableHeader.module.css
+++ b/packages/circuit-ui/components/ComparisonTable/components/TableHeader/TableHeader.module.css
@@ -23,7 +23,6 @@
 }
 
 .action {
-  display: none;
   margin-top: var(--cui-spacings-mega);
 }
 


### PR DESCRIPTION
(no ticket)

## Purpose

In working with the Comparison Table, we noted that while on desktop screens we could have a button in the Table Header for each compared item, on mobile that button would disappear. After reviewing with the design system team, we've received the go-ahead to show this button on mobile screens also.

## Approach and changes

- removed the `display: none;` from the `.action` class of the comparison table's `TableHeader` component

## Before

![Screenshot 2025-04-29 at 10 59 54](https://github.com/user-attachments/assets/867c1cfb-5f71-42eb-b0b7-826b34132248)


## After

![Screenshot 2025-04-29 at 10 59 47](https://github.com/user-attachments/assets/bf279860-0f36-4e1b-9438-7e3e89116c34)


## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
