### PR TITLE
Fix the disabled button color

### DIFF
--- a/.changeset/fast-sites-heal.md
+++ b/.changeset/fast-sites-heal.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Fixed the background color of disabled buttons.
+Fixed the background color of disabled primary buttons.

--- a/.changeset/fast-sites-heal.md
+++ b/.changeset/fast-sites-heal.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the background color of disabled buttons.

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -225,7 +225,7 @@
 .primary[disabled],
 .primary[aria-disabled="true"] {
   color: var(--cui-fg-normal-disabled);
-  background-color: var(--cui-bg-highlight-disabled);
+  background-color: var(--cui-bg-accent-strong-disabled);
   border-color: transparent;
 }
 


### PR DESCRIPTION
## Purpose

I discovered that we're using the wrong background color for disabled buttons when answering a question from the mobile devs about it.

## Approach and changes

- Changed the disabled primary button background color from `bg/highlight-disabled` to `bg/accent-strong-disabled` to match the design in Figma and to consistently use `bg/accent-strong-*` across all states of the primary variant

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements