### PR TITLE
fix: eliminate glitch on top corner

### DIFF
--- a/packages/circuit-ui/components/Field/Field.module.css
+++ b/packages/circuit-ui/components/Field/Field.module.css
@@ -59,6 +59,12 @@
   transition: color var(--cui-transitions-default);
 }
 
+/* Prevent hint glyphs from bleeding through semi-transparent dropdown corners */
+.fieldset:has([aria-expanded="true"]) .validation-hint,
+.wrapper:has([aria-expanded="true"]) .validation-hint {
+  visibility: hidden;
+}
+
 [disabled] .validation-hint,
 :global([data-disabled="true"]) .validation-hint {
   color: var(--cui-fg-subtle-disabled);


### PR DESCRIPTION
Before

<img width="401" height="260" alt="image" src="https://github.com/user-attachments/assets/81554e7c-fafb-4a2f-bdcb-3e3924f9aff7" />

After

<img width="396" height="274" alt="image" src="https://github.com/user-attachments/assets/07a20923-8f6c-4a99-9663-e5a689adf4d7" />



## Purpose

To fix the awkward visual glitch

## Approach and changes

- hide the text while is expanded

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
