### PR TITLE
Specified a z-index value for the DateInput's Dialog.

### DIFF
--- a/.changeset/proud-planets-argue.md
+++ b/.changeset/proud-planets-argue.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Specified a z-index value for the DateInput's Dialog.

--- a/packages/circuit-ui/components/DateInput/DateInput.module.css
+++ b/packages/circuit-ui/components/DateInput/DateInput.module.css
@@ -108,6 +108,7 @@
 }
 
 .dialog {
+  z-index: var(--cui-z-index-popover);
   width: max-content;
   max-width: 410px;
   max-width: min(410px, 100vw);


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

In https://github.com/sumup-oss/circuit-ui/pull/3072 I removed the z-index property from the Dialog styles and added to each overlay component its own specific value. I had overlooked the DateInput which is not built on top of the Popover component.

## Approach and changes

Add `z-index: var(--cui-z-index-popover);` css property to DateInput's Dialog.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
