### PR TITLE
Add comment for specific chrome behaviour for the Dialog's preventEsc…

### DIFF
--- a/packages/circuit-ui/components/Dialog/Dialog.tsx
+++ b/packages/circuit-ui/components/Dialog/Dialog.tsx
@@ -96,7 +96,10 @@ export interface DialogProps extends PublicDialogProps {
    */
   preventOutsideClickClose?: boolean;
   /**
-   * Prevent users from closing the modal by pressing the escape key.
+   * Prevent users from closing the dialog by pressing the escape key.
+   * On Chromium-based modal dialogs, this would prevent closing on the first press of the escape key
+   * but would close the modal on the second press, as intended by Chromium.
+   * To learn more about this particular behaviour, see https://issues.chromium.org/issues/41491338
    * @default false
    */
   preventEscapeKeyClose?: boolean;


### PR DESCRIPTION
…apeKeyClose prop

## Purpose

On Chromium based browsers, intercepting and preventing the `cancel` event fired by pressing the escape key on a modal <dialog> does not block the closing of the dialog on the second time the escape key is pressed. This behaviour is intentional, designed to allow users to exist a modal screen and not be trapped in it. In order for users to have an experience that resembles the native element as much as possible, we decided to keep this behaviour. 

## Approach and changes

Edit the `preventEscapeKeyClose` prop description to reflect the expected behaviour.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
