### PR TITLE
feat(circuit-ui): allow leading zeros in `DateInput`

### DIFF
--- a/.changeset/ten-years-jog.md
+++ b/.changeset/ten-years-jog.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': patch
+---
+
+Fixed `DateInput` segment entry to accept leading zeros and advance focus after a complete day or month value is typed.

--- a/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
@@ -249,6 +249,33 @@ describe('DateInput', () => {
       expect(ref.current).toHaveValue('2017-08-28');
     });
 
+    it('should allow leading zeros when typing a day', async () => {
+      const ref = createRef<HTMLInputElement>();
+
+      render(<DateInput {...props} ref={ref} />);
+
+      await userEvent.type(screen.getByLabelText('Year'), '2017');
+      await userEvent.type(screen.getByLabelText('Month'), '8');
+
+      const dayInput = screen.getByLabelText('Day');
+
+      await userEvent.type(dayInput, '0');
+      expect(dayInput).toHaveValue('0');
+
+      await userEvent.type(dayInput, '2');
+      expect(ref.current).toHaveValue('2017-08-02');
+    });
+
+    it('should move focus to the next segment after typing a complete day with a leading zero', async () => {
+      render(<DateInput {...props} />);
+
+      await userEvent.type(screen.getByLabelText('Year'), '2017');
+      await userEvent.type(screen.getByLabelText('Month'), '8');
+      await userEvent.type(screen.getByLabelText('Day'), '01');
+
+      expect(screen.getByLabelText('Year')).toHaveFocus();
+    });
+
     it('should update the minimum and maximum input values as the user types', async () => {
       render(<DateInput {...props} min="2000-04-29" max="2001-02-15" />);
 

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.spec.tsx
@@ -92,6 +92,14 @@ describe('DateSegment', () => {
       expect(props.focus.next).toHaveBeenCalled();
     });
 
+    it('should preserve a single leading zero while the value is still incomplete', async () => {
+      render(<DateSegment {...props} value="" />);
+      const input = screen.getByRole('spinbutton');
+      await userEvent.type(input, '0');
+      expect(input).toHaveValue('0');
+      expect(props.onChange).toHaveBeenCalledWith('');
+    });
+
     it.each([
       'ArrowUp',
       'ArrowDown',

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.spec.tsx
@@ -85,6 +85,13 @@ describe('DateSegment', () => {
       expect(props.focus.next).toHaveBeenCalled();
     });
 
+    it('should move the focus to the next segment when typing a complete value with a leading zero', async () => {
+      render(<DateSegment {...props} value="" />);
+      const input = screen.getByRole('spinbutton');
+      await userEvent.type(input, '01');
+      expect(props.focus.next).toHaveBeenCalled();
+    });
+
     it.each([
       'ArrowUp',
       'ArrowDown',

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
@@ -16,6 +16,7 @@
 'use client';
 
 import {
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -69,6 +70,13 @@ export function DateSegment({
   const sizeRef = useRef<HTMLSpanElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const [width, setWidth] = useState('4ch');
+  const [draftValue, setDraftValue] = useState('');
+
+  useEffect(() => {
+    if (props.value !== '' && draftValue) {
+      setDraftValue('');
+    }
+  }, [draftValue, props.value]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: The width needs to be recalculated when the value changes
   useLayoutEffect(() => {
@@ -183,13 +191,32 @@ export function DateSegment({
   };
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const value = Number.parseInt(event.currentTarget.value, 10);
+    const nextValue = event.currentTarget.value;
+
+    if (!nextValue) {
+      setDraftValue('');
+      onChange('');
+      return;
+    }
+
+    if (nextValue === '0') {
+      setDraftValue(nextValue);
+      onChange('');
+      return;
+    }
+
+    const value = Number.parseInt(nextValue, 10);
+
+    setDraftValue('');
 
     onChange(value || '');
 
-    // Focus the next segment if typing any other digit would exceed the
-    // maximum value
-    if (value && value > Math.floor(max / 10)) {
+    // Focus the next segment once the segment is complete or typing any
+    // other digit would exceed the maximum value.
+    if (
+      nextValue.length >= props.placeholder.length ||
+      (value && value > Math.floor(max / 10))
+    ) {
       focus.next();
     }
   };
@@ -213,6 +240,7 @@ export function DateSegment({
         onChange={handleChange}
         {...focus.props}
         {...props}
+        value={draftValue || props.value}
       />
       <span ref={sizeRef} className={classes.size} aria-hidden="true">
         {props.value || props.placeholder}

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.tsx
@@ -16,7 +16,6 @@
 'use client';
 
 import {
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -71,12 +70,6 @@ export function DateSegment({
   const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const [width, setWidth] = useState('4ch');
   const [draftValue, setDraftValue] = useState('');
-
-  useEffect(() => {
-    if (props.value !== '' && draftValue) {
-      setDraftValue('');
-    }
-  }, [draftValue, props.value]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: The width needs to be recalculated when the value changes
   useLayoutEffect(() => {
@@ -191,21 +184,21 @@ export function DateSegment({
   };
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const nextValue = event.currentTarget.value;
+    const rawValue = event.currentTarget.value;
 
-    if (!nextValue) {
+    if (!rawValue) {
       setDraftValue('');
       onChange('');
       return;
     }
 
-    if (nextValue === '0') {
-      setDraftValue(nextValue);
+    if (rawValue === '0') {
+      setDraftValue(rawValue);
       onChange('');
       return;
     }
 
-    const value = Number.parseInt(nextValue, 10);
+    const value = Number.parseInt(rawValue, 10);
 
     setDraftValue('');
 
@@ -214,7 +207,7 @@ export function DateSegment({
     // Focus the next segment once the segment is complete or typing any
     // other digit would exceed the maximum value.
     if (
-      nextValue.length >= props.placeholder.length ||
+      rawValue.length >= props.placeholder.length ||
       (value && value > Math.floor(max / 10))
     ) {
       focus.next();
@@ -240,7 +233,7 @@ export function DateSegment({
         onChange={handleChange}
         {...focus.props}
         {...props}
-        value={draftValue || props.value}
+        value={props.value === '' ? draftValue : props.value}
       />
       <span ref={sizeRef} className={classes.size} aria-hidden="true">
         {props.value || props.placeholder}


### PR DESCRIPTION
Handle leading zeros in date input such that if the user types `01` for a day it correctly sets the day as `1` an advances the focus to the next field. With the current behavior typing `01` leaves the input on the day.
