### PR TITLE
Differentiate countries by area code in PhoneNumberInput

### DIFF
--- a/.changeset/six-insects-thank.md
+++ b/.changeset/six-insects-thank.md
@@ -8,7 +8,7 @@ Added support to the PhoneNumberInput component for differentiating between coun
 function Component() {
   const options = [
     { country: 'US', code: '+1' },
-    { country: 'AG', code: '+1', areaCode: '268' },
+    { country: 'AG', code: '+1', areaCodes: ['268'] },
     // ...other countries
   ];
   return <PhoneNumberInput countryCode={{ options }} /* ...other props */ />;

--- a/.changeset/six-insects-thank.md
+++ b/.changeset/six-insects-thank.md
@@ -1,0 +1,16 @@
+---
+'@sumup-oss/circuit-ui': minor
+---
+
+Added support to the PhoneNumberInput component for differentiating between countries that share a country calling code by area code. For example, to differentiate between Antigua & Barbuda and the USA which share the `+1` country code, provide the area code for Antigua & Barbuda (`268`) in the `countryCode.options` prop:
+
+```tsx
+function Component() {
+  const options = [
+    { country: 'US', code: '+1' },
+    { country: 'AG', code: '+1', areaCode: '268' },
+    // ...other countries
+  ];
+  return <PhoneNumberInput countryCode={{ options }} /* ...other props */ />;
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -4153,7 +4153,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -4170,7 +4170,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=12"
       },
@@ -4182,7 +4182,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=12"
       },
@@ -4194,7 +4194,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -4211,7 +4211,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -4226,7 +4226,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -8039,7 +8039,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -14542,7 +14541,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -14600,7 +14599,7 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/encoding": {
       "version": "0.1.13",
@@ -17018,7 +17017,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -17523,7 +17522,7 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -19155,7 +19154,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -25885,7 +25884,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -27534,7 +27533,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/package-manager-detector": {
       "version": "0.2.11",
@@ -27731,7 +27730,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -27747,7 +27746,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -29667,9 +29666,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "devOptional": true,
       "license": "ISC"
     },
@@ -30317,7 +30316,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -30331,7 +30330,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -30466,7 +30465,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -30944,22 +30943,23 @@
       "dev": true
     },
     "node_modules/stylus": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.62.0.tgz",
-      "integrity": "sha512-v3YCf31atbwJQIMtPNX8hcQ+okD4NQaTuKGUWfII8eaqn+3otrbttGL1zSMZAAtiPsBztQnujVBugg/cXFUpyg==",
+      "version": "0.64.0",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.64.0.tgz",
+      "integrity": "sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "@adobe/css-tools": "~4.3.1",
+        "@adobe/css-tools": "~4.3.3",
         "debug": "^4.3.2",
-        "glob": "^7.1.6",
-        "sax": "~1.3.0",
+        "glob": "^10.4.5",
+        "sax": "~1.4.1",
         "source-map": "^0.7.3"
       },
       "bin": {
         "stylus": "bin/stylus"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://opencollective.com/stylus"
@@ -30970,50 +30970,6 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.3.tgz",
       "integrity": "sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==",
       "devOptional": true
-    },
-    "node_modules/stylus/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/stylus/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "devOptional": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/stylus/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "devOptional": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/stylus/node_modules/source-map": {
       "version": "0.7.4",
@@ -31110,12 +31066,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/svgo/node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "dev": true
     },
     "node_modules/symbol-observable": {
       "version": "1.2.0",
@@ -33228,7 +33178,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   "overrides": {
     "storybook": "$storybook",
     "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "@types/react-dom": "^19.0.0",
+    "stylus": "^0.64.0"
   }
 }

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -116,7 +116,8 @@ describe('PhoneNumberInputService', () => {
         { country: 'US', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const actual = mapCountryCodeOptions(options);
+      const locale = undefined;
+      const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].value).toBe('CA');
       expect(actual[1].value).toBe('DE');
       expect(actual[2].value).toBe('US');
@@ -128,7 +129,8 @@ describe('PhoneNumberInputService', () => {
         { country: 'US', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const actual = mapCountryCodeOptions(options);
+      const locale = undefined;
+      const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].label).toBe('Canada (+1)');
       expect(actual[1].label).toBe('Germany (+49)');
       expect(actual[2].label).toBe('United States (+1)');
@@ -136,7 +138,8 @@ describe('PhoneNumberInputService', () => {
 
     it('should omit the country name when it is not available', () => {
       const options = [{ country: '', code: '+49' }];
-      const actual = mapCountryCodeOptions(options);
+      const locale = undefined;
+      const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].label).toBe('+49');
     });
 
@@ -146,7 +149,8 @@ describe('PhoneNumberInputService', () => {
         { country: 'US', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const actual = mapCountryCodeOptions(options);
+      const locale = undefined;
+      const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].label).toBe('Canada (+1)');
       expect(actual[1].label).toBe('Germany (+49)');
       expect(actual[2].label).toBe('United States (+1)');
@@ -158,7 +162,8 @@ describe('PhoneNumberInputService', () => {
         { country: 'US', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const actual = mapCountryCodeOptions(options, 'DE');
+      const locale = 'DE';
+      const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].value).toBe('DE');
     });
   });

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -25,6 +25,7 @@ describe('PhoneNumberInputService', () => {
   describe('parsePhoneNumber', () => {
     const options = [
       { country: 'US', code: '+1' },
+      { country: 'AG', code: '+1', areaCode: '268' },
       { country: 'CA', code: '+1' },
       { country: 'DE', code: '+49' },
     ];
@@ -76,6 +77,13 @@ describe('PhoneNumberInputService', () => {
       const actual = parsePhoneNumber(phoneNumber, options);
       expect(actual.countryCode).toBe('DE');
       expect(actual.subscriberNumber).toBeUndefined();
+    });
+
+    it('should parse a phone number with a country-specific area code', () => {
+      const phoneNumber = '+1 (268) 32423424';
+      const actual = parsePhoneNumber(phoneNumber, options);
+      expect(actual.countryCode).toBe('AG');
+      expect(actual.subscriberNumber).toBe('268 32423424');
     });
   });
 

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -25,7 +25,7 @@ describe('PhoneNumberInputService', () => {
   describe('parsePhoneNumber', () => {
     const options = [
       { country: 'US', code: '+1' },
-      { country: 'AG', code: '+1', areaCode: '268' },
+      { country: 'AG', code: '+1', areaCodes: ['268'] },
       { country: 'CA', code: '+1' },
       { country: 'DE', code: '+49' },
     ];

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
@@ -26,11 +26,11 @@ export type CountryCodeOption = {
    */
   code: string;
   /**
-   * An optional area code for countries that share a country calling code
+   * A list of area codes for countries that share a country calling code
    * and are differentiated by area code, e.g. Antigua & Barbuda: `+1 (268)`,
    * where `268` is the area code.
    */
-  areaCode?: string;
+  areaCodes?: string[];
 };
 
 export function parsePhoneNumber(
@@ -64,19 +64,23 @@ export function parsePhoneNumber(
   const matchedOption = options
     .sort((a, b) => {
       // Match options with area code first
-      if (a.areaCode && !b.areaCode) {
+      if (a.areaCodes && !b.areaCodes) {
         return -1;
       }
-      if (!a.areaCode && b.areaCode) {
+      if (!a.areaCodes && b.areaCodes) {
         return 1;
       }
       // Match longer, more specific country codes first
       return b.code.length - a.code.length;
     })
-    .find(({ code, areaCode }) => {
-      const prefix = areaCode ? `${code}${areaCode}` : code;
+    .find(({ code, areaCodes }) => {
+      if (!areaCodes) {
+        return sanitizedValue.startsWith(code);
+      }
       const noWhitespaceValue = sanitizedValue.replace(/\s/g, '');
-      return noWhitespaceValue.startsWith(prefix);
+      return areaCodes.some((areaCode) =>
+        noWhitespaceValue.startsWith(`${code}${areaCode}`),
+      );
     });
 
   if (!matchedOption) {


### PR DESCRIPTION
## Purpose

Some countries share a country calling code, for example Antigua & Barbuda, Canada, and the USA all use `+1`. When parsing a phone number, the PhoneNumberInput currently cannot differentiate these countries and picks whichever one comes first in the `options` array.

Antigua & Barbuda can be definitively differentiated by its area code (`268`). This pull request adds support for that. ~~This does not solve differentiating between the US and Canada.~~

## Approach and changes

- Added support for including an `areaCode` for country code options which the PhoneNumberInput component will consider when parsing a phone number.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
