### PR TITLE
improve component behaviour on mobile devices

### DIFF
--- a/.changeset/orange-times-read.md
+++ b/.changeset/orange-times-read.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed rendering issues in the AutocompleteInput when rendered inside a scrollable container.

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.module.css
@@ -93,3 +93,29 @@
   justify-content: center;
   padding: var(--cui-spacings-mega);
 }
+
+/* When an input element gets focused, iOS Safari tries to put it in the center by scrolling (and zooming.)
+Zooming can be easily disabled using a meta tag, but the scrolling hasn't been quite easy.
+The main quirk (I think) is that iOS Safari changes viewport when scrolling; i.e., toolbars shrink.
+Since the viewport _should_ change, it thinks the input _will_ move, so it _should_ scroll, always.
+Even times when it doesn't need to scroll—the input is fixed, all we need is the keyboard—
+the window always scrolls _up and down_ resulting in some janky animation.
+
+https://gist.github.com/kiding/72721a0553fa93198ae2bb6eefaa3299
+*/
+
+@keyframes blink-input-opacity-to-prevent-scrolling-when-focus {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 479px) {
+  .input:focus {
+    animation: blink-input-opacity-to-prevent-scrolling-when-focus 0.01s;
+  }
+}

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -27,6 +27,7 @@ import {
   useState,
 } from 'react';
 import {
+  autoUpdate,
   flip,
   offset,
   shift,
@@ -266,6 +267,7 @@ export const AutocompleteInput = forwardRef<
         flip({ padding: boundaryPadding, fallbackPlacements: ['top'] }),
         size(sizeOptions),
       ],
+      whileElementsMounted: autoUpdate,
     });
 
     useEffect(() => {
@@ -354,6 +356,9 @@ export const AutocompleteInput = forwardRef<
     // biome-ignore lint/correctness/useExhaustiveDependencies: we need to update the floating element styles if the suggestions length changes
     useEffect(() => {
       if (isOpen) {
+        if (isMobile) {
+          textBoxRef.current?.scrollIntoView({ behavior: 'smooth' });
+        }
         update();
       }
     }, [isOpen, update, suggestions.length]);
@@ -465,6 +470,7 @@ export const AutocompleteInput = forwardRef<
               ref={textBoxRef}
               {...comboboxProps}
               className={classes['modal-input']}
+              inputClassName={classes.input}
               aria-expanded={true}
             />
 

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -173,6 +173,7 @@ export const AutocompleteInput = forwardRef<
       value?.label ?? '',
     );
     const isMobile = useMedia('(max-width: 479px)');
+    const hasTouch = !useMedia('(hover: hover) and (pointer: fine)');
     const isImmersive = isMobile && variant === 'immersive';
     const [isOpen, setIsOpen] = useState(false);
     const [activeSuggestion, setActiveSuggestion] = useState<number>();
@@ -356,7 +357,7 @@ export const AutocompleteInput = forwardRef<
     // biome-ignore lint/correctness/useExhaustiveDependencies: we need to update the floating element styles if the suggestions length changes
     useEffect(() => {
       if (isOpen) {
-        if (isMobile) {
+        if (isMobile && hasTouch) {
           textBoxRef.current?.scrollIntoView({ behavior: 'smooth' });
         }
         update();


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

When rendered inside a scrollable container, the AutocompleteInput's floating element's position is not updated if a parent container is scrolled.
Also, when focused, the input field is scrolled outside the viewport when the component is rendered inside a scrollable parent. 

## Approach and changes

- Update the floating element's position by using floating-ui's `whileElementsMounted: autoUpdate` parameter.
- disable the browser's native scroll on the input element on focus and trigger focus programmatically.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
