### PR TITLE
Replace header/footer elements with divs in CardHeader and CardFooter

### DIFF
--- a/.changeset/fast-mugs-help.md
+++ b/.changeset/fast-mugs-help.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Refactored CardHeader and CardFooter components to use `<div>`s instead of `<header>`/`<footer>` to prevent duplicate landmark roles and ensure accessibility compliance.

--- a/packages/circuit-ui/components/Card/components/Footer/Footer.tsx
+++ b/packages/circuit-ui/components/Card/components/Footer/Footer.tsx
@@ -34,7 +34,7 @@ export interface CardFooterProps extends HTMLAttributes<HTMLElement> {
  */
 export const CardFooter = forwardRef<HTMLElement, CardFooterProps>(
   (
-    { as: Element = 'footer', children, className, align = 'right', ...props },
+    { as: Element = 'div', children, className, align = 'right', ...props },
     ref,
   ) => (
     <Element

--- a/packages/circuit-ui/components/Card/components/Header/Header.tsx
+++ b/packages/circuit-ui/components/Card/components/Header/Header.tsx
@@ -51,11 +51,11 @@ export type CardHeaderProps = {
  * Header used in the Card component. Used for styling and alignment
  * purposes only.
  */
-export const CardHeader = forwardRef<HTMLElement, CardHeaderProps>(
+export const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
   ({ onClose, children, closeButtonLabel, className, ...props }, ref) => {
     const noHeadline = isArray(children) && !children[0];
     return (
-      <header
+      <div
         className={clsx(
           classes.base,
           noHeadline && classes['no-headline'],
@@ -70,7 +70,7 @@ export const CardHeader = forwardRef<HTMLElement, CardHeaderProps>(
             {closeButtonLabel}
           </CloseButton>
         )}
-      </header>
+      </div>
     );
   },
 );


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

The CardHeader and CardFooter components include a `<header>` and `<footer>` elements by default. This can be problematic if used in an app that already has these elements, with no way to override these roles, leading to an accessibility failure and accidentally breaking [WCAG 2.1 Success Criterion 1.3.1: Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html).

## Approach and changes

Replace `<header>` and `<footer>` elements with simple `<div>`s

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
