### PR TITLE
Fix floating UI height issue

### DIFF
--- a/.changeset/social-wasps-write.md
+++ b/.changeset/social-wasps-write.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Improved the sizing of floating elements in the Popover and AutocompleteInput components using a custom Rect as boundary.

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -33,6 +33,7 @@ import {
   offset,
   shift,
   size,
+  type SizeOptions,
   useFloating,
 } from '@floating-ui/react-dom';
 
@@ -291,6 +292,28 @@ export const AutocompleteInput = forwardRef<
       setIsOpen(true);
     }, []);
 
+    const sizeOptions: SizeOptions = useMemo(
+      () => ({
+        padding: boundaryPadding,
+        apply({ availableHeight, elements }) {
+          elements.floating.style.setProperty(
+            '--results-max-height',
+            `${availableHeight}px`,
+          );
+        },
+        boundary:
+          typeof window !== 'undefined'
+            ? ({
+                x: 0,
+                y: 0,
+                width: window.innerWidth,
+                height: window.innerHeight,
+              } as DOMRect)
+            : undefined,
+      }),
+      [],
+    );
+
     const { floatingStyles, refs, update } = useFloating<HTMLElement>({
       open: isOpen,
       placement: 'bottom',
@@ -302,19 +325,7 @@ export const AutocompleteInput = forwardRef<
           padding: boundaryPadding,
           fallbackPlacements: multiple ? [] : ['top'],
         }),
-        size({
-          padding: boundaryPadding,
-          apply({ availableHeight, elements }) {
-            elements.floating.style.setProperty(
-              '--results-max-height',
-              `${availableHeight}px`,
-            );
-          },
-          boundary:
-            typeof window !== 'undefined'
-              ? document.documentElement
-              : undefined,
-        }),
+        size(sizeOptions),
       ],
       whileElementsMounted: autoUpdate,
     });

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -127,6 +127,16 @@ export type AutocompleteInputProps = Omit<
   };
 const boundaryPadding = 8;
 
+const sizeOptions: SizeOptions = {
+  padding: boundaryPadding,
+  apply({ availableHeight, elements }) {
+    elements.floating.style.setProperty(
+      '--results-max-height',
+      `${availableHeight}px`,
+    );
+  },
+};
+
 export const AutocompleteInput = forwardRef<
   HTMLInputElement,
   AutocompleteInputProps
@@ -292,28 +302,6 @@ export const AutocompleteInput = forwardRef<
       setIsOpen(true);
     }, []);
 
-    const sizeOptions: SizeOptions = useMemo(
-      () => ({
-        padding: boundaryPadding,
-        apply({ availableHeight, elements }) {
-          elements.floating.style.setProperty(
-            '--results-max-height',
-            `${availableHeight}px`,
-          );
-        },
-        boundary:
-          typeof window !== 'undefined'
-            ? ({
-                x: 0,
-                y: 0,
-                width: window.innerWidth,
-                height: window.innerHeight,
-              } as DOMRect)
-            : undefined,
-      }),
-      [],
-    );
-
     const { floatingStyles, refs, update } = useFloating<HTMLElement>({
       open: isOpen,
       placement: 'bottom',
@@ -325,7 +313,18 @@ export const AutocompleteInput = forwardRef<
           padding: boundaryPadding,
           fallbackPlacements: multiple ? [] : ['top'],
         }),
-        size(sizeOptions),
+        size(() => ({
+          ...sizeOptions,
+          boundary:
+            typeof window !== 'undefined'
+              ? ({
+                  x: 0,
+                  y: 0,
+                  width: window.innerWidth,
+                  height: window.innerHeight,
+                } as DOMRect)
+              : undefined,
+        })),
       ],
       whileElementsMounted: autoUpdate,
     });

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -33,7 +33,6 @@ import {
   offset,
   shift,
   size,
-  type SizeOptions,
   useFloating,
 } from '@floating-ui/react-dom';
 
@@ -292,21 +291,6 @@ export const AutocompleteInput = forwardRef<
       setIsOpen(true);
     }, []);
 
-    const sizeOptions: SizeOptions = useMemo(
-      () => ({
-        padding: boundaryPadding,
-        apply({ availableHeight, elements }) {
-          elements.floating.style.setProperty(
-            '--results-max-height',
-            `${availableHeight}px`,
-          );
-        },
-        boundary:
-          typeof window !== 'undefined' ? document.documentElement : undefined,
-      }),
-      [],
-    );
-
     const { floatingStyles, refs, update } = useFloating<HTMLElement>({
       open: isOpen,
       placement: 'bottom',
@@ -318,7 +302,19 @@ export const AutocompleteInput = forwardRef<
           padding: boundaryPadding,
           fallbackPlacements: multiple ? [] : ['top'],
         }),
-        size(sizeOptions),
+        size({
+          padding: boundaryPadding,
+          apply({ availableHeight, elements }) {
+            elements.floating.style.setProperty(
+              '--results-max-height',
+              `${availableHeight}px`,
+            );
+          },
+          boundary:
+            typeof window !== 'undefined'
+              ? document.documentElement
+              : undefined,
+        }),
       ],
       whileElementsMounted: autoUpdate,
     });

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -32,7 +32,6 @@ import {
   useCallback,
   useEffect,
   useId,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -103,6 +102,16 @@ export interface PopoverProps
 
 const boundaryPadding = 8;
 
+const sizeOptions: SizeOptions = {
+  padding: boundaryPadding,
+  apply({ availableHeight, elements }) {
+    elements.floating.style.setProperty(
+      '--popover-max-height',
+      `${availableHeight}px`,
+    );
+  },
+};
+
 export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
   (
     {
@@ -128,28 +137,6 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
     const animationDuration = isMobile ? 300 : 0;
     const prevOpen = usePrevious(isOpen);
 
-    const sizeOptions: SizeOptions = useMemo(
-      () => ({
-        padding: boundaryPadding,
-        apply({ availableHeight, elements }) {
-          elements.floating.style.setProperty(
-            '--popover-max-height',
-            `${availableHeight}px`,
-          );
-        },
-        boundary:
-          typeof window !== 'undefined'
-            ? ({
-                x: 0,
-                y: 0,
-                width: window.innerWidth,
-                height: window.innerHeight,
-              } as DOMRect)
-            : undefined,
-      }),
-      [],
-    );
-
     const { floatingStyles, refs, update } = useFloating<HTMLElement>({
       open: isOpen,
       placement,
@@ -161,7 +148,18 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
           padding: boundaryPadding,
           fallbackPlacements,
         }),
-        size(sizeOptions),
+        size(() => ({
+          ...sizeOptions,
+          boundary:
+            typeof window !== 'undefined'
+              ? ({
+                  x: 0,
+                  y: 0,
+                  width: window.innerWidth,
+                  height: window.innerHeight,
+                } as DOMRect)
+              : undefined,
+        })),
       ],
     });
 

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -138,7 +138,14 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
           );
         },
         boundary:
-          typeof window !== 'undefined' ? document.documentElement : undefined,
+          typeof window !== 'undefined'
+            ? ({
+                x: 0,
+                y: 0,
+                width: window.innerWidth,
+                height: window.innerHeight,
+              } as DOMRect)
+            : undefined,
       }),
       [],
     );


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

A recent change on the floating elements of the AutocompleteInput and Popover components introduced an issue of inconsistent height of the elements even when screen size allowed large room for content to render. I believe this is due to using the whole documentElement to check for overflow instead of the window. 


https://github.com/user-attachments/assets/605acb73-43e2-4a09-a49e-f5eb90c678f8



## Approach and changes

Use a custom Rect with the window dimension as a boundary.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
