### PR TITLE
Add a `disableModalOnMobile` prop to Popover

### DIFF
--- a/.changeset/new-states-guess.md
+++ b/.changeset/new-states-guess.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added a `disableModalOnMobile` prop to render Popover and ActionMenu content as a floating container on narrow screens.

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
@@ -111,7 +111,7 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
         className={clsx(className, classes.base)}
         contentClassName={classes.content}
         ref={ref}
-        hideCloseButton={!isMobile}
+        hideCloseButton={!isMobile || props.disableModalOnMobile}
         onToggle={onToggle}
         component={(refProps) => (
           <Component

--- a/packages/circuit-ui/components/Popover/Popover.module.css
+++ b/packages/circuit-ui/components/Popover/Popover.module.css
@@ -5,8 +5,14 @@
   border-radius: var(--cui-border-radius-byte);
 }
 
+.non-modal {
+  z-index: var(--cui-z-index-popover);
+  box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);
+}
+
 .content {
   max-height: inherit;
+  padding: var(--cui-spacings-mega);
   overflow-y: auto;
 }
 
@@ -14,19 +20,8 @@
   display: inline-block;
 }
 
-@media (min-width: 480px) {
-  .base {
-    z-index: var(--cui-z-index-popover);
-    box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);
-  }
-
-  .content {
-    padding: var(--cui-spacings-mega);
-  }
-}
-
 @media (max-width: 479px) {
-  .base {
+  .modal {
     top: unset;
     right: 0;
     bottom: 0;

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -60,7 +60,7 @@ export interface PopoverReferenceProps {
 type OnToggle = (open: boolean | ((prevOpen: boolean) => boolean)) => void;
 
 export interface PopoverProps
-  extends Omit<PublicDialogProps, 'open' | 'onToggle'>,
+  extends Omit<PublicDialogProps, 'open' | 'onToggle' | 'isModal'>,
     Pick<DialogProps, 'hideCloseButton'> {
   /**
    * The state of the Popover.
@@ -98,6 +98,10 @@ export interface PopoverProps
    * An optional class name to be applied to the component's content.
    */
   contentClassName?: string;
+  /**
+   * If set to true, the Popover will not render as a modal on mobile
+   */
+  disableModalOnMobile?: boolean;
 }
 
 const boundaryPadding = 8;
@@ -125,6 +129,7 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
       className,
       contentClassName,
       style,
+      disableModalOnMobile,
       ...props
     },
     ref,
@@ -134,7 +139,8 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
     const contentId = useId();
     const [isClosing, setClosing] = useState(false);
     const isMobile = useMedia('(max-width: 479px)');
-    const animationDuration = isMobile ? 300 : 0;
+    const isModalOnMobile = !disableModalOnMobile && isMobile;
+    const animationDuration = isModalOnMobile ? 300 : 0;
     const prevOpen = usePrevious(isOpen);
 
     const { floatingStyles, refs, update } = useFloating<HTMLElement>({
@@ -206,10 +212,12 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
       setClosing(true);
     }, []);
 
-    const outAnimation = isMobile
+    const outAnimation = isModalOnMobile
       ? sharedClasses.animationSlideUpOut
       : undefined;
-    const inAnimation = isMobile ? sharedClasses.animationSlideUpIn : undefined;
+    const inAnimation = isModalOnMobile
+      ? sharedClasses.animationSlideUpIn
+      : undefined;
 
     useEffect(() => {
       // Focus the reference element after closing
@@ -234,15 +242,16 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
           open={isOpen}
           onCloseStart={handleCloseStart}
           onCloseEnd={handleCloseEnd}
-          isModal={isMobile}
+          isModal={isModalOnMobile}
           ref={applyMultipleRefs(ref, refs.setFloating, dialogRef)}
           className={clsx(
             classes.base,
             isClosing ? outAnimation : inAnimation,
+            isModalOnMobile ? classes.modal : classes['non-modal'],
             className,
           )}
           animationDuration={animationDuration}
-          style={isMobile ? style : { ...style, ...floatingStyles }}
+          style={isModalOnMobile ? style : { ...style, ...floatingStyles }}
           preventOutsideClickRefs={refs.reference}
         >
           <div


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

By default, the Popover component — and consequently the ActionMenu — renders its content as a modal on narrow screens.
For the upcoming navigation redesign, we need an option to display the ActionMenu content without this modal behavior. This PR introduces a new prop that disables the modal presentation on narrow screens while preserving the existing default behavior.


## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
