### PR TITLE
Remove value attribute from input prefix elements

### DIFF
--- a/.changeset/metal-games-jog.md
+++ b/.changeset/metal-games-jog.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Removed invalid HTML attributes from the CurrencyInput and SearchInput's prefix elements.

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -120,7 +120,6 @@ export const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
       currencyPosition === 'prefix'
         ? (prefixProps: { className?: string }) => (
             <span
-              {...prefixProps}
               className={clsx(prefixProps.className, classes.currency)}
               id={currencySymbolId}
             >

--- a/packages/circuit-ui/components/SearchInput/SearchInput.tsx
+++ b/packages/circuit-ui/components/SearchInput/SearchInput.tsx
@@ -82,7 +82,13 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
       <Input
         value={value}
         type="search"
-        renderPrefix={(renderProps) => <Search size="16" {...renderProps} />}
+        renderPrefix={(prefixProps) => (
+          <Search
+            size="16"
+            className={prefixProps.className}
+            aria-hidden="true"
+          />
+        )}
         {...(value && onClear && clearLabel
           ? {
               renderSuffix: (renderProps) => (


### PR DESCRIPTION
Relates to #3241.

## Purpose

#3241 passed the Input's `value` to the `renderPrefix` render prop. This caused it to be inadvertently spread onto the HTML elements in the CurrencyInput and SearchInput components.

## Approach and changes

- Don't spread the prefix props onto the elements, only set the `className` prop.
- Bonus: Hide the SearchInput's search icon from the accessibility tree.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
