### PR TITLE
Remove uniqueId export

### DIFF
--- a/.changeset/cold-papayas-tan.md
+++ b/.changeset/cold-papayas-tan.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed the `uniqueId` utility from the public API. Use React’s `useId` hook instead.

--- a/packages/circuit-ui/legacy.ts
+++ b/packages/circuit-ui/legacy.ts
@@ -31,5 +31,3 @@ export {
   typography,
   center,
 } from './styles/style-mixins.js';
-
-export { uniqueId } from './util/id.js';

--- a/templates/astro/src/components/DocCard.astro
+++ b/templates/astro/src/components/DocCard.astro
@@ -1,6 +1,5 @@
 ---
 import { Body, Card, Headline } from '@sumup-oss/circuit-ui';
-import { uniqueId } from '@sumup-oss/circuit-ui/legacy';
 
 interface Props {
   title: string;
@@ -9,7 +8,7 @@ interface Props {
 }
 
 const { title, description, href } = Astro.props;
-const descriptionId = uniqueId();
+const descriptionId = `${title}-description`;
 ---
 
 <Card>


### PR DESCRIPTION
Addresses [DSYS-1677](https://sumupteam.atlassian.net/browse/DSYS-1677)

## Purpose

uniqueId is deprecated and is not widely used across the org. It is safe to remove.

## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
