### PR TITLE
Remove special handling of onBlur event handler in input groups

### DIFF
--- a/.changeset/ten-radios-teach.md
+++ b/.changeset/ten-radios-teach.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': minor
+---
+
+Removed special handling for the `onBlur` prop in the CheckboxGroup, RadioButtonGroup and SelectorGroup components. We consider this an implementation detail, however, you might need to update your types from `FocusEventHandler<HTMLInputElement>` to `FocusEventHandler<HTMLFieldsetElement>`.

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.spec.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.spec.tsx
@@ -183,6 +183,16 @@ describe('CheckboxGroup', () => {
       expect(onChange).toHaveBeenCalledTimes(1);
     });
 
+    it('should call the focus handler when gaining focus', async () => {
+      const onFocus = vi.fn();
+      render(<CheckboxGroup {...defaultProps} onFocus={onFocus} />);
+      const inputEl = screen.getByLabelText('Option 1');
+
+      await userEvent.click(inputEl);
+
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+
     it('should call the blur handler when loosing focus', async () => {
       const onBlur = vi.fn();
       render(<CheckboxGroup {...defaultProps} onBlur={onBlur} />);

--- a/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/circuit-ui/components/CheckboxGroup/CheckboxGroup.tsx
@@ -40,7 +40,7 @@ import { idx } from '../../util/idx.js';
 import classes from './CheckboxGroup.module.css';
 
 // TODO: Remove the value override in the next major.
-type Options = Omit<
+type Option = Omit<
   CheckboxProps,
   'onChange' | 'validationHint' | 'name' | 'value' | 'optionalLabel'
 > & {
@@ -50,7 +50,7 @@ type Options = Omit<
 export interface CheckboxGroupProps
   extends Omit<
     FieldsetHTMLAttributes<HTMLFieldSetElement>,
-    'onChange' | 'onBlur' | 'defaultValue'
+    'onChange' | 'defaultValue'
   > {
   /**
    * A name for the CheckboxGroup. This name is shared among the individual Checkboxes.
@@ -61,25 +61,20 @@ export interface CheckboxGroupProps
    * for the respective Checkbox.
    * Pass the optional `required` prop to indicate a Checkbox is required.
    */
-  options: Options[];
+  options: Option[];
   /**
    * The values of the Checkboxes that are checked by default (uncontrolled).
    */
-  defaultValue?: Options['value'][];
+  defaultValue?: Option['value'][];
   /**
    * The values of the Checkboxes that are checked by default (controlled).
    */
-  value?: Options['value'][];
+  value?: Option['value'][];
   /**
    * A callback that is called when any of the inputs change their values.
    * Passed on to the Checkboxes.
    */
   onChange?: CheckboxProps['onChange'];
-  /**
-   * A callback that is called when any of the inputs lose focus.
-   * Passed on to the Checkboxes.
-   */
-  onBlur?: CheckboxProps['onBlur'];
   /**
    * A description of the selector group.
    */
@@ -130,7 +125,6 @@ export const CheckboxGroup = forwardRef(
       value,
       defaultValue,
       onChange,
-      onBlur,
       name,
       label,
       invalid,
@@ -190,7 +184,6 @@ export const CheckboxGroup = forwardRef(
                 {...option}
                 name={name}
                 onChange={onChange}
-                onBlur={onBlur}
                 disabled={disabled || option.disabled}
                 invalid={invalid || option.invalid}
                 checked={value ? value.includes(option.value) : option.checked}

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.spec.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.spec.tsx
@@ -200,6 +200,16 @@ describe('RadioButtonGroup', () => {
       expect(onChange).toHaveBeenCalledTimes(1);
     });
 
+    it('should call the focus handler when gaining focus', async () => {
+      const onFocus = vi.fn();
+      render(<RadioButtonGroup {...defaultProps} onFocus={onFocus} />);
+      const inputEl = screen.getByLabelText('Option 1');
+
+      await userEvent.click(inputEl);
+
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+
     it('should call the blur handler when loosing focus', async () => {
       const onBlur = vi.fn();
       render(<RadioButtonGroup {...defaultProps} onBlur={onBlur} />);

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonGroup.tsx
@@ -42,10 +42,7 @@ import {
 
 import classes from './RadioButtonGroup.module.css';
 
-type Option = Omit<
-  RadioButtonProps,
-  'onChange' | 'onBlur' | 'name' | 'children'
-> & {
+type Option = Omit<RadioButtonProps, 'onChange' | 'name' | 'children'> & {
   /**
    * A clear and concise description of the option's purpose.
    */
@@ -57,10 +54,7 @@ type Option = Omit<
 };
 
 export interface RadioButtonGroupProps
-  extends Omit<
-    FieldsetHTMLAttributes<HTMLFieldSetElement>,
-    'onChange' | 'onBlur'
-  > {
+  extends Omit<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'onChange'> {
   /**
    * A collection of available options. Each option must have at least a value
    * and a label.
@@ -71,11 +65,6 @@ export interface RadioButtonGroupProps
    * Passed on to the RadioButtons.
    */
   onChange?: RadioButtonProps['onChange'];
-  /**
-   * A callback that is called when any of the inputs lose focus.
-   * Passed on to the RadioButtons.
-   */
-  onBlur?: RadioButtonProps['onBlur'];
   /**
    * A visually hidden description of the selector group for screen readers.
    */
@@ -132,7 +121,6 @@ export const RadioButtonGroup = forwardRef(
     {
       options,
       onChange,
-      onBlur,
       value,
       defaultValue,
       'name': customName,
@@ -202,7 +190,6 @@ export const RadioButtonGroup = forwardRef(
               required={required || option.required}
               name={name}
               onChange={onChange}
-              onBlur={onBlur}
               checked={value ? option.value === value : option.checked}
               defaultChecked={
                 defaultValue

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.spec.tsx
@@ -158,6 +158,16 @@ describe('SelectorGroup', () => {
       expect(onChange).toHaveBeenCalledTimes(1);
     });
 
+    it('should call the focus handler when loosing focus', async () => {
+      const onFocus = vi.fn();
+      render(<SelectorGroup {...defaultProps} onFocus={onFocus} />);
+      const inputEl = screen.getByLabelText('Option 1');
+
+      await userEvent.click(inputEl);
+
+      expect(onFocus).toHaveBeenCalledTimes(1);
+    });
+
     it('should call the blur handler when loosing focus', async () => {
       const onBlur = vi.fn();
       render(<SelectorGroup {...defaultProps} onBlur={onBlur} />);

--- a/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
+++ b/packages/circuit-ui/components/SelectorGroup/SelectorGroup.tsx
@@ -39,25 +39,17 @@ import { idx } from '../../util/idx.js';
 import classes from './SelectorGroup.module.css';
 
 export interface SelectorGroupProps
-  extends Omit<
-    FieldsetHTMLAttributes<HTMLFieldSetElement>,
-    'onChange' | 'onBlur'
-  > {
+  extends Omit<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'onChange'> {
   /**
    * A collection of available options. Each option must have at least
    * a value and label.
    */
-  options: Omit<SelectorProps, 'onChange' | 'onBlur' | 'name'>[];
+  options: Omit<SelectorProps, 'onChange' | 'name'>[];
   /**
    * A callback that is called when any of the inputs change their values.
    * Passed on to the Selectors.
    */
   onChange?: SelectorProps['onChange'];
-  /**
-   * A callback that is called when any of the inputs lose focus.
-   * Passed on to the Selectors.
-   */
-  onBlur?: SelectorProps['onBlur'];
   /**
    * The value of the currently checked options.
    */
@@ -129,7 +121,6 @@ export const SelectorGroup = forwardRef<
     {
       options,
       onChange,
-      onBlur,
       value,
       defaultValue,
       'name': customName,
@@ -197,7 +188,6 @@ export const SelectorGroup = forwardRef<
               className={clsx(classes.option, option.className)}
               name={name}
               onChange={onChange}
-              onBlur={onBlur}
               multiple={multiple}
               size={size}
               disabled={disabled || option.disabled}


### PR DESCRIPTION
## Purpose

While upgrading the marketing website to Circuit UI v10, I noticed that the input group components – CheckboxGroup, RadioButtonGroup and SelectorGroup – support the `onBlur` prop but not the `onFocus` prop.

## Approach and changes

- Add support for the `onFocus` prop. It is forwarded to each individual option input, so it triggers even when changing focus within the input group.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
