### PR TITLE
update AutocompleteInput badge tag to experimental

### DIFF
--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.stories.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.stories.tsx
@@ -43,7 +43,7 @@ import type { AutocompleteInputOption } from './components/Option/Option.js';
 export default {
   title: 'Forms/AutocompleteInput',
   component: AutocompleteInput,
-  tags: ['status:stable'],
+  tags: ['status:experimental'],
   argTypes: {
     // Value & change handling
     value: {


### PR DESCRIPTION
## Purpose

@missating has noticed that the AutocompleteInput component did not have the correct `experimental` tag and was incorrectly tagged as stable.

## Approach and changes

Update the AutocompleteInput's story tags for correct filtering on storybook

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
