### PR TITLE
fix(ISSUE-3272): adjustments to header height for Comparison table

### DIFF
--- a/packages/circuit-ui/components/ComparisonTable/components/TableHeader/TableHeader.module.css
+++ b/packages/circuit-ui/components/ComparisonTable/components/TableHeader/TableHeader.module.css
@@ -8,7 +8,7 @@
 
 .wrapper {
   padding: 0;
-  vertical-align: bottom;
+  vertical-align: top;
 }
 
 .title {
@@ -32,7 +32,6 @@
 
 @media (min-width: 768px) {
   .base {
-    min-height: 96px;
     padding: 0 var(--cui-spacings-mega);
   }
 


### PR DESCRIPTION
Addresses https://github.com/sumup-oss/circuit-ui/issues/3272

## Purpose

**Before fix:**

<img width="509" height="500" alt="Screenshot 2025-09-04 at 15 57 41" src="https://github.com/user-attachments/assets/9c4af17f-93a8-4f14-b9c4-6ca2a9999075" />

<img width="1496" height="793" alt="Screenshot 2025-09-04 at 15 39 56" src="https://github.com/user-attachments/assets/da96a4cb-4419-41d1-92db-2fd7f087989f" />

**After fix:**

<img width="510" height="428" alt="Screenshot 2025-09-04 at 16 02 47" src="https://github.com/user-attachments/assets/cf89cbb8-1bcd-4d63-9592-a1744096deb3" />

<img width="1489" height="495" alt="Screenshot 2025-09-04 at 16 02 08" src="https://github.com/user-attachments/assets/1a8297c8-5d55-4a15-9454-71092a186096" />


## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
