### PR TITLE
Lighten the disabled background color

### DIFF
--- a/.changeset/common-garlics-accept.md
+++ b/.changeset/common-garlics-accept.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/design-tokens": patch
+---
+
+Lightened the `--cui-bg-normal-disabled` color to reduce the visual prominence of disabled elements.

--- a/.changeset/nasty-cougars-study.md
+++ b/.changeset/nasty-cougars-study.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Dimmed the text of disabled ListItems so they actually look disabled.

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -46,6 +46,6 @@ jobs:
           exitOnceUploaded: true
           onlyChanged: true
           externals: |
-            '.storybook/public/**'
-            'packages/design-tokens/**'
-            'packages/icons/**'
+            .storybook/public/**
+            packages/design-tokens/**
+            packages/icons/**

--- a/packages/circuit-ui/components/ListItem/ListItem.module.css
+++ b/packages/circuit-ui/components/ListItem/ListItem.module.css
@@ -21,6 +21,11 @@
   border-color: var(--cui-border-subtle-disabled);
 }
 
+.base:disabled *,
+.base[disabled] * {
+  color: var(--cui-fg-normal-disabled);
+}
+
 /* Interactive */
 
 a.base,

--- a/packages/design-tokens/themes/light.ts
+++ b/packages/design-tokens/themes/light.ts
@@ -33,7 +33,7 @@ export const light = [
   },
   {
     name: '--cui-bg-normal-disabled',
-    value: 'rgba(227, 226, 214, 0.6000)',
+    value: 'rgba(251, 251, 249, 0.4000)',
     type: 'color',
   },
   {

--- a/skills/circuit-ui/references/design-tokens.md
+++ b/skills/circuit-ui/references/design-tokens.md
@@ -7,7 +7,7 @@ CSS variables provided by the Circuit UI design system and their values.
 | `--cui-bg-normal` | `color` | no |  | `#fbfbf9` | `#000000` |
 | `--cui-bg-normal-hovered` | `color` | no |  | `#f1f0e9` | `#0f0e0c` |
 | `--cui-bg-normal-pressed` | `color` | no |  | `#e3e2d6` | `#1a1816` |
-| `--cui-bg-normal-disabled` | `color` | no |  | `rgba(227, 226, 214, 0.6000)` | `rgba(10, 9, 8, 0.6000)` |
+| `--cui-bg-normal-disabled` | `color` | no |  | `rgba(251, 251, 249, 0.4000)` | `rgba(10, 9, 8, 0.6000)` |
 | `--cui-bg-subtle` | `color` | no |  | `#f5f4ed` | `#141311` |
 | `--cui-bg-subtle-hovered` | `color` | no |  | `#f0eee7` | `#1a1816` |
 | `--cui-bg-subtle-pressed` | `color` | no |  | `#e8e6dc` | `#1e1c18` |


### PR DESCRIPTION
## Purpose

The `bg/normal-disabled` color changed from opaque white to opaque beige as part of the brand refresh changes. This gives too much visual prominence to disabled elements. 

## Approach and changes

- Lighten the `--cui-bg-normal-disabled` color token value

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
