### PR TITLE
Bring back weight prop for Display component

### DIFF
--- a/.changeset/all-singers-smell.md
+++ b/.changeset/all-singers-smell.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Bring back the `weight` prop for the Display component. The `regular` and `semibold` values remain deprecated and a new `black` weight has been added.

--- a/.changeset/wild-trams-pull.md
+++ b/.changeset/wild-trams-pull.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": minor
 ---
 
-Deprecated the Display component's `weight` prop. Since the brand refresh, only `bold` is supported. The `weight` prop will be removed in the next major version.
+Deprecated the Display component's `regular` and `semibold` weights and added a new `black` weight. By default, sizes `s`, `m`, and `l` render as `bold` and size `xl` renders as `black`.

--- a/packages/circuit-ui/components/Display/Display.mdx
+++ b/packages/circuit-ui/components/Display/Display.mdx
@@ -20,6 +20,12 @@ The Display component comes in three sizes. In most cases, use the [Headline com
 
 <Story of={Stories.Sizes} />
 
+### Weights
+
+The Display component comes in two weights. By default, sizes `s`, `m`, and `l` render as `bold` and size `xl` renders as `black`.
+
+<Story of={Stories.Weights} />
+
 ---
 
 ## Accessibility

--- a/packages/circuit-ui/components/Display/Display.module.css
+++ b/packages/circuit-ui/components/Display/Display.module.css
@@ -1,9 +1,18 @@
 .base {
   margin: 0;
-  font-family: var(--cui-font-stack-display);
-  font-weight: var(--cui-font-weight-bold);
   color: var(--cui-fg-normal);
   letter-spacing: var(--cui-letter-spacing-tight, var(--cui-letter-spacing));
+}
+
+/* Weights */
+
+.black {
+  font-family: var(--cui-font-stack-display);
+}
+
+.bold {
+  font-family: var(--cui-font-stack-default);
+  font-weight: var(--cui-font-weight-bold);
 }
 
 /* Sizes */

--- a/packages/circuit-ui/components/Display/Display.stories.tsx
+++ b/packages/circuit-ui/components/Display/Display.stories.tsx
@@ -26,7 +26,7 @@ export const Base = (args: DisplayProps) => (
 );
 
 Base.args = {
-  as: 'h1',
+  as: 'h2',
 };
 
 const sizes = ['xl', 'l', 'm', 's'] as const;
@@ -39,5 +39,18 @@ export const Sizes = (args: DisplayProps) =>
   ));
 
 Sizes.args = {
-  as: 'h1',
+  as: 'h2',
+};
+
+const weights = ['black', 'bold'] as const;
+
+export const Weights = (args: DisplayProps) =>
+  weights.map((weight) => (
+    <Display key={weight} {...args} weight={weight}>
+      This is {weight}
+    </Display>
+  ));
+
+Weights.args = {
+  as: 'h2',
 };

--- a/packages/circuit-ui/components/Display/Display.tsx
+++ b/packages/circuit-ui/components/Display/Display.tsx
@@ -24,14 +24,26 @@ import classes from './Display.module.css';
 
 export interface DisplayProps extends HTMLAttributes<HTMLHeadingElement> {
   /**
-   * @deprecated Since the brand refresh, only `bold` is supported.
-   * The `weight` prop will be removed in the next major version.
+   * Choose from two font weights.
    *
-   * Choose from three font weights. Default: `bold`.
+   * @default 'bold' for sizes s, m, l
+   * @default 'black' for size xl
    */
-  weight?: 'regular' | 'semibold' | 'bold';
+  weight?:
+    | 'black'
+    | 'bold'
+    /**
+     * @deprecated
+     */
+    | 'semibold'
+    /**
+     * @deprecated
+     */
+    | 'regular';
   /**
-   * Choose from 3 font sizes. Defaults to `m`.
+   * Choose from 3 font sizes.
+   *
+   * @default 'm'
    */
   size?:
     | 's'
@@ -69,6 +81,17 @@ const deprecatedSizeMap: Record<string, string> = {
   'four': 's',
 };
 
+function getWeight(weight: DisplayProps['weight'], size: DisplayProps['size']) {
+  switch (weight) {
+    case 'black':
+      return 'black';
+    case 'bold':
+      return 'bold';
+    default:
+      return size === 'xl' ? 'black' : 'bold';
+  }
+}
+
 /**
  * A flexible title component capable of rendering any HTML heading element.
  */
@@ -85,6 +108,16 @@ export const Display = forwardRef<HTMLHeadingElement, DisplayProps>(
 
     if (
       process.env.NODE_ENV !== 'production' &&
+      (weight === 'regular' || weight === 'semibold')
+    ) {
+      deprecate(
+        'Display',
+        `The "${weight}" weight has been deprecated. Use the "bold" or "black" weights instead.`,
+      );
+    }
+
+    if (
+      process.env.NODE_ENV !== 'production' &&
       legacySize in deprecatedSizeMap
     ) {
       deprecate(
@@ -96,6 +129,7 @@ export const Display = forwardRef<HTMLHeadingElement, DisplayProps>(
     const Element = as || 'h1';
 
     const size = (deprecatedSizeMap[legacySize] || legacySize) as
+      | 'xl'
       | 'l'
       | 'm'
       | 's';
@@ -104,7 +138,12 @@ export const Display = forwardRef<HTMLHeadingElement, DisplayProps>(
       <Element
         {...props}
         ref={ref}
-        className={clsx(classes.base, classes[size], className)}
+        className={clsx(
+          classes.base,
+          classes[size],
+          classes[getWeight(weight, size)],
+          className,
+        )}
       />
     );
   },

--- a/packages/circuit-ui/components/Display/Display.tsx
+++ b/packages/circuit-ui/components/Display/Display.tsx
@@ -41,7 +41,7 @@ export interface DisplayProps extends HTMLAttributes<HTMLHeadingElement> {
      */
     | 'regular';
   /**
-   * Choose from 3 font sizes.
+   * Choose from 4 font sizes.
    *
    * @default 'm'
    */


### PR DESCRIPTION
## Purpose

Due to some misalignment, I erroneously removed the `weight` prop from the Display component.

## Approach and changes

- Brought back the `weight` prop
- Deprecated the `regular` and `semibold` weights and added a new `black` weight

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
