### PR TITLE
Render desktop navigation on the server

### DIFF
--- a/.changeset/yellow-beds-start.md
+++ b/.changeset/yellow-beds-start.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Changed the SideNavigation component to render the desktop navigation during server-side rendering (SSR).

--- a/packages/circuit-ui/components/Button/Button.mdx
+++ b/packages/circuit-ui/components/Button/Button.mdx
@@ -1,5 +1,6 @@
 import { Meta, Status, Props, Story } from '../../../../.storybook/components';
 import * as Stories from './Button.stories';
+import * as ButtonGroupStories from '../ButtonGroup/ButtonGroup.stories';
 
 <Meta of={Stories} />
 
@@ -78,6 +79,6 @@ When the button's action is inputting/saving information, you can indicate a loa
 Used when users have two opposite actions to be taken in a certain step of a flow. It is generally used aligned to the right,
 with a primary button for the expected action and a secondary button on its left.
 
-<Story id="components-buttongroup--base" />
+<Story of={ButtonGroupStories.Base} />
 
 - **Do** use the same verb tenses for both actions

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.mdx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.mdx
@@ -1,5 +1,6 @@
 import { Meta, Status, Props, Story } from '../../../../.storybook/components';
 import * as Stories from './SideNavigation.stories';
+import * as TopNavigationStories from '../TopNavigation/TopNavigation.stories';
 
 <Meta of={Stories} />
 
@@ -13,7 +14,7 @@ The side navigation is part of the [application shell](https://developers.google
 
 ## Usage with the top navigation
 
-<Story id="navigation-topnavigation--with-side-navigation" />
+<Story of={TopNavigationStories.WithSideNavigation} inline={false} />
 
 The side navigation is meant to be used alongside the [TopNavigation](Navigation/TopNavigation) component, which displays a hamburger button on narrow viewports to toggle the side navigation.
 

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
@@ -143,7 +143,7 @@ const placeHolderContent = (
 );
 
 export const Base = (args: SideNavigationProps) => {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(args.isOpen);
 
   const onSideNavigationClose = () => {
     setIsOpen(false);

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
@@ -71,7 +71,7 @@ export function SideNavigation({
     }
   }
 
-  const isMobile = useMedia('(max-width: 1279px)', true);
+  const isMobile = useMedia('(max-width: 1279px)');
 
   const prevOpen = usePrevious(isOpen);
 

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.tsx
@@ -20,7 +20,6 @@ import {
   AccessibilityError,
   isSufficientlyLabelled,
 } from '../../util/errors.js';
-import { usePrevious } from '../../hooks/usePrevious/index.js';
 
 import { DesktopNavigation } from './components/DesktopNavigation/index.js';
 import type { DesktopNavigationProps } from './components/DesktopNavigation/DesktopNavigation.js';
@@ -73,8 +72,6 @@ export function SideNavigation({
 
   const isMobile = useMedia('(max-width: 1279px)');
 
-  const prevOpen = usePrevious(isOpen);
-
   return isMobile ? (
     <MobileNavigation
       UNSAFE_components={UNSAFE_components}
@@ -82,7 +79,7 @@ export function SideNavigation({
       closeButtonLabel={closeButtonLabel}
       primaryNavigationLabel={primaryNavigationLabel}
       onClose={onClose}
-      open={!prevOpen && isOpen}
+      open={isOpen}
       {...rest}
     />
   ) : (


### PR DESCRIPTION
## Purpose

Currently, the SideNavigation renders the mobile navigation on the server. This makes no sense, since the mobile navigation is hidden by default.

## Approach and changes

- Render the desktop version of the SideNavigation by default. It is hidden using CSS on mobile viewports.
- Fixed component docs that referenced stories by id (doesn't appear to be supported anymore)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
