### PR TITLE
Add IconName type export

### DIFF
--- a/.changeset/breezy-jeans-sit.md
+++ b/.changeset/breezy-jeans-sit.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/icons": minor
+---
+
+Added an `IconName` type export which holds a union of the raw icon names in snake case, matching the icon names expected by the `getIconURL` helper.

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -146,6 +146,9 @@ function buildDeclarationFile(components: Component[]): string {
   const exportNames = components
     .filter(({ icons }) => icons.some((icon) => !icon.skipComponentFile))
     .map((component) => component.name);
+  const iconNames = components.map(
+    (component) => `'${component.icons[0].name}'`,
+  );
   const iconSizes = components.map((component) => {
     const iconName = component.icons[0].name;
     const sizes = component.icons.map(({ size }) => `'${size}'`).sort();
@@ -168,9 +171,11 @@ function buildDeclarationFile(components: Component[]): string {
 
     export { ${exportNames.join(', ')} };
 
+    export type IconName = ${iconNames.join(' | ')};
+
     export type IconsManifest = {
       icons: {
-        name: string;
+        name: IconName;
         category: string;
         skipComponentFile?: boolean;
         keywords?: string[];
@@ -183,7 +188,7 @@ function buildDeclarationFile(components: Component[]): string {
       ${iconSizes.join('\n')}
     }
 
-    export function getIconURL<Name extends keyof Icons>(name: Name, size?: Icons[Name]): string;
+    export function getIconURL<Name extends IconName>(name: Name, size?: Icons[Name]): string;
   `;
 }
 


### PR DESCRIPTION
## Purpose

While refactoring some code to load the card scheme & payment method icons from a URL, I struggled to type the `icon` parameter that's expected by the `getIconURL` helper.

## Approach and changes

- Add a new `IconName` type export which holds a union of the raw icon names in snake case (e.g. `american_express`)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
