### PR TITLE
Revert Body m line-height to 22px

### DIFF
--- a/.changeset/eleven-waves-write.md
+++ b/.changeset/eleven-waves-write.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/design-tokens": patch
+---
+
+Reverted the --cui-body-m-line-height` to 22px.

--- a/.changeset/eleven-waves-write.md
+++ b/.changeset/eleven-waves-write.md
@@ -2,4 +2,4 @@
 "@sumup-oss/design-tokens": patch
 ---
 
-Reverted the --cui-body-m-line-height` to 22px.
+Reverted the `--cui-body-m-line-height` token value to 22px.

--- a/packages/circuit-ui/styles/style-mixins.spec.tsx
+++ b/packages/circuit-ui/styles/style-mixins.spec.tsx
@@ -163,7 +163,7 @@ describe('Style helpers', () => {
     it('should match the snapshot for size one', () => {
       const { styles } = typography('one')(light);
       expect(styles).toMatchInlineSnapshot(
-        `"font-size:1.0625rem;line-height:1.5rem;"`,
+        `"font-size:1.0625rem;line-height:1.375rem;"`,
       );
     });
 

--- a/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
+++ b/packages/design-tokens/tests/__snapshots__/index.spec.ts.snap
@@ -117,7 +117,7 @@ exports[`Themes > light > should match the snapshot 1`] = `
     "body": {
       "one": {
         "fontSize": "1.0625rem",
-        "lineHeight": "1.5rem",
+        "lineHeight": "1.375rem",
       },
       "two": {
         "fontSize": "0.9375rem",

--- a/packages/design-tokens/themes/legacy/light.ts
+++ b/packages/design-tokens/themes/legacy/light.ts
@@ -103,7 +103,7 @@ export const typography = {
   body: {
     one: {
       fontSize: '1.0625rem',
-      lineHeight: '1.5rem',
+      lineHeight: '1.375rem',
     },
     two: {
       fontSize: '0.9375rem',

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -300,7 +300,7 @@ export const shared = [
   },
   {
     name: '--cui-body-m-line-height',
-    value: '1.5rem',
+    value: '1.375rem',
     type: 'dimension',
   },
   {


### PR DESCRIPTION
## Purpose

As part of the typography changes for the brand refresh, we had initially increased the line-height of Body size "m" from 22px to 24px. This had the unintended side effect of increasing the height of the input components by 2px.

## Approach and changes

- Reverted the `--cui-body-m-line-height` token value to 22px

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
