### PR TITLE
remove relative position from modal content class

### DIFF
--- a/.changeset/gentle-avocados-tie.md
+++ b/.changeset/gentle-avocados-tie.md
@@ -2,5 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Removed the `position: relative` CSS property
-on the Modal component's content class.
+Removed the `position: relative` CSS property on the Modal component's content class.

--- a/.changeset/gentle-avocados-tie.md
+++ b/.changeset/gentle-avocados-tie.md
@@ -1,0 +1,6 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed the `position: relative` CSS property
+on the Modal component's content class.

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -5,7 +5,6 @@
 }
 
 .content {
-  position: relative;
   max-height: 90vh;
   overflow-y: auto;
 }


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

The Modal component's content wrapper has a `position: relative` css that can lead to the component's content erroneously being positioned relative to it. 

## Approach and changes

Remove unnecessary position styles from the content class.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
