### PR TITLE
remove max-height rule for immersive modal content

### DIFF
--- a/.changeset/early-wings-brush.md
+++ b/.changeset/early-wings-brush.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed max-height restriction from immersive Modal content.

--- a/packages/circuit-ui/components/Modal/Modal.module.css
+++ b/packages/circuit-ui/components/Modal/Modal.module.css
@@ -42,6 +42,14 @@
       0;
   }
 
+  .base .content {
+    padding: var(--cui-spacings-mega);
+    padding-bottom: calc(
+      env(safe-area-inset-bottom) + var(--cui-spacings-mega)
+    );
+    -webkit-overflow-scrolling: touch;
+  }
+
   .immersive {
     height: 100%;
     max-height: unset;
@@ -49,11 +57,7 @@
     border-radius: unset;
   }
 
-  .base .content {
-    padding: var(--cui-spacings-mega);
-    padding-bottom: calc(
-      env(safe-area-inset-bottom) + var(--cui-spacings-mega)
-    );
-    -webkit-overflow-scrolling: touch;
+  .immersive .content {
+    max-height: unset;
   }
 }


### PR DESCRIPTION
Issue reported by @michael-callahan-sumup 

## Purpose

For immersive modals, the content does not fill the entire screen height. Modal content is restricted to a 90vh max-height for contextual modals, this rule should not apply to immersive variants.

## Approach and changes

Remove `max-height` rule for immersive modals on mobile.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
