### PR TITLE
fix(components): AutocompleteInput X-axis overflow

### DIFF
--- a/.changeset/olive-rats-report.md
+++ b/.changeset/olive-rats-report.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed autocomplete option labels and descriptions overflowing horizontally.

--- a/packages/circuit-ui/components/AutocompleteInput/components/Option/Option.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/components/Option/Option.module.css
@@ -41,11 +41,19 @@
   flex: 1;
   flex-direction: column;
   gap: var(--cui-spacings-bit);
+  min-width: 0;
 }
 
 .has-media {
   justify-content: center;
   min-height: 32px;
+}
+
+.label,
+.description {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .media img {

--- a/packages/circuit-ui/components/AutocompleteInput/components/Option/Option.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/components/Option/Option.tsx
@@ -109,11 +109,16 @@ export const Option = ({
           (image || Icon) && classes['has-media'],
         )}
       >
-        <Compact id={labelId} size="s" weight="semibold">
+        <Compact
+          id={labelId}
+          size="s"
+          weight="semibold"
+          className={classes.label}
+        >
           {label}
         </Compact>
         {description && (
-          <Compact size="s" color="subtle">
+          <Compact size="s" color="subtle" className={classes.description}>
             {description}
           </Compact>
         )}


### PR DESCRIPTION
Prevent overflow on X axis for `AutocompleteInput` by using ellipsis for long labels and descriptions. Currently, if the label is a long string without word break it makes the `AutocompleteInput` scroll on X axis which is quite awkward to use as it pushes the checkbox outside the visible content.
