### PR TITLE
Update side panel styles on desktop

### DIFF
--- a/.changeset/bumpy-pumas-open.md
+++ b/.changeset/bumpy-pumas-open.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Updated the SidePanel visual design to better integrate with surrounding layouts. The component no longer uses borders, and its content is now placed on a subtle background to improve visual separation.

--- a/.changeset/bumpy-pumas-open.md
+++ b/.changeset/bumpy-pumas-open.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": minor
 ---
 
-Updated the SidePanel visual design to better integrate with surrounding layouts. The component no longer uses borders, and its content is now placed on a subtle background to improve visual separation.
+Updated the SidePanel's design to visually distance it from adjacent elements above l(e.g., the viewport or top navigation). This serves as an intermediate step ahead of an upcoming navigation redesign.

--- a/.changeset/bumpy-pumas-open.md
+++ b/.changeset/bumpy-pumas-open.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": minor
 ---
 
-Updated the SidePanel's design to visually distance it from adjacent elements above l(e.g., the viewport or top navigation). This serves as an intermediate step ahead of an upcoming navigation redesign.
+Updated the SidePanel's design to visually distance it from adjacent elements above (e.g., the viewport or top navigation). This serves as an intermediate step ahead of an upcoming navigation redesign.

--- a/packages/circuit-ui/components/SidePanel/SidePanel.module.css
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.module.css
@@ -18,6 +18,7 @@
 }
 
 .wrapper {
+  outline: none;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -60,7 +61,6 @@
     height: calc(100dvh - var(--top-navigation-height, 0));
     margin: 0;
     background-color: var(--cui-bg-normal);
-    box-shadow: inset var(--cui-border-width-kilo) 0 0 var(--cui-border-divider);
   }
 
   .base::after {
@@ -74,10 +74,15 @@
   }
 
   .wrapper {
-    padding-left: 0;
+    height: calc(100% - var(--cui-spacings-kilo));
+    margin-top: var(--cui-spacings-kilo);
+    border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
+    border-right: none;
+    border-bottom: none;
+    border-top-left-radius: var(--cui-border-radius-kilo);
   }
 
   .content {
-    padding: 0 var(--cui-spacings-giga);
+    padding: 0 var(--cui-spacings-giga) var(--cui-spacings-giga);
   }
 }

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.module.css
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.module.css
@@ -11,20 +11,13 @@
 @media (min-width: 768px) {
   .base {
     background-color: var(--cui-bg-normal);
-    box-shadow: inset var(--cui-border-width-kilo) 0 0 var(--cui-border-divider);
+    border-top-left-radius: var(--cui-border-radius-mega);
   }
 }
 
 .sticky {
   box-shadow: inset 0 calc(-1 * var(--cui-border-width-kilo)) 0
     var(--cui-border-divider);
-}
-
-@media (min-width: 768px) {
-  .sticky {
-    box-shadow: inset var(--cui-border-width-kilo)
-      calc(-1 * var(--cui-border-width-kilo)) 0 var(--cui-border-divider);
-  }
 }
 
 .base .button {


### PR DESCRIPTION
Addresses [DSYS-1607](https://sumupteam.atlassian.net/browse/DSYS-1607)

## Purpose

In order to support ze-dashboard app's navigation redesign, we need to slightly adjust the height of the side panel to distance it from surrounding elements, notably the top navigation. This is an intermediate step before an upcoming redesign to CUI's navigation components.

## Approach and changes

adjust the height of the side panel to create distance between the component and the surrounding elements (viewport or top navigation)

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
