### PR TITLE
remove h4 from listitem label

### DIFF
--- a/.changeset/smart-rings-talk.md
+++ b/.changeset/smart-rings-talk.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Updated ListItemGroup to render the `label` prop as a plain Body component instead of an `h4` heading.

--- a/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
+++ b/packages/circuit-ui/components/ListItemGroup/ListItemGroup.tsx
@@ -115,13 +115,7 @@ export const ListItemGroup = forwardRef<HTMLDivElement, ListItemGroupProps>(
                 hideLabel && utilClasses.hideVisually,
               )}
             >
-              {isString(label) ? (
-                <Body as="h4" size="s">
-                  {label}
-                </Body>
-              ) : (
-                label
-              )}
+              {isString(label) ? <Body size="s">{label}</Body> : label}
             </div>
           )}
           {details && (


### PR DESCRIPTION
Addresses [DSYS-1681](https://sumupteam.atlassian.net/browse/DSYS-1681)

## Purpose

Replace headline level 4 with simple Body in ListItemGroup’s label

## Approach and changes

- Removed `h4` from Body component in label prop

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
