### PR TITLE
fix accessibility issue in autocomplete input in immersive mode

### DIFF
--- a/.changeset/ten-buses-pump.md
+++ b/.changeset/ten-buses-pump.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the accessibility relationship between the `AutocompleteInput` combobox and its controlled listbox.

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.spec.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.spec.tsx
@@ -630,10 +630,8 @@ describe('AutocompleteInput', () => {
       expect(screen.getByRole('listbox')).toBeVisible();
       expect(input).toHaveAttribute('aria-expanded', 'true');
 
-      const popupId = screen
-        .getByTestId(`${input.getAttribute('data-id')}-popup`)
-        .getAttribute('id');
-      expect(input).toHaveAttribute('aria-controls', popupId);
+      const listboxId = screen.getByRole('listbox').getAttribute('id');
+      expect(input).toHaveAttribute('aria-controls', listboxId);
       expect(screen.getAllByRole('option')).toHaveLength(options.length);
     });
 

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -201,7 +201,7 @@ export const AutocompleteInput = forwardRef<
     const inputWrapperRef = useRef<HTMLDivElement>(null);
     const presentationFieldRef = useRef<HTMLInputElement>(null);
     const resultsRef = useRef<HTMLDivElement>(null);
-    const resultsId = useId();
+    const listboxId = useId();
     const autocompleteId = useId();
 
     if (
@@ -478,6 +478,7 @@ export const AutocompleteInput = forwardRef<
     const results =
       searchText || options.length ? (
         <Results
+          listboxId={listboxId}
           ref={resultsRef}
           isLoading={isLoading}
           isLoadingMore={isLoadingMore}
@@ -525,7 +526,7 @@ export const AutocompleteInput = forwardRef<
       onClear: onClear && !multiple ? onComboboxClear : undefined,
       onKeyDown: isLoading ? undefined : onComboboxKeyDown,
       role: 'combobox',
-      'aria-controls': resultsId,
+      'aria-controls': listboxId,
       autoComplete: 'off',
       'aria-autocomplete': 'list' as const,
       'aria-activedescendant': activeDescendant,
@@ -602,9 +603,7 @@ export const AutocompleteInput = forwardRef<
         {isOpen && (
           <div
             className={classes.results}
-            data-testid={`${autocompleteId}-popup`}
             ref={refs.setFloating}
-            id={resultsId}
             style={{
               ...floatingStyles,
               width: comboboxRef.current?.parentElement?.offsetWidth ?? 0,

--- a/packages/circuit-ui/components/AutocompleteInput/components/Results/Results.spec.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/components/Results/Results.spec.tsx
@@ -28,6 +28,7 @@ const props = {
   resultsSummary: 'results summary',
   loadMoreLabel: 'Load more',
   searchText: '',
+  listboxId: 'listbox-id',
 } satisfies ResultsProps;
 
 describe('Results', () => {

--- a/packages/circuit-ui/components/AutocompleteInput/components/Results/Results.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/components/Results/Results.tsx
@@ -39,6 +39,10 @@ export type ResultsProps = OptionsProps & {
    * An optional button to display below the options.
    */
   action?: Omit<ButtonProps, 'variant' | 'size'>;
+  /**
+   * Id of the listbox element.
+   */
+  listboxId: string;
   resultsSummary: string;
   isImmersive?: boolean;
 };
@@ -63,13 +67,12 @@ export const Results = forwardRef<HTMLDivElement, ResultsProps>(
       resultsSummary,
       isImmersive,
       loadMoreLabel,
-      id,
+      listboxId,
       ...rest
     },
     ref,
   ) => (
     <div
-      id={id}
       ref={ref}
       className={clsx(
         !isImmersive && classes.modal,
@@ -95,6 +98,7 @@ export const Results = forwardRef<HTMLDivElement, ResultsProps>(
       {(options.length > 0 || (allowNewItems && options.length === 0)) && (
         <>
           <Options
+            id={listboxId}
             value={value}
             options={options}
             onOptionClick={onOptionClick}


### PR DESCRIPTION
## Purpose

Currently the AutocompleteInput does not reference correctly the search results in the immersive mode. Upon inspection, the ID_REF passed to the combobox via `aria-controls` should be on the element with the role "listbox" which is not the case in either modes.

## Approach and changes

Add a `listboxId` prop to the Results component to pass on to Options, the component with the role "listbox".

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
