### PR TITLE
Migrate icons to React's new JSX runtime

### DIFF
--- a/.changeset/full-chicken-cough.md
+++ b/.changeset/full-chicken-cough.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/icons": minor
+---
+
+Switched to using React's new JSX runtime to improve compatibility with React 19.

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -262,13 +262,15 @@ async function main() {
     },
     {} as Record<string, Icon[]>,
   );
-  const components = Object.entries(iconsByName).map(
-    ([name, icons]): Component => ({
-      name: getComponentName(name),
-      icons,
-      deprecation: icons.find((icon) => icon.deprecation)?.deprecation,
-    }),
-  );
+  const components = Object.entries(iconsByName)
+    .map(
+      ([name, icons]): Component => ({
+        name: getComponentName(name),
+        icons,
+        deprecation: icons.find((icon) => icon.deprecation)?.deprecation,
+      }),
+    )
+    .filter(({ icons }) => icons.some((icon) => !icon.skipComponentFile));
 
   const indexRaw = buildIndexFile(components);
   const helpersRaw = buildHelpersFile();

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -146,18 +146,14 @@ function buildIndexFile(components: Component[]): string {
 }
 
 function buildDeclarationFile(components: Component[]): string {
-  const declarationStatements = components
-    .filter(({ icons }) => icons.some((icon) => !icon.skipComponentFile))
-    .map((component) => {
-      const sizes = component.icons.map(({ size }) => `'${size}'`).sort();
-      const SizesType = sizes.join(' | ');
-      return `
+  const declarationStatements = components.map((component) => {
+    const sizes = component.icons.map(({ size }) => `'${size}'`).sort();
+    const SizesType = sizes.join(' | ');
+    return `
       ${createDeprecationComment(component)}
       declare const ${component.name}: IconComponentType<${SizesType}>;`;
-    });
-  const exportNames = components
-    .filter(({ icons }) => icons.some((icon) => !icon.skipComponentFile))
-    .map((component) => component.name);
+  });
+  const exportNames = components.map((component) => component.name);
   const iconNames = components.map(
     (component) => `'${component.icons[0].name}'`,
   );

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -217,7 +217,12 @@ async function transpileModule(fileName: string, code: string) {
           exclude: ['transform-object-rest-spread'],
         },
       ],
-      '@babel/preset-react',
+      [
+        '@babel/preset-react',
+        {
+          'runtime': 'automatic',
+        },
+      ],
     ],
     plugins: [
       [

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -103,7 +103,6 @@ function buildComponentFile(component: Component): string {
   }' icon. Please use one of the available sizes: '${sizes.join("', '")}'.`;
 
   return `
-    import React from 'react';
     ${iconImports.join('\n')}
 
     const sizeMap = {


### PR DESCRIPTION
## Purpose

React 19 changes the React element API. Developers should use the [new JSX runtime](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) over the legacy `React.createElement` API to avoid compatibility issues.

## Approach and changes

- Enable React's new JSX runtime for icons 
- Stop generating empty component definitions for flag components (fortunately, these weren't exported anyway)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
