### PR TITLE
Utility classes docs

### DIFF
--- a/.changeset/purple-tires-build.md
+++ b/.changeset/purple-tires-build.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added new spacing utility classes for new spacing values `yotta`, `ronna` and `quetta`

--- a/packages/circuit-ui/styles/style-mixins.mdx
+++ b/packages/circuit-ui/styles/style-mixins.mdx
@@ -11,7 +11,7 @@ import * as Stories from './style-mixins.stories';
 
 # Style Mixins
 
-<Status variant="deprecated">Use the `utilClasses` instead.</Status>
+<Status variant="deprecated">Use the [`utilClasses`](Features/Utility-Classes/Docs) instead.</Status>
 
 <Intro>
   Style mixins are small helper functions to apply common styles to an HTML

--- a/packages/circuit-ui/styles/utility.mdx
+++ b/packages/circuit-ui/styles/utility.mdx
@@ -1,42 +1,39 @@
-import {
-  Meta,
-  Intro,
-  Status,
-  Props,
-  Story,
-} from '../../../.storybook/components';
-import * as Stories from './utility.stories.tsx';
-
-# Utility classes
-
-<Intro>
-  <Intro>
-    Utility classes provide reusable `className` values for applying some common Circuit UI styling patterns to elements and components.
-  </Intro></Intro>
-
-## Usage
-Import the `utilClasses` object from `@sumup-oss/@circuit-ui` and pass the desired utility class to the `className` prop.
-
-```tsx
-import { utilClasses } from '@sumup-oss/circuit-ui';
-
-function MyComponent() {
-  return <div className={utilClasses['<className>']} />;
-}
-
-```
+import { Meta, Intro, Story, Status } from "../../../.storybook/components";
+import * as Stories from "./utility.stories";
 
 <Meta of={Stories} />
 
-## Center
-`utilClasses.center`
+# Utility classes
 
+<Status variant="stable" />
+
+<Intro>
+  Utility classes provide reusable `className` values for applying some common
+  Circuit UI styling patterns to elements and components.
+</Intro>
+
+## Usage
+
+Import the `utilClasses` object from `@sumup-oss/circuit-ui` and pass the desired utility class to the `className` prop.
+
+```tsx
+import { utilClasses } from "@sumup-oss/circuit-ui";
+
+function MyComponent() {
+  return <div className={utilClasses["<className>"]} />;
+}
+```
+
+## Center
+
+`utilClasses.center`
 
 Pass the utility class to a parent element to center its children.
 
 <Story of={Stories.Center} />
 
 ## Hide Visually
+
 `utilClasses.hideVisually`
 
 Visually hides an element while keeping it accessible to users
@@ -45,16 +42,16 @@ who rely on a screen reader.
 <Story of={Stories.HideVisually} />
 
 ## Hide scrollbar
+
 `utilClasses.hideScrollbar`
 
 Hides the browser scrollbar on a scrollable element, e.g. with overflow.
 
 <Story of={Stories.HideScrollbar} />
 
-
 ## Focus
-`utilClasses.focusVisible` or `utilClasses.focusVisibleInset`
 
+`utilClasses.focusVisible` or `utilClasses.focusVisibleInset`
 
 Shows a focus indicator when the browser determines that focus should be visible, such as during keyboard navigation.
 

--- a/packages/circuit-ui/styles/utility.mdx
+++ b/packages/circuit-ui/styles/utility.mdx
@@ -1,0 +1,68 @@
+import {
+  Meta,
+  Intro,
+  Status,
+  Props,
+  Story,
+} from '../../../.storybook/components';
+import * as Stories from './utility.stories.tsx';
+
+# Utility classes
+
+<Intro>
+  <Intro>
+    Utility classes provide reusable `className` values for applying some common Circuit UI styling patterns to elements and components.
+  </Intro></Intro>
+
+## Usage
+Import the `utilClasses` object from `@sumup-oss/@circuit-ui` and pass the desired utility class to the `className` prop.
+
+```tsx
+import { utilClasses } from '@sumup-oss/circuit-ui';
+
+function MyComponent() {
+  return <div className={utilClasses['<className>']} />;
+}
+
+```
+
+<Meta of={Stories} />
+
+## Center
+`utilClasses.center`
+
+
+Pass the utility class to a parent element to center its children.
+
+<Story of={Stories.Center} />
+
+## Hide Visually
+`utilClasses.hideVisually`
+
+Visually hides an element while keeping it accessible to users
+who rely on a screen reader.
+
+<Story of={Stories.HideVisually} />
+
+## Hide scrollbar
+`utilClasses.hideScrollbar`
+
+Hides the browser scrollbar on a scrollable element, e.g. with overflow.
+
+<Story of={Stories.HideScrollbar} />
+
+
+## Focus
+`utilClasses.focusVisible` or `utilClasses.focusVisibleInset`
+
+
+Shows a focus indicator when the browser determines that focus should be visible, such as during keyboard navigation.
+
+<Story of={Stories.FocusVisible} />
+<Story of={Stories.FocusVisibleInset} />
+
+## Spacing
+
+Applies Circuit-UI spacing values as margins to one or all sides of an element.
+
+<Story of={Stories.Spacing} />

--- a/packages/circuit-ui/styles/utility.module.css
+++ b/packages/circuit-ui/styles/utility.module.css
@@ -97,6 +97,18 @@
   margin: var(--cui-spacings-zetta);
 }
 
+.margin-yotta {
+  margin: var(--cui-spacings-yotta);
+}
+
+.margin-ronna {
+  margin: var(--cui-spacings-ronna);
+}
+
+.margin-quetta {
+  margin: var(--cui-spacings-quetta);
+}
+
 /* Left */
 .margin-left-bit {
   margin-left: var(--cui-spacings-bit);
@@ -132,6 +144,18 @@
 
 .margin-left-zetta {
   margin-left: var(--cui-spacings-zetta);
+}
+
+.margin-left-yotta {
+  margin-left: var(--cui-spacings-yotta);
+}
+
+.margin-left-ronna {
+  margin-left: var(--cui-spacings-ronna);
+}
+
+.margin-left-quetta {
+  margin-left: var(--cui-spacings-quetta);
 }
 
 /* Right */
@@ -171,6 +195,18 @@
   margin-right: var(--cui-spacings-zetta);
 }
 
+.margin-right-yotta {
+  margin-right: var(--cui-spacings-yotta);
+}
+
+.margin-right-ronna {
+  margin-right: var(--cui-spacings-ronna);
+}
+
+.margin-right-quetta {
+  margin-right: var(--cui-spacings-quetta);
+}
+
 /* Top */
 .margin-top-bit {
   margin-top: var(--cui-spacings-bit);
@@ -208,6 +244,18 @@
   margin-top: var(--cui-spacings-zetta);
 }
 
+.margin-top-yotta {
+  margin-top: var(--cui-spacings-yotta);
+}
+
+.margin-top-ronna {
+  margin-top: var(--cui-spacings-ronna);
+}
+
+.margin-top-quetta {
+  margin-top: var(--cui-spacings-quetta);
+}
+
 /* Bottom */
 .margin-bottom-bit {
   margin-bottom: var(--cui-spacings-bit);
@@ -243,4 +291,16 @@
 
 .margin-bottom-zetta {
   margin-bottom: var(--cui-spacings-zetta);
+}
+
+.margin-bottom-yotta {
+  margin-bottom: var(--cui-spacings-yotta);
+}
+
+.margin-bottom-ronna {
+  margin-bottom: var(--cui-spacings-ronna);
+}
+
+.margin-bottom-quetta {
+  margin-bottom: var(--cui-spacings-quetta);
 }

--- a/packages/circuit-ui/styles/utility.stories.tsx
+++ b/packages/circuit-ui/styles/utility.stories.tsx
@@ -1,0 +1,277 @@
+import { utilClasses } from './utility.js';
+import { useState } from 'react';
+import { Toggle } from '../components/Toggle/index.js';
+import { RadioButtonGroup } from '../components/RadioButtonGroup/index.js';
+import { clsx } from './clsx.js';
+import styles from './utilityStories.module.css';
+import { Body } from '../components/Body/index.js';
+import { userEvent } from 'storybook/test';
+
+export default {
+  title: 'Features/Utility Classes',
+  tags: ['status:stable'],
+  parameters: {
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+};
+
+async function pressTab() {
+  await userEvent.tab();
+}
+
+export const Center = () => {
+  const [className, setClassName] = useState<string | undefined>(
+    utilClasses.center,
+  );
+  return (
+    <>
+      <div className={clsx(styles.wrapper, className)}>
+        <Body>{className ? 'Centered' : 'Not centered'}</Body>
+      </div>
+      <Toggle
+        label={'Apply center class name'}
+        checked={className !== undefined}
+        className={utilClasses.marginTopGiga}
+        onChange={() =>
+          setClassName((current) => (current ? undefined : utilClasses.center))
+        }
+      />
+    </>
+  );
+};
+
+export const HideVisually = () => {
+  const [className, setClassName] = useState<string | undefined>(
+    utilClasses.hideVisually,
+  );
+
+  return (
+    <>
+      <Body className={className}>Hidden</Body>
+      <Toggle
+        label={'Apply hideVisually class name'}
+        checked={className === utilClasses.hideVisually}
+        className={utilClasses.marginTopGiga}
+        onChange={() =>
+          setClassName((current) =>
+            current ? undefined : utilClasses.hideVisually,
+          )
+        }
+      />
+    </>
+  );
+};
+
+export const HideScrollbar = () => {
+  const [className, setClassName] = useState<string | undefined>(
+    utilClasses.hideScrollbar,
+  );
+
+  return (
+    <>
+      <div className={clsx(styles.wrapper, className)}>
+        <div className={styles.scrollable}>Scroll me</div>
+      </div>
+      <Toggle
+        label={'Apply hideScrollbar class name'}
+        checked={className === utilClasses.hideScrollbar}
+        className={utilClasses.marginTopGiga}
+        onChange={() =>
+          setClassName((current) =>
+            current ? undefined : utilClasses.hideScrollbar,
+          )
+        }
+      />
+    </>
+  );
+};
+
+export const FocusVisible = () => {
+  const [className, setClassName] = useState<string | undefined>(
+    utilClasses.focusVisible,
+  );
+
+  return (
+    <>
+      <div
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: for demo purposes only
+        tabIndex={0}
+        className={className}
+      >
+        I&apos;m an interactive div
+      </div>
+      <Toggle
+        label={'Apply focusVisible class name'}
+        checked={className === utilClasses.focusVisible}
+        className={utilClasses.marginTopGiga}
+        onChange={() =>
+          setClassName((current) =>
+            current ? undefined : utilClasses.focusVisible,
+          )
+        }
+      />
+    </>
+  );
+};
+FocusVisible.play = pressTab;
+
+export const FocusVisibleInset = () => {
+  const [className, setClassName] = useState<string | undefined>(
+    utilClasses.focusVisibleInset,
+  );
+
+  return (
+    <>
+      <div
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: for demo purposes only
+        tabIndex={0}
+        className={className}
+      >
+        I&apos;m an interactive div
+      </div>
+      <Toggle
+        label={'Apply focusVisibleInset class name'}
+        checked={className === utilClasses.focusVisibleInset}
+        className={utilClasses.marginTopGiga}
+        onChange={() =>
+          setClassName((current) =>
+            current ? undefined : utilClasses.focusVisibleInset,
+          )
+        }
+      />
+    </>
+  );
+};
+FocusVisibleInset.play = pressTab;
+
+const sizes = [
+  'Bit',
+  'Byte',
+  'Kilo',
+  'Mega',
+  'Giga',
+  'Tera',
+  'Peta',
+  'Exa',
+  'Zetta',
+  'Yotta',
+  'Ronna',
+  'Quetta',
+] as const;
+type Size = (typeof sizes)[number];
+
+export const Spacing = () => {
+  const sizeOptions = sizes.map((size) => ({ label: size, value: size }));
+  const [allDirections, setAllDirections] = useState(true);
+  const [allDirectionsSpacingValue, setAllDirectionsSpacingValue] =
+    useState<Size>('Bit');
+  const [spacingTopValue, setSpacingTopValue] = useState<Size>('Bit');
+  const [spacingBottomValue, setSpacingBottomValue] = useState<Size>('Bit');
+  const [spacingLeftValue, setSpacingLeftValue] = useState<Size>('Bit');
+  const [spacingRightValue, setSpacingRightValue] = useState<Size>('Bit');
+  const className = allDirections
+    ? utilClasses[`margin${allDirectionsSpacingValue}`]
+    : clsx(
+        utilClasses[`marginTop${spacingTopValue}`],
+        utilClasses[`marginBottom${spacingBottomValue}`],
+        utilClasses[`marginLeft${spacingLeftValue}`],
+        utilClasses[`marginRight${spacingRightValue}`],
+      );
+
+  return (
+    <>
+      <div className={clsx(styles.wrapper, styles.flex)}>
+        <div
+          className={clsx(
+            className,
+            styles.content,
+            styles.flex,
+            utilClasses.center,
+          )}
+        >
+          {allDirections && (
+            <Body color="on-strong">
+              className applied: {`margin${allDirectionsSpacingValue}`}
+            </Body>
+          )}
+          {!allDirections && (
+            <>
+              <Body
+                color="on-strong"
+                className={styles.left}
+              >{`marginLeft${spacingLeftValue}`}</Body>
+
+              <Body
+                color="on-strong"
+                className={styles.top}
+              >{`marginTop${spacingTopValue}`}</Body>
+              <Body
+                color="on-strong"
+                className={styles.bottom}
+              >{`marginBottom${spacingBottomValue}`}</Body>
+
+              <Body color="on-strong" className={styles.right}>
+                {' '}
+                {`marginRight${spacingRightValue}`}
+              </Body>
+            </>
+          )}
+        </div>
+      </div>
+      <Toggle
+        label={'Apply spacing to all directions'}
+        checked={allDirections}
+        className={clsx(
+          utilClasses.marginTopGiga,
+          utilClasses.marginBottomGiga,
+        )}
+        onChange={() => setAllDirections((current) => !current)}
+      />
+      {allDirections ? (
+        <RadioButtonGroup
+          value={allDirectionsSpacingValue}
+          onChange={(event) =>
+            setAllDirectionsSpacingValue(event.target.value as Size)
+          }
+          options={sizeOptions}
+          label={'Spacing value'}
+        />
+      ) : (
+        <div className={styles.directions}>
+          <RadioButtonGroup
+            value={spacingTopValue}
+            onChange={(event) => setSpacingTopValue(event.target.value as Size)}
+            options={sizeOptions}
+            label={'Spacing top value'}
+          />
+          <RadioButtonGroup
+            value={spacingBottomValue}
+            onChange={(event) =>
+              setSpacingBottomValue(event.target.value as Size)
+            }
+            options={sizeOptions}
+            label={'Spacing bottom value'}
+          />
+          <RadioButtonGroup
+            value={spacingLeftValue}
+            onChange={(event) =>
+              setSpacingLeftValue(event.target.value as Size)
+            }
+            options={sizeOptions}
+            label={'Spacing left value'}
+          />
+          <RadioButtonGroup
+            value={spacingRightValue}
+            onChange={(event) =>
+              setSpacingRightValue(event.target.value as Size)
+            }
+            options={sizeOptions}
+            label={'Spacing right value'}
+          />
+        </div>
+      )}
+    </>
+  );
+};

--- a/packages/circuit-ui/styles/utility.ts
+++ b/packages/circuit-ui/styles/utility.ts
@@ -32,6 +32,9 @@ export const utilClasses = {
   marginPeta: _classes['margin-peta'],
   marginExa: _classes['margin-exa'],
   marginZetta: _classes['margin-zetta'],
+  marginYotta: _classes['margin-yotta'],
+  marginRonna: _classes['margin-ronna'],
+  marginQuetta: _classes['margin-quetta'],
   // left
   marginLeftBit: _classes['margin-left-bit'],
   marginLeftByte: _classes['margin-left-byte'],
@@ -42,6 +45,9 @@ export const utilClasses = {
   marginLeftPeta: _classes['margin-left-peta'],
   marginLeftExa: _classes['margin-left-exa'],
   marginLeftZetta: _classes['margin-left-zetta'],
+  marginLeftYotta: _classes['margin-left-yotta'],
+  marginLeftRonna: _classes['margin-left-ronna'],
+  marginLeftQuetta: _classes['margin-left-quetta'],
   // right
   marginRightBit: _classes['margin-right-bit'],
   marginRightByte: _classes['margin-right-byte'],
@@ -52,6 +58,9 @@ export const utilClasses = {
   marginRightPeta: _classes['margin-right-peta'],
   marginRightExa: _classes['margin-right-exa'],
   marginRightZetta: _classes['margin-right-zetta'],
+  marginRightYotta: _classes['margin-right-yotta'],
+  marginRightRonna: _classes['margin-right-ronna'],
+  marginRightQuetta: _classes['margin-right-quetta'],
   // top
   marginTopBit: _classes['margin-top-bit'],
   marginTopByte: _classes['margin-top-byte'],
@@ -62,6 +71,9 @@ export const utilClasses = {
   marginTopPeta: _classes['margin-top-peta'],
   marginTopExa: _classes['margin-top-exa'],
   marginTopZetta: _classes['margin-top-zetta'],
+  marginTopYotta: _classes['margin-top-yotta'],
+  marginTopRonna: _classes['margin-top-ronna'],
+  marginTopQuetta: _classes['margin-top-quetta'],
   // bottom
   marginBottomBit: _classes['margin-bottom-bit'],
   marginBottomByte: _classes['margin-bottom-byte'],
@@ -72,4 +84,7 @@ export const utilClasses = {
   marginBottomPeta: _classes['margin-bottom-peta'],
   marginBottomExa: _classes['margin-bottom-exa'],
   marginBottomZetta: _classes['margin-bottom-zetta'],
+  marginBottomYotta: _classes['margin-bottom-yotta'],
+  marginBottomRonna: _classes['margin-bottom-ronna'],
+  marginBottomQuetta: _classes['margin-bottom-quetta'],
 };

--- a/packages/circuit-ui/styles/utilityStories.module.css
+++ b/packages/circuit-ui/styles/utilityStories.module.css
@@ -1,0 +1,53 @@
+.wrapper {
+  width: 600px;
+  height: 400px;
+  overflow: auto;
+  background: var(--cui-bg-neutral);
+}
+
+.content {
+  position: relative;
+  background: var(--cui-bg-strong);
+}
+
+.scrollable {
+  height: 800px;
+}
+
+.flex {
+  display: flex;
+  flex: 1;
+}
+
+.directions {
+  display: flex;
+  gap: var(--cui-spacings-giga);
+}
+
+.bottom {
+  position: absolute;
+  bottom: var(--cui-spacings-byte);
+  left: 50%;
+  transform: translate(-50%);
+}
+
+.top {
+  position: absolute;
+  top: var(--cui-spacings-byte);
+  left: 50%;
+  transform: translate(-50%);
+}
+
+.left {
+  position: absolute;
+  top: 50%;
+  left: var(--cui-spacings-byte);
+  transform: translateY(-50%);
+}
+
+.right {
+  position: absolute;
+  top: 50%;
+  right: var(--cui-spacings-byte);
+  transform: translateY(-50%);
+}


### PR DESCRIPTION
Addresses [DSYS-1705](https://sumupteam.atlassian.net/browse/DSYS-1705)

## Purpose

The recently added spacing utility classes offer an alternative to the deprecated spacing mixin, but they don't support the newly added spacing sizes (`yotta` , `ronna` and `quetta`). On the other hand, Circuit UI exports the `utilClasses` object but has no documentation about it. 

## Approach and changes

- add spacing classes for the new values
- add documentation for utility classes

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
