### PR TITLE
Mark React components of brand icons as deprecated

### DIFF
--- a/.changeset/forty-weeks-walk.md
+++ b/.changeset/forty-weeks-walk.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/icons': minor
+---
+
+Marked the React component exports of the icons in the _Card scheme_ and _Payment method_ categories as deprecated. [Load them from a URL instead](https://circuit.sumup.com/?path=/docs/packages-icons--docs#load-from-a-url).

--- a/.changeset/forty-weeks-walk.md
+++ b/.changeset/forty-weeks-walk.md
@@ -2,4 +2,4 @@
 '@sumup-oss/icons': minor
 ---
 
-Marked the React component exports of the icons in the _Card scheme_ and _Payment method_ categories as deprecated. [Load them from a URL instead](https://circuit.sumup.com/?path=/docs/packages-icons--docs#load-from-a-url).
+Marked the React component exports of the icons in the "Card scheme" and "Payment method" categories as deprecated. [Load them from a URL instead](https://circuit.sumup.com/?path=/docs/packages-icons--docs#load-from-a-url).

--- a/.storybook/components/Icons.tsx
+++ b/.storybook/components/Icons.tsx
@@ -182,6 +182,8 @@ export function Icons() {
   );
 }
 
+const DEPRECATED_CATEGORIES = ['Card scheme', 'Payment method'];
+
 function Icon({
   icon,
   scale,
@@ -219,20 +221,19 @@ function Icon({
   };
 
   const copyIconReactName = () => {
-    const reactName = getComponentName(icon.name);
     navigator.clipboard
-      .writeText(reactName)
+      .writeText(componentName)
       .then(() => {
         setToast({
           variant: 'success',
-          body: `Copied the ${icon.name} icon's React name to the clipboard.`,
+          body: `Copied the ${componentName} React component name to the clipboard.`,
         });
       })
       .catch((error) => {
         console.error(error);
         setToast({
           variant: 'danger',
-          body: `Failed to copy the ${icon.name} icon's React name to the clipboard.`,
+          body: `Failed to copy the ${componentName} React component name to the clipboard.`,
         });
       });
   };
@@ -294,16 +295,17 @@ function Icon({
             Copy URL
           </IconButton>
         )}
-        {!icon.skipComponentFile && (
-          <IconButton
-            variant="tertiary"
-            size="s"
-            icon={ReactIcon}
-            onClick={copyIconReactName}
-          >
-            Copy React component name
-          </IconButton>
-        )}
+        {!icon.skipComponentFile &&
+          !DEPRECATED_CATEGORIES.includes(icon.category) && (
+            <IconButton
+              variant="tertiary"
+              size="s"
+              icon={ReactIcon}
+              onClick={copyIconReactName}
+            >
+              Copy React component name
+            </IconButton>
+          )}
       </div>
     </div>
   );

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -45,14 +45,26 @@ type Component = {
   deprecation?: string;
 };
 
-function createDeprecationComment(deprecation?: string) {
-  if (!deprecation) {
-    return '';
-  }
-  return `
+const DEPRECATED_CATEGORIES = ['Card scheme', 'Payment method'];
+
+function createDeprecationComment(component: Component) {
+  if (component.deprecation) {
+    return `
     /**
-     * @deprecated ${deprecation}
+     * @deprecated ${component.deprecation}
      */`;
+  }
+  if (
+    component.icons.some((icon) =>
+      DEPRECATED_CATEGORIES.includes(icon.category),
+    )
+  ) {
+    return `
+    /**
+     * @deprecated This icon is too heavy to be inlined as a React component. [Load it from a URL instead](https://circuit.sumup.com/?path=/docs/packages-icons--docs#load-from-a-url).
+     */`;
+  }
+  return '';
 }
 
 function getComponentName(name: string): string {
@@ -97,7 +109,7 @@ function buildComponentFile(component: Component): string {
       ${sizeMap.join('\n')}
     }
 
-    ${createDeprecationComment(component.deprecation)}
+    ${createDeprecationComment(component)}
     export function ${component.name}({ size = '${defaultSize}', ...props }) {
       const Icon = sizeMap[size] || sizeMap['${defaultSize}'];
 
@@ -140,7 +152,7 @@ function buildDeclarationFile(components: Component[]): string {
       const sizes = component.icons.map(({ size }) => `'${size}'`).sort();
       const SizesType = sizes.join(' | ');
       return `
-      ${createDeprecationComment(component.deprecation)}
+      ${createDeprecationComment(component)}
       declare const ${component.name}: IconComponentType<${SizesType}>;`;
     });
   const exportNames = components


### PR DESCRIPTION
Addresses [DSYS-1143](https://sumupteam.atlassian.net/browse/DSYS-1143)

## Purpose

Importing SVGs as React components enables changing their color using CSS and ensures they’re included in the initial HTML when server-side rendering. On the other hand, inlining, parsing, and executing them as JavaScript has a significant performance overhead. This tradeoff is acceptable for our small, monochromatic product icons. It can’t be justified for complex, multi-colored icons such as country flags and brand logos.

## Approach and changes

- Mark the React component exports of the icons in the _Card Scheme_ and _Payment Method_ categories as deprecated. Recommend loading the icons from a URL instead.
- Hide the "Copy React component name" button from the docs for icons in the _Card Scheme_ and _Payment Method_ categories.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
