### PR TITLE
fix DateInput's text color contrast issue when readonly

### DIFF
--- a/.changeset/smooth-plants-pick.md
+++ b/.changeset/smooth-plants-pick.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Improved DateInput's text contrast when the field is readonly to meet WCAG AA contrast ratio.

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.module.css
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.module.css
@@ -30,10 +30,6 @@
   background-color: var(--cui-bg-highlight);
 }
 
-.base:read-only {
-  color: var(--cui-fg-subtle);
-}
-
 .base:disabled,
 .base[disabled] {
   color: var(--cui-fg-normal-disabled);


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

Compared to other input fields in the library, the DateInput has a different text color when `readOnly` prop is true (`var(--cui-fg-subtle)`). This causes the component to fail WCAG AA contrast ratio requirement.

## Approach and changes

Align DateInput text color with the other input components.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
