### PR TITLE
Add as prop to the Status component

### DIFF
--- a/.changeset/common-windows-behave.md
+++ b/.changeset/common-windows-behave.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added a new `as` prop to the Status component. 

--- a/packages/circuit-ui/components/Status/Status.tsx
+++ b/packages/circuit-ui/components/Status/Status.tsx
@@ -64,7 +64,7 @@ const isDynamicWidth = (children: StatusProps['children']) =>
  * The status component communicates the condition of an entity
  * by conveying semantic meaning or indicating new, important information.
  */
-export const Status = forwardRef<any, StatusProps>(
+export const Status = forwardRef<HTMLDivElement, StatusProps>(
   (
     {
       as: Element = 'div',

--- a/packages/circuit-ui/components/Status/Status.tsx
+++ b/packages/circuit-ui/components/Status/Status.tsx
@@ -17,6 +17,7 @@ import { forwardRef, type HTMLAttributes } from 'react';
 
 import type { IconComponentType } from '@sumup-oss/icons';
 
+import type { AsPropType } from '../../types/prop-types.js';
 import { clsx } from '../../styles/clsx.js';
 import { utilClasses } from '../../styles/utility.js';
 
@@ -50,6 +51,10 @@ export interface StatusProps extends HTMLAttributes<HTMLDivElement> {
    * Leading icon for the line variant.
    */
   icon?: IconComponentType<'16'>;
+  /**
+   * Render the status using any HTML element.
+   */
+  as?: AsPropType;
 }
 
 const isDynamicWidth = (children: StatusProps['children']) =>
@@ -59,9 +64,10 @@ const isDynamicWidth = (children: StatusProps['children']) =>
  * The status component communicates the condition of an entity
  * by conveying semantic meaning or indicating new, important information.
  */
-export const Status = forwardRef<HTMLDivElement, StatusProps>(
+export const Status = forwardRef<any, StatusProps>(
   (
     {
+      as: Element = 'div',
       variant = 'pill',
       color = 'neutral',
       icon: Icon,
@@ -76,7 +82,7 @@ export const Status = forwardRef<HTMLDivElement, StatusProps>(
       variant === 'badge' && isDynamicWidth(children) ? 'auto' : undefined;
 
     return (
-      <div
+      <Element
         {...props}
         ref={ref}
         className={clsx(
@@ -95,7 +101,7 @@ export const Status = forwardRef<HTMLDivElement, StatusProps>(
         ) : (
           children
         )}
-      </div>
+      </Element>
     );
   },
 );


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

This adds a new `as` prop to the `Status component,` similar to the now-deprecated `Badge component.`

## Approach and changes

- Added an `as` prop to the `Status component,` allowing consumers to render a different Element

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
