### PR TITLE
refactor optional contentClassName prop

### DIFF
--- a/.changeset/big-crews-deny.md
+++ b/.changeset/big-crews-deny.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/design-tokens": major
+---
+
+Added a new `--cui-z-index-side-panel` token for side panels. Removed obsolete `--cui-z-index-modal` token.

--- a/.changeset/big-crews-deny.md
+++ b/.changeset/big-crews-deny.md
@@ -2,4 +2,4 @@
 "@sumup-oss/design-tokens": major
 ---
 
-Added a new `--cui-z-index-side-panel` token for side panels. Removed obsolete `--cui-z-index-modal` token.
+Removed obsolete `--cui-z-index-modal` token. Use `--cui-z-index-popover` instead.

--- a/.changeset/chatty-knives-push.md
+++ b/.changeset/chatty-knives-push.md
@@ -1,5 +1,5 @@
 ---
-"@sumup-oss/design-tokens": minor
+"@sumup-oss/design-tokens": major
 ---
 
 Removed unused token `--cui-z-index-backdrop`.

--- a/.changeset/chatty-knives-push.md
+++ b/.changeset/chatty-knives-push.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/design-tokens": minor
+---
+
+Removed unused token `--cui-z-index-backdrop`.

--- a/.changeset/cuddly-days-dress.md
+++ b/.changeset/cuddly-days-dress.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Added missing backgroud color to SidePanel header on mobile.

--- a/.changeset/puny-zebras-peel.md
+++ b/.changeset/puny-zebras-peel.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/design-tokens": minor
+---
+
+Added a new `--cui-z-index-side-panel` token for side panels.

--- a/.changeset/shiny-tires-taste.md
+++ b/.changeset/shiny-tires-taste.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed optional `contentClassName` from the Dialog component.

--- a/packages/circuit-ui/components/DateInput/DateInput.module.css
+++ b/packages/circuit-ui/components/DateInput/DateInput.module.css
@@ -108,7 +108,6 @@
 }
 
 .dialog {
-  z-index: var(--cui-z-index-modal);
   width: max-content;
   max-width: 410px;
   max-width: min(410px, 100vw);

--- a/packages/circuit-ui/components/Dialog/Dialog.module.css
+++ b/packages/circuit-ui/components/Dialog/Dialog.module.css
@@ -1,5 +1,4 @@
 .base {
-  z-index: var(--cui-z-index-modal);
   padding: 0 !important;
   pointer-events: none;
   outline: none;

--- a/packages/circuit-ui/components/Dialog/Dialog.tsx
+++ b/packages/circuit-ui/components/Dialog/Dialog.tsx
@@ -78,10 +78,6 @@ export interface PublicDialogProps
     | ReactNode
     | (({ onClose }: { onClose?: DialogProps['onCloseEnd'] }) => ReactNode);
   [key: DataAttribute]: string | undefined;
-  /**
-   * An optional class name to be applied to the component's content.
-   */
-  contentClassName?: string;
 }
 
 export interface DialogProps extends PublicDialogProps {
@@ -125,7 +121,6 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
       onCloseEnd,
       closeButtonLabel,
       className,
-      contentClassName,
       preventOutsideClickRefs,
       preventOutsideClickClose = false,
       hideCloseButton = false,
@@ -426,12 +421,11 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
           }}
           {...rest}
         >
-          <div className={contentClassName}>
-            {(open || isClosing) &&
-              (typeof children === 'function'
-                ? children?.({ onClose: onCloseEnd })
-                : children)}
-          </div>
+          {(open || isClosing) &&
+            (typeof children === 'function'
+              ? children?.({ onClose: onCloseEnd })
+              : children)}
+
           {!hideCloseButton && (
             <CloseButton onClick={handleDialogClose} className={classes.close}>
               {closeButtonLabel}

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -50,6 +50,10 @@ export interface ModalProps extends PublicDialogProps {
    * @default false
    */
   preventClose?: boolean;
+  /**
+   * An optional class name to be applied to the component's content.
+   */
+  contentClassName?: string;
   ref?: Ref<HTMLDialogElement>;
 }
 
@@ -107,13 +111,14 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
         variant === 'immersive' && classes.immersive,
         className,
       )}
-      contentClassName={clsx(classes.content, contentClassName)}
       preventEscapeKeyClose={preventClose}
       preventOutsideClickClose={preventClose}
       hideCloseButton={preventClose}
       {...rest}
     >
-      {typeof children === 'function' ? children?.({ onClose }) : children}
+      <div className={clsx(classes.content, contentClassName)}>
+        {typeof children === 'function' ? children?.({ onClose }) : children}
+      </div>
     </Dialog>
   );
 });

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -94,6 +94,10 @@ export interface PopoverProps
    * reference element.
    */
   component: ComponentType<PopoverReferenceProps>;
+  /**
+   * An optional class name to be applied to the component's content.
+   */
+  contentClassName?: string;
 }
 
 const sizeOptions: SizeOptions = {
@@ -212,7 +216,6 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
         </div>
         <Dialog
           {...props}
-          id={contentId}
           open={isOpen}
           onCloseStart={handleCloseStart}
           onCloseEnd={handleCloseEnd}
@@ -223,7 +226,6 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
             isClosing ? outAnimation : inAnimation,
             className,
           )}
-          contentClassName={clsx(classes.content, contentClassName)}
           animationDuration={animationDuration}
           style={
             isMobile
@@ -236,9 +238,14 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
           }
           preventOutsideClickRefs={refs.reference}
         >
-          {typeof children === 'function'
-            ? children?.({ onClose: handleCloseEnd })
-            : children}
+          <div
+            id={contentId}
+            className={clsx(classes.content, contentClassName)}
+          >
+            {typeof children === 'function'
+              ? children?.({ onClose: handleCloseEnd })
+              : children}
+          </div>
         </Dialog>
       </Fragment>
     );

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.tsx
@@ -18,7 +18,6 @@
 import { Fragment, useCallback, useState } from 'react';
 import { ChevronDown } from '@sumup-oss/icons';
 
-import { StackContext } from '../../../StackContext/index.js';
 import { useCollapsible } from '../../../../hooks/useCollapsible/index.js';
 import { useFocusList } from '../../../../hooks/useFocusList/index.js';
 import type { PrimaryLinkProps } from '../../types.js';
@@ -148,50 +147,48 @@ export const MobileNavigation = ({
 
   return (
     <ComponentsContext.Provider value={UNSAFE_components}>
-      <StackContext.Provider value={'var(--cui-z-index-modal)'}>
-        <Dialog
-          onCloseStart={handleDialogCloseStart}
-          onCloseEnd={handleDialogCloseEnd}
-          isModal
-          className={clsx(
-            classes.base,
-            isClosing
-              ? sharedClasses.animationSlideDownOut
-              : sharedClasses.animationSlideDownIn,
-          )}
-          closeButtonLabel={closeButtonLabel}
-          animationDuration={120} /* .12s */
-          {...props}
-        >
-          <div className={classes.content}>
-            <nav
-              aria-label={primaryNavigationLabel}
-              className={classes.navigation}
-            >
-              <ul className={classes.list}>
-                {primaryLinks.map(({ secondaryGroups, onClick, ...link }) => (
-                  <li key={link.label}>
-                    {secondaryGroups && secondaryGroups.length > 0 ? (
-                      <Group
-                        {...link}
-                        secondaryGroups={secondaryGroups}
-                        onClose={onClose}
-                        {...focusProps}
-                      />
-                    ) : (
-                      <PrimaryLink
-                        {...link}
-                        {...focusProps}
-                        onClick={combineClickHandlers(onClick, onClose)}
-                      />
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </nav>
-          </div>
-        </Dialog>
-      </StackContext.Provider>
+      <Dialog
+        onCloseStart={handleDialogCloseStart}
+        onCloseEnd={handleDialogCloseEnd}
+        isModal
+        className={clsx(
+          classes.base,
+          isClosing
+            ? sharedClasses.animationSlideDownOut
+            : sharedClasses.animationSlideDownIn,
+        )}
+        closeButtonLabel={closeButtonLabel}
+        animationDuration={120} /* .12s */
+        {...props}
+      >
+        <div className={classes.content}>
+          <nav
+            aria-label={primaryNavigationLabel}
+            className={classes.navigation}
+          >
+            <ul className={classes.list}>
+              {primaryLinks.map(({ secondaryGroups, onClick, ...link }) => (
+                <li key={link.label}>
+                  {secondaryGroups && secondaryGroups.length > 0 ? (
+                    <Group
+                      {...link}
+                      secondaryGroups={secondaryGroups}
+                      onClose={onClose}
+                      {...focusProps}
+                    />
+                  ) : (
+                    <PrimaryLink
+                      {...link}
+                      {...focusProps}
+                      onClick={combineClickHandlers(onClick, onClose)}
+                    />
+                  )}
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+      </Dialog>
     </ComponentsContext.Provider>
   );
 };

--- a/packages/circuit-ui/components/SidePanel/SidePanel.module.css
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.module.css
@@ -3,7 +3,7 @@
   right: 0;
   bottom: 0;
   left: unset;
-  z-index: var(--cui-z-index-popover);
+  z-index: var(--cui-z-index-side-panel);
   box-shadow: none;
   transform: translateX(100%);
   transition: transform var(--dialog-animation-duration) ease-in-out;

--- a/packages/circuit-ui/components/SidePanel/SidePanel.module.css
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.module.css
@@ -3,7 +3,7 @@
   right: 0;
   bottom: 0;
   left: unset;
-  overflow-y: auto;
+  z-index: var(--cui-z-index-popover);
   box-shadow: none;
   transform: translateX(100%);
   transition: transform var(--dialog-animation-duration) ease-in-out;

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.module.css
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.module.css
@@ -5,6 +5,7 @@
   display: flex;
   align-items: center;
   width: 100%;
+  background-color: var(--cui-bg-elevated);
 }
 
 @media (min-width: 768px) {

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -213,7 +213,7 @@ export const Toggletip = forwardRef<HTMLDialogElement, ToggletipProps>(
           style={{
             ...style,
             ...dialogStyles,
-            zIndex: zIndex || 'var(--cui-z-index-modal)',
+            zIndex: zIndex || 'var(--cui-z-index-tooltip)',
           }}
         >
           <div className={classes.content}>

--- a/packages/design-tokens/themes/schema.ts
+++ b/packages/design-tokens/themes/schema.ts
@@ -413,6 +413,7 @@ export const schema = [
   { name: '--cui-z-index-absolute', type: 'number' },
   { name: '--cui-z-index-input', type: 'number' },
   { name: '--cui-z-index-popover', type: 'number' },
+  { name: '--cui-z-index-side-panel', type: 'number' },
   { name: '--cui-z-index-tooltip', type: 'number' },
   { name: '--cui-z-index-header', type: 'number' },
   { name: '--cui-z-index-backdrop', type: 'number' },

--- a/packages/design-tokens/themes/schema.ts
+++ b/packages/design-tokens/themes/schema.ts
@@ -417,7 +417,6 @@ export const schema = [
   { name: '--cui-z-index-header', type: 'number' },
   { name: '--cui-z-index-backdrop', type: 'number' },
   { name: '--cui-z-index-navigation', type: 'number' },
-  { name: '--cui-z-index-modal', type: 'number' },
   { name: '--cui-z-index-toast', type: 'number' },
 ] satisfies {
   name: TokenName;

--- a/packages/design-tokens/themes/schema.ts
+++ b/packages/design-tokens/themes/schema.ts
@@ -416,7 +416,6 @@ export const schema = [
   { name: '--cui-z-index-side-panel', type: 'number' },
   { name: '--cui-z-index-tooltip', type: 'number' },
   { name: '--cui-z-index-header', type: 'number' },
-  { name: '--cui-z-index-backdrop', type: 'number' },
   { name: '--cui-z-index-navigation', type: 'number' },
   { name: '--cui-z-index-toast', type: 'number' },
 ] satisfies {

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -466,6 +466,11 @@ export const shared = [
   },
   {
     name: '--cui-z-index-popover',
+    value: 1000,
+    type: 'number',
+  },
+  {
+    name: '--cui-z-index-side-panel',
     value: 30,
     type: 'number',
   },

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -485,11 +485,6 @@ export const shared = [
     type: 'number',
   },
   {
-    name: '--cui-z-index-backdrop',
-    value: 700,
-    type: 'number',
-  },
-  {
     name: '--cui-z-index-navigation',
     value: 800,
     type: 'number',

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -466,7 +466,7 @@ export const shared = [
   },
   {
     name: '--cui-z-index-popover',
-    value: 1000,
+    value: 30,
     type: 'number',
   },
   {
@@ -487,11 +487,6 @@ export const shared = [
   {
     name: '--cui-z-index-navigation',
     value: 800,
-    type: 'number',
-  },
-  {
-    name: '--cui-z-index-modal',
-    value: 1000,
     type: 'number',
   },
   {


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

As modal components now render in the top layer, the `--cui-z-index-modal` is no longer necessary to place the modal layer on top of other content. For older browsers, the dialog-polyfill overrides this values with its own. It is thus safe to remove this token.

I introduced a new token `--cui-z-index-side-panel` to decouple it from the previously used value `--cui-z-index-popover`. The latter should have a high enough value to appear above all other content, which in not always true for the side panel.

## Approach and changes

- clean up usages of `--cui-z-index-modal` 
- add new token to schema and use it in the SidePanel component
- Remove optional `contentClassName` from the Dialog component

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
