### PR TITLE
Fix(ProgessBar): Inifinite loop always true even when loop prop set to false

### DIFF
--- a/.changeset/yellow-moose-jog.md
+++ b/.changeset/yellow-moose-jog.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Fix ProgressBar component duration / loop bug

--- a/.changeset/yellow-moose-jog.md
+++ b/.changeset/yellow-moose-jog.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": minor
 ---
 
-Fix ProgressBar component duration / loop bug
+Fixed an issue in the ProgressBar component where the animation continued looping even when the `loop` prop was set to `false`.

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.module.css
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.module.css
@@ -69,7 +69,7 @@
   animation-play-state: var(--pagination-animation-play-state);
 }
 
-.base:not([aria-valuenow])[data-loop]::after {
+.base:not([aria-valuenow])[data-loop="true"]::after {
   animation-name: loop;
   animation-iteration-count: infinite;
 }


### PR DESCRIPTION
Addresses [No Ticket](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

Fix a small bug with the ProgressBar component where it looped infinitely when using the ```duration``` prop, even with ```loop=false```.

## Approach and changes

Explicitly have the CSS property check ```data-loop="true"``` to set animation loop to ```infinite```.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
