### PR TITLE
Fix support for the required attribute for radio button groups

### DIFF
--- a/.changeset/blue-comics-float.md
+++ b/.changeset/blue-comics-float.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed support for the `required` attribute in the RadioButtonGroup and SelectorGroup components.

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -199,6 +199,7 @@ export const RadioButtonGroup = forwardRef(
               {...option}
               key={option.value?.toString() || option.label}
               disabled={disabled || option.disabled}
+              required={required || option.required}
               name={name}
               onChange={onChange}
               onBlur={onBlur}

--- a/packages/circuit-ui/components/Selector/Selector.tsx
+++ b/packages/circuit-ui/components/Selector/Selector.tsx
@@ -111,6 +111,7 @@ export const Selector = forwardRef<HTMLInputElement, SelectorProps>(
       'id': customId,
       name,
       disabled,
+      required,
       invalid,
       multiple,
       onChange,
@@ -164,6 +165,7 @@ export const Selector = forwardRef<HTMLInputElement, SelectorProps>(
           name={name}
           value={value}
           disabled={disabled}
+          required={multiple ? undefined : required}
           // @ts-expect-error Change is handled by onClick for browser support, see https://stackoverflow.com/a/5575369
           onClick={onChange}
           // Noop to silence React warning: https://github.com/facebook/react/issues/3070#issuecomment-73311114

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -201,6 +201,7 @@ export const SelectorGroup = forwardRef<
               multiple={multiple}
               size={size}
               disabled={disabled || option.disabled}
+              required={required || option.required}
               invalid={invalid || option.invalid}
               checked={
                 value ? isChecked(option, value, multiple) : option.checked


### PR DESCRIPTION
## Purpose

Currently, the RadioButtonGroup and SelectorGroup components fail to forward the `required` attribute to the underlying `input` elements. From the [HTML spec](https://html.spec.whatwg.org/multipage/input.html#the-required-attribute):

> For radio buttons, the [required](https://html.spec.whatwg.org/multipage/input.html#attr-input-required) attribute is satisfied if any of the radio buttons in the [group](https://html.spec.whatwg.org/multipage/input.html#radio-button-group) is selected.

> To avoid confusion as to whether a [radio button group](https://html.spec.whatwg.org/multipage/input.html#radio-button-group) is required or not, authors are encouraged to specify the attribute on all the radio buttons in a group. Indeed, in general, authors are encouraged to avoid having radio button groups that do not have any initially checked controls in the first place, as this is a state that the user cannot return to, and is therefore generally considered a poor user interface.

Unfortunately, groups of check boxes don't support the `required` attribute, though it could be simulated using JavaScript. Since we try to keep Circuit UI stateless, we leave it up to developers to implement this in their apps.

## Approach and changes

- Forward the `required` attribute to the `input` elements inside the RadioButtonGroup and SelectorGroup components

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
