### PR TITLE
Fix sticky Table header on mobile

### DIFF
--- a/.changeset/swift-meals-change.md
+++ b/.changeset/swift-meals-change.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the Table header not being sticky when scrolling horizontally on narrow viewports.

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.module.css
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.module.css
@@ -22,26 +22,6 @@
   background-color: var(--cui-bg-normal-hovered);
 }
 
-@media (max-width: 767px) {
-  .fixed {
-    position: sticky;
-    left: 0;
-    z-index: var(--cui-z-index-absolute);
-    width: 145px;
-    overflow-wrap: break-word;
-  }
-
-  .fixed::after {
-    position: absolute;
-    top: 0;
-    left: 100%;
-    width: 6px;
-    height: 100%;
-    content: "";
-    background: linear-gradient(90deg, rgb(0 0 0 / 12%), rgb(255 255 255 / 0%));
-  }
-}
-
 .condensed {
   padding: var(--cui-spacings-kilo) var(--cui-spacings-mega)
     var(--cui-spacings-kilo) var(--cui-spacings-giga);
@@ -113,4 +93,24 @@
 .base[aria-sort="ascending"] > button,
 .base[aria-sort="descending"] > button {
   opacity: 1;
+}
+
+@media (max-width: 767px) {
+  .base.fixed {
+    position: sticky;
+    left: 0;
+    z-index: var(--cui-z-index-absolute);
+    width: 145px;
+    overflow-wrap: break-word;
+  }
+
+  .base.fixed::after {
+    position: absolute;
+    top: 0;
+    left: 100%;
+    width: 6px;
+    height: 100%;
+    content: "";
+    background: linear-gradient(90deg, rgb(0 0 0 / 12%), rgb(255 255 255 / 0%));
+  }
 }


### PR DESCRIPTION
Fixes #3525. 

## Purpose

The styles for sortable columns had higher specificity than the styles for being sticky, thus overriding the `position` style attribute.

## Approach and changes

- Increase the specificity of the fixed styles

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
