### PR TITLE
Add flag of Catalonia

### DIFF
--- a/.changeset/tough-birds-occur.md
+++ b/.changeset/tough-birds-occur.md
@@ -1,0 +1,9 @@
+---
+"@sumup-oss/icons": minor
+---
+
+Added the flag of Catalonia. Load it using the `getIconURL` helper:
+
+```jsx
+<img src={getIconURL("flag_es-ct")} alt="Catalonia" />
+```

--- a/.changeset/tough-birds-occur.md
+++ b/.changeset/tough-birds-occur.md
@@ -1,9 +1,14 @@
 ---
+"@sumup-oss/circuit-ui": minor
 "@sumup-oss/icons": minor
 ---
 
-Added the flag of Catalonia. Load it using the `getIconURL` helper:
+Added the flag of Catalonia. Load it using `Flag` component or the `getIconURL` helper:
 
 ```jsx
+import { Flag } from '@sumup-oss/circuit-ui';
+import { getIconURL } from '@sumup-oss/icons';
+
+<Flag countryCode="ES-CT" />
 <img src={getIconURL("flag_es-ct")} alt="Catalonia" />
 ```

--- a/.changeset/tough-birds-occur.md
+++ b/.changeset/tough-birds-occur.md
@@ -3,7 +3,7 @@
 "@sumup-oss/icons": minor
 ---
 
-Added the flag of Catalonia. Load it using `Flag` component or the `getIconURL` helper:
+Added the flag of Catalonia. Load it using the `Flag` component or the `getIconURL()` helper:
 
 ```jsx
 import { Flag } from '@sumup-oss/circuit-ui';

--- a/packages/circuit-ui/components/Flag/Flag.stories.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.stories.tsx
@@ -29,13 +29,23 @@ export const Base = () => {
   // eslint-disable-next-line compat/compat
   const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
 
+  function formatCountryName(countryCode: string) {
+    if (countryCode === 'XX') {
+      return 'Unknown';
+    }
+    if (countryCode === 'ES-CT') {
+      return 'Catalonia';
+    }
+    return regionNames.of(countryCode);
+  }
+
   return (
     <div className={classes.list}>
       {FLAGS.map((code) => (
         <div key={code} className={classes.wrapper}>
           <Flag key={code} countryCode={code} alt="" width={32} />
           <Body>
-            {code === 'XX' ? 'Unknown' : regionNames.of(code)} ({code})
+            {formatCountryName(code)} ({code})
           </Body>
         </div>
       ))}

--- a/packages/circuit-ui/components/Flag/constants.ts
+++ b/packages/circuit-ui/components/Flag/constants.ts
@@ -263,6 +263,6 @@ const COUNTRIES = [
 
 const TERRITORIES = ['AQ', 'BQ', 'CP', 'DG', 'IC', 'MF', 'SX', 'UM'] as const;
 
-const SPECIAL_FLAGS = ['EU', 'UN', 'XX', 'PC'] as const;
+const SPECIAL_FLAGS = ['EU', 'UN', 'XX', 'PC', 'ES-CT'] as const;
 
 export const FLAGS = [...COUNTRIES, ...TERRITORIES, ...SPECIAL_FLAGS] as const;

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -1484,6 +1484,13 @@
     {
       "category": "Flag",
       "skipComponentFile": true,
+      "keywords": ["Catalonia"],
+      "name": "flag_es-ct",
+      "size": "480"
+    },
+    {
+      "category": "Flag",
+      "skipComponentFile": true,
       "keywords": ["Ethiopia"],
       "name": "flag_et",
       "size": "480"

--- a/packages/icons/tests/index.spec.ts
+++ b/packages/icons/tests/index.spec.ts
@@ -91,7 +91,7 @@ function parseFileName(fileName: string) {
   try {
     const [, name, size] = fileName.match(/(.+?)(?:_(\d+))?\.svg$/)!;
     // assign size of 480 for flag icons when size not specified in file name
-    if (!size && name.match(/^flag_[a-z]{2}$/)) {
+    if (!size && name.match(/^flag_[a-z]{2}(?:-[a-z]{2})?$/)) {
       return { name, size: '480' };
     }
     return { name, size };

--- a/packages/icons/web/v2/flag_es-ct.svg
+++ b/packages/icons/web/v2/flag_es-ct.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+    <path fill="#fcdd09" d="M0 0h640v480H0z"/>
+    <path stroke="#da121a" stroke-width="60" d="M0 90h810m0 120H0m0 120h810m0 120H0" transform="scale(.79012 .88889)"/>
+</svg>


### PR DESCRIPTION
## Purpose

SumUp supports Catalan translations in some of our products.

## Approach and changes

- Add the flag of Catalonia to the collection of flag icons
- Add support for it to the Flag component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
