### PR TITLE
Fix vendored react-number-format type resolution

### DIFF
--- a/.changeset/shiny-kings-beam.md
+++ b/.changeset/shiny-kings-beam.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the types for the CurrencyInput and PercentageInput components.

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -18,10 +18,8 @@
 import { forwardRef, useId } from 'react';
 import { resolveCurrencyFormat } from '@sumup-oss/intl';
 
-import {
-  NumericFormat,
-  type NumericFormatProps,
-} from '../../vendor/react-number-format/index.js';
+import { NumericFormat } from '../../vendor/react-number-format/index.js';
+import type { OnValueChange } from '../../vendor/react-number-format/types.js';
 import { clsx } from '../../styles/clsx.js';
 import { idx } from '../../util/idx.js';
 import type { Locale } from '../../util/i18n.js';
@@ -33,10 +31,9 @@ import classes from './CurrencyInput.module.css';
 
 export interface CurrencyInputProps
   extends Omit<
-      InputProps,
-      'placeholder' | 'ref' | 'value' | 'defaultValue' | 'type'
-    >,
-    Pick<NumericFormatProps, 'onValueChange' | 'allowNegative'> {
+    InputProps,
+    'placeholder' | 'ref' | 'value' | 'defaultValue' | 'type'
+  > {
   /**
    * A ISO 4217 currency code, such as 'USD' for the US dollar,
    * 'EUR' for the Euro, or 'CNY' for the Chinese RMB.
@@ -63,6 +60,8 @@ export interface CurrencyInputProps
    * The default value of the input element.
    */
   defaultValue?: string | number;
+  allowNegative?: boolean;
+  onValueChange?: OnValueChange;
 }
 
 const DEFAULT_FORMAT = {

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
@@ -18,10 +18,8 @@
 import { forwardRef, useId } from 'react';
 import { resolveNumberFormat } from '@sumup-oss/intl';
 
-import {
-  NumericFormat,
-  type NumericFormatProps,
-} from '../../vendor/react-number-format/index.js';
+import { NumericFormat } from '../../vendor/react-number-format/index.js';
+import type { OnValueChange } from '../../vendor/react-number-format/types.js';
 import { clsx } from '../../styles/clsx.js';
 import { idx } from '../../util/idx.js';
 import { Input, type InputProps } from '../Input/index.js';
@@ -31,13 +29,9 @@ import classes from './PercentageInput.module.css';
 
 export interface PercentageInputProps
   extends Omit<
-      InputProps,
-      'placeholder' | 'ref' | 'value' | 'defaultValue' | 'type'
-    >,
-    Pick<
-      NumericFormatProps,
-      'onValueChange' | 'decimalScale' | 'fixedDecimalScale' | 'allowNegative'
-    > {
+    InputProps,
+    'placeholder' | 'ref' | 'value' | 'defaultValue' | 'type'
+  > {
   /**
    * One or more Unicode BCP 47 locale identifiers, such as `'de-DE'` or
    * `['GB', 'en-US']` (the first supported locale is used).
@@ -56,6 +50,10 @@ export interface PercentageInputProps
    * The default value of the input element.
    */
   defaultValue?: string | number;
+  allowNegative?: boolean;
+  decimalScale?: number;
+  fixedDecimalScale?: boolean;
+  onValueChange?: OnValueChange;
 }
 
 const DEFAULT_FORMAT = {

--- a/packages/circuit-ui/tsconfig.json
+++ b/packages/circuit-ui/tsconfig.json
@@ -28,6 +28,7 @@
     "styles/**/*",
     "types/**/*",
     "util/**/*",
+    "vendor/**/*",
     "index.ts",
     "legacy.ts",
     "experimental.ts",

--- a/packages/circuit-ui/vendor/react-number-format/types.ts
+++ b/packages/circuit-ui/vendor/react-number-format/types.ts
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent } from 'react';
+import React, { type SyntheticEvent } from 'react';
 export declare type Timeout = ReturnType<typeof setTimeout>;
 export interface NumberFormatState {
     value?: string;


### PR DESCRIPTION
## Purpose

For some reason, TypeScript doesn't copy over type declaration files (`.d.ts`) to the build output. This causes wrong prop types for the CurrencyInput and PercentageInput components.

## Approach and changes

- Changed the file extension of `/react-number-format/types` from `.d.ts` to `.ts` to ensure it's included in the build output
- Imported the required types from there instead
 
## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
