### PR TITLE
Pass defaultValue to Select prefix

### DIFF
--- a/.changeset/olive-rabbits-crash.md
+++ b/.changeset/olive-rabbits-crash.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Passed the `defaultValue` to the Select component's prefix render prop when the `value` is undefined.

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -58,7 +58,7 @@ Base.args = {
   label: 'Phone number',
   countryCode: {
     label: 'Country code',
-    defaultValue: '+1',
+    defaultValue: 'CA',
     options: Object.keys(countryCodeMap).map((key) => ({
       country: key,
       code: countryCodeMap[key],

--- a/packages/circuit-ui/components/Select/Select.tsx
+++ b/packages/circuit-ui/components/Select/Select.tsx
@@ -73,6 +73,7 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
    * currently selected.
    */
   value?: string | number;
+  defaultValue?: string | number;
   /**
    * String to show when no selection is made.
    */
@@ -139,7 +140,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     );
 
     const prefix = RenderPrefix && (
-      <RenderPrefix className={classes.prefix} value={value} />
+      <RenderPrefix className={classes.prefix} value={value ?? defaultValue} />
     );
     const hasPrefix = Boolean(prefix);
 


### PR DESCRIPTION
## Purpose

In the PhoneNumberInput, it's useful to set a `defaultValue` for the country code before a value has been entered. 

The Select component's `renderPrefix` prop can be used to render a country flag with the country code. This render prop receives the currently selected `value`, however, in the scenario described above, the `value` is undefined until the user starts typing a number.

## Approach and changes

- Pass the `defaultValue` to the Select component's prefix render prop when the `value` is undefined.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
