### PR TITLE
Omit isModal and animationDuration props from ToggletipProps

### DIFF
--- a/.changeset/large-pumas-nail.md
+++ b/.changeset/large-pumas-nail.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed Dialog specific props `isModal` and `animationDuration` from the `ToggletipProps` interface .

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -54,7 +54,10 @@ export interface ToggletipReferenceProps {
 }
 
 export interface ToggletipProps
-  extends Omit<PublicDialogProps, 'open' | 'children'> {
+  extends Omit<
+    PublicDialogProps,
+    'open' | 'children' | 'isModal' | 'animationDuration'
+  > {
   /**
    * The button element that triggers the toggletip.
    */


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

The `isModal` and `animationDuration`  props are specific to the Dialog component and should not have leaked to the ToggletipProps

## Approach and changes

Omit irrelevant props.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
