### PR TITLE
Remove deprecated component props

### DIFF
--- a/.changeset/bitter-dancers-grin.md
+++ b/.changeset/bitter-dancers-grin.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed the deprecated Italic decoration prop from the `Numeral` component following the brand refresh.

--- a/.changeset/bitter-dancers-grin.md
+++ b/.changeset/bitter-dancers-grin.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": major
 ---
 
-Removed the deprecated Italic decoration prop from the `Numeral` component following the brand refresh.
+Removed the deprecated `Italic` decoration prop from the `Numeral` component following the brand refresh.

--- a/.changeset/curvy-snakes-heal.md
+++ b/.changeset/curvy-snakes-heal.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": major
 ---
 
-Removed `role` prop from `ActionMenu` component. The component now renders with correct `menu` ARIA semantics.
+Removed the `menu` ARIA role from the `ActionMenu` component. The `role="menu"` pattern triggers screen reader "Application mode" which requires non-standard keystrokes that most users are unaware of.

--- a/.changeset/curvy-snakes-heal.md
+++ b/.changeset/curvy-snakes-heal.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed `role` prop from `ActionMenu` component. The component now renders with correct `menu` ARIA semantics.

--- a/.changeset/curvy-snakes-heal.md
+++ b/.changeset/curvy-snakes-heal.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": major
 ---
 
-Removed the `menu` ARIA role from the `ActionMenu` component. The `role="menu"` pattern triggers screen reader "Application mode" which requires non-standard keystrokes that most users are unaware of.
+Removed the `menu` ARIA role from the `ActionMenu` component. The `role="menu"` pattern is reserved for complex, desktop-like applications and is not appropriate for the ActionMenu component.

--- a/.changeset/hip-ducks-mix.md
+++ b/.changeset/hip-ducks-mix.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed the default value for the `alt` prop in the `Avatar` component. The `alt` prop is now required.

--- a/.changeset/slow-bikes-admire.md
+++ b/.changeset/slow-bikes-admire.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed the deprecated Italic decoration prop from the `Body` component following the brand refresh.

--- a/.changeset/slow-bikes-admire.md
+++ b/.changeset/slow-bikes-admire.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": major
 ---
 
-Removed the deprecated Italic decoration prop from the `Body` component following the brand refresh.
+Removed the deprecated `Italic` decoration prop from the `Body` component following the brand refresh.

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.spec.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.spec.tsx
@@ -161,9 +161,7 @@ describe('ActionMenu', () => {
   it('should close the action menu when clicking a action menu item', async () => {
     renderActionMenu(baseProps);
 
-    const actionMenuItems = screen.getAllByRole('menuitem');
-
-    await userEvent.click(actionMenuItems[0]);
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
 
     expect(baseProps.onToggle).toHaveBeenCalledTimes(1);
   });
@@ -180,9 +178,7 @@ describe('ActionMenu', () => {
 
     rerender(<ActionMenu {...baseProps} isOpen />);
 
-    const actionMenuItems = screen.getAllByRole('menuitem');
-
-    expect(actionMenuItems[0]).toHaveFocus();
+    expect(screen.getByRole('button', { name: 'Add' })).toHaveFocus();
 
     await flushMicrotasks();
   });
@@ -211,17 +207,6 @@ describe('ActionMenu', () => {
       const actual = await axe(container);
       expect(actual).toHaveNoViolations();
     });
-  });
-
-  it('should render the action menu with menu semantics by default', async () => {
-    renderActionMenu(baseProps);
-
-    const menu = screen.getByRole('menu');
-    expect(menu).toBeVisible();
-    const menuitems = screen.getAllByRole('menuitem');
-    expect(menuitems.length).toBe(2);
-
-    await flushMicrotasks();
   });
 
   it('should hide dividers from the accessibility tree', async () => {

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.spec.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.spec.tsx
@@ -224,17 +224,6 @@ describe('ActionMenu', () => {
     await flushMicrotasks();
   });
 
-  it('should render the action menu without menu semantics', async () => {
-    renderActionMenu({ ...baseProps, role: null });
-
-    const menu = screen.queryByRole('menu');
-    expect(menu).toBeNull();
-    const menuitems = screen.queryAllByRole('menuitem');
-    expect(menuitems.length).toBe(0);
-
-    await flushMicrotasks();
-  });
-
   it('should hide dividers from the accessibility tree', async () => {
     const { baseElement } = renderActionMenu(baseProps);
 

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
@@ -15,13 +15,7 @@
 
 'use client';
 
-import {
-  useId,
-  useRef,
-  forwardRef,
-  useCallback,
-  type KeyboardEvent,
-} from 'react';
+import { useRef, forwardRef, useCallback, type KeyboardEvent } from 'react';
 
 import type { ClickEvent } from '../../types/events.js';
 import { Hr } from '../Hr/index.js';
@@ -54,9 +48,7 @@ type TriggerKey = 'ArrowUp' | 'ArrowDown';
 
 export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
   ({ actions, className, onToggle, component: Component, ...props }, ref) => {
-    const menuEl = useRef<HTMLDivElement>(null);
     const triggerKey = useRef<TriggerKey | null>(null);
-    const menuId = useId();
     const isMobile = useMedia('(max-width: 479px)');
 
     const focusProps = useFocusList();
@@ -93,23 +85,19 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
         )}
         {...props}
       >
-        <div id={menuId} ref={menuEl}>
-          {actions.map((action, index) => {
-            const key = isDivider(action)
-              ? `divider-${index}`
-              : action.children;
-            return isDivider(action) ? (
-              <Hr className={classes.divider} key={key} />
-            ) : (
-              <ActionMenuItem
-                key={key}
-                {...action}
-                {...focusProps}
-                onClick={handleActionMenuItemClick(action.onClick)}
-              />
-            );
-          })}
-        </div>
+        {actions.map((action, index) => {
+          const key = isDivider(action) ? `divider-${index}` : action.children;
+          return isDivider(action) ? (
+            <Hr className={classes.divider} key={key} />
+          ) : (
+            <ActionMenuItem
+              key={key}
+              {...action}
+              {...focusProps}
+              onClick={handleActionMenuItemClick(action.onClick)}
+            />
+          );
+        })}
       </Popover>
     );
   },

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
@@ -44,7 +44,7 @@ function isDivider(action: Action): action is Divider {
   return 'type' in action && action.type === 'divider';
 }
 
-export interface ActionMenuProps extends Omit<PopoverProps, 'role'> {
+export interface ActionMenuProps extends PopoverProps {
   /**
    * An array of ActionMenuItem or Divider.
    */

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
@@ -49,30 +49,11 @@ export interface ActionMenuProps extends Omit<PopoverProps, 'role'> {
    * An array of ActionMenuItem or Divider.
    */
   actions: Action[];
-  /**
-   * Remove the [`menu` role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/roles/menu_role)
-   * when its semantics aren't appropriate for the use case, for example when
-   * the ActionMenu is used as part of a navigation.
-   * @default 'menu'.
-   *
-   * Learn more: https://inclusive-components.design/menus-menu-buttons/
-   */
-  role?: 'menu' | null;
 }
 type TriggerKey = 'ArrowUp' | 'ArrowDown';
 
 export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
-  (
-    {
-      actions,
-      role = 'menu',
-      className,
-      onToggle,
-      component: Component,
-      ...props
-    },
-    ref,
-  ) => {
+  ({ actions, className, onToggle, component: Component, ...props }, ref) => {
     const menuEl = useRef<HTMLDivElement>(null);
     const triggerKey = useRef<TriggerKey | null>(null);
     const triggerId = useId();
@@ -101,11 +82,6 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
         onToggle(false);
       };
 
-    const isMenu = role === 'menu';
-    const menuProps = isMenu
-      ? { 'role': 'menu', 'aria-labelledby': triggerId }
-      : {};
-
     return (
       <Popover
         className={clsx(className, classes.base)}
@@ -122,20 +98,23 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
         )}
         {...props}
       >
-        <div id={menuId} ref={menuEl} {...menuProps}>
-          {actions.map((action, index) =>
-            isDivider(action) ? (
-              <Hr className={classes.divider} key={index} />
+        <div id={menuId} ref={menuEl} role="menu" aria-labelledby={triggerId}>
+          {actions.map((action, index) => {
+            const key = isDivider(action)
+              ? `divider-${index}`
+              : action.children;
+            return isDivider(action) ? (
+              <Hr className={classes.divider} key={key} />
             ) : (
               <ActionMenuItem
-                key={index}
+                key={key}
+                role="menuitem"
                 {...action}
                 {...focusProps}
-                role={isMenu ? 'menuitem' : undefined}
                 onClick={handleActionMenuItemClick(action.onClick)}
               />
-            ),
-          )}
+            );
+          })}
         </div>
       </Popover>
     );

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
@@ -89,10 +89,7 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
         hideCloseButton={!isMobile || props.disableModalOnMobile}
         onToggle={onToggle}
         component={(refProps) => (
-          <Component
-            {...refProps}
-            onKeyDown={handleTriggerKeyDown}
-          />
+          <Component {...refProps} onKeyDown={handleTriggerKeyDown} />
         )}
         {...props}
       >

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.tsx
@@ -56,7 +56,6 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
   ({ actions, className, onToggle, component: Component, ...props }, ref) => {
     const menuEl = useRef<HTMLDivElement>(null);
     const triggerKey = useRef<TriggerKey | null>(null);
-    const triggerId = useId();
     const menuId = useId();
     const isMobile = useMedia('(max-width: 479px)');
 
@@ -92,13 +91,12 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
         component={(refProps) => (
           <Component
             {...refProps}
-            id={triggerId}
             onKeyDown={handleTriggerKeyDown}
           />
         )}
         {...props}
       >
-        <div id={menuId} ref={menuEl} role="menu" aria-labelledby={triggerId}>
+        <div id={menuId} ref={menuEl}>
           {actions.map((action, index) => {
             const key = isDivider(action)
               ? `divider-${index}`
@@ -108,7 +106,6 @@ export const ActionMenu = forwardRef<HTMLDialogElement, ActionMenuProps>(
             ) : (
               <ActionMenuItem
                 key={key}
-                role="menuitem"
                 {...action}
                 {...focusProps}
                 onClick={handleActionMenuItemClick(action.onClick)}

--- a/packages/circuit-ui/components/Avatar/Avatar.tsx
+++ b/packages/circuit-ui/components/Avatar/Avatar.tsx
@@ -92,7 +92,7 @@ const legacyVariantMap: Record<string, 'person' | 'object' | 'business'> = {
  */
 export const Avatar = ({
   src,
-  alt = '', // This default should be removed in the next major
+  alt,
   variant: legacyVariant = 'object',
   size: legacySize = 'm',
   initials,

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -52,13 +52,7 @@ export interface BodyProps extends HTMLAttributes<HTMLParagraphElement> {
    * Use the `as` prop to render the component as the `em` or `del` HTML
    * elements if appropriate.
    */
-  decoration?:
-    | 'strikethrough'
-    /**
-     * @deprecated Since the brand refresh, italic text is no longer supported.
-     * The `italic` decoration value will be removed in the next major version.
-     */
-    | 'italic';
+  decoration?: 'strikethrough';
   /**
    * Choose a foreground color token name. Default: `normal`.
    */

--- a/packages/circuit-ui/components/Numeral/Numeral.tsx
+++ b/packages/circuit-ui/components/Numeral/Numeral.tsx
@@ -48,13 +48,7 @@ export interface NumeralProps extends HTMLAttributes<HTMLParagraphElement> {
    * Use the `as` prop to render the component as the `em` or `del` HTML
    * elements if appropriate.
    */
-  decoration?:
-    | 'strikethrough'
-    /**
-     * @deprecated Since the brand refresh, italic text is no longer supported.
-     * The `italic` decoration value will be removed in the next major version.
-     */
-    | 'italic';
+  decoration?: 'strikethrough';
 }
 
 /**


### PR DESCRIPTION
Addresses [DSYS-1693](https://sumupteam.atlassian.net/browse/DSYS-1693),  [DSYS-1682](https://sumupteam.atlassian.net/browse/DSYS-1682) and  [DSYS-1676](https://sumupteam.atlassian.net/browse/DSYS-1676)

## Purpose

This removes deprecated props from the `Body`, `Numeral`, `Avatar`, and `ActionMenu` components.

## Approach and changes

- Removed deprecated `Italic` decoration prop from the `Numeral` and the `Body` component
- Removed `role` prop from `ActionMenu` component
- Removed the default value for the `alt` prop in the `Avatar` component 

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
