### PR TITLE
CRMIOP-00 fix mixed start support

### DIFF
--- a/.changeset/whole-sheep-count.md
+++ b/.changeset/whole-sheep-count.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-fixed mixed support for align-items and justify-content in Option and RowHeader components
+Replaced CSS rules in the AutocompleteInput and ComparisonTable components that aren't supported in older browsers.

--- a/.changeset/whole-sheep-count.md
+++ b/.changeset/whole-sheep-count.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+fixed mixed support for align-items and justify-content in Option and RowHeader components

--- a/.changeset/whole-sheep-count.md
+++ b/.changeset/whole-sheep-count.md
@@ -1,5 +1,5 @@
 ---
-"@sumup-oss/circuit-ui": minor
+"@sumup-oss/circuit-ui": patch
 ---
 
 fixed mixed support for align-items and justify-content in Option and RowHeader components

--- a/packages/circuit-ui/components/AutocompleteInput/components/Option/Option.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/components/Option/Option.module.css
@@ -1,6 +1,6 @@
 .base {
   display: flex;
-  align-items: start;
+  align-items: flex-start;
   min-height: 40px;
   padding: var(--cui-spacings-byte);
   margin-bottom: var(--cui-spacings-bit);

--- a/packages/circuit-ui/components/ComparisonTable/components/RowHeader/RowHeader.module.css
+++ b/packages/circuit-ui/components/ComparisonTable/components/RowHeader/RowHeader.module.css
@@ -9,7 +9,7 @@
   display: flex;
   gap: var(--cui-spacings-byte);
   align-items: center;
-  justify-content: start;
+  justify-content: flex-start;
 }
 
 .description {


### PR DESCRIPTION
This is a small fix for warnings that I noticed in our logs in the Hive around mixed support for `start` values in `text-align` and `jutstify-content`. 

## Purpose

Fixing this error specifically:

```
(6383:3) autoprefixer: start value has mixed support, consider using flex-start instead

Import trace for requested module:
../../node_modules/.pnpm/@sumup-oss+circuit-ui@10.12.4_@emotion+is-prop-valid@1.3.1_@emotion+react@11.11.4_@types+reac_nr6knfaqs6ykpceeapqkedtjt4/node_modules/@sumup-oss/circuit-ui/dist/styles.css.webpack[javascript/auto]!=!../../node_modules/.pnpm/next@15.5.3_@babel+core@7.24.5_@opentelemetry+api@1.9.0_babel-plugin-macros@3.1.0_react-dom@1_fg5swd6wn474yntnhmysgrlffa/node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[14].oneOf[10].use[2]!../../node_modules/.pnpm/next@15.5.3_@babel+core@7.24.5_@opentelemetry+api@1.9.0_babel-plugin-macros@3.1.0_react-dom@1_fg5swd6wn474yntnhmysgrlffa/node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[14].oneOf[10].use[3]!../../node_modules/.pnpm/@sumup-oss+circuit-ui@10.12.4_@emotion+is-prop-valid@1.3.1_@emotion+react@11.11.4_@types+reac_nr6knfaqs6ykpceeapqkedtjt4/node_modules/@sumup-oss/circuit-ui/dist/styles.css
../../node_modules/.pnpm/@sumup-oss+circuit-ui@10.12.4_@emotion+is-prop-valid@1.3.1_@emotion+react@11.11.4_@types+reac_nr6knfaqs6ykpceeapqkedtjt4/node_modules/@sumup-oss/circuit-ui/dist/styles.css
```
According to MDN there is full support for these but might be due to mixed support in earlier browser versions? Not sure. I did find a [mozilla PR](https://github.com/mozilla/addons/issues/3110) doing the same thing though and managed to get rid of the error locally with the same approach.

## Approach and changes

Got the error locally, went into the built `styles.css`, changed the css props and managed to get rid of the warnings so I changed the module definitions in this PR.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
