### PR TITLE
add documentation for the no-deprecated-spacing-mixin rule

### DIFF
--- a/packages/eslint-plugin-circuit-ui/no-deprecated-spacing-mixin/README.md
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-spacing-mixin/README.md
@@ -1,0 +1,39 @@
+
+# Remove deprecated `spacing` mixin (`no-deprecated-spacing-mixin`)
+
+Circuit UI’s legacy Emotion mixins are deprecated and will be removed in the next major release.
+This rule reports usages of the `spacing` mixin and helps migrate them to utility spacing classes.
+
+## Rule Details
+
+This rule aims to speed up the migration away from Emotion.js. Utility spacing classes are available as an alternative to the `spacing` mixin and should be used instead. Setting the rule's error level to warn (or 1) is recommended.
+When upgrading to the next major version of Circuit UI (v12.0.0), set the rule's error level to error (or 2) to help migrate any remaining usages.
+
+Examples of **incorrect** code for this rule:
+
+```tsx
+function Component() {
+  return <Body variant="alert" />;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```tsx
+function Component() {
+  return <Body css={spacing('giga')} />;
+}
+```
+
+### Options
+
+n/a
+
+## When Not To Use It
+
+n/a
+
+## Further Reading
+
+- [Utility classes](https://circuit.sumup.com/?path=/docs/features-utility-classes--docs)
+- [V11.0.0 release notes](https://github.com/sumup-oss/circuit-ui/releases/tag/%40sumup-oss%2Fcircuit-ui%4011.0.0)


### PR DESCRIPTION
## Purpose

In https://github.com/sumup-oss/circuit-ui/pull/3666 I added the no-deprecated-spacing-mixin eslint rule and forgot to add a README.md file

## Approach and changes

- add rule documentation

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
