### PR TITLE
Add type declarations to lint plugins

### DIFF
--- a/.changeset/fair-friends-scream.md
+++ b/.changeset/fair-friends-scream.md
@@ -1,0 +1,6 @@
+---
+"@sumup-oss/stylelint-plugin-circuit-ui": minor
+"@sumup-oss/eslint-plugin-circuit-ui": minor
+---
+
+Added type declarations to the published package.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { configs, defineConfig, files } from '@sumup-oss/foundry/eslint';
 import storybook from 'eslint-plugin-storybook';
 import testingLibrary from 'eslint-plugin-testing-library';
+// eslint-disable-next-line import-x/namespace, import-x/no-deprecated, import-x/default, import-x/no-named-as-default, import-x/no-named-as-default-member
 import circuitUI from '@sumup-oss/eslint-plugin-circuit-ui';
 
 // TODO: Re-add react-server-components plugin once it supports ESLint v9

--- a/package-lock.json
+++ b/package-lock.json
@@ -10094,12 +10094,6 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
-      "dev": true
-    },
     "node_modules/@tsconfig/node20": {
       "version": "20.1.6",
       "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.6.tgz",
@@ -35029,7 +35023,7 @@
     },
     "packages/circuit-ui": {
       "name": "@sumup-oss/circuit-ui",
-      "version": "10.12.1",
+      "version": "10.12.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.6",
@@ -35147,7 +35141,7 @@
     },
     "packages/icons": {
       "name": "@sumup-oss/icons",
-      "version": "5.20.0",
+      "version": "5.21.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.28.3",
@@ -35173,7 +35167,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@sumup-oss/design-tokens": "^9.0.0",
-        "@tsconfig/node18": "^18.2.4",
+        "@tsconfig/node20": "^20.1.6",
         "jest-preset-stylelint": "^8.0.0",
         "typescript": "^5.9.2",
         "vitest": "^3.0.9"

--- a/packages/eslint-plugin-circuit-ui/index.ts
+++ b/packages/eslint-plugin-circuit-ui/index.ts
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import type { FlatConfig } from '@typescript-eslint/utils/ts-eslint';
+
 import pkg from './package.json' with { type: 'json' };
 
 import { componentLifecycleImports } from './component-lifecycle-imports/index.js';
@@ -41,7 +43,7 @@ const plugin = {
     version: pkg.version,
     namespace,
   },
-  configs: {},
+  configs: {} as { recommended: FlatConfig.Config },
   rules,
 };
 

--- a/packages/eslint-plugin-circuit-ui/package.json
+++ b/packages/eslint-plugin-circuit-ui/package.json
@@ -10,6 +10,7 @@
   ],
   "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/eslint-plugin-circuit-ui/tsconfig.json
+++ b/packages/eslint-plugin-circuit-ui/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
+    "declaration": true,
     "moduleResolution": "nodenext",
     "outDir": "dist"
   }

--- a/packages/stylelint-plugin-circuit-ui/package.json
+++ b/packages/stylelint-plugin-circuit-ui/package.json
@@ -11,6 +11,7 @@
     "stylelint-plugin"
   ],
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
@@ -30,7 +31,7 @@
   },
   "devDependencies": {
     "@sumup-oss/design-tokens": "^9.0.0",
-    "@tsconfig/node18": "^18.2.4",
+    "@tsconfig/node20": "^20.1.6",
     "jest-preset-stylelint": "^8.0.0",
     "typescript": "^5.9.2",
     "vitest": "^3.0.9"

--- a/packages/stylelint-plugin-circuit-ui/tsconfig.json
+++ b/packages/stylelint-plugin-circuit-ui/tsconfig.json
@@ -1,4 +1,8 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
-  "compilerOptions": { "outDir": "dist" }
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "moduleResolution": "nodenext",
+    "outDir": "dist"
+  }
 }


### PR DESCRIPTION
## Purpose

The ESLint and Stylelint plugins are written in TypeScript, but the types aren't emitted during build and are thus lost when publishing the packages.

## Approach and changes

- Emit type declarations
- Target Node 20 when building the Stylelint plugin

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
