### PR TITLE
fix scroll issue inside combobox input

### DIFF
--- a/.changeset/sweet-facts-type.md
+++ b/.changeset/sweet-facts-type.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed an overflow issue caused by the AutocompleteInput clear button being slightly too large.

--- a/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
@@ -101,11 +101,8 @@
 
 .clear {
   position: absolute;
-  top: 0;
-  right: 0;
-  width: var(--cui-spacings-exa);
-  height: var(--cui-spacings-exa);
-  padding: var(--cui-spacings-kilo) var(--cui-spacings-mega);
+  top: var(--cui-spacings-byte);
+  right: var(--cui-spacings-byte);
   color: var(--cui-fg-subtle);
 }
 


### PR DESCRIPTION
## Purpose

I noticed an unnecessary scrollbar on the autocomplete when a value is selected. The overflow is caused by the clear button being slightly too large

https://github.com/user-attachments/assets/58a579bb-43cc-42b2-8349-ee2e8c7410f6

## Approach and changes

adjust the styling of the clear button to fit inside the combobox input without overflowing it.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
