### PR TITLE
Mark AutocompleteInput component as stable

### DIFF
--- a/.changeset/bumpy-tools-fall.md
+++ b/.changeset/bumpy-tools-fall.md
@@ -2,5 +2,5 @@
 "@sumup-oss/eslint-plugin-circuit-ui": minor
 ---
 
-Added the `AutocompleteInput` to the `component-lifecycle-imports` rule. Imports from `@sumup-oss/circuit-ui/experimental` 
+Updated the `component-lifecycle-imports` rule to flag and fix imports of the now stable AutocompleteInput component and its related imports.
 will now be flagged and auto-fixed to import from `@sumup-oss/circuit-ui`.

--- a/.changeset/bumpy-tools-fall.md
+++ b/.changeset/bumpy-tools-fall.md
@@ -1,0 +1,6 @@
+---
+"@sumup-oss/eslint-plugin-circuit-ui": minor
+---
+
+Added the `AutocompleteInput` to the `component-lifecycle-imports` rule. Imports from `@sumup-oss/circuit-ui/experimental` 
+will now be flagged and auto-fixed to import from `@sumup-oss/circuit-ui`.

--- a/.changeset/bumpy-tools-fall.md
+++ b/.changeset/bumpy-tools-fall.md
@@ -3,4 +3,3 @@
 ---
 
 Updated the `component-lifecycle-imports` rule to flag and fix imports of the now stable AutocompleteInput component and its related imports.
-will now be flagged and auto-fixed to import from `@sumup-oss/circuit-ui`.

--- a/.changeset/young-otters-walk.md
+++ b/.changeset/young-otters-walk.md
@@ -3,4 +3,4 @@
 "@sumup-oss/eslint-plugin-circuit-ui": minor
 ---
 
-Marked AutocompleteInput component as stable. Import it from `@sumup-oss/circuit-ui` instead of `@sumup-oss/circuit-ui/experimental`.
+Marked the AutocompleteInput component as stable. Import it from `@sumup-oss/circuit-ui` instead of `@sumup-oss/circuit-ui/experimental`.

--- a/.changeset/young-otters-walk.md
+++ b/.changeset/young-otters-walk.md
@@ -1,6 +1,5 @@
 ---
 "@sumup-oss/circuit-ui": major
-"@sumup-oss/eslint-plugin-circuit-ui": minor
 ---
 
-Marked the AutocompleteInput component as stable. Import it from `@sumup-oss/circuit-ui` instead of `@sumup-oss/circuit-ui/experimental`.
+Marked the `AutocompleteInput` component as stable. Import it from `@sumup-oss/circuit-ui` instead of `@sumup-oss/circuit-ui/experimental`.

--- a/.changeset/young-otters-walk.md
+++ b/.changeset/young-otters-walk.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": major
 ---
 
-Marked the `AutocompleteInput` component as stable. Import it from `@sumup-oss/circuit-ui` instead of `@sumup-oss/circuit-ui/experimental`.
+Marked the AutocompleteInput component as stable. Import it from `@sumup-oss/circuit-ui` instead of `@sumup-oss/circuit-ui/experimental`.

--- a/.changeset/young-otters-walk.md
+++ b/.changeset/young-otters-walk.md
@@ -1,0 +1,6 @@
+---
+"@sumup-oss/circuit-ui": major
+"@sumup-oss/eslint-plugin-circuit-ui": minor
+---
+
+Marked AutocompleteInput component as stable. Import it from `@sumup-oss/circuit-ui` instead of `@sumup-oss/circuit-ui/experimental`.

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.mdx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.mdx
@@ -5,7 +5,7 @@ import * as Stories from "./AutocompleteInput.stories";
 
 # AutocompleteInput
 
-<Status variant="experimental" />
+<Status variant="stable" />
 
 An input field that allows users to filter and select one or many options from a provided set of options.
 

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.stories.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.stories.tsx
@@ -43,7 +43,7 @@ import type { AutocompleteInputOption } from './components/Option/Option.js';
 export default {
   title: 'Forms/AutocompleteInput',
   component: AutocompleteInput,
-  tags: ['status:experimental'],
+  tags: ['status:stable'],
   argTypes: {
     // Value & change handling
     value: {

--- a/packages/circuit-ui/components/AutocompleteInput/index.ts
+++ b/packages/circuit-ui/components/AutocompleteInput/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023, SumUp Ltd.
+ * Copyright 2026, SumUp Ltd.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,5 +13,8 @@
  * limitations under the License.
  */
 
-export { TimeInput } from './components/TimeInput/TimeInput.js';
-export type { TimeInputProps } from './components/TimeInput/TimeInput.js';
+export { AutocompleteInput } from './AutocompleteInput.js';
+export type { AutocompleteInputProps } from './AutocompleteInput.js';
+export type { AutocompleteInputOption } from './components/Option/Option.js';
+export type { AutocompleteInputOptionGroup } from './components/Options/Options.js';
+export { updateMultipleSelectionValue } from './AutocompleteInputService.js';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -68,6 +68,15 @@ export { PhoneNumberInput } from './components/PhoneNumberInput/index.js';
 export type { PhoneNumberInputProps } from './components/PhoneNumberInput/index.js';
 export { ColorInput } from './components/ColorInput/index.js';
 export type { ColorInputProps } from './components/ColorInput/index.js';
+export {
+  AutocompleteInput,
+  updateMultipleSelectionValue,
+} from './components/AutocompleteInput/index.js';
+export type {
+  AutocompleteInputProps,
+  AutocompleteInputOption,
+  AutocompleteInputOptionGroup,
+} from './components/AutocompleteInput/index.js';
 
 // Actions
 export { Button } from './components/Button/index.js';

--- a/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.spec.ts
@@ -44,6 +44,12 @@ ruleTester.run('component-lifecycle-imports', componentLifecycleImports, {
       `,
     },
     {
+      name: 'AutocompleteInput import from correct package',
+      code: `
+        import { AutocompleteInput } from '@sumup-oss/circuit-ui';
+      `,
+    },
+    {
       name: 'unrelated import from matching package',
       code: `
         import { Button } from '@sumup-oss/circuit-ui/experimental';
@@ -109,6 +115,26 @@ ruleTester.run('component-lifecycle-imports', componentLifecycleImports, {
       `,
       output: `
         import type { TimestampProps } from '@sumup-oss/circuit-ui';
+      `,
+      errors: [{ messageId: 'refactor' }],
+    },
+    {
+      name: 'AutocompleteInput import from experimental',
+      code: `
+        import { AutocompleteInput } from '@sumup-oss/circuit-ui/experimental';
+      `,
+      output: `
+        import { AutocompleteInput } from '@sumup-oss/circuit-ui';
+      `,
+      errors: [{ messageId: 'refactor' }],
+    },
+    {
+      name: 'AutocompleteInput type import from experimental',
+      code: `
+        import type { AutocompleteInputProps } from '@sumup-oss/circuit-ui/experimental';
+      `,
+      output: `
+        import type { AutocompleteInputProps } from '@sumup-oss/circuit-ui';
       `,
       errors: [{ messageId: 'refactor' }],
     },

--- a/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.ts
+++ b/packages/eslint-plugin-circuit-ui/component-lifecycle-imports/index.ts
@@ -25,7 +25,15 @@ const mappings = [
   {
     from: '@sumup-oss/circuit-ui/experimental',
     to: '@sumup-oss/circuit-ui',
-    specifiers: ['Timestamp', 'TimestampProps'],
+    specifiers: [
+      'Timestamp',
+      'TimestampProps',
+      'AutocompleteInput',
+      'AutocompleteInputProps',
+      'AutocompleteInputOption',
+      'AutocompleteInputOptionGroup',
+      'updateMultipleSelectionValue',
+    ],
   },
 ];
 

--- a/skills/circuit-ui/references/components.md
+++ b/skills/circuit-ui/references/components.md
@@ -22,6 +22,7 @@
 
 | Component | Status | Package | Source export | Usage reference |
 | --- | --- | --- | --- | --- |
+| `AutocompleteInput` | `stable` | `@sumup-oss/circuit-ui` | `./components/AutocompleteInput/index.js` | [Read MDX reference](components/AutocompleteInput.mdx) |
 | `Calendar` | `stable` | `@sumup-oss/circuit-ui` | `./components/Calendar/index.js` | [Read MDX reference](components/Calendar.mdx) |
 | `Checkbox` | `stable` | `@sumup-oss/circuit-ui` | `./components/Checkbox/index.js` | [Read MDX reference](components/Checkbox.mdx) |
 | `CheckboxGroup` | `stable` | `@sumup-oss/circuit-ui` | `./components/CheckboxGroup/index.js` | [Read MDX reference](components/CheckboxGroup.mdx) |

--- a/skills/circuit-ui/references/components/AutocompleteInput.mdx
+++ b/skills/circuit-ui/references/components/AutocompleteInput.mdx
@@ -1,0 +1,131 @@
+import { Meta, Status, Props, Story } from "../../../../.storybook/components";
+import * as Stories from "./AutocompleteInput.stories";
+
+<Meta of={Stories} />
+
+# AutocompleteInput
+
+<Status variant="stable" />
+
+An input field that allows users to filter and select one or many options from a provided set of options.
+
+<Story of={Stories.Base} />
+<Props />
+
+## When to use
+
+Use the AutocompleteInput component when you want to help users find and select from a large set of options. Common use cases:
+
+- Location picker: Address or city field
+- Product catalog: choosing from a long list of products
+
+For short lists, consider using the [Select](Forms/Select/Docs) component instead.
+
+While the AutocompleteInput component is accessible, it can be complex to interact with, especially for keyboard and screen reader users. Use it only when necessary and aim to keep the interaction simple and to respect the component usage recommendations as much as possible.
+
+## How to use
+
+- Use the `onSearch` prop to update the list of options as the user types. You can optionally set the `minQueryLength` prop to delay this behavior until a minimum number of characters has been typed.
+- Use the `onChange` prop to handle the selection of an option and set the input's `value` prop to the selected option. After the selection, make sure to reset the value of the `options` prop.
+- Use the `onClear` prop to handle the clearing of the input field, and reset the input's `value` prop to reflect this change.
+- The component can receive a flat list or a list of grouped options via the `options` prop. To ensure a consistent and user-friendly experience, keep the visual format uniform. For example, make sure all options include (or not) an image or a description. Keep labels and descriptions short and easy to scan.
+- To enable multiple selections, set the `multiple` prop to "true". In this mode, the `value` prop must be an array of `AutocompleteInputOption` objects. The `onChange` callback will still receive a single `AutocompleteInputOption`—the option that was just selected or removed. The `updateMultipleSelectionValue` utility function can be used to compute the new value of the field.
+- To support the selection of the user's input as the field's value, enable the `allowNewItems` prop. This will display the user's input as an available option in the list box.
+
+<Story of={Stories.AllowNewItems} />
+
+- For a mobile-optimized experience, use the "immersive" `variant` to open the AutocompleteInput in a modal dialog on narrow viewports.
+
+## Customisation
+
+- The "no results" screen can be customised using the `noResultsMessage` prop.
+- The "loading" message can be customised using the `loadingLabel` prop.
+- The "load more" button label can be customised using the `loadMoreLabel` prop.
+- The options can be customised by adding avatar images or icons and a description.
+- Use the `action` prop to add a contextual action at the bottom of the list box, such as a button to create a new item.
+
+<Story of={Stories.WithAction} />
+
+## Performance
+
+### Debouncing
+
+The component's `onSearch` callback is debounced by default to avoid excessive calls while the user types. The debounce delay is set to 300 ms.
+
+### Paginated results
+
+For better performance and scalability when loading dynamic, paginated results, use the `loadMore` prop to fetch additional options. When this prop is provided, a "Load more" button appears at the bottom of the list box. You can customize the button label with `loadMoreLabel`. Use the `isLoadingMore` prop to indicate that more options are being fetched, and `aria-setsize` to convey the total number of options available to assistive technologies. Learn more about `aria-setsize` in the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-setsize).
+
+<Story of={Stories.LoadMore} />
+
+### Fetching options
+
+To ensure you always show the most relevant options, consider using an [Abort Controller](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) to cancel previous fetch requests. This prevents showing outdated options and improves the user experience.
+
+```tsx
+import { useState, useCallback, useRef } from "react";
+import { AutocompleteInput } from "@sumup-oss/circuit-ui";
+
+const MyComponent = () => {
+  const [options, setOptions] = useState([]);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const fetchOptions = useCallback(async (query: string) => {
+    // Abort previous request if it exists
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+    // Create a new AbortController for the new request
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    try {
+      const results = await getOptions(query, controller.signal);
+      setOptions(results);
+    } catch (error) {
+      if (error.name !== "AbortError") {
+        // Handle non-abort errors (e.g., server issues)
+      }
+    }
+  }, []);
+
+  return (
+    <AutocompleteInput
+      label="Customer"
+      placeholder="Search for a customer"
+      options={options}
+      onSearch={fetchOptions}
+    />
+  );
+};
+
+async function getOptions(query: string, signal: AbortSignal) {
+  const response = await fetch(`https://my-search-api.com?query=${query}`, {
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error("Network response was not ok");
+  }
+  return response.json();
+}
+```
+
+## Accessibility
+
+The AutocompleteInput component is designed to be accessible, adopting ARIA's [Combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/). It includes:
+
+### Keyboard navigation
+
+- Arrow down key: Opens the list box
+- Escape key: Closes the list box
+- Arrow Up/Down keys: navigate through options
+- Enter key: selects an option
+- Backspace key: deletes a selected option in multi-selection mode.
+
+### Screen reader support
+
+The component announces the number of options available and the selected option, if any.
+
+### Focus management
+
+The component manages focus appropriately. The focus remains on the input field when the list box is open, and navigated options are announced properly as the user navigates through them.


### PR DESCRIPTION
Addresses [DSYS-1675](https://sumupteam.atlassian.net/browse/DSYS-1675)

## Purpose

Mark `AutocompleteInput` component as stable

## Approach and changes

- created barrel export required for all stable components
- Added `AutocompleteInput, AutocompleteInputProps, AutocompleteInputOption, AutocompleteInputOptionGroup, and updateMultipleSelectionValue` exports to `packages/circuit-ui/index.ts.`
- Removed all `AutocompleteInput` exports from `packages/circuit-ui/experimental.ts.`
- Updated `AutocompleteInput.mdx and AutocompleteInput.stories.tsx` status badges from `experimental` to `stable.`
- Added `AutocompleteInput` specifiers to the `component-lifecycle-imports` ESLint rule so consumers get an auto-fixable lint error guiding them to update their import path from `@sumup-oss/circuit-ui/experimental` to `@sumup-oss/circuit-ui`

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
