### PR TITLE
Fix custom class name when Anchor renders as span

### DIFF
--- a/.changeset/gentle-snakes-allow.md
+++ b/.changeset/gentle-snakes-allow.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': patch
+---
+
+Fixed applying a custom class name to the Anchor component when it renders as a `span` when neither the `href` nor the `onClick` props have been passed.

--- a/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
@@ -24,125 +24,163 @@ import { Anchor } from './Anchor.js';
 describe('Anchor', () => {
   const baseProps = { children: 'Anchor' };
 
-  it('should merge a custom class name with the default ones', () => {
-    const className = 'foo';
-    render(
-      <Anchor className={className} href="https://sumup.com">
-        Anchor
-      </Anchor>,
-    );
-    const anchor = screen.getByRole('link');
-    expect(anchor?.className).toContain(className);
-  });
-
-  it('should forward a ref for a button', () => {
-    const ref = createRef<HTMLButtonElement>();
-    render(
-      <Anchor ref={ref} onClick={vi.fn}>
-        Anchor
-      </Anchor>,
-    );
-    const button = screen.getByRole('button');
-    expect(ref.current).toBe(button);
-  });
-
-  it('should forward a ref for a link', () => {
-    const ref = createRef<HTMLAnchorElement>();
-    render(
-      <Anchor ref={ref} href="https://sumup.com">
-        Anchor
-      </Anchor>,
-    );
-    const anchor = screen.getByRole('link');
-    expect(ref.current).toBe(anchor);
-  });
-
-  it('should forward a ref for a span', () => {
-    const ref = createRef<HTMLSpanElement>();
-    render(<Anchor ref={ref}>Anchor</Anchor>);
-    const span = screen.getByText('Anchor');
-    expect(ref.current).toBe(span);
-  });
-
-  it('should render as a `span` when neither href nor onClick is passed', () => {
-    render(<Anchor {...baseProps} />);
-    const actual = screen.getByText('Anchor');
-    expect(actual.tagName).toBe('SPAN');
-    expect(actual).toBeVisible();
-  });
-
-  it('should render as an `a` when an href (and onClick) is passed', () => {
-    render(<Anchor {...baseProps} href="https://sumup.com" onClick={vi.fn} />);
-    const actual = screen.getByText('Anchor');
-    expect(actual.tagName).toBe('A');
-    expect(actual).toBeVisible();
-  });
-
-  it('should render as a `button` when an onClick is passed', () => {
-    render(<Anchor {...baseProps} onClick={vi.fn} />);
-    const actual = screen.getByText('Anchor');
-    expect(actual.tagName).toBe('BUTTON');
-    expect(actual).toBeVisible();
-  });
-
-  it('should call the onClick handler when rendered as a link', async () => {
-    const onClick = vi.fn((event: ClickEvent) => {
-      event.preventDefault(); // navigation is not implemented in jsdom
+  describe('as a link', () => {
+    it('should render as an `a` when an href (and onClick) is passed', () => {
+      render(
+        <Anchor {...baseProps} href="https://sumup.com" onClick={vi.fn()} />,
+      );
+      const actual = screen.getByText('Anchor');
+      expect(actual.tagName).toBe('A');
+      expect(actual).toBeVisible();
     });
-    render(
-      <Anchor {...baseProps} href="https://sumup.com" onClick={onClick} />,
-    );
 
-    await userEvent.click(screen.getByRole('link'));
+    it('should merge a custom class name with the default ones', () => {
+      const className = 'foo';
+      render(
+        <Anchor className={className} href="https://sumup.com">
+          Anchor
+        </Anchor>,
+      );
+      const anchor = screen.getByRole('link');
+      expect(anchor.className).toContain(className);
+    });
 
-    expect(onClick).toHaveBeenCalledTimes(1);
+    it('should forward a ref for', () => {
+      const ref = createRef<HTMLAnchorElement>();
+      render(
+        <Anchor ref={ref} href="https://sumup.com">
+          Anchor
+        </Anchor>,
+      );
+      const anchor = screen.getByRole('link');
+      expect(ref.current).toBe(anchor);
+    });
+
+    it('should call the onClick handler', async () => {
+      const onClick = vi.fn((event: ClickEvent) => {
+        event.preventDefault(); // navigation is not implemented in jsdom
+      });
+      render(
+        <Anchor {...baseProps} href="https://sumup.com" onClick={onClick} />,
+      );
+
+      await userEvent.click(screen.getByRole('link'));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render with a description label when it renders an external link', () => {
+      render(
+        <Anchor
+          href="www.external.link.com"
+          {...baseProps}
+          rel="external"
+          externalLabel="Opens in a new tab"
+        />,
+      );
+
+      expect(screen.getByRole('link')).toHaveAccessibleDescription(
+        'Opens in a new tab',
+      );
+    });
+
+    it('should meet accessibility guidelines', async () => {
+      const { container } = render(
+        <Anchor {...baseProps} href="https://sumup.com" />,
+      );
+      const actual = await axe(container);
+      expect(actual).toHaveNoViolations();
+    });
   });
 
-  it('should call the onClick handler when rendered as a button', async () => {
-    const onClick = vi.fn();
-    render(<Anchor {...baseProps} onClick={onClick} />);
+  describe('as a button', () => {
+    it('should render as a `button` when an onClick is passed', () => {
+      render(<Anchor {...baseProps} onClick={vi.fn()} />);
+      const actual = screen.getByText('Anchor');
+      expect(actual.tagName).toBe('BUTTON');
+      expect(actual).toBeVisible();
+    });
 
-    await userEvent.click(screen.getByRole('button'));
+    it('should merge a custom class name with the default ones', () => {
+      const className = 'foo';
+      render(
+        <Anchor className={className} onClick={vi.fn()}>
+          Anchor
+        </Anchor>,
+      );
+      const button = screen.getByRole('button');
+      expect(button.className).toContain(className);
+    });
 
-    expect(onClick).toHaveBeenCalledTimes(1);
+    it('should forward a ref', () => {
+      const ref = createRef<HTMLButtonElement>();
+      render(
+        <Anchor ref={ref} onClick={vi.fn()}>
+          Anchor
+        </Anchor>,
+      );
+      const button = screen.getByRole('button');
+      expect(ref.current).toBe(button);
+    });
+
+    it('should call the onClick handler', async () => {
+      const onClick = vi.fn();
+      render(<Anchor {...baseProps} onClick={onClick} />);
+
+      await userEvent.click(screen.getByRole('button'));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render with a description label when it renders an external link', () => {
+      render(
+        <Anchor
+          onClick={vi.fn()}
+          {...baseProps}
+          rel="external"
+          externalLabel="Opens in a new tab"
+        />,
+      );
+
+      expect(screen.getByRole('button')).toHaveAccessibleDescription(
+        'Opens in a new tab',
+      );
+    });
+
+    it('should meet accessibility guidelines', async () => {
+      const { container } = render(<Anchor {...baseProps} onClick={vi.fn()} />);
+      const actual = await axe(container);
+      expect(actual).toHaveNoViolations();
+    });
   });
 
-  it('should render as link with an description label when it renders an external link', () => {
-    render(
-      <Anchor
-        href="www.external.link.com"
-        {...baseProps}
-        rel="external"
-        externalLabel="Opens in a new tab"
-      />,
-    );
+  describe('as a span', () => {
+    it('should render as a `span` when neither href nor onClick is passed', () => {
+      render(<Anchor {...baseProps} />);
+      const actual = screen.getByText('Anchor');
+      expect(actual.tagName).toBe('SPAN');
+      expect(actual).toBeVisible();
+    });
 
-    expect(screen.getByRole('link')).toHaveAccessibleDescription(
-      'Opens in a new tab',
-    );
-  });
+    it('should merge a custom class name with the default ones', () => {
+      const className = 'foo';
+      render(<Anchor className={className}>Anchor</Anchor>);
+      const span = screen.getByText('Anchor');
+      expect(span.className).toContain(className);
+    });
 
-  it('should render as button with an description label when it renders an external link', () => {
-    render(
-      <Anchor
-        onClick={vi.fn()}
-        {...baseProps}
-        rel="external"
-        externalLabel="Opens in a new tab"
-      />,
-    );
+    it('should forward a ref for a span', () => {
+      const ref = createRef<HTMLSpanElement>();
+      render(<Anchor ref={ref}>Anchor</Anchor>);
+      const span = screen.getByText('Anchor');
+      expect(ref.current).toBe(span);
+    });
 
-    expect(screen.getByRole('button')).toHaveAccessibleDescription(
-      'Opens in a new tab',
-    );
-  });
-
-  it('should meet accessibility guidelines', async () => {
-    const { container } = render(
-      <Anchor {...baseProps} href="https://sumup.com" onClick={vi.fn} />,
-    );
-    const actual = await axe(container);
-    expect(actual).toHaveNoViolations();
+    it('should meet accessibility guidelines', async () => {
+      const { container } = render(<Anchor {...baseProps} />);
+      const actual = await axe(container);
+      expect(actual).toHaveNoViolations();
+    });
   });
 
   it('should throw an accessibility error when the externalLabel prop is missing', () => {

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -102,7 +102,7 @@ export const Anchor = forwardRef(
 
     if (!props.href && !props.onClick) {
       return (
-        <Body as="span" {...props} ref={ref}>
+        <Body as="span" {...props} className={className} ref={ref}>
           {children}
         </Body>
       );


### PR DESCRIPTION
## Purpose

While upgrading the support center to Circuit UI v10, I noticed a bug in the Anchor component. When it's missing the `href` and `onClick` props, and is thus rendered as a simple `span`, a custom class name isn't forwarded.

## Approach and changes

- Forward custom class names to the `span` element
- Add additional unit tests to prevent regressions in the future

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
