### PR TITLE
Filter locale attribute from SearchInput

### DIFF
--- a/.changeset/ripe-dodos-beg.md
+++ b/.changeset/ripe-dodos-beg.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the SearchInput component accidentally setting the `locale` prop as an HTML attribute.

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -57,10 +57,8 @@ export type SearchInputProps = InputProps & {
  */
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   (props, ref) => {
-    const { value, onClear, clearLabel, inputClassName, ...rest } = useI18n(
-      props,
-      translations,
-    );
+    const { value, onClear, clearLabel, inputClassName, locale, ...rest } =
+      useI18n(props, translations);
     const localRef = useRef<HTMLInputElement>(null);
 
     if (


### PR DESCRIPTION
## Purpose

#3139 localized the SearchInput's `clearLabel` and accidentally forwarded the `locale` prop as an HTML attribute.

## Approach and changes

- Remove the `locale` HTML attribute

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
