### PR TITLE
fix: visual glitch on top corner #2

### DIFF
--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -310,7 +310,7 @@ export const AutocompleteInput = forwardRef<
       placement: 'bottom',
       strategy: 'fixed',
       middleware: [
-        offset({ mainAxis: size === 's' ? 14 : 21, crossAxis: 0 }), // bottom padding + 1px border + 8px gap
+        offset({ mainAxis: size === 's' ? 10 : 17, crossAxis: 0 }), // bottom padding + 1px border + 4px gap
         shift({ padding: boundaryPadding }),
         flip({
           padding: boundaryPadding,


### PR DESCRIPTION
No ticket

Before

<img width="401" height="260" alt="image" src="https://github.com/user-attachments/assets/81554e7c-fafb-4a2f-bdcb-3e3924f9aff7" />

After

<img width="927" height="488" alt="image" src="https://github.com/user-attachments/assets/2a6af8d9-6b5c-46d4-a9ae-e7d9de935c1c" />

## Purpose

To eliminate this visual glitch which looks like a broken pixel

## Approach and changes

- using a backdrop (instead of hiding the text tried on https://github.com/sumup-oss/circuit-ui/pull/3633)

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
