### PR TITLE
fix DateInput content overflow style

### DIFF
--- a/.changeset/dirty-snakes-behave.md
+++ b/.changeset/dirty-snakes-behave.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the overflow styles of the DateInput content on desktop.

--- a/packages/circuit-ui/components/DateInput/DateInput.module.css
+++ b/packages/circuit-ui/components/DateInput/DateInput.module.css
@@ -109,7 +109,6 @@
 
 .content {
   padding: 0;
-  overflow: unset;
 }
 
 .header {


### PR DESCRIPTION
## Purpose

The scroll indicator scrolls along with the content of the DateInput popover

## Approach and changes

Remove superflous `overflow: unset` on the Popover content class

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
