### PR TITLE
feat(circuit-ui): Input passwordManagerIgnore

### DIFF
--- a/.changeset/soft-cameras-matter.md
+++ b/.changeset/soft-cameras-matter.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': patch
+---
+
+Added a `passwordManagerIgnore` prop to `Input`. `passwordManagerIgnore` prevents password overlays on the `Input` component in case it might be incorrectly considered a login input. Use-cases involve inputs one-time-codes delivered via a side-channel (such as SMS or email).

--- a/.changeset/soft-cameras-matter.md
+++ b/.changeset/soft-cameras-matter.md
@@ -2,4 +2,4 @@
 '@sumup-oss/circuit-ui': patch
 ---
 
-Added a `passwordManagerIgnore` prop to `Input`. `passwordManagerIgnore` prevents password overlays on the `Input` component in case it might be incorrectly considered a login input. Use-cases involve inputs one-time-codes delivered via a side-channel (such as SMS or email).
+Added a `passwordManagerIgnore` prop to `Input`. `passwordManagerIgnore` prevents password overlays on the `Input` component in case it might be incorrectly considered a login input. Use-cases include inputs one-time-codes delivered via a side-channel (such as SMS or email).

--- a/packages/circuit-ui/components/Input/Input.stories.tsx
+++ b/packages/circuit-ui/components/Input/Input.stories.tsx
@@ -128,3 +128,7 @@ Password.args = {
   type: 'password',
   validationHint: 'Use at least 8 characters.',
 };
+
+Password.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/packages/circuit-ui/components/Input/Input.stories.tsx
+++ b/packages/circuit-ui/components/Input/Input.stories.tsx
@@ -114,3 +114,17 @@ HiddenLabel.args = {
   validationHint: '',
   hideLabel: true,
 };
+
+export const Password = (args: InputProps) => (
+  <Stack>
+    <Input {...args} label="Password" />
+    <Input {...args} label="One time code" passwordManagerIgnore />
+  </Stack>
+);
+
+Password.args = {
+  label: 'Password',
+  placeholder: 'Enter password',
+  type: 'password',
+  validationHint: 'Use at least 8 characters.',
+};

--- a/packages/circuit-ui/components/Input/Input.tsx
+++ b/packages/circuit-ui/components/Input/Input.tsx
@@ -109,6 +109,11 @@ export interface BaseInputProps {
    * Class to overwrite the input element styles.
    */
   inputClassName?: string;
+  /**
+   * Disable password manager overlayes on non-credential inputs that might
+   * be incorrectly classify as login fields.
+   */
+  passwordManagerIgnore?: boolean;
 }
 
 export interface InputProps
@@ -141,6 +146,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       disabled,
       textAlign = 'left',
       inputClassName,
+      passwordManagerIgnore,
       'as': Element = 'input',
       label,
       hideLabel,
@@ -212,6 +218,11 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             aria-invalid={invalid && 'true'}
             required={required}
             disabled={disabled}
+            data-1p-ignore={passwordManagerIgnore}
+            data-bwignore={passwordManagerIgnore}
+            data-lpignore={passwordManagerIgnore}
+            data-op-ignore={passwordManagerIgnore}
+            data-protonpass-ignore={passwordManagerIgnore}
             {...props}
           />
           {suffix}


### PR DESCRIPTION
## Purpose

Allow preventing password overlays on `Input` components.

NOTE: No strong opinion on whether this should be part of design system or not but we currently have at least 2 use-cases - SSO pages and MFA in the dashboard.

## Approach and changes

Add `passwordManagerIgnore` prop to `Input`.

`passwordManagerIgnore` prevents password overlays on the `Input` component in case it might be incorrectly considered a login input. Use-cases involve inputs for one-time-codes delivered via a side-channel (such as SMS or email).

Inspiration taken from: https://kumo-ui.com/components/input/#password-manager-overlays, another example ref: https://stackoverflow.com/questions/41945535/html-disable-password-manager

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
