### PR TITLE
Use dynamic viewport units as a progressive enhancement

### DIFF
--- a/.storybook/components/FullViewport.module.css
+++ b/.storybook/components/FullViewport.module.css
@@ -1,6 +1,7 @@
 .base {
   width: 100vw;
   height: 100vh;
+  height: 100dvh;
 }
 
 :global(.docs-story) .base {

--- a/packages/circuit-ui/components/CarouselPagination/examples/Carousel.module.css
+++ b/packages/circuit-ui/components/CarouselPagination/examples/Carousel.module.css
@@ -27,6 +27,7 @@
   flex-shrink: 0;
   width: 80vw;
   height: min(60vw, 80vh);
+  height: min(60vw, 80dvh);
   scroll-snap-align: start;
 }
 

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -1,11 +1,13 @@
 .base {
   position: fixed;
   max-height: 90vh;
+  max-height: 90dvh;
   background-color: var(--cui-bg-elevated);
 }
 
 .content {
   max-height: 90vh;
+  max-height: 90dvh;
   overflow-y: auto;
 }
 

--- a/packages/circuit-ui/components/Popover/Popover.module.css
+++ b/packages/circuit-ui/components/Popover/Popover.module.css
@@ -34,6 +34,7 @@
     width: auto;
     max-width: 100%;
     max-height: 90vh;
+    max-height: 90dvh;
     border-radius: var(--cui-border-radius-byte) var(--cui-border-radius-byte) 0
       0;
   }

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.module.css
@@ -32,6 +32,7 @@
   flex-direction: column;
   width: var(--cui-icon-sizes-tera);
   height: calc(100vh - var(--top-navigation-height, 0px));
+  height: calc(100dvh - var(--top-navigation-height, 0px));
   padding-top: var(--cui-spacings-kilo);
   overflow-x: hidden;
   overflow-y: auto;
@@ -66,6 +67,7 @@
   flex-direction: column;
   width: 200px;
   height: calc(100vh - var(--top-navigation-height, 0px));
+  height: calc(100dvh - var(--top-navigation-height, 0px));
   margin-left: var(--primary-navigation-width);
   overflow-y: auto;
   background-color: var(--cui-bg-normal);

--- a/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/MobileNavigation/MobileNavigation.module.css
@@ -15,7 +15,9 @@
   width: 100vw;
   min-width: 100vw;
   height: 100vh;
+  height: 100dvh;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .navigation {

--- a/packages/circuit-ui/components/SidePanel/SidePanel.module.css
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.module.css
@@ -35,6 +35,7 @@
     top: 0;
     min-width: 100vw;
     height: 100vh;
+    height: 100dvh;
     max-height: unset;
     margin: auto;
     border-radius: 0;
@@ -50,6 +51,7 @@
     top: var(--top-navigation-height, 0);
     width: var(--side-panel-width);
     height: calc(100vh - var(--top-navigation-height, 0));
+    height: calc(100dvh - var(--top-navigation-height, 0));
     margin: 0;
     background-color: var(--cui-bg-normal);
     box-shadow: inset var(--cui-border-width-kilo) 0 0 var(--cui-border-divider);


### PR DESCRIPTION
## Purpose

For mobile devices, the use of tradional viewport units like `vh` can sometimes cause some components to render incorrectly due to change in the initially computed viewport size (example: when the address bar disappears). This can be improved by using dynamic viewport units, that respond to changes in the browser’s UI, making components unaffected by these fluctuations. Example:

before:
<img src="https://github.com/user-attachments/assets/f4d1cb56-9855-4fcd-a720-94df230926d9" width="150" >

after:
<img src="https://github.com/user-attachments/assets/ff34bd7d-eb1b-47f4-bf1e-7752eae8572e" width="150" >

## Approach and changes

Add declarations with `dvh` and keep `vh` unit as fallback.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
