### PR TITLE
Refactor DateInput with Popover

### DIFF
--- a/.changeset/lazy-mangos-push.md
+++ b/.changeset/lazy-mangos-push.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Refactored the DateInput component using the Popover.

--- a/.changeset/lazy-mangos-push.md
+++ b/.changeset/lazy-mangos-push.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Refactored the DateInput component using the Popover.
+Refactored the DateInput component using the Popover component.

--- a/.changeset/lazy-mangos-push.md
+++ b/.changeset/lazy-mangos-push.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Refactored the DateInput component using the Popover component.
+Refactored the DateInput component to use the Popover component under the hood.

--- a/.changeset/sad-cooks-refuse.md
+++ b/.changeset/sad-cooks-refuse.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Improved the Popover's floating element's positioning.

--- a/packages/circuit-ui/components/DateInput/DateInput.module.css
+++ b/packages/circuit-ui/components/DateInput/DateInput.module.css
@@ -107,36 +107,8 @@
   z-index: calc(var(--cui-z-index-absolute) + 1);
 }
 
-.dialog {
-  z-index: var(--cui-z-index-popover);
-  width: max-content;
-  max-width: 410px;
-  max-width: min(410px, 100vw);
-  max-height: 100vh;
-  margin: 0;
-  overflow: scroll;
-  border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
-  border-radius: var(--cui-border-radius-byte);
-}
-
-.dialog::after {
-  display: none;
-}
-
 .content {
-  color: var(--cui-fg-normal);
-  outline: 0;
-  background-color: var(--cui-bg-elevated);
-  box-shadow: 0 2px 6px 0 rgb(0 0 0 / 8%);
-}
-
-@media (max-width: 479px) {
-  .dialog {
-    width: 100%;
-    max-width: 100%;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
-  }
+  padding: 0;
 }
 
 .header {
@@ -148,6 +120,15 @@
 }
 
 @media (min-width: 480px) {
+  .dialog {
+    width: max-content;
+    max-width: 410px;
+    max-width: min(410px, 100vw);
+    max-height: 100vh;
+    overflow: scroll;
+    border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
+  }
+
   /* Hide visually */
   .header {
     position: absolute;

--- a/packages/circuit-ui/components/DateInput/DateInput.module.css
+++ b/packages/circuit-ui/components/DateInput/DateInput.module.css
@@ -107,8 +107,13 @@
   z-index: calc(var(--cui-z-index-absolute) + 1);
 }
 
+.dialog {
+  box-shadow: none;
+}
+
 .content {
   padding: 0;
+  overflow: unset;
 }
 
 .header {
@@ -124,7 +129,6 @@
     width: max-content;
     max-width: 410px;
     max-width: min(410px, 100vw);
-    max-height: 100vh;
     overflow: scroll;
     border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
   }

--- a/packages/circuit-ui/components/DateInput/DateInput.module.css
+++ b/packages/circuit-ui/components/DateInput/DateInput.module.css
@@ -107,10 +107,6 @@
   z-index: calc(var(--cui-z-index-absolute) + 1);
 }
 
-.dialog {
-  box-shadow: none;
-}
-
 .content {
   padding: 0;
   overflow: unset;

--- a/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
@@ -320,7 +320,11 @@ describe('DateInput', () => {
 
       expect(ref.current).toHaveValue('2000-01-12');
       expect(onChange).toHaveBeenCalled();
-      expect(openCalendarButton).toHaveFocus();
+      expect(
+        screen.getByRole('button', {
+          name: /change date/i,
+        }),
+      ).toHaveFocus();
     });
 
     it('should allow users to clear the date', async () => {
@@ -349,7 +353,11 @@ describe('DateInput', () => {
 
       expect(ref.current).toHaveValue('');
       expect(onChange).toHaveBeenCalled();
-      expect(openCalendarButton).toHaveFocus();
+      expect(
+        screen.getByRole('button', {
+          name: /change date/i,
+        }),
+      ).toHaveFocus();
     });
 
     it('should close calendar on outside click', async () => {

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -19,6 +19,7 @@ import {
   flip,
   offset as offsetMiddleware,
   type Placement,
+  shift,
   size,
   type SizeOptions,
   useFloating,
@@ -100,7 +101,10 @@ export interface PopoverProps
   contentClassName?: string;
 }
 
+const boundaryPadding = 8;
+
 const sizeOptions: SizeOptions = {
+  padding: boundaryPadding,
   apply({ availableHeight, elements }) {
     elements.floating.style.setProperty(
       '--popover-max-height',
@@ -139,13 +143,15 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
       open: isOpen,
       placement,
       strategy: 'fixed',
-      middleware: offset
-        ? [
-            offsetMiddleware(offset),
-            flip({ fallbackPlacements }),
-            size(sizeOptions),
-          ]
-        : [flip({ fallbackPlacements }), size(sizeOptions)],
+      middleware: [
+        offset ? offsetMiddleware(offset) : undefined,
+        shift({ padding: boundaryPadding }),
+        flip({
+          padding: boundaryPadding,
+          fallbackPlacements,
+        }),
+        size(sizeOptions),
+      ],
     });
 
     const handleTriggerClick = () => {


### PR DESCRIPTION
Addresses [DSYS-1053](https://sumupteam.atlassian.net/browse/DSYS-1053)

## Purpose

In v10, multiple "popup" components were refactored using the Popover component. Although the DateInput already uses the Dialog component under the hood, refactoring it with Popover makes the codebase more coherent and abstracts state management, accessibility and styling aspects already made available by the Popover component

## Approach and changes

Replace Dialog with Popover component.

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
