### PR TITLE
Fix autocomplete refs

### DIFF
--- a/.changeset/many-stars-count.md
+++ b/.changeset/many-stars-count.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the behavior responsible for restoring the AutocompleteInput's displayed value when it loses focus.

--- a/.changeset/ninety-carrots-rule.md
+++ b/.changeset/ninety-carrots-rule.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed the AutocompleteInput suggestion box incorrectly scrolling with the combobox input.

--- a/.changeset/warm-things-shine.md
+++ b/.changeset/warm-things-shine.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed an overflow issue in the AutocompleteInput when using multi-selection mode.

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.spec.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.spec.tsx
@@ -293,28 +293,34 @@ describe('AutocompleteInput', () => {
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     });
 
-    it('should close the list box when the escape key is pressed', async () => {
-      render(<AutocompleteInput {...props} />);
+    it('should close the list box and restore value when the escape key is pressed', async () => {
+      render(<AutocompleteInput {...props} value={options[0]} />);
       await userEvent.click(
         screen.getByRole('combobox', { name: props.label }),
       );
       expect(screen.getByRole('listbox')).toBeVisible();
       await userEvent.keyboard('{Escape}');
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: props.label })).toHaveValue(
+        'Mochi',
+      );
     });
 
-    it('should close the list box on outside click', async () => {
-      render(<AutocompleteInput {...props} />);
+    it('should close the list box and restore value on outside click', async () => {
+      render(<AutocompleteInput {...props} value={options[0]} />);
       await userEvent.click(
         screen.getByRole('combobox', { name: props.label }),
       );
       expect(screen.getByRole('listbox')).toBeVisible();
       await userEvent.click(document.body);
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: props.label })).toHaveValue(
+        'Mochi',
+      );
     });
 
-    it('should close the list box when Enter key is pressed', async () => {
-      render(<AutocompleteInput {...props} />);
+    it('should close the list box and restore value when Enter key is pressed', async () => {
+      render(<AutocompleteInput {...props} value={options[0]} />);
 
       await userEvent.click(screen.getByLabelText(props.label));
 
@@ -324,6 +330,15 @@ describe('AutocompleteInput', () => {
 
       await userEvent.keyboard('{Enter}');
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+
+      expect(screen.getByRole('combobox', { name: props.label })).toHaveValue(
+        'Mochi',
+      );
+      // reopen the list box
+      await userEvent.keyboard('{ArrowDown}');
+      expect(screen.getByRole('combobox', { name: props.label })).toHaveValue(
+        'Mochi',
+      );
     });
   });
 

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.spec.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.spec.tsx
@@ -125,10 +125,8 @@ describe('AutocompleteInput', () => {
     });
     expect(input).toHaveValue('baz');
 
-    // simulate blur
-    act(() => {
-      input.blur();
-    });
+    // simulate click outside
+    await userEvent.click(document.body);
     expect(input).toHaveValue('Foo');
   });
 

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.spec.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.spec.tsx
@@ -69,19 +69,15 @@ describe('AutocompleteInput', () => {
 
   it('should forward a ref', () => {
     const ref = createRef<HTMLInputElement>();
-    const { container } = render(<AutocompleteInput {...props} ref={ref} />);
-    // eslint-disable-next-line testing-library/no-node-access
-    const input = container.querySelector('input');
+    render(<AutocompleteInput {...props} ref={ref} />);
+    const input = screen.queryByRole('combobox');
     expect(ref.current).toBe(input);
   });
 
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
-    const { container } = render(
-      <AutocompleteInput {...props} inputClassName={className} />,
-    );
-    // eslint-disable-next-line testing-library/no-node-access
-    const input = container.querySelector('input');
+    render(<AutocompleteInput {...props} inputClassName={className} />);
+    const input = screen.queryByRole('combobox');
     expect(input?.className).toContain(className);
   });
 

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.stories.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.stories.tsx
@@ -45,6 +45,8 @@ export default {
   component: AutocompleteInput,
   tags: ['status:stable'],
   argTypes: {
+    comboboxRef: { table: { disable: true } },
+
     // Value & change handling
     value: {
       table: {

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -17,7 +17,6 @@
 
 import {
   type ChangeEvent,
-  type FocusEventHandler,
   type KeyboardEventHandler,
   useCallback,
   useEffect,
@@ -295,8 +294,13 @@ export function AutocompleteInput({
     if (!isOpen) {
       comboboxRef?.current?.select();
       setIsOpen(true);
+      // when we close the listbox, set the search text to the value of the combobox,
+      // otherwise, reset it.
+      if (!Array.isArray(value)) {
+        setSearchText(value?.label ?? '');
+      }
     }
-  }, [isOpen]);
+  }, [isOpen, value]);
 
   const { floatingStyles, refs, update } = useFloating<HTMLElement>({
     open: isOpen,
@@ -491,26 +495,13 @@ export function AutocompleteInput({
       />
     ) : null;
 
-  const restoreValue: FocusEventHandler<HTMLInputElement> = useCallback(
-    (event) => {
-      if (!Array.isArray(value) && searchText !== value?.value) {
-        setSearchText(value?.label ?? '');
-        if (isImmersive) {
-          setPresentationFieldValue(value?.label ?? '');
-        }
-      }
-      props.onBlur?.(event);
-    },
-    [value, searchText, isImmersive, props.onBlur],
-  );
-
   const comboboxProps = {
     ...props,
     label,
     size,
     'data-id': autocompleteId,
     clearLabel,
-    value: searchText,
+    value: !Array.isArray(value) && !isOpen ? value?.label : searchText,
     onChange: onComboboxChange,
     onClear: onClear && !multiple ? onComboboxClear : undefined,
     onKeyDown: isLoading ? undefined : onComboboxKeyDown,
@@ -522,7 +513,6 @@ export function AutocompleteInput({
     onClick: !readOnly && !disabled ? onComboboxClick : undefined,
     readOnly,
     disabled,
-    onBlur: allowNewItems ? undefined : restoreValue,
     tags: Array.isArray(value) ? value : undefined,
     onTagRemove,
     isOpen,

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -303,7 +303,7 @@ export function AutocompleteInput({
     placement: 'bottom',
     strategy: 'fixed',
     middleware: [
-      offset({ mainAxis: size === 's' ? 10 : 17, crossAxis: 0 }), // bottom padding + 1px border + 4px gap
+      offset({ mainAxis: 4, crossAxis: 0 }),
       shift({ padding: boundaryPadding }),
       flip({
         padding: boundaryPadding,
@@ -578,7 +578,8 @@ export function AutocompleteInput({
     <>
       <div ref={inputWrapperRef}>
         <ComboboxInput
-          ref={applyMultipleRefs(comboboxRef, ref, refs.setReference)}
+          ref={applyMultipleRefs(comboboxRef, ref)}
+          comboboxRef={refs.setReference}
           inputClassName={props.inputClassName}
           aria-expanded={isOpen}
           aria-haspopup="listbox"
@@ -591,8 +592,8 @@ export function AutocompleteInput({
           ref={refs.setFloating}
           style={{
             ...floatingStyles,
-            width: comboboxRef.current?.parentElement?.offsetWidth ?? 0,
-            maxWidth: comboboxRef.current?.parentElement?.offsetWidth ?? 0,
+            width: refs.reference.current?.parentElement?.offsetWidth ?? 0,
+            maxWidth: refs.reference.current?.parentElement?.offsetWidth ?? 0,
           }}
         >
           {results}

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -238,8 +238,13 @@ export function AutocompleteInput({
 
   const closeResults = useCallback(() => {
     setIsOpen(false);
+    // when we close the listbox, set the search text to the value of the combobox,
+    // otherwise, reset it.
+    if (!Array.isArray(value)) {
+      changeInputValue(comboboxRef.current, value?.label ?? '');
+    }
     setActiveOption(undefined);
-  }, []);
+  }, [value]);
 
   const debouncedOnSearch = useMemo(
     () =>
@@ -294,13 +299,8 @@ export function AutocompleteInput({
     if (!isOpen) {
       comboboxRef?.current?.select();
       setIsOpen(true);
-      // when we close the listbox, set the search text to the value of the combobox,
-      // otherwise, reset it.
-      if (!Array.isArray(value)) {
-        setSearchText(value?.label ?? '');
-      }
     }
-  }, [isOpen, value]);
+  }, [isOpen]);
 
   const { floatingStyles, refs, update } = useFloating<HTMLElement>({
     open: isOpen,
@@ -394,7 +394,7 @@ export function AutocompleteInput({
             );
           }
           if (!activeOption || !searchText) {
-            setIsOpen(false);
+            closeResults();
           }
         }
         if (
@@ -422,6 +422,7 @@ export function AutocompleteInput({
       options,
       allowNewItems,
       value,
+      closeResults,
     ],
   );
 

--- a/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
@@ -105,6 +105,10 @@
     max-height: 150px;
     overflow-y: auto;
   }
+
+  .content {
+    max-height: 124px;
+  }
 }
 
 /* Sizes */
@@ -141,4 +145,13 @@
 .m .clear {
   right: var(--cui-spacings-byte);
   bottom: var(--cui-spacings-byte);
+}
+
+.content {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--cui-spacings-byte);
+  width: 100%;
+  max-height: 174px;
+  overflow-y: auto;
 }

--- a/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
@@ -4,7 +4,6 @@
   flex-wrap: wrap;
   gap: var(--cui-spacings-byte);
   width: 100%;
-  max-height: 200px;
   overflow-y: auto;
   background-color: var(--cui-bg-normal);
   border: 1px solid var(--cui-border-normal);
@@ -40,6 +39,14 @@
 
 .base:placeholder-shown {
   text-overflow: ellipsis;
+}
+
+.content {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--cui-spacings-byte);
+  width: 100%;
+  overflow-y: auto;
 }
 
 /* Validations */
@@ -102,12 +109,23 @@
 
 @media (max-width: 479px) {
   .base {
-    max-height: 150px;
     overflow-y: auto;
   }
 
-  .content {
-    max-height: 124px;
+  .m {
+    max-height: 150px;
+  }
+
+  .m .content {
+    max-height: 124px; /* 150 */
+  }
+
+  .s {
+    max-height: 120px;
+  }
+
+  .s .content {
+    max-height: 108px;
   }
 }
 
@@ -116,8 +134,13 @@
 /* s */
 
 .s {
+  max-height: 150px;
   padding: var(--field-input-padding-block) var(--field-input-padding-inline);
   border-radius: var(--field-input-border-radius);
+}
+
+.s .content {
+  max-height: 138px;
 }
 
 .s input {
@@ -133,8 +156,13 @@
 /* m */
 
 .m {
+  max-height: 200px;
   padding: var(--field-input-padding-block) var(--field-input-padding-inline);
   border-radius: var(--field-input-border-radius);
+}
+
+.m .content {
+  max-height: 174px;
 }
 
 .m input {
@@ -145,13 +173,4 @@
 .m .clear {
   right: var(--cui-spacings-byte);
   bottom: var(--cui-spacings-byte);
-}
-
-.content {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: var(--cui-spacings-byte);
-  width: 100%;
-  max-height: 174px;
-  overflow-y: auto;
 }

--- a/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
@@ -117,7 +117,7 @@
   }
 
   .m .content {
-    max-height: 124px; /* 150 */
+    max-height: 124px;
   }
 
   .s {

--- a/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.tsx
@@ -15,7 +15,7 @@
 
 'use client';
 
-import { useEffect, useId, useRef, useState } from 'react';
+import { type Ref, useEffect, useId, useRef, useState } from 'react';
 
 import type { ReturnType } from '../../../../types/return-type.js';
 import { idx } from '../../../../util/idx.js';
@@ -68,6 +68,7 @@ export interface ComboboxInputProps
    */
   locale?: Locale;
   'data-id'?: string;
+  comboboxRef?: Ref<HTMLDivElement>;
 }
 
 export function ComboboxInput({
@@ -99,6 +100,7 @@ export function ComboboxInput({
   removeTagButtonLabel,
   moreResults,
   ref,
+  comboboxRef,
   ...props
 }: ComboboxInputProps): ReturnType {
   const id = useId();
@@ -156,6 +158,7 @@ export function ComboboxInput({
           readOnly && classes.readonly,
           !disabled && hasWarning && classes.warning,
         )}
+        ref={comboboxRef}
       >
         {tags.slice(0, isOpen || showAllTags ? tags.length : 4).map((tag) => {
           const onRemoveProps =

--- a/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.tsx
@@ -40,6 +40,7 @@ import { Button } from '../../../Button/index.js';
 import type { AutocompleteInputOption } from '../Option/Option.js';
 
 import classes from './ComboboxInput.module.css';
+import { utilClasses } from '../../../../styles/utility.js';
 
 export interface ComboboxInputProps
   extends Omit<
@@ -160,58 +161,60 @@ export function ComboboxInput({
         )}
         ref={comboboxRef}
       >
-        {tags.slice(0, isOpen || showAllTags ? tags.length : 4).map((tag) => {
-          const onRemoveProps =
-            readOnly || disabled
-              ? {}
-              : {
-                  onRemove: () => onTagRemove?.(tag),
-                  removeButtonLabel: `${removeTagButtonLabel} ${tag.label}`,
-                };
-          return (
-            <Tag
-              key={tag.value}
-              className={clsx(disabled && classes['disabled-tag'])}
-              {...onRemoveProps}
+        <div className={clsx(classes.content, utilClasses.hideScrollbar)}>
+          {tags.slice(0, isOpen || showAllTags ? tags.length : 4).map((tag) => {
+            const onRemoveProps =
+              readOnly || disabled
+                ? {}
+                : {
+                    onRemove: () => onTagRemove?.(tag),
+                    removeButtonLabel: `${removeTagButtonLabel} ${tag.label}`,
+                  };
+            return (
+              <Tag
+                key={tag.value}
+                className={clsx(disabled && classes['disabled-tag'])}
+                {...onRemoveProps}
+              >
+                {tag.label}
+              </Tag>
+            );
+          })}
+          {!showAllTags && !isOpen && tags.length > 4 && (
+            <Button
+              style={{ padding: 0 }}
+              variant="tertiary"
+              onClick={() => setShowAllTags(true)}
             >
-              {tag.label}
-            </Tag>
-          );
-        })}
-        {!showAllTags && !isOpen && tags.length > 4 && (
-          <Button
-            style={{ padding: 0 }}
-            variant="tertiary"
-            onClick={() => setShowAllTags(true)}
-          >
-            + {tags.length - 4} {moreResults}
-          </Button>
-        )}
-        <input
-          id={inputId}
-          value={value}
-          data-id={comboboxInputId}
-          ref={applyMultipleRefs(localRef, ref)}
-          aria-describedby={descriptionIds}
-          className={clsx(
-            textAlign === 'right' && classes['align-right'],
-            inputClassName,
+              + {tags.length - 4} {moreResults}
+            </Button>
           )}
-          aria-invalid={invalid && 'true'}
-          required={required}
-          disabled={disabled}
-          readOnly={readOnly}
-          {...props}
-        />
-        {value && !disabled && !readOnly && onClear && clearLabel && (
-          <CloseButton
-            className={classes.clear}
-            size="s"
-            onClick={onClearButtonClick}
-          >
-            {clearLabel}
-          </CloseButton>
-        )}
+          <input
+            id={inputId}
+            value={value}
+            data-id={comboboxInputId}
+            ref={applyMultipleRefs(localRef, ref)}
+            aria-describedby={descriptionIds}
+            className={clsx(
+              textAlign === 'right' && classes['align-right'],
+              inputClassName,
+            )}
+            aria-invalid={invalid && 'true'}
+            required={required}
+            disabled={disabled}
+            readOnly={readOnly}
+            {...props}
+          />
+          {value && !disabled && !readOnly && onClear && clearLabel && (
+            <CloseButton
+              className={classes.clear}
+              size="s"
+              onClick={onClearButtonClick}
+            >
+              {clearLabel}
+            </CloseButton>
+          )}
+        </div>
       </div>
       <FieldValidationHint
         id={validationHintId}


### PR DESCRIPTION
Addresses [DSYS-1709](https://sumupteam.atlassian.net/browse/DSYS-1709)

## Purpose

In the AutocompleteInput, the listbox is positioned relative to the combobox through floating-ui's refs. In multi selection mode, the field can overflow and have scroll, causing the listbox to scroll along with it. 
Before react 19, we were unable to separate refs to the combobox from the ref to its wrapper to fix this behaviour.  Since we dropped support for react 18, we can now safely pass separate refs to the combobox.

## Approach and changes

- fix combobox scroll issue
- fix issue when focusing the clear button with tab key press
- fix slight overflow in multi selection mode caused by using inset shadow in fields

https://github.com/user-attachments/assets/27c063f1-d7b9-452b-96ab-2417843ece99


https://github.com/user-attachments/assets/01510309-c031-4624-b7e8-ae0cf0331c28

<img width="500" alt="Screenshot 2026-06-11 at 14 19 26" src="https://github.com/user-attachments/assets/3de07270-3e34-4387-b84b-e0f57612b59e" />


## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
