### PR TITLE
Add helper to get hosted icon URLs

### DIFF
--- a/.changeset/public-schools-beg.md
+++ b/.changeset/public-schools-beg.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/icons": minor
+---
+
+Added a `getIconURL` helper function to obtain the URL for the hosted icons with full type-safety.

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -26,7 +26,7 @@ yarn add @sumup-oss/icons
 
 The easiest way to use an icon in [React](https://reactjs.org/) is to import it as a component. This approach works out of the box (no special loaders needed), is tree-shaking enabled, and comes with TypeScript typings included.
 
-```jsx
+```tsx
 import { Check } from '@sumup-oss/icons';
 
 const SuccessMessage = ({ description }) => (
@@ -39,7 +39,7 @@ const SuccessMessage = ({ description }) => (
 
 Some icons have multiple sizes. They default to size '24', if supported, or to the smallest available size. Use the `size` prop to show one of the other sizes ('16' or '32') instead:
 
-```jsx
+```tsx
 import { CircleCheckmark } from '@sumup-oss/icons';
 
 const SuccessMessage = ({ description }) => (
@@ -50,20 +50,24 @@ const SuccessMessage = ({ description }) => (
 );
 ```
 
-To change the color of an icon, set the `color` property in CSS. The color will [cascade down](https://css-tricks.com/cascading-svg-fill-color/) since the `fill` and `stroke` attributes of all monochrome icons are set to `currentColor`. Here's an example with a CSS-in-JS library:
+To change the color of an icon, set the `color` property in CSS. The color will [cascade down](https://css-tricks.com/cascading-svg-fill-color/) since the `fill` and `stroke` attributes of all monochrome icons are set to `currentColor`. Here's an example using CSS Modules:
 
-```jsx
-import styled from '@emotion/styled';
-import { Check } from '@sumup-oss/icons';
-
-const GreenCheck = styled(Check)`
+```css
+/* SuccessMessage.module.css */
+.icon {
   color: green;
-`;
+}
+```
 
-const SuccessMessage = ({ description }) => (
+```tsx
+// SuccessMessage.tsx
+import { Check } from '@sumup-oss/icons';
+import styles from './SuccessMessage.module.css';
+
+const SuccessMessage = ({ message }) => (
   <div>
-    <GreenCheck />
-    <span>{description}</span>
+    <Check className={styles.icon} />
+    <span>{message}</span>
   </div>
 );
 ```
@@ -72,13 +76,13 @@ const SuccessMessage = ({ description }) => (
 
 Alternatively, it's possible to import the raw SVG files. Most bundlers require a special loader to make this work. For Webpack, we recommend the [file-loader](https://github.com/webpack-contrib/file-loader) which turns the import into a URL to the SVG.
 
-```jsx
-import checkIcon from '@sumup-oss/icons/check_small.svg';
+```tsx
+import checkIcon from '@sumup-oss/icons/check_24.svg';
 
-const SuccessMessage = ({ description }) => (
+const SuccessMessage = ({ message }) => (
   <div>
     <img src={checkIcon} alt="" aria-hidden="true" />
-    <span>{description}</span>
+    <span>{message}</span>
   </div>
 );
 ```
@@ -87,14 +91,20 @@ It is not possible to change the color of an external SVG using the `css` color 
 
 ### Load from a URL
 
-The latest version of the icon library is [automatically deployed](https://circuit.sumup.com/icons/v2) to [Vercel](https://vercel.com/). The files are hosted behind a global CDN, so they load quickly for all users. You can load the icons from `https://circuit.sumup.com/icons/v2/<name>_<size>.svg`. Below are some examples:
+The latest version of the icon library is [automatically deployed](https://circuit.sumup.com/icons/v2) to [Vercel](https://vercel.com/). The files are hosted behind a global CDN, so they load quickly for all users. Use the `getIconURL` helper function to obtain the full URL with type-safety:
 
-```html
-<img
-  src="https://circuit.sumup.com/icons/v2/checkmark_16.svg"
-  alt="checkmark"
-/>
+```tsx
+import { getIconURL } from '@sumup-oss/icons';
+
+const SuccessMessage = ({ message }) => (
+  <div>
+    <img src={getIconURL('check', '24')} alt="" aria-hidden="true" />
+    <span>{message}</span>
+  </div>
+);
 ```
+
+Alternatively, you can manually construct the URL:
 
 ```css
 .icon {

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -161,7 +161,16 @@ async function transpileModule(fileName: string, code: string) {
   const output = transformSync(code, {
     cwd: BASE_DIR,
     targets: { esmodules: true },
-    presets: [['@babel/preset-env', { modules: false }], '@babel/preset-react'],
+    presets: [
+      [
+        '@babel/preset-env',
+        {
+          modules: false,
+          exclude: ['transform-object-rest-spread'],
+        },
+      ],
+      '@babel/preset-react',
+    ],
     plugins: [
       [
         path.join(BASE_DIR, './vendor/babel-plugin-inline-react-svg/index.js'),


### PR DESCRIPTION
## Purpose

All icons are hosted at https://circuit.sumup.com/icons/v2/. Loading SVGs from a URL has performance benefits compared to importing them as a React component for large number of icons or when the required icon name isn't statically known.

While it's possible to manually construct the icon URL using the URL above, there is no type safety and we might want to change this URL in the future.

## Approach and changes

- Add a fully type-safe `getIconURL` helper that returns the full icon URL

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
