### PR TITLE
Move AutocompleteInput exports to the experimental module

### DIFF
--- a/.changeset/honest-roses-doubt.md
+++ b/.changeset/honest-roses-doubt.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Moved the AutocompleteInput component and related types exports to the experimental module.

--- a/packages/circuit-ui/experimental.ts
+++ b/packages/circuit-ui/experimental.ts
@@ -13,3 +13,8 @@
  * limitations under the License.
  */
 
+/* AutocompleteInput */
+export { AutocompleteInput } from './components/AutocompleteInput/AutocompleteInput.js';
+export type { AutocompleteInputProps } from './components/AutocompleteInput/AutocompleteInput.js';
+export type { AutocompleteInputOption } from './components/AutocompleteInput/components/Option/Option.js';
+export type { AutocompleteInputOptionGroup } from './components/AutocompleteInput/components/Options/Options.js';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -68,10 +68,6 @@ export { PhoneNumberInput } from './components/PhoneNumberInput/index.js';
 export type { PhoneNumberInputProps } from './components/PhoneNumberInput/index.js';
 export { ColorInput } from './components/ColorInput/index.js';
 export type { ColorInputProps } from './components/ColorInput/index.js';
-export { AutocompleteInput } from './components/AutocompleteInput/AutocompleteInput.js';
-export type { AutocompleteInputProps } from './components/AutocompleteInput/AutocompleteInput.js';
-export type { AutocompleteInputOption } from './components/AutocompleteInput/components/Option/Option.js';
-export type { AutocompleteInputOptionGroup } from './components/AutocompleteInput/components/Options/Options.js';
 
 // Actions
 export { Button } from './components/Button/index.js';


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

The AutocompleteInput component was released as an experimental compoent but it was not exported from the right module.

## Approach and changes

Move AutocompleteInput exports to the experimental module.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
