### PR TITLE
Update the Toggle knob background color

### DIFF
--- a/.changeset/yellow-kings-fold.md
+++ b/.changeset/yellow-kings-fold.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Updated the Toggle knob background color to better reflect the unchecked state.

--- a/packages/circuit-ui/components/Toggle/Toggle.module.css
+++ b/packages/circuit-ui/components/Toggle/Toggle.module.css
@@ -63,10 +63,12 @@
   display: block;
   width: var(--toggle-knob-size);
   height: var(--toggle-knob-size);
-  background-color: var(--cui-bg-strong);
+  background-color: var(--cui-fg-placeholder);
   border-radius: var(--toggle-knob-size);
   transform: translate3d(var(--cui-spacings-bit), -50%, 0);
-  transition: transform var(--toggle-animation-timing);
+  transition:
+    transform var(--toggle-animation-timing),
+    background-color var(--toggle-animation-timing);
 }
 
 [aria-checked="true"] .knob {


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

The design community recommended changing the knob's background color in the unchecked state to avoid confusing it with the active state.

## Approach and changes

Change the knob's background color to `var(--cui-fg-placeholder)`

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
