### PR TITLE
Fix Headline font weight

### DIFF
--- a/.changeset/tender-bananas-sit.md
+++ b/.changeset/tender-bananas-sit.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the font weight of the Headline component in sizes "s" und "l".

--- a/packages/circuit-ui/components/Headline/Headline.module.css
+++ b/packages/circuit-ui/components/Headline/Headline.module.css
@@ -15,11 +15,13 @@
 .m {
   font-family: var(--cui-font-stack-default);
   font-size: var(--cui-headline-m-font-size);
+  font-weight: var(--cui-font-weight-bold);
   line-height: var(--cui-headline-m-line-height);
 }
 
 .s {
   font-family: var(--cui-font-stack-default);
   font-size: var(--cui-headline-s-font-size);
+  font-weight: var(--cui-font-weight-bold);
   line-height: var(--cui-headline-s-line-height);
 }


### PR DESCRIPTION
## Purpose

I discovered that I forgot to set an explicit font weight for the Headline component when changing the font family to SumUp Narrow in #3467. It's hard to spot because browsers render headings as bold (700) by default. 

## Approach and changes

- Style Headlines in size "s" or "m" with `--cui-font-weight-bold` (650)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
