### PR TITLE
feat(circuit-ui): InlineNotification promo variant

### DIFF
--- a/.changeset/true-spiders-hug.md
+++ b/.changeset/true-spiders-hug.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added `promo` variant for `InlineNotification`.

--- a/packages/circuit-ui/components/Notification/constants.ts
+++ b/packages/circuit-ui/components/Notification/constants.ts
@@ -18,10 +18,16 @@ import {
   Confirm,
   Info,
   Notify,
+  Sparkles,
   type IconComponentType,
 } from '@sumup-oss/icons';
 
-export type NotificationVariant = 'info' | 'success' | 'warning' | 'danger';
+export type NotificationVariant =
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'promo';
 
 export const NOTIFICATION_ICONS: Record<
   NotificationVariant,
@@ -31,6 +37,7 @@ export const NOTIFICATION_ICONS: Record<
   success: Confirm,
   warning: Notify,
   danger: Alert,
+  promo: Sparkles,
 };
 
 export const TRANSITION_DURATION = 200;

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.mdx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.mdx
@@ -22,6 +22,7 @@ The `NotificationInline` component renders an inline notification within the con
 - Use the 'success' variant the successful messages.
 - Use the 'warning' variant for warning messages, and other information a user should be aware of.
 - Use the 'danger' variant for error messages. Be descriptive and give users clear next steps.
+- Use the 'promo' variant for promotional messages or recommendations.
 
 ### Dismissable notifications
 

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.module.css
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.module.css
@@ -57,6 +57,14 @@
   color: var(--cui-fg-danger);
 }
 
+.promo {
+  background-color: var(--cui-bg-promo);
+}
+
+.promo .icon {
+  color: var(--cui-fg-promo);
+}
+
 .content {
   display: flex;
   flex-direction: column;

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.spec.tsx
@@ -49,6 +49,23 @@ describe('NotificationInline', () => {
     });
   });
 
+  it.each([
+    'info',
+    'success',
+    'warning',
+    'danger',
+    'promo',
+  ] as const)('should render the %s variant', async (variant) => {
+    renderNotificationInline({
+      ...baseProps,
+      variant,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(baseProps.body)).toBeVisible();
+    });
+  });
+
   it('should render notification inline with headline', () => {
     renderNotificationInline({
       ...baseProps,

--- a/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
+++ b/packages/circuit-ui/components/NotificationInline/NotificationInline.stories.tsx
@@ -29,7 +29,7 @@ export default {
   tags: ['status:stable'],
 };
 
-const variants = ['info', 'success', 'warning', 'danger'] as const;
+const variants = ['info', 'success', 'warning', 'danger', 'promo'] as const;
 
 export const Base = (args: NotificationInlineProps) => (
   <NotificationInline {...args} isVisible={true} />

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.module.css
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.module.css
@@ -57,6 +57,14 @@
   color: var(--cui-fg-danger);
 }
 
+.promo {
+  background-color: var(--cui-bg-promo);
+}
+
+.promo .icon {
+  color: var(--cui-fg-promo);
+}
+
 .content {
   display: flex;
   flex-direction: column;

--- a/skills/circuit-ui/references/components/NotificationInline.mdx
+++ b/skills/circuit-ui/references/components/NotificationInline.mdx
@@ -22,6 +22,7 @@ The `NotificationInline` component renders an inline notification within the con
 - Use the 'success' variant the successful messages.
 - Use the 'warning' variant for warning messages, and other information a user should be aware of.
 - Use the 'danger' variant for error messages. Be descriptive and give users clear next steps.
+- Use the 'promo' variant for promotional messages or recommendations.
 
 ### Dismissable notifications
 


### PR DESCRIPTION
Needs `Promote` icon in size `16`.

---

Add `promo` variant for `InlineNotification`. It uses our existing brand tokens. The use-case in mind is the developer portal build on top of Starlight (Astro) where we use the `Aside` component from Starlight which I would like to replace with `NotificationInline` but in a few places we use the promo variant which isn't available in circuit-ui.
