### PR TITLE
increase the Modal component's close button z-index value.

### DIFF
--- a/.changeset/light-buttons-relate.md
+++ b/.changeset/light-buttons-relate.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Increased the Modal component's close button z-index value.

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -170,5 +170,5 @@
   position: absolute;
   top: var(--cui-spacings-byte);
   right: var(--cui-spacings-byte);
-  z-index: var(--cui-z-index-absolute);
+  z-index: calc(var(--cui-z-index-input) + 1);
 }


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

Content in the Modal component might overlap with its close button. To avoid this, we need to increase its z-index value.

## Approach and changes

Make the new z-index value higher than other inline components (inputs have a z-index of 20) in the library but below other overlay components.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
