### PR TITLE
Fix lingering hover state on SideNavigation on touch devices

### DIFF
--- a/.changeset/brave-oranges-search.md
+++ b/.changeset/brave-oranges-search.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed an issue where the SideNavigation component remained expanded on touch devices after interaction due to lingering `:hover` state.

--- a/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/DesktopNavigation/DesktopNavigation.module.css
@@ -43,7 +43,13 @@
     box-shadow var(--cui-transitions-default);
 }
 
-.primary:hover,
+@media (hover: hover) and (pointer: fine) {
+  .primary:hover {
+    width: var(--primary-navigation-width-open);
+    box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);
+  }
+}
+
 .primary:focus-within {
   width: var(--primary-navigation-width-open);
   box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);


### PR DESCRIPTION
Issue reported by @Oskar Kunik

## Purpose

On large touch screen devices, the SideNavigation stays open after a navigation event, obscuring the main content until the next interaction

## Approach and changes

The issue is caused by lingering `:hover` styles on the DesktopNavigation component of the SideNavigation.
Wrap SideNavigation :hover styles inside a media query that targets only touch devices.

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
