### PR TITLE
Fix DateInput width when rendered inside Dialog

### DIFF
--- a/.changeset/witty-adults-fall.md
+++ b/.changeset/witty-adults-fall.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed calculating the input widths when the DateInput component is rendered inside the Dialog component.

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
@@ -67,6 +67,7 @@ export function DateSegment({
   ...props
 }: DateSegmentProps) {
   const sizeRef = useRef<HTMLSpanElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const [width, setWidth] = useState('4ch');
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: The width needs to be recalculated when the value changes
@@ -86,11 +87,13 @@ export function DateSegment({
 
       // Try again after up to 1 second using exponential backoff
       if (retryDelay <= 1000) {
-        const timerId = setTimeout(() => {
+        timerRef.current = setTimeout(() => {
           calculateWidth(retryDelay ** 2);
         }, retryDelay);
         return () => {
-          clearTimeout(timerId);
+          if (timerRef.current) {
+            clearTimeout(timerRef.current);
+          }
         };
       }
 

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
@@ -88,7 +88,7 @@ export function DateSegment({
       // Try again after up to 1 second using exponential backoff
       if (retryDelay <= 1000) {
         timerRef.current = setTimeout(() => {
-          calculateWidth(retryDelay ** 2);
+          calculateWidth(retryDelay * 10);
         }, retryDelay);
         return () => {
           if (timerRef.current) {

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
@@ -71,15 +71,33 @@ export function DateSegment({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: The width needs to be recalculated when the value changes
   useLayoutEffect(() => {
-    if (sizeRef.current) {
-      const cursorWidth = 1;
-      const elementSize = sizeRef.current.getBoundingClientRect();
-      const elementWidth = Math.ceil(elementSize.width);
-      // The element width can be 0 if a parent element isn't rendered to the DOM (yet)
-      if (elementWidth > 0) {
-        setWidth(`${cursorWidth + elementWidth}px`);
+    function calculateWidth(attempt = 1) {
+      if (sizeRef.current) {
+        const cursorWidth = 1;
+        const elementSize = sizeRef.current.getBoundingClientRect();
+        const elementWidth = Math.ceil(elementSize.width);
+
+        // The element width can be 0 if a parent element isn't rendered to the DOM (yet)
+        if (elementWidth > 0) {
+          setWidth(`${cursorWidth + elementWidth}px`);
+          return undefined;
+        }
       }
+
+      // Try again on the next tick up to 5 times
+      if (attempt <= 5) {
+        const timerId = setTimeout(() => {
+          calculateWidth(attempt + 1);
+        }, 1);
+        return () => {
+          clearTimeout(timerId);
+        };
+      }
+
+      return undefined;
     }
+
+    return calculateWidth();
   }, [props.value]);
 
   const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
@@ -71,7 +71,7 @@ export function DateSegment({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: The width needs to be recalculated when the value changes
   useLayoutEffect(() => {
-    function calculateWidth(attempt = 1) {
+    function calculateWidth(retryDelay = 10) {
       if (sizeRef.current) {
         const cursorWidth = 1;
         const elementSize = sizeRef.current.getBoundingClientRect();
@@ -84,11 +84,11 @@ export function DateSegment({
         }
       }
 
-      // Try again on the next tick up to 5 times
-      if (attempt <= 5) {
+      // Try again after up to 1 second using exponential backoff
+      if (retryDelay <= 1000) {
         const timerId = setTimeout(() => {
-          calculateWidth(attempt + 1);
-        }, 1);
+          calculateWidth(retryDelay ** 2);
+        }, retryDelay);
         return () => {
           clearTimeout(timerId);
         };


### PR DESCRIPTION
## Purpose

The DateInput component's input segments are dynamically resized based on the input value. The initial width calculation can fail when a parent element hasn't been rendered to the DOM (yet). One such case occurs when the DateInput is rendered inside a Dialog component.

## Approach and changes

- Retry calculating the input width using exponential backoff up to 1 second after the DateInput component has been rendered 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
