### PR TITLE
fix(circuit-ui): ColorInput border radius

### DIFF
--- a/.changeset/few-nights-rush.md
+++ b/.changeset/few-nights-rush.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the ColorInput text field border radius so its left corners stayed square next to the color swatch after the shared Input border changes in `b37eec9b` and the follow-up ColorInput composite input update in `d39dc282`.

--- a/.changeset/few-nights-rush.md
+++ b/.changeset/few-nights-rush.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Fixed the ColorInput text field border radius so its left corners stayed square next to the color swatch after the shared Input border changes in `b37eec9b` and the follow-up ColorInput composite input update in `d39dc282`.
+Fixed a style specificity issue in the ColorInput component that caused the text field to have a border radius towards the color swatch.

--- a/packages/circuit-ui/components/ColorInput/ColorInput.module.css
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.module.css
@@ -75,8 +75,7 @@
   color: var(--cui-fg-subtle);
 }
 
-/* Repeat the local class to outrank the shared Input base radius styles. */
-.input.input {
+.wrapper .input {
   position: relative;
   padding-left: var(--cui-spacings-giga);
   font-family: var(--cui-font-stack-mono);
@@ -87,11 +86,11 @@
   transform: translateX(-1px);
 }
 
-.input:hover,
+.wrapper .input:hover,
 .input:focus {
   z-index: var(--cui-z-index-absolute);
 }
 
-.input::placeholder {
+.wrapper .input::placeholder {
   font-family: var(--cui-font-stack-mono);
 }

--- a/packages/circuit-ui/components/ColorInput/ColorInput.module.css
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.module.css
@@ -75,7 +75,8 @@
   color: var(--cui-fg-subtle);
 }
 
-.input {
+/* Repeat the local class to outrank the shared Input base radius styles. */
+.input.input {
   position: relative;
   padding-left: var(--cui-spacings-giga);
   font-family: var(--cui-font-stack-mono);


### PR DESCRIPTION
Fix additional border-radius on inner edge between color swatch and hex code input.

<img width="341" height="116" alt="Screenshot 2026-04-10 at 22 32 32" src="https://github.com/user-attachments/assets/460a421c-2bba-4c8c-9fee-0b94d3e4fc84" />
