### PR TITLE
fix: refactor field wrapper styles to be consistent with input

### DIFF
--- a/packages/circuit-ui/components/Field/Field.module.css
+++ b/packages/circuit-ui/components/Field/Field.module.css
@@ -118,12 +118,14 @@
 
 .s .validation-hint-icon {
   margin-top: calc(
-    (var(--cui-compact-s-line-height) - var(--cui-icon-sizes-kilo)) / 2
+    (var(--cui-compact-s-line-height) - var(--cui-icon-sizes-kilo)) /
+    2
   );
 }
 
 .m .validation-hint-icon {
   margin-top: calc(
-    (var(--cui-body-s-line-height) - var(--cui-icon-sizes-kilo)) / 2
+    (var(--cui-body-s-line-height) - var(--cui-icon-sizes-kilo)) /
+    2
   );
 }

--- a/packages/circuit-ui/components/Field/Field.module.css
+++ b/packages/circuit-ui/components/Field/Field.module.css
@@ -13,13 +13,6 @@
   pointer-events: none;
 }
 
-.s {
-  --field-label-font-size: var(--cui-compact-s-font-size);
-  --field-label-line-height: var(--cui-compact-s-line-height);
-  --field-validation-font-size: var(--cui-compact-s-font-size);
-  --field-validation-line-height: var(--cui-compact-s-line-height);
-}
-
 .label,
 .legend {
   display: block;
@@ -33,8 +26,6 @@
 .label-text {
   display: block;
   margin-bottom: var(--cui-spacings-bit);
-  font-size: var(--field-label-font-size, var(--cui-body-s-font-size));
-  line-height: var(--field-label-line-height, var(--cui-body-s-line-height));
 }
 
 [disabled] .label-text,
@@ -53,8 +44,6 @@
 
 .description {
   display: block;
-  font-size: var(--field-label-font-size, var(--cui-body-s-font-size));
-  line-height: var(--field-label-line-height, var(--cui-body-s-line-height));
   color: var(--cui-fg-subtle);
 }
 
@@ -66,11 +55,6 @@
 .validation-hint {
   display: flex;
   margin-top: var(--cui-spacings-bit);
-  font-size: var(--field-validation-font-size, var(--cui-body-s-font-size));
-  line-height: var(
-    --field-validation-line-height,
-    var(--cui-body-s-line-height)
-  );
   color: var(--cui-fg-subtle);
   transition: color var(--cui-transitions-default);
 }
@@ -113,12 +97,33 @@
   align-self: flex-start;
   width: var(--cui-icon-sizes-kilo);
   height: var(--cui-icon-sizes-kilo);
-  margin-top: calc(
-    (
-      var(--field-validation-line-height, var(--cui-body-s-line-height)) -
-      var(--cui-icon-sizes-kilo)
-    ) /
-    2
-  );
   margin-right: var(--cui-spacings-bit);
+}
+
+/* Sizes */
+
+.s .label-text,
+.s .description,
+.s .validation-hint {
+  font-size: var(--cui-compact-s-font-size);
+  line-height: var(--cui-compact-s-line-height);
+}
+
+.m .label-text,
+.m .description,
+.m .validation-hint {
+  font-size: var(--cui-body-s-font-size);
+  line-height: var(--cui-body-s-line-height);
+}
+
+.s .validation-hint-icon {
+  margin-top: calc(
+    (var(--cui-compact-s-line-height) - var(--cui-icon-sizes-kilo)) / 2
+  );
+}
+
+.m .validation-hint-icon {
+  margin-top: calc(
+    (var(--cui-body-s-line-height) - var(--cui-icon-sizes-kilo)) / 2
+  );
 }

--- a/packages/circuit-ui/components/Field/Field.tsx
+++ b/packages/circuit-ui/components/Field/Field.tsx
@@ -48,11 +48,11 @@ interface FieldWrapperProps extends HTMLAttributes<HTMLDivElement> {
  * @private
  */
 export const FieldWrapper = forwardRef<HTMLDivElement, FieldWrapperProps>(
-  ({ children, disabled, size, className, ...props }, ref) => (
+  ({ children, disabled, size = 'm', className, ...props }, ref) => (
     <div
       ref={ref}
       data-disabled={disabled}
-      className={clsx(classes.wrapper, size === 's' && classes.s, className)}
+      className={clsx(classes.wrapper, classes[size], className)}
       {...props}
     >
       {children}
@@ -71,11 +71,11 @@ interface FieldSetProps extends FieldsetHTMLAttributes<HTMLFieldSetElement> {
  * @private
  */
 export const FieldSet = forwardRef<HTMLFieldSetElement, FieldSetProps>(
-  ({ size, className, ...props }, ref) => (
+  ({ size = 'm', className, ...props }, ref) => (
     <fieldset
       {...props}
       ref={ref}
-      className={clsx(classes.fieldset, size === 's' && classes.s, className)}
+      className={clsx(classes.fieldset, classes[size], className)}
     />
   ),
 );


### PR DESCRIPTION
## Purpose

After refactoring the `Input component` styles on https://github.com/sumup-oss/circuit-ui/pull/3606 I think it would be a good idea to extend that refactor to the `Field Wrapper`. Each size class owns its full set of size-specific properties, with no CSS variable indirection or `size=m` fallback.

## Approach and changes

`packages/circuit-ui/components/Field/Field.module.css` previously used 4 CSS variable ` (--field-label-font-size, --field-label-line-height, --field-validation-font-size, --field-validation-line-height)` where `.label-text, .description, .validation-hint, and .validation-hint-icon` referenced `var(--field-*, <medium fallback>)` and the `.s` class only existed to override those vars. This change removes those and replaces it with descendants selectors driven by size classes. 

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
