### PR TITLE
feat(eslint-plugin-circuit-ui): add no-default-props rule

### DIFF
--- a/.changeset/famous-candles-laugh.md
+++ b/.changeset/famous-candles-laugh.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/eslint-plugin-circuit-ui": patch
+---
+
+Added the `no-default-props` rule to remove redundant Circuit UI props that match component defaults.

--- a/.changeset/famous-candles-laugh.md
+++ b/.changeset/famous-candles-laugh.md
@@ -1,5 +1,5 @@
 ---
-"@sumup-oss/eslint-plugin-circuit-ui": patch
+"@sumup-oss/eslint-plugin-circuit-ui": minor
 ---
 
 Added the `no-default-props` rule to remove redundant Circuit UI props that match component defaults.

--- a/packages/eslint-plugin-circuit-ui/README.md
+++ b/packages/eslint-plugin-circuit-ui/README.md
@@ -44,6 +44,7 @@ Rules are configured under the rules section:
 
 - [`component-lifecycle-imports`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/component-lifecycle-imports)
 - [`no-invalid-custom-properties`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-invalid-custom-properties)
+- [`no-default-props`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-default-props)
 - [`no-deprecated-props`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-deprecated-props)
 - [`no-renamed-props`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/no-renamed-props)
 - [`prefer-custom-properties`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/prefer-custom-properties)

--- a/packages/eslint-plugin-circuit-ui/index.ts
+++ b/packages/eslint-plugin-circuit-ui/index.ts
@@ -21,6 +21,7 @@ import type { RuleSeverity } from './utils/meta.js';
 import { componentLifecycleImports } from './component-lifecycle-imports/index.js';
 import { noInvalidCustomProperties } from './no-invalid-custom-properties/index.js';
 import { noDeprecatedCustomProperties } from './no-deprecated-custom-properties/index.js';
+import { noDefaultProps } from './no-default-props/index.js';
 import { noDeprecatedProps } from './no-deprecated-props/index.js';
 import { noRenamedProps } from './no-renamed-props/index.js';
 import { preferCustomProperties } from './prefer-custom-properties/index.js';
@@ -30,6 +31,7 @@ export const rules = {
   'component-lifecycle-imports': componentLifecycleImports,
   'no-invalid-custom-properties': noInvalidCustomProperties,
   'no-deprecated-custom-properties': noDeprecatedCustomProperties,
+  'no-default-props': noDefaultProps,
   'no-deprecated-props': noDeprecatedProps,
   'no-renamed-props': noRenamedProps,
   'prefer-custom-properties': preferCustomProperties,

--- a/packages/eslint-plugin-circuit-ui/no-default-props/README.md
+++ b/packages/eslint-plugin-circuit-ui/no-default-props/README.md
@@ -1,0 +1,44 @@
+# no-default-props
+
+Omit explicitly passed props when they match Circuit UI defaults and do not
+change the rendered output.
+
+## Rule Details
+
+This rule flags a small allowlist of redundant props and removes them
+automatically. It is intentionally explicit rather than trying to infer defaults
+from component implementations.
+
+Known conditional cases:
+
+- `Body as="p"` is only removed when `variant` is absent or statically known not
+  to be `highlight` or `quote`.
+- `Body weight="regular"` is only removed when `as` is absent or statically
+  known not to be `strong`.
+
+Use standard ESLint disable comments for exceptions when a codebase prefers to
+keep a default prop explicit in a specific location.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+import { Body, Button, IconButton } from '@sumup-oss/circuit-ui';
+
+<Body size="m" color="normal">Hello</Body>;
+<Button size="m" variant="secondary">Submit</Button>;
+<IconButton size="m" variant="secondary" icon={More}>
+  More
+</IconButton>;
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+import { Body, Button, IconButton } from '@sumup-oss/circuit-ui';
+
+<Body>Hello</Body>;
+<Button>Submit</Button>;
+<IconButton icon={More}>More</IconButton>;
+```

--- a/packages/eslint-plugin-circuit-ui/no-default-props/index.spec.tsx
+++ b/packages/eslint-plugin-circuit-ui/no-default-props/index.spec.tsx
@@ -1,0 +1,367 @@
+/**
+ * Copyright 2026, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { noDefaultProps } from './index.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run('no-default-props', noDefaultProps, {
+  valid: [
+    {
+      name: 'ignores components imported from another package',
+      code: `
+        import { Button } from 'some-other-package';
+
+        function Component() {
+          return <Button size="m" variant="secondary" />;
+        }
+      `,
+    },
+    {
+      name: 'ignores non-default values',
+      code: `
+        import { Button } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return <Button size="s" variant="primary">Submit</Button>;
+        }
+      `,
+    },
+    {
+      name: 'keeps Body as when variant changes the rendered element',
+      code: `
+        import { Body } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return <Body as="p" variant="highlight">Hello</Body>;
+        }
+      `,
+    },
+    {
+      name: 'keeps Body weight when the as prop changes the default weight',
+      code: `
+        import { Body } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return <Body as="strong" weight="regular">Hello</Body>;
+        }
+      `,
+    },
+    {
+      name: 'keeps Body defaults when sibling props are dynamic',
+      code: `
+        import { Body } from '@sumup-oss/circuit-ui';
+
+        function Component({ as, variant }) {
+          return (
+            <>
+              <Body as="p" variant={variant}>Hello</Body>
+              <Body as={as} weight="regular">World</Body>
+            </>
+          );
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'removes simple default props from a button',
+      code: `
+        import { Button } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return <Button size="m" variant="secondary">Submit</Button>;
+        }
+      `,
+      output: `
+        import { Button } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return <Button>Submit</Button>;
+        }
+      `,
+      errors: [{ messageId: 'redundant' }, { messageId: 'redundant' }],
+    },
+    {
+      name: 'removes aliased component defaults',
+      code: `
+        import { IconButton as ActionButton } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return <ActionButton size="m" variant="secondary" icon={More}>More</ActionButton>;
+        }
+      `,
+      output: `
+        import { IconButton as ActionButton } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return <ActionButton icon={More}>More</ActionButton>;
+        }
+      `,
+      errors: [{ messageId: 'redundant' }, { messageId: 'redundant' }],
+    },
+    {
+      name: 'removes conditional Body defaults when safe',
+      code: `
+        import { Body } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return (
+            <>
+              <Body as="p" weight="regular" size="m" color="normal">Hello</Body>
+              <Body weight="regular">World</Body>
+            </>
+          );
+        }
+      `,
+      output: `
+        import { Body } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return (
+            <>
+              <Body>Hello</Body>
+              <Body>World</Body>
+            </>
+          );
+        }
+      `,
+      errors: [
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+      ],
+    },
+    {
+      name: 'removes boolean and numeric defaults',
+      code: `
+        import { Toggletip, Tooltip } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return (
+            <>
+              <Toggletip
+                component={Reference}
+                body="Help"
+                defaultOpen={false}
+                placement="top"
+                offset={12}
+                strategy="fixed"
+              />
+              <Tooltip component={Reference} label="Help" type="label" placement="top" />
+            </>
+          );
+        }
+      `,
+      output: `
+        import { Toggletip, Tooltip } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return (
+            <>
+              <Toggletip
+                component={Reference}
+                body="Help"
+              />
+              <Tooltip component={Reference} label="Help" type="label" />
+            </>
+          );
+        }
+      `,
+      errors: [
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+      ],
+    },
+    {
+      name: 'removes defaults from several supported components',
+      code: `
+        import {
+          Avatar,
+          Badge,
+          ButtonGroup,
+          Card,
+          Compact,
+          Numeral,
+        } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return (
+            <>
+              <Avatar size="m" alt="" />
+              <Badge as="div" variant="neutral">1</Badge>
+              <ButtonGroup align="center" size="m" />
+              <Card as="div" spacing="giga" />
+              <Compact as="p" size="m" weight="regular" color="normal">Text</Compact>
+              <Numeral as="p" size="m" color="normal">42</Numeral>
+            </>
+          );
+        }
+      `,
+      output: `
+        import {
+          Avatar,
+          Badge,
+          ButtonGroup,
+          Card,
+          Compact,
+          Numeral,
+        } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return (
+            <>
+              <Avatar alt="" />
+              <Badge>1</Badge>
+              <ButtonGroup />
+              <Card />
+              <Compact>Text</Compact>
+              <Numeral>42</Numeral>
+            </>
+          );
+        }
+      `,
+      errors: [
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+      ],
+    },
+    {
+      name: 'removes defaults from additional simple public props',
+      code: `
+        import {
+          Display,
+          Headline,
+          List,
+          ListItemGroup,
+          Modal,
+          NotificationInline,
+          NotificationToast,
+          Popover,
+          ProgressBar,
+          Spinner,
+          Timestamp,
+        } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return (
+            <>
+              <Display as="h1" size="m" weight="bold">Title</Display>
+              <Headline as="h2" size="m">Headline</Headline>
+              <List variant="unordered" size="m" />
+              <ListItemGroup variant="inset" items={items} label="Group" />
+              <Modal open variant="contextual" preventClose={false}>Content</Modal>
+              <NotificationInline variant="info" body="Inline" />
+              <NotificationToast variant="info" body="Toast" isVisible />
+              <Popover isOpen onToggle={setOpen} component={Reference} placement="bottom">
+                Content
+              </Popover>
+              <ProgressBar label="Loading" size="m" />
+              <Spinner size="m" />
+              <Timestamp
+                datetime="2026-01-01T00:00:00.000+00:00[UTC]"
+                variant="auto"
+                formatStyle="long"
+                includeTime={false}
+              />
+            </>
+          );
+        }
+      `,
+      output: `
+        import {
+          Display,
+          Headline,
+          List,
+          ListItemGroup,
+          Modal,
+          NotificationInline,
+          NotificationToast,
+          Popover,
+          ProgressBar,
+          Spinner,
+          Timestamp,
+        } from '@sumup-oss/circuit-ui';
+
+        function Component() {
+          return (
+            <>
+              <Display as="h1">Title</Display>
+              <Headline as="h2">Headline</Headline>
+              <List />
+              <ListItemGroup items={items} label="Group" />
+              <Modal open>Content</Modal>
+              <NotificationInline body="Inline" />
+              <NotificationToast body="Toast" isVisible />
+              <Popover isOpen onToggle={setOpen} component={Reference}>
+                Content
+              </Popover>
+              <ProgressBar label="Loading" />
+              <Spinner />
+              <Timestamp
+                datetime="2026-01-01T00:00:00.000+00:00[UTC]"
+              />
+            </>
+          );
+        }
+      `,
+      errors: [
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+        { messageId: 'redundant' },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-circuit-ui/no-default-props/index.spec.tsx
+++ b/packages/eslint-plugin-circuit-ui/no-default-props/index.spec.tsx
@@ -30,47 +30,7 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-default-props', noDefaultProps, {
   valid: [
     {
-      name: 'ignores components imported from another package',
-      code: `
-        import { Button } from 'some-other-package';
-
-        function Component() {
-          return <Button size="m" variant="secondary" />;
-        }
-      `,
-    },
-    {
-      name: 'ignores non-default values',
-      code: `
-        import { Button } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return <Button size="s" variant="primary">Submit</Button>;
-        }
-      `,
-    },
-    {
-      name: 'keeps Body as when variant changes the rendered element',
-      code: `
-        import { Body } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return <Body as="p" variant="highlight">Hello</Body>;
-        }
-      `,
-    },
-    {
-      name: 'keeps Body weight when the as prop changes the default weight',
-      code: `
-        import { Body } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return <Body as="strong" weight="regular">Hello</Body>;
-        }
-      `,
-    },
-    {
-      name: 'keeps Body defaults when sibling props are dynamic',
+      name: 'keeps conditional defaults when sibling props affect semantics',
       code: `
         import { Body } from '@sumup-oss/circuit-ui';
 
@@ -78,6 +38,7 @@ ruleTester.run('no-default-props', noDefaultProps, {
           return (
             <>
               <Body as="p" variant={variant}>Hello</Body>
+              <Body as="strong" weight="regular">Strong</Body>
               <Body as={as} weight="regular">World</Body>
             </>
           );
@@ -102,25 +63,38 @@ ruleTester.run('no-default-props', noDefaultProps, {
           return <Button>Submit</Button>;
         }
       `,
-      errors: [{ messageId: 'redundant' }, { messageId: 'redundant' }],
-    },
-    {
-      name: 'removes aliased component defaults',
-      code: `
-        import { IconButton as ActionButton } from '@sumup-oss/circuit-ui';
+      errors: [
+        {
+          messageId: 'redundant',
+          suggestions: [
+            {
+              messageId: 'removeSingle',
+              output: `
+        import { Button } from '@sumup-oss/circuit-ui';
 
         function Component() {
-          return <ActionButton size="m" variant="secondary" icon={More}>More</ActionButton>;
+          return <Button variant="secondary">Submit</Button>;
         }
       `,
-      output: `
-        import { IconButton as ActionButton } from '@sumup-oss/circuit-ui';
+            },
+          ],
+        },
+        {
+          messageId: 'redundant',
+          suggestions: [
+            {
+              messageId: 'removeSingle',
+              output: `
+        import { Button } from '@sumup-oss/circuit-ui';
 
         function Component() {
-          return <ActionButton icon={More}>More</ActionButton>;
+          return <Button size="m">Submit</Button>;
         }
       `,
-      errors: [{ messageId: 'redundant' }, { messageId: 'redundant' }],
+            },
+          ],
+        },
+      ],
     },
     {
       name: 'removes conditional Body defaults when safe',
@@ -129,10 +103,7 @@ ruleTester.run('no-default-props', noDefaultProps, {
 
         function Component() {
           return (
-            <>
-              <Body as="p" weight="regular" size="m" color="normal">Hello</Body>
-              <Body weight="regular">World</Body>
-            </>
+            <Body as="p" weight="regular" size="m" color="normal">Hello</Body>
           );
         }
       `,
@@ -141,226 +112,79 @@ ruleTester.run('no-default-props', noDefaultProps, {
 
         function Component() {
           return (
-            <>
-              <Body>Hello</Body>
-              <Body>World</Body>
-            </>
+            <Body>Hello</Body>
           );
         }
       `,
       errors: [
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-      ],
-    },
-    {
-      name: 'removes boolean and numeric defaults',
-      code: `
-        import { Toggletip, Tooltip } from '@sumup-oss/circuit-ui';
+        {
+          messageId: 'redundant',
+          suggestions: [
+            {
+              messageId: 'removeSingle',
+              output: `
+        import { Body } from '@sumup-oss/circuit-ui';
 
         function Component() {
           return (
-            <>
-              <Toggletip
-                component={Reference}
-                body="Help"
-                defaultOpen={false}
-                placement="top"
-                offset={12}
-                strategy="fixed"
-              />
-              <Tooltip component={Reference} label="Help" type="label" placement="top" />
-            </>
+            <Body weight="regular" size="m" color="normal">Hello</Body>
           );
         }
       `,
-      output: `
-        import { Toggletip, Tooltip } from '@sumup-oss/circuit-ui';
+            },
+          ],
+        },
+        {
+          messageId: 'redundant',
+          suggestions: [
+            {
+              messageId: 'removeSingle',
+              output: `
+        import { Body } from '@sumup-oss/circuit-ui';
 
         function Component() {
           return (
-            <>
-              <Toggletip
-                component={Reference}
-                body="Help"
-              />
-              <Tooltip component={Reference} label="Help" type="label" />
-            </>
+            <Body as="p" size="m" color="normal">Hello</Body>
           );
         }
       `,
-      errors: [
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-      ],
-    },
-    {
-      name: 'removes defaults from several supported components',
-      code: `
-        import {
-          Avatar,
-          Badge,
-          ButtonGroup,
-          Card,
-          Compact,
-          Numeral,
-        } from '@sumup-oss/circuit-ui';
+            },
+          ],
+        },
+        {
+          messageId: 'redundant',
+          suggestions: [
+            {
+              messageId: 'removeSingle',
+              output: `
+        import { Body } from '@sumup-oss/circuit-ui';
 
         function Component() {
           return (
-            <>
-              <Avatar size="m" alt="" />
-              <Badge as="div" variant="neutral">1</Badge>
-              <ButtonGroup align="center" size="m" />
-              <Card as="div" spacing="giga" />
-              <Compact as="p" size="m" weight="regular" color="normal">Text</Compact>
-              <Numeral as="p" size="m" color="normal">42</Numeral>
-            </>
+            <Body as="p" weight="regular" color="normal">Hello</Body>
           );
         }
       `,
-      output: `
-        import {
-          Avatar,
-          Badge,
-          ButtonGroup,
-          Card,
-          Compact,
-          Numeral,
-        } from '@sumup-oss/circuit-ui';
+            },
+          ],
+        },
+        {
+          messageId: 'redundant',
+          suggestions: [
+            {
+              messageId: 'removeSingle',
+              output: `
+        import { Body } from '@sumup-oss/circuit-ui';
 
         function Component() {
           return (
-            <>
-              <Avatar alt="" />
-              <Badge>1</Badge>
-              <ButtonGroup />
-              <Card />
-              <Compact>Text</Compact>
-              <Numeral>42</Numeral>
-            </>
+            <Body as="p" weight="regular" size="m">Hello</Body>
           );
         }
       `,
-      errors: [
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-      ],
-    },
-    {
-      name: 'removes defaults from additional simple public props',
-      code: `
-        import {
-          Display,
-          Headline,
-          List,
-          ListItemGroup,
-          Modal,
-          NotificationInline,
-          NotificationToast,
-          Popover,
-          ProgressBar,
-          Spinner,
-          Timestamp,
-        } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return (
-            <>
-              <Display as="h1" size="m" weight="bold">Title</Display>
-              <Headline as="h2" size="m">Headline</Headline>
-              <List variant="unordered" size="m" />
-              <ListItemGroup variant="inset" items={items} label="Group" />
-              <Modal open variant="contextual" preventClose={false}>Content</Modal>
-              <NotificationInline variant="info" body="Inline" />
-              <NotificationToast variant="info" body="Toast" isVisible />
-              <Popover isOpen onToggle={setOpen} component={Reference} placement="bottom">
-                Content
-              </Popover>
-              <ProgressBar label="Loading" size="m" />
-              <Spinner size="m" />
-              <Timestamp
-                datetime="2026-01-01T00:00:00.000+00:00[UTC]"
-                variant="auto"
-                formatStyle="long"
-                includeTime={false}
-              />
-            </>
-          );
-        }
-      `,
-      output: `
-        import {
-          Display,
-          Headline,
-          List,
-          ListItemGroup,
-          Modal,
-          NotificationInline,
-          NotificationToast,
-          Popover,
-          ProgressBar,
-          Spinner,
-          Timestamp,
-        } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return (
-            <>
-              <Display as="h1">Title</Display>
-              <Headline as="h2">Headline</Headline>
-              <List />
-              <ListItemGroup items={items} label="Group" />
-              <Modal open>Content</Modal>
-              <NotificationInline body="Inline" />
-              <NotificationToast body="Toast" isVisible />
-              <Popover isOpen onToggle={setOpen} component={Reference}>
-                Content
-              </Popover>
-              <ProgressBar label="Loading" />
-              <Spinner />
-              <Timestamp
-                datetime="2026-01-01T00:00:00.000+00:00[UTC]"
-              />
-            </>
-          );
-        }
-      `,
-      errors: [
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
-        { messageId: 'redundant' },
+            },
+          ],
+        },
       ],
     },
   ],

--- a/packages/eslint-plugin-circuit-ui/no-default-props/index.spec.tsx
+++ b/packages/eslint-plugin-circuit-ui/no-default-props/index.spec.tsx
@@ -60,39 +60,15 @@ ruleTester.run('no-default-props', noDefaultProps, {
         import { Button } from '@sumup-oss/circuit-ui';
 
         function Component() {
-          return <Button>Submit</Button>;
+          return <Button  >Submit</Button>;
         }
       `,
       errors: [
         {
           messageId: 'redundant',
-          suggestions: [
-            {
-              messageId: 'removeSingle',
-              output: `
-        import { Button } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return <Button variant="secondary">Submit</Button>;
-        }
-      `,
-            },
-          ],
         },
         {
           messageId: 'redundant',
-          suggestions: [
-            {
-              messageId: 'removeSingle',
-              output: `
-        import { Button } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return <Button size="m">Submit</Button>;
-        }
-      `,
-            },
-          ],
         },
       ],
     },
@@ -112,78 +88,22 @@ ruleTester.run('no-default-props', noDefaultProps, {
 
         function Component() {
           return (
-            <Body>Hello</Body>
+            <Body    >Hello</Body>
           );
         }
       `,
       errors: [
         {
           messageId: 'redundant',
-          suggestions: [
-            {
-              messageId: 'removeSingle',
-              output: `
-        import { Body } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return (
-            <Body weight="regular" size="m" color="normal">Hello</Body>
-          );
-        }
-      `,
-            },
-          ],
         },
         {
           messageId: 'redundant',
-          suggestions: [
-            {
-              messageId: 'removeSingle',
-              output: `
-        import { Body } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return (
-            <Body as="p" size="m" color="normal">Hello</Body>
-          );
-        }
-      `,
-            },
-          ],
         },
         {
           messageId: 'redundant',
-          suggestions: [
-            {
-              messageId: 'removeSingle',
-              output: `
-        import { Body } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return (
-            <Body as="p" weight="regular" color="normal">Hello</Body>
-          );
-        }
-      `,
-            },
-          ],
         },
         {
           messageId: 'redundant',
-          suggestions: [
-            {
-              messageId: 'removeSingle',
-              output: `
-        import { Body } from '@sumup-oss/circuit-ui';
-
-        function Component() {
-          return (
-            <Body as="p" weight="regular" size="m">Hello</Body>
-          );
-        }
-      `,
-            },
-          ],
         },
       ],
     },

--- a/packages/eslint-plugin-circuit-ui/no-default-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-default-props/index.ts
@@ -1,0 +1,421 @@
+/**
+ * Copyright 2026, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ESLintUtils, TSESTree, type TSESLint } from '@typescript-eslint/utils';
+
+import type { RuleDocs } from '../utils/meta.js';
+
+const createRule = ESLintUtils.RuleCreator<RuleDocs>(
+  (name) =>
+    `https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/${name}`,
+);
+
+const DYNAMIC_VALUE = Symbol('dynamic');
+const CIRCUIT_UI_PACKAGE = '@sumup-oss/circuit-ui';
+
+type StaticValue = string | number | boolean;
+type AttributeValue = StaticValue | typeof DYNAMIC_VALUE | undefined;
+
+type AttributeValues = Record<string, AttributeValue>;
+
+type RuleConfig = {
+  propName: string;
+  value: StaticValue;
+  isSafeToRemove?: (context: { attributeValues: AttributeValues }) => boolean;
+};
+
+const configs: Record<string, RuleConfig[]> = {
+  Avatar: [{ propName: 'size', value: 'm' }],
+  Badge: [
+    { propName: 'as', value: 'div' },
+    { propName: 'variant', value: 'neutral' },
+  ],
+  Body: [
+    { propName: 'size', value: 'm' },
+    { propName: 'color', value: 'normal' },
+    {
+      propName: 'as',
+      value: 'p',
+      isSafeToRemove: ({ attributeValues }) => {
+        const { variant } = attributeValues;
+        if (variant === DYNAMIC_VALUE) {
+          return false;
+        }
+        return variant !== 'highlight' && variant !== 'quote';
+      },
+    },
+    {
+      propName: 'weight',
+      value: 'regular',
+      isSafeToRemove: ({ attributeValues }) => {
+        const { as } = attributeValues;
+        if (as === DYNAMIC_VALUE) {
+          return false;
+        }
+        return as !== 'strong';
+      },
+    },
+  ],
+  Display: [
+    { propName: 'size', value: 'm' },
+    { propName: 'weight', value: 'bold' },
+  ],
+  Button: [
+    { propName: 'size', value: 'm' },
+    { propName: 'variant', value: 'secondary' },
+  ],
+  ButtonGroup: [
+    { propName: 'align', value: 'center' },
+    { propName: 'size', value: 'm' },
+  ],
+  Card: [
+    { propName: 'as', value: 'div' },
+    { propName: 'spacing', value: 'giga' },
+  ],
+  Compact: [
+    { propName: 'as', value: 'p' },
+    { propName: 'size', value: 'm' },
+    { propName: 'weight', value: 'regular' },
+    { propName: 'color', value: 'normal' },
+  ],
+  Headline: [{ propName: 'size', value: 'm' }],
+  IconButton: [
+    { propName: 'size', value: 'm' },
+    { propName: 'variant', value: 'secondary' },
+  ],
+  List: [
+    { propName: 'variant', value: 'unordered' },
+    { propName: 'size', value: 'm' },
+  ],
+  ListItemGroup: [{ propName: 'variant', value: 'inset' }],
+  Modal: [
+    { propName: 'variant', value: 'contextual' },
+    { propName: 'preventClose', value: false },
+  ],
+  Numeral: [
+    { propName: 'as', value: 'p' },
+    { propName: 'size', value: 'm' },
+    { propName: 'color', value: 'normal' },
+  ],
+  NotificationInline: [{ propName: 'variant', value: 'info' }],
+  NotificationToast: [{ propName: 'variant', value: 'info' }],
+  Popover: [{ propName: 'placement', value: 'bottom' }],
+  ProgressBar: [{ propName: 'size', value: 'm' }],
+  Spinner: [{ propName: 'size', value: 'm' }],
+  Toggletip: [
+    { propName: 'defaultOpen', value: false },
+    { propName: 'placement', value: 'top' },
+    { propName: 'offset', value: 12 },
+    { propName: 'strategy', value: 'fixed' },
+  ],
+  Timestamp: [
+    { propName: 'variant', value: 'auto' },
+    { propName: 'formatStyle', value: 'long' },
+    { propName: 'includeTime', value: false },
+  ],
+  Tooltip: [{ propName: 'placement', value: 'top' }],
+};
+
+function getAttributeValue(attribute: TSESTree.JSXAttribute): AttributeValue {
+  if (!attribute.value) {
+    return true;
+  }
+
+  if (
+    attribute.value.type === TSESTree.AST_NODE_TYPES.Literal &&
+    typeof attribute.value.value !== 'undefined'
+  ) {
+    return attribute.value.value as StaticValue;
+  }
+
+  if (
+    attribute.value.type === TSESTree.AST_NODE_TYPES.JSXExpressionContainer &&
+    attribute.value.expression.type === TSESTree.AST_NODE_TYPES.Literal &&
+    typeof attribute.value.expression.value !== 'undefined'
+  ) {
+    return attribute.value.expression.value as StaticValue;
+  }
+
+  return DYNAMIC_VALUE;
+}
+
+function getAttributeValues(
+  attributes: TSESTree.JSXOpeningElement['attributes'],
+): AttributeValues {
+  return attributes.reduce((acc, attribute) => {
+    if (
+      attribute.type !== TSESTree.AST_NODE_TYPES.JSXAttribute ||
+      attribute.name.type !== TSESTree.AST_NODE_TYPES.JSXIdentifier
+    ) {
+      return acc;
+    }
+
+    acc[attribute.name.name] = getAttributeValue(attribute);
+    return acc;
+  }, {} as AttributeValues);
+}
+
+function getFixRange(
+  sourceCode: TSESLint.SourceCode,
+  attribute: TSESTree.JSXAttribute,
+): [number, number] {
+  const source = sourceCode.text;
+  let start = attribute.range[0];
+  let end = attribute.range[1];
+
+  while ([' ', '\t'].includes(source[end])) {
+    end += 1;
+  }
+
+  if (source[end] === '\r') {
+    end += 1;
+  }
+
+  if (source[end] === '\n') {
+    end += 1;
+
+    while ([' ', '\t'].includes(source[end])) {
+      end += 1;
+    }
+
+    return [start, end];
+  }
+
+  if (end > attribute.range[1]) {
+    return [start, end];
+  }
+
+  while (start > 0 && [' ', '\t'].includes(source[start - 1])) {
+    start -= 1;
+  }
+
+  return [start, attribute.range[1]];
+}
+
+function removeRanges(
+  text: string,
+  ranges: [number, number][],
+  offset: number,
+): string {
+  const mergedRanges = ranges
+    .toSorted((a, b) => a[0] - b[0])
+    .reduce(
+      (acc, [start, end]) => {
+        const previous = acc.at(-1);
+
+        if (!previous || start > previous[1]) {
+          acc.push([start, end]);
+          return acc;
+        }
+
+        previous[1] = Math.max(previous[1], end);
+        return acc;
+      },
+      [] as [number, number][],
+    )
+    .toSorted((a, b) => b[0] - a[0]);
+
+  return mergedRanges
+    .toSorted((a, b) => b[0] - a[0])
+    .reduce((acc, [start, end]) => {
+      const relativeStart = start - offset;
+      const relativeEnd = end - offset;
+      return acc.slice(0, relativeStart) + acc.slice(relativeEnd);
+    }, text);
+}
+
+function getLineIndent(source: string, index: number): string {
+  const lineStart = source.lastIndexOf('\n', index - 1) + 1;
+  let cursor = lineStart;
+
+  while ([' ', '\t'].includes(source[cursor])) {
+    cursor += 1;
+  }
+
+  return source.slice(lineStart, cursor);
+}
+
+function normalizeOpeningElement(
+  text: string,
+  sourceCode: TSESLint.SourceCode,
+  openingElement: TSESTree.JSXOpeningElement,
+): string {
+  const openingIndent = getLineIndent(sourceCode.text, openingElement.range[0]);
+
+  return text
+    .replace(/ +(?=>)/g, '')
+    .replace(/ +\/>/g, ' />')
+    .replace(/\n[ \t]*\/>$/, `\n${openingIndent}/>`);
+}
+
+export const noDefaultProps = createRule({
+  name: 'no-default-props',
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [],
+    docs: {
+      description:
+        'Default Circuit UI props should be omitted when they do not change the rendered output',
+      recommended: 'off',
+    },
+    messages: {
+      redundant:
+        "The {{component}}'s `{{propName}}` prop is redundant because `{{value}}` is the default value.",
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    const trackedImports = new Map<string, RuleConfig[]>();
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== CIRCUIT_UI_PACKAGE) {
+          return;
+        }
+
+        node.specifiers.forEach((specifier) => {
+          if (specifier.type !== TSESTree.AST_NODE_TYPES.ImportSpecifier) {
+            return;
+          }
+
+          const importedName =
+            specifier.imported.type === TSESTree.AST_NODE_TYPES.Identifier
+              ? specifier.imported.name
+              : specifier.imported.value;
+          const componentConfigs = configs[importedName];
+
+          if (!componentConfigs) {
+            return;
+          }
+
+          trackedImports.set(specifier.local.name, componentConfigs);
+        });
+      },
+      JSXElement(node) {
+        if (
+          node.openingElement.name.type !==
+          TSESTree.AST_NODE_TYPES.JSXIdentifier
+        ) {
+          return;
+        }
+
+        const localName = node.openingElement.name.name;
+        const componentConfigs = trackedImports.get(localName);
+
+        if (!componentConfigs) {
+          return;
+        }
+
+        const attributeValues = getAttributeValues(
+          node.openingElement.attributes,
+        );
+        const component = localName;
+        const removableAttributes = node.openingElement.attributes
+          .filter(
+            (attribute): attribute is TSESTree.JSXAttribute =>
+              attribute.type === TSESTree.AST_NODE_TYPES.JSXAttribute &&
+              attribute.name.type === TSESTree.AST_NODE_TYPES.JSXIdentifier,
+          )
+          .filter((attribute) => {
+            const config = componentConfigs.find(
+              ({ propName }) => propName === attribute.name.name,
+            );
+
+            if (!config) {
+              return false;
+            }
+
+            const attributeValue = getAttributeValue(attribute);
+
+            if (attributeValue !== config.value) {
+              return false;
+            }
+
+            if (
+              config.isSafeToRemove &&
+              !config.isSafeToRemove({ attributeValues })
+            ) {
+              return false;
+            }
+
+            return true;
+          });
+
+        if (removableAttributes.length === 0) {
+          return;
+        }
+
+        const fixedOpeningElement = normalizeOpeningElement(
+          removeRanges(
+            context.sourceCode.getText(node.openingElement),
+            removableAttributes.map((attribute) =>
+              getFixRange(context.sourceCode, attribute),
+            ),
+            node.openingElement.range[0],
+          ),
+          context.sourceCode,
+          node.openingElement,
+        );
+
+        node.openingElement.attributes.forEach((attribute) => {
+          if (
+            attribute.type !== TSESTree.AST_NODE_TYPES.JSXAttribute ||
+            attribute.name.type !== TSESTree.AST_NODE_TYPES.JSXIdentifier
+          ) {
+            return;
+          }
+
+          const config = componentConfigs.find(
+            ({ propName }) => propName === attribute.name.name,
+          );
+
+          if (!config) {
+            return;
+          }
+
+          const attributeValue = getAttributeValue(attribute);
+
+          if (attributeValue !== config.value) {
+            return;
+          }
+
+          if (
+            config.isSafeToRemove &&
+            !config.isSafeToRemove({ attributeValues })
+          ) {
+            return;
+          }
+
+          context.report({
+            node: attribute,
+            messageId: 'redundant',
+            data: {
+              component,
+              propName: config.propName,
+              value: String(config.value),
+            },
+            fix(fixer) {
+              return fixer.replaceText(
+                node.openingElement,
+                fixedOpeningElement,
+              );
+            },
+          });
+        });
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-circuit-ui/no-default-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-default-props/index.ts
@@ -167,6 +167,8 @@ function getAttributeValues(
   }, {} as AttributeValues);
 }
 
+// Used to delete surrounding spaces of the remove redundant attribute.
+// E.g. `<Body as="p">...</Body>` becomes `<Body>...</Body>`.
 function getFixRange(
   sourceCode: TSESLint.SourceCode,
   attribute: TSESTree.JSXAttribute,
@@ -204,6 +206,18 @@ function getFixRange(
   return [start, attribute.range[1]];
 }
 
+function removeRange(
+  text: string,
+  range: [number, number],
+  offset: number,
+): string {
+  const [start, end] = range;
+  const relativeStart = start - offset;
+  const relativeEnd = end - offset;
+
+  return text.slice(0, relativeStart) + text.slice(relativeEnd);
+}
+
 function removeRanges(
   text: string,
   ranges: [number, number][],
@@ -224,16 +238,11 @@ function removeRanges(
         return acc;
       },
       [] as [number, number][],
-    )
-    .toSorted((a, b) => b[0] - a[0]);
+    );
 
   return mergedRanges
     .toSorted((a, b) => b[0] - a[0])
-    .reduce((acc, [start, end]) => {
-      const relativeStart = start - offset;
-      const relativeEnd = end - offset;
-      return acc.slice(0, relativeStart) + acc.slice(relativeEnd);
-    }, text);
+    .reduce((acc, range) => removeRange(acc, range, offset), text);
 }
 
 function getLineIndent(source: string, index: number): string {
@@ -247,6 +256,8 @@ function getLineIndent(source: string, index: number): string {
   return source.slice(lineStart, cursor);
 }
 
+// Normalizes the element after removal of redundant props.
+// E.g. `<Tooltip/>` to `<Tooltip />`.
 function normalizeOpeningElement(
   text: string,
   sourceCode: TSESLint.SourceCode,
@@ -265,6 +276,7 @@ export const noDefaultProps = createRule({
   meta: {
     type: 'suggestion',
     fixable: 'code',
+    hasSuggestions: true,
     schema: [],
     docs: {
       description:
@@ -274,6 +286,8 @@ export const noDefaultProps = createRule({
     messages: {
       redundant:
         "The {{component}}'s `{{propName}}` prop is redundant because `{{value}}` is the default value.",
+      removeSingle:
+        'Remove the redundant `{{propName}}` prop without changing the other attributes.',
     },
   },
   defaultOptions: [],
@@ -370,7 +384,7 @@ export const noDefaultProps = createRule({
           node.openingElement,
         );
 
-        node.openingElement.attributes.forEach((attribute) => {
+        removableAttributes.forEach((attribute) => {
           if (
             attribute.type !== TSESTree.AST_NODE_TYPES.JSXAttribute ||
             attribute.name.type !== TSESTree.AST_NODE_TYPES.JSXIdentifier
@@ -413,6 +427,30 @@ export const noDefaultProps = createRule({
                 fixedOpeningElement,
               );
             },
+            suggest: [
+              {
+                messageId: 'removeSingle',
+                data: {
+                  propName: config.propName,
+                },
+                fix(fixer) {
+                  const singleFixOpeningElement = normalizeOpeningElement(
+                    removeRange(
+                      context.sourceCode.getText(node.openingElement),
+                      getFixRange(context.sourceCode, attribute),
+                      node.openingElement.range[0],
+                    ),
+                    context.sourceCode,
+                    node.openingElement,
+                  );
+
+                  return fixer.replaceText(
+                    node.openingElement,
+                    singleFixOpeningElement,
+                  );
+                },
+              },
+            ],
           });
         });
       },

--- a/packages/eslint-plugin-circuit-ui/no-default-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-default-props/index.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { ESLintUtils, TSESTree, type TSESLint } from '@typescript-eslint/utils';
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
 
 import type { RuleDocs } from '../utils/meta.js';
 
@@ -167,116 +167,11 @@ function getAttributeValues(
   }, {} as AttributeValues);
 }
 
-// Used to delete surrounding spaces of the remove redundant attribute.
-// E.g. `<Body as="p">...</Body>` becomes `<Body>...</Body>`.
-function getFixRange(
-  sourceCode: TSESLint.SourceCode,
-  attribute: TSESTree.JSXAttribute,
-): [number, number] {
-  const source = sourceCode.text;
-  let start = attribute.range[0];
-  let end = attribute.range[1];
-
-  while ([' ', '\t'].includes(source[end])) {
-    end += 1;
-  }
-
-  if (source[end] === '\r') {
-    end += 1;
-  }
-
-  if (source[end] === '\n') {
-    end += 1;
-
-    while ([' ', '\t'].includes(source[end])) {
-      end += 1;
-    }
-
-    return [start, end];
-  }
-
-  if (end > attribute.range[1]) {
-    return [start, end];
-  }
-
-  while (start > 0 && [' ', '\t'].includes(source[start - 1])) {
-    start -= 1;
-  }
-
-  return [start, attribute.range[1]];
-}
-
-function removeRange(
-  text: string,
-  range: [number, number],
-  offset: number,
-): string {
-  const [start, end] = range;
-  const relativeStart = start - offset;
-  const relativeEnd = end - offset;
-
-  return text.slice(0, relativeStart) + text.slice(relativeEnd);
-}
-
-function removeRanges(
-  text: string,
-  ranges: [number, number][],
-  offset: number,
-): string {
-  const mergedRanges = ranges
-    .toSorted((a, b) => a[0] - b[0])
-    .reduce(
-      (acc, [start, end]) => {
-        const previous = acc.at(-1);
-
-        if (!previous || start > previous[1]) {
-          acc.push([start, end]);
-          return acc;
-        }
-
-        previous[1] = Math.max(previous[1], end);
-        return acc;
-      },
-      [] as [number, number][],
-    );
-
-  return mergedRanges
-    .toSorted((a, b) => b[0] - a[0])
-    .reduce((acc, range) => removeRange(acc, range, offset), text);
-}
-
-function getLineIndent(source: string, index: number): string {
-  const lineStart = source.lastIndexOf('\n', index - 1) + 1;
-  let cursor = lineStart;
-
-  while ([' ', '\t'].includes(source[cursor])) {
-    cursor += 1;
-  }
-
-  return source.slice(lineStart, cursor);
-}
-
-// Normalizes the element after removal of redundant props.
-// E.g. `<Tooltip/>` to `<Tooltip />`.
-function normalizeOpeningElement(
-  text: string,
-  sourceCode: TSESLint.SourceCode,
-  openingElement: TSESTree.JSXOpeningElement,
-): string {
-  const openingIndent = getLineIndent(sourceCode.text, openingElement.range[0]);
-
-  return text
-    .replace(/ +(?=>)/g, '')
-    .replace(/ +\/>/g, ' />')
-    .replace(/\n[ \t]*\/>$/, `\n${openingIndent}/>`);
-}
-
 export const noDefaultProps = createRule({
   name: 'no-default-props',
   meta: {
     type: 'suggestion',
     fixable: 'code',
-    hasSuggestions: true,
     schema: [],
     docs: {
       description:
@@ -286,8 +181,6 @@ export const noDefaultProps = createRule({
     messages: {
       redundant:
         "The {{component}}'s `{{propName}}` prop is redundant because `{{value}}` is the default value.",
-      removeSingle:
-        'Remove the redundant `{{propName}}` prop without changing the other attributes.',
     },
   },
   defaultOptions: [],
@@ -337,54 +230,8 @@ export const noDefaultProps = createRule({
           node.openingElement.attributes,
         );
         const component = localName;
-        const removableAttributes = node.openingElement.attributes
-          .filter(
-            (attribute): attribute is TSESTree.JSXAttribute =>
-              attribute.type === TSESTree.AST_NODE_TYPES.JSXAttribute &&
-              attribute.name.type === TSESTree.AST_NODE_TYPES.JSXIdentifier,
-          )
-          .filter((attribute) => {
-            const config = componentConfigs.find(
-              ({ propName }) => propName === attribute.name.name,
-            );
 
-            if (!config) {
-              return false;
-            }
-
-            const attributeValue = getAttributeValue(attribute);
-
-            if (attributeValue !== config.value) {
-              return false;
-            }
-
-            if (
-              config.isSafeToRemove &&
-              !config.isSafeToRemove({ attributeValues })
-            ) {
-              return false;
-            }
-
-            return true;
-          });
-
-        if (removableAttributes.length === 0) {
-          return;
-        }
-
-        const fixedOpeningElement = normalizeOpeningElement(
-          removeRanges(
-            context.sourceCode.getText(node.openingElement),
-            removableAttributes.map((attribute) =>
-              getFixRange(context.sourceCode, attribute),
-            ),
-            node.openingElement.range[0],
-          ),
-          context.sourceCode,
-          node.openingElement,
-        );
-
-        removableAttributes.forEach((attribute) => {
+        node.openingElement.attributes.forEach((attribute) => {
           if (
             attribute.type !== TSESTree.AST_NODE_TYPES.JSXAttribute ||
             attribute.name.type !== TSESTree.AST_NODE_TYPES.JSXIdentifier
@@ -422,35 +269,8 @@ export const noDefaultProps = createRule({
               value: String(config.value),
             },
             fix(fixer) {
-              return fixer.replaceText(
-                node.openingElement,
-                fixedOpeningElement,
-              );
+              return fixer.remove(attribute);
             },
-            suggest: [
-              {
-                messageId: 'removeSingle',
-                data: {
-                  propName: config.propName,
-                },
-                fix(fixer) {
-                  const singleFixOpeningElement = normalizeOpeningElement(
-                    removeRange(
-                      context.sourceCode.getText(node.openingElement),
-                      getFixRange(context.sourceCode, attribute),
-                      node.openingElement.range[0],
-                    ),
-                    context.sourceCode,
-                    node.openingElement,
-                  );
-
-                  return fixer.replaceText(
-                    node.openingElement,
-                    singleFixOpeningElement,
-                  );
-                },
-              },
-            ],
           });
         });
       },


### PR DESCRIPTION
Adds a new eslint rule that checks that usage of Circuit UI components
omits explicitly passing in default props. Further discussed internally
on a related PR.

The logic behind this change is that it leads to inconsistency. We
see usage of both - passing the default props as well as not passing them
in. This is worse than relying on one or the other everywhere as changing
the default (which would be a breaking change) would lead to different
results in different places based on whether the component explicitly
receives the default or not.
