### PR TITLE
Work around broken gradients caused by CSS minification

### DIFF
--- a/.changeset/kind-monkeys-join.md
+++ b/.changeset/kind-monkeys-join.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Added a workaround for gradients in the ComparisonTable, Modal, Popover, and SideNavigation components that could be broken by CSS minifiers.

--- a/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.module.css
+++ b/packages/circuit-ui/components/ComparisonTable/components/PlanTable/PlanTable.module.css
@@ -46,7 +46,7 @@
   min-height: 96px;
   content: "";
   background: linear-gradient(
-    color-mix(in sRGB, var(--cui-bg-normal) 0%, transparent),
+    color-mix(in sRGB, var(--cui-bg-normal) 1%, transparent),
     color-mix(in sRGB, var(--cui-bg-normal) 90%, transparent),
     color-mix(in sRGB, var(--cui-bg-normal) 100%, transparent)
   );

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -12,7 +12,7 @@
   display: block;
   content: "";
   background: linear-gradient(
-    color-mix(in sRGB, var(--cui-bg-elevated) 0%, transparent),
+    color-mix(in sRGB, var(--cui-bg-elevated) 1%, transparent),
     color-mix(in sRGB, var(--cui-bg-elevated) 66%, transparent),
     color-mix(in sRGB, var(--cui-bg-elevated) 100%, transparent)
   );

--- a/packages/circuit-ui/components/Popover/Popover.module.css
+++ b/packages/circuit-ui/components/Popover/Popover.module.css
@@ -96,7 +96,7 @@
   height: var(--cui-spacings-kilo);
   content: "";
   background: linear-gradient(
-    color-mix(in sRGB, var(--cui-bg-elevated) 0%, transparent),
+    color-mix(in sRGB, var(--cui-bg-elevated) 1%, transparent),
     color-mix(in sRGB, var(--cui-bg-elevated) 66%, transparent),
     color-mix(in sRGB, var(--cui-bg-elevated) 100%, transparent)
   );

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.module.css
@@ -25,7 +25,7 @@
   height: var(--cui-spacings-mega);
   content: "";
   background: linear-gradient(
-    color-mix(in sRGB, var(--cui-bg-normal) 0%, transparent),
+    color-mix(in sRGB, var(--cui-bg-normal) 1%, transparent),
     color-mix(in sRGB, var(--cui-bg-normal) 66%, transparent),
     color-mix(in sRGB, var(--cui-bg-normal) 100%, transparent)
   );
@@ -82,7 +82,7 @@
   background: linear-gradient(
     color-mix(in sRGB, var(--cui-bg-normal) 100%, transparent),
     color-mix(in sRGB, var(--cui-bg-normal) 100%, transparent) 66%,
-    color-mix(in sRGB, var(--cui-bg-normal) 0%, transparent)
+    color-mix(in sRGB, var(--cui-bg-normal) 1%, transparent)
   );
 }
 


### PR DESCRIPTION
## Purpose

CSS minifiers often strip the unit from 0 lengths such as `0px` or `0%` to save bytes. This breaks the `color-mix` function which requires the percentage unit to always be present.

## Approach and changes

- Work around the minification bug by replacing `0%` with `1%` inside all `color-mix` functions

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
