### PR TITLE
fix(Anchor): respect 'as' prop in combination with 'href'

### DIFF
--- a/.changeset/nine-fans-chew.md
+++ b/.changeset/nine-fans-chew.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed `Anchor` component to respect the provided `as` prop when an `href` is present.

--- a/.changeset/nine-fans-chew.md
+++ b/.changeset/nine-fans-chew.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Fixed `Anchor` component to respect the provided `as` prop when an `href` is present.
+Fixed the Anchor component to respect the provided `as` prop when an `href` is present.

--- a/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.spec.tsx
@@ -91,6 +91,19 @@ describe('Anchor', () => {
       const actual = await axe(container);
       expect(actual).toHaveNoViolations();
     });
+
+    it('should respect a custom `as` prop when href is passed', () => {
+      const CustomLink = ({ children, ...rest }: any) => (
+        <span data-testid="custom" {...rest}>
+          {children}
+        </span>
+      );
+      render(
+        <Anchor {...baseProps} href="https://sumup.com" as={CustomLink} />,
+      );
+      const el = screen.getByTestId('custom');
+      expect(el.tagName).toBe('SPAN');
+    });
   });
 
   describe('as a button', () => {

--- a/packages/circuit-ui/components/Anchor/Anchor.tsx
+++ b/packages/circuit-ui/components/Anchor/Anchor.tsx
@@ -111,10 +111,10 @@ export const Anchor = forwardRef(
     if (props.href) {
       return (
         <Body
+          as={Link}
           {...props}
           aria-describedby={descriptionIds}
           className={clsx(classes.base, utilClasses.focusVisible, className)}
-          as={Link}
           ref={ref}
         >
           {children}


### PR DESCRIPTION
## Purpose

Fixes `Anchor` component to respect the provided `as` prop when an `href` is present.
This allows rendering custom `<a>` implementations/wrappers like `next/link` for example.

## Approach and changes

Change the prop order so `props.as` has the chance to override the default `as={Link}`.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
