### PR TITLE
remove pseudo-element from dialog

### DIFF
--- a/packages/circuit-ui/components/Dialog/Dialog.module.css
+++ b/packages/circuit-ui/components/Dialog/Dialog.module.css
@@ -20,7 +20,7 @@
   box-shadow: 0 0 0 100vmax var(--cui-bg-overlay);
 }
 
-.base::after {
+.scroll-indicator {
   position: absolute;
   right: 0;
   bottom: env(safe-area-inset-bottom);
@@ -58,7 +58,7 @@
 }
 
 @media (min-width: 480px) {
-  .base::after {
+  .scroll-indicator {
     height: var(--cui-spacings-giga);
   }
 
@@ -69,7 +69,7 @@
 }
 
 @media (max-width: 479px) {
-  .base::after {
+  .scroll-indicator {
     height: var(--cui-spacings-mega);
   }
 

--- a/packages/circuit-ui/components/Dialog/Dialog.tsx
+++ b/packages/circuit-ui/components/Dialog/Dialog.tsx
@@ -463,6 +463,7 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
               {closeButtonLabel}
             </CloseButton>
           )}
+          <div className={classes['scroll-indicator']} />
         </dialog>
       </>
     );


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

For some reason, Storybook's accessibility features is unable to determine correct contrast mesures when pseudo elements are present in the DOM. 
`Element's background color could not be determined due to a pseudo element.`

This leads to fake accessibility failures in multiple component, polluting the testing experience.

## Approach and changes

When possible, replace pseudo elements with css classes to reduce false accessibility issues. In this case, I am replaceing the scroll indicator in the Dialog component made with the `:after` pseudo-element with a css class to remove the 40 "errors" reported on the [DateInput component](https://5f27fec87f827f00226fd51a-cilapogzng.chromatic.com/?path=/story/forms-dateinput--optional&globals=colorScheme:light).

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
