### PR TITLE
Add business variant to Avatar component

### DIFF
--- a/.changeset/ripe-lamps-sneeze.md
+++ b/.changeset/ripe-lamps-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Deprecated the Avatar component's "identity" variant. Use the new "person" variant instead.

--- a/.changeset/rotten-bags-lose.md
+++ b/.changeset/rotten-bags-lose.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added a new "business" variant to the Avatar component for commercial entities such as a merchant.

--- a/packages/circuit-ui/components/Avatar/Avatar.mdx
+++ b/packages/circuit-ui/components/Avatar/Avatar.mdx
@@ -28,20 +28,11 @@ However, if the image is purely presentational, the alt text can be set to `""`.
 
 ## Variants
 
-There are two variants and two sizes available for the component.
+There are three variants and two sizes available for the component.
 
-### Object variant
+<Story of={Stories.Variants} />
 
-Use the object variant with a square shape for product item purposes (e.g. product catalogue).
+- **Object**: Use for product item purposes (e.g. product catalogue).
+- **Business**: Use for commercial entities (e.g. merchant, company).
+- **Identity**: Use for individual persons (e.g. profile, customer). The identity variant supports `initials` as an alternative placeholder.
 
-<Story of={Stories.ObjectVariant} />
-
-### Identity variant
-
-Use the identity variant with a circle shape for identity account purposes (e.g. profile, contact, business).
-
-<Story of={Stories.IdentityVariant} />
-
-### Sizes
-
-<Story of={Stories.Sizes} />

--- a/packages/circuit-ui/components/Avatar/Avatar.mdx
+++ b/packages/circuit-ui/components/Avatar/Avatar.mdx
@@ -7,7 +7,7 @@ import * as Stories from './Avatar.stories';
 
 <Status variant="stable" />
 
-The Avatar component displays an identity or an object image. It can be passed to the [ImageInput](Forms/ImageInput) to allow users to upload an avatar.
+The Avatar component displays an image representing an object, person or business. It can be passed to the [ImageInput](Forms/ImageInput) to allow users to upload an avatar.
 
 <Story of={Stories.Base} />
 
@@ -34,5 +34,5 @@ There are three variants and two sizes available for the component.
 
 - **Object**: Use for product item purposes (e.g. product catalogue).
 - **Business**: Use for commercial entities (e.g. merchant, company).
-- **Identity**: Use for individual persons (e.g. profile, customer). The identity variant supports `initials` as an alternative placeholder.
+- **Person**: Use for individual persons (e.g. profile, customer). The person variant supports `initials` as an alternative placeholder.
 

--- a/packages/circuit-ui/components/Avatar/Avatar.module.css
+++ b/packages/circuit-ui/components/Avatar/Avatar.module.css
@@ -42,6 +42,6 @@ div.m {
 
 /* Variants */
 
-.identity {
+.person {
   border-radius: var(--cui-border-radius-circle);
 }

--- a/packages/circuit-ui/components/Avatar/Avatar.spec.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.spec.tsx
@@ -30,14 +30,14 @@ describe('Avatar', () => {
 
   it('should render with an image', () => {
     const src = '/images/illustration-coffee.jpg';
-    renderAvatar({ src, variant: 'identity', alt: '' });
+    renderAvatar({ src, variant: 'person', alt: '' });
     const image = screen.getByRole('presentation');
     expect(image).toBeVisible();
     expect(image).toHaveAttribute('src', src);
   });
 
   it('should render with initials', () => {
-    renderAvatar({ initials: 'JD', variant: 'identity', alt: '' });
+    renderAvatar({ initials: 'JD', variant: 'person', alt: '' });
     expect(screen.getByText('JD')).toBeVisible();
   });
 

--- a/packages/circuit-ui/components/Avatar/Avatar.stories.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { Stack } from '../../../../.storybook/components/index.js';
+import { Matrix } from '../../../../.storybook/components/index.js';
 
 import { Avatar, type AvatarProps } from './Avatar.js';
 
@@ -32,62 +32,15 @@ Base.args = {
   alt: 'A cup of coffee on a table',
 };
 
-export const ObjectVariant = () => (
-  <Stack>
-    <Avatar
-      src="/images/illustration-coffee.jpg"
-      variant="object"
-      alt="A cup of coffee on a table"
-    />
-    <Avatar variant="object" alt="A cup of coffee on a table" />
-  </Stack>
+export const Variants = (args: AvatarProps) => (
+  <Matrix
+    component={Avatar}
+    args={args}
+    horizontal={{ prop: 'size', values: ['s', 'm'] }}
+    vertical={{ prop: 'variant', values: ['object', 'business', 'identity'] }}
+  />
 );
 
-export const IdentityVariant = () => (
-  <Stack>
-    <Avatar
-      src="/images/illustration-cat.jpg"
-      variant="identity"
-      alt="A portrait of a grey cat"
-    />
-    <Avatar variant="identity" alt="" />
-    <Avatar variant="identity" alt="John Dorian" initials="JD" />
-  </Stack>
-);
-
-export const Sizes = () => (
-  <Stack>
-    <Stack>
-      <Avatar
-        src="/images/illustration-coffee.jpg"
-        variant="object"
-        size="m"
-        alt="A cup of coffee on a table"
-      />
-      <Avatar
-        src="/images/illustration-coffee.jpg"
-        variant="object"
-        size="s"
-        alt="A cup of coffee on a table"
-      />
-    </Stack>
-    <Stack>
-      <Avatar
-        src="/images/illustration-cat.jpg"
-        variant="identity"
-        size="m"
-        alt="A portrait of a grey cat"
-      />
-      <Avatar
-        src="/images/illustration-cat.jpg"
-        variant="identity"
-        size="s"
-        alt="A portrait of a grey cat"
-      />
-    </Stack>
-    <Stack>
-      <Avatar variant="identity" alt="John Dorian" initials="JD" size="m" />
-      <Avatar variant="identity" alt="John Dorian" initials="JD" size="s" />
-    </Stack>
-  </Stack>
-);
+Variants.args = {
+  alt: '',
+};

--- a/packages/circuit-ui/components/Avatar/Avatar.stories.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.stories.tsx
@@ -37,7 +37,7 @@ export const Variants = (args: AvatarProps) => (
     component={Avatar}
     args={args}
     horizontal={{ prop: 'size', values: ['s', 'm'] }}
-    vertical={{ prop: 'variant', values: ['object', 'business', 'identity'] }}
+    vertical={{ prop: 'variant', values: ['object', 'business', 'person'] }}
   />
 );
 

--- a/packages/circuit-ui/components/Avatar/Avatar.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.tsx
@@ -14,7 +14,7 @@
  */
 
 import type { ImgHTMLAttributes } from 'react';
-import { Profile, Image as ImageIcon } from '@sumup-oss/icons';
+import { Profile, Image as ImageIcon, Company } from '@sumup-oss/icons';
 
 import { CircuitError } from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
@@ -37,13 +37,16 @@ export interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
    */
   alt: string;
   /**
-   * The variant of the Avatar, either identity or object. Refer to the docs for usage guidelines.
+   * The variant of the Avatar. Refer to the docs for usage guidelines.
    * The variant also changes which placeholder is rendered when the `src` prop is not provided.
-   * Defaults to `object`.
+   *
+   * @default 'object'
    */
-  variant?: 'object' | 'identity';
+  variant?: 'object' | 'identity' | 'business';
   /**
-   * Choose from 2 sizes. Default: 'm'.
+   * Choose from 2 sizes.
+   *
+   * @default 'm'
    */
   size?:
     | 's'
@@ -66,6 +69,7 @@ export interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
 const placeholders = {
   object: <ImageIcon size="24" />,
   identity: <Profile size="24" />,
+  business: <Company size="24" />,
 };
 
 const legacySizeMap: Record<string, 's' | 'm'> = {
@@ -115,7 +119,6 @@ export const Avatar = ({
 
   if (src) {
     return (
-      // biome-ignore lint/a11y/useAltText: The `alt` prop is marked as required.
       <img
         src={src}
         alt={alt}

--- a/packages/circuit-ui/components/Avatar/Avatar.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.tsx
@@ -42,7 +42,14 @@ export interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
    *
    * @default 'object'
    */
-  variant?: 'object' | 'identity' | 'business';
+  variant?:
+    | 'object'
+    | 'business'
+    | 'person'
+    /**
+     * @deprecated Use the 'person' variant instead.
+     */
+    | 'identity';
   /**
    * Choose from 2 sizes.
    *
@@ -52,11 +59,11 @@ export interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
     | 's'
     | 'm'
     /**
-     * @deprecated
+     * @deprecated Use size 's' instead.
      */
     | 'giga'
     /**
-     * @deprecated
+     * @deprecated Use size 'm' instead.
      */
     | 'yotta';
   /**
@@ -68,13 +75,16 @@ export interface AvatarProps extends ImgHTMLAttributes<HTMLImageElement> {
 
 const placeholders = {
   object: <ImageIcon size="24" />,
-  identity: <Profile size="24" />,
+  person: <Profile size="24" />,
   business: <Company size="24" />,
 };
 
 const legacySizeMap: Record<string, 's' | 'm'> = {
   giga: 's',
   yotta: 'm',
+};
+const legacyVariantMap: Record<string, 'person' | 'object' | 'business'> = {
+  identity: 'person',
 };
 
 /**
@@ -83,12 +93,28 @@ const legacySizeMap: Record<string, 's' | 'm'> = {
 export const Avatar = ({
   src,
   alt = '', // This default should be removed in the next major
-  variant = 'object',
+  variant: legacyVariant = 'object',
   size: legacySize = 'm',
   initials,
   className,
   ...props
 }: AvatarProps) => {
+  if (process.env.NODE_ENV !== 'production' && legacySizeMap[legacySize]) {
+    deprecate(
+      'Avatar',
+      `The \`${legacySize}\` size has been deprecated. Use the \`${legacySizeMap[legacySize]}\` size instead.`,
+    );
+  }
+
+  if (process.env.NODE_ENV !== 'production' && legacyVariant === 'identity') {
+    deprecate(
+      'Avatar',
+      `The \`identity\` variant has been deprecated. Use the \`person\` variant instead.`,
+    );
+  }
+
+  const variant = legacyVariantMap[legacyVariant] || legacyVariant;
+
   if (
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test'
@@ -108,13 +134,6 @@ export const Avatar = ({
     }
   }
 
-  if (process.env.NODE_ENV !== 'production' && legacySizeMap[legacySize]) {
-    deprecate(
-      'Avatar',
-      `The \`${legacySize}\` size has been deprecated. Use the \`${legacySizeMap[legacySize]}\` size instead.`,
-    );
-  }
-
   const size = legacySizeMap[legacySize] || legacySize;
 
   if (src) {
@@ -125,7 +144,7 @@ export const Avatar = ({
         className={clsx(
           classes.base,
           classes[size],
-          variant === 'identity' && classes.identity,
+          variant === 'person' && classes.person,
           className,
         )}
         {...props}
@@ -134,7 +153,7 @@ export const Avatar = ({
   }
 
   const placeholder =
-    variant === 'identity' && initials
+    variant === 'person' && initials
       ? initials.slice(0, 2).toUpperCase()
       : placeholders[variant];
 
@@ -146,7 +165,7 @@ export const Avatar = ({
       className={clsx(
         classes.base,
         classes[size],
-        variant === 'identity' && classes.identity,
+        variant === 'person' && classes.person,
         className,
       )}
       {...props}

--- a/skills/circuit-ui/references/components/Avatar.mdx
+++ b/skills/circuit-ui/references/components/Avatar.mdx
@@ -28,20 +28,11 @@ However, if the image is purely presentational, the alt text can be set to `""`.
 
 ## Variants
 
-There are two variants and two sizes available for the component.
+There are three variants and two sizes available for the component.
 
-### Object variant
+<Story of={Stories.Variants} />
 
-Use the object variant with a square shape for product item purposes (e.g. product catalogue).
+- **Object**: Use for product item purposes (e.g. product catalogue).
+- **Business**: Use for commercial entities (e.g. merchant, company).
+- **Identity**: Use for individual persons (e.g. profile, customer). The identity variant supports `initials` as an alternative placeholder.
 
-<Story of={Stories.ObjectVariant} />
-
-### Identity variant
-
-Use the identity variant with a circle shape for identity account purposes (e.g. profile, contact, business).
-
-<Story of={Stories.IdentityVariant} />
-
-### Sizes
-
-<Story of={Stories.Sizes} />

--- a/skills/circuit-ui/references/components/Avatar.mdx
+++ b/skills/circuit-ui/references/components/Avatar.mdx
@@ -7,7 +7,7 @@ import * as Stories from './Avatar.stories';
 
 <Status variant="stable" />
 
-The Avatar component displays an identity or an object image. It can be passed to the [ImageInput](Forms/ImageInput) to allow users to upload an avatar.
+The Avatar component displays an image representing an object, person or business. It can be passed to the [ImageInput](Forms/ImageInput) to allow users to upload an avatar.
 
 <Story of={Stories.Base} />
 
@@ -34,5 +34,5 @@ There are three variants and two sizes available for the component.
 
 - **Object**: Use for product item purposes (e.g. product catalogue).
 - **Business**: Use for commercial entities (e.g. merchant, company).
-- **Identity**: Use for individual persons (e.g. profile, customer). The identity variant supports `initials` as an alternative placeholder.
+- **Person**: Use for individual persons (e.g. profile, customer). The person variant supports `initials` as an alternative placeholder.
 


### PR DESCRIPTION
## Purpose

SumUp distinguishes between users (an individual person) and merchants (a commercial entity). We've got an avatar variant for users ("identity") but none for merchants.

## Approach and changes

- Added a new "business" variant to the Avatar component to represent commercial entities such as a merchant
- Deprecated the "identity" variant in favor of a new "person" variant to make its purpose clearer and distinguish it from the "business" variant
- Consolidated the Avatar stories to save on Chromatic snapshots

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
