### PR TITLE
Remove deprecated props from the Modal and Toggle components

### DIFF
--- a/.changeset/nice-pillows-shake.md
+++ b/.changeset/nice-pillows-shake.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed the deprecated `checkedLabel` and `uncheckedLabel` props from `Toggle`.

--- a/.changeset/soft-lies-invite.md
+++ b/.changeset/soft-lies-invite.md
@@ -1,0 +1,6 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed the deprecated `hideCloseButton` prop from `Modal` (use `preventClose` instead).
+Removed the deprecated `checkedLabel` and `uncheckedLabel` props from `Toggle`.

--- a/.changeset/soft-lies-invite.md
+++ b/.changeset/soft-lies-invite.md
@@ -3,4 +3,3 @@
 ---
 
 Removed the deprecated `hideCloseButton` prop from `Modal` (use `preventClose` instead).
-Removed the deprecated `checkedLabel` and `uncheckedLabel` props from `Toggle`.

--- a/packages/circuit-ui/components/Modal/Modal.tsx
+++ b/packages/circuit-ui/components/Modal/Modal.tsx
@@ -18,7 +18,6 @@
 import { forwardRef, useCallback, useState, type Ref } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
-import { deprecate } from '../../util/logger.js';
 import {
   Dialog,
   type DialogProps,
@@ -40,11 +39,6 @@ export interface ModalProps extends Omit<PublicDialogProps, 'isModal'> {
    */
   onClose?: DialogProps['onCloseEnd'];
   /**
-   * @deprecated This prop was passed to `react-modal` and is no longer relevant.
-   * Use the `preventClose` prop instead. Also see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role#required_javascript_features
-   */
-  hideCloseButton?: boolean;
-  /**
    * Prevent users from closing the modal by clicking/tapping the overlay or
    * pressing the escape key, and hides the close button.
    * @default false
@@ -61,7 +55,6 @@ export const ANIMATION_DURATION = 300;
 
 export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
   const {
-    hideCloseButton,
     variant = 'contextual',
     className,
     contentClassName,
@@ -70,12 +63,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>((props, ref) => {
     onClose,
     ...rest
   } = props;
-  if (process.env.NODE_ENV !== 'production' && hideCloseButton) {
-    deprecate(
-      'Modal',
-      'The `hideCloseButton` prop has been deprecated. Use the `preventClose` prop instead.',
-    );
-  }
+
   const [isClosing, setIsClosing] = useState(false);
 
   const handleModalCloseEnd = useCallback(() => {

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -24,7 +24,6 @@ import {
 import { FieldDescription, FieldWrapper } from '../Field/index.js';
 import { clsx } from '../../styles/clsx.js';
 import { utilClasses } from '../../styles/utility.js';
-import { deprecate } from '../../util/logger.js';
 
 import classes from './Toggle.module.css';
 
@@ -41,14 +40,6 @@ export interface ToggleProps extends ButtonHTMLAttributes<HTMLButtonElement> {
    * Is the Switch on?
    */
   checked?: boolean;
-  /**
-   * @deprecated This prop is no longer needed.
-   */
-  checkedLabel?: string;
-  /**
-   * @deprecated This prop is no longer needed.
-   */
-  uncheckedLabel?: string;
 }
 
 /**
@@ -60,8 +51,6 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
       label,
       description,
       'aria-describedby': describedBy,
-      checkedLabel,
-      uncheckedLabel,
       checked = false,
       onChange,
       className,
@@ -87,24 +76,6 @@ export const Toggle = forwardRef<HTMLButtonElement, ToggleProps>(
         'Toggle',
         'The `label` prop is missing or invalid.',
       );
-    }
-
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      process.env.NODE_ENV !== 'test'
-    ) {
-      if (checkedLabel) {
-        deprecate(
-          'Toggle',
-          'The `checkedLabel` prop is deprecated and can be removed.',
-        );
-      }
-      if (uncheckedLabel) {
-        deprecate(
-          'Toggle',
-          'The `uncheckedLabel` prop is deprecated and can be removed.',
-        );
-      }
     }
 
     return (


### PR DESCRIPTION
Addresses [DSYS-1670](https://sumupteam.atlassian.net/browse/DSYS-1670)

## Purpose

Remove deprecated props from `Modal` and `Toggle` components

## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
