### PR TITLE
fix Popover's --popover-max-height property

### DIFF
--- a/.changeset/every-kings-send.md
+++ b/.changeset/every-kings-send.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Improved the calculation of `availableHeight` against the viewport instead of clipping ancestors for the Popover component. This ensures that nested Popovers take available viewport space to display their content.

--- a/.changeset/funny-foxes-enjoy.md
+++ b/.changeset/funny-foxes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Limited the AutocompleteInput text field height to 200px.

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -135,6 +135,7 @@ const sizeOptions: SizeOptions = {
       `${availableHeight}px`,
     );
   },
+  boundary: document.documentElement,
 };
 
 export const AutocompleteInput = forwardRef<

--- a/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
@@ -4,7 +4,9 @@
   flex-wrap: wrap;
   gap: var(--cui-spacings-byte);
   width: 100%;
+  max-height: 200px;
   padding: var(--cui-spacings-kilo) var(--cui-spacings-mega);
+  overflow-y: scroll;
   background-color: var(--cui-bg-normal);
   border: 1px solid var(--cui-border-normal);
   border-radius: var(--cui-border-radius-byte);

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -110,6 +110,7 @@ const sizeOptions: SizeOptions = {
       `${availableHeight}px`,
     );
   },
+  boundary: document.documentElement,
 };
 
 export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(


### PR DESCRIPTION
## Purpose

Floating UI clips content relative to the parent element's bounds. This leads to nested elements not allowed to take the space they need to render their content, as they are restricted by their parent elements' size. Components relying on Floating UI like the AutocompleteInput and the Popover are affected by this behaviour (screenshot below)

<img width="837" height="970" alt="Screenshot 2025-09-26 at 16 18 49" src="https://github.com/user-attachments/assets/c238383a-f61f-4c92-8304-fc7c348451c5" />

## Approach and changes

Change the `boundry` parameter in the size middleware to `document.documentElement` instead of `clippingAncestors ` default value.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
