### PR TITLE
Refactor Toggle component

### DIFF
--- a/.changeset/ten-parks-kneel.md
+++ b/.changeset/ten-parks-kneel.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": major
 ---
 
-Repalaced the `<button role="switch">` implementation with `<input type="checkbox" role="switch">`  in the Toggle component, `onChange` now fires a native `ChangeEvent<HTMLInputElement>` instead of `ClickEvent<HTMLButtonElement>`.
+Changed the Toggle component implementation to use a native input element instead of a button element under the hood. `onChange` now fires a native `ChangeEvent<HTMLInputElement>` instead of `ClickEvent<HTMLButtonElement>`.

--- a/.changeset/ten-parks-kneel.md
+++ b/.changeset/ten-parks-kneel.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Repalaced the `<button role="switch">` implementation with `<input type="checkbox" role="switch">`  in the Toggle component, `onChange` now fires a native `ChangeEvent<HTMLInputElement>` instead of `ClickEvent<HTMLButtonElement>`.

--- a/packages/circuit-ui/components/Toggle/Toggle.module.css
+++ b/packages/circuit-ui/components/Toggle/Toggle.module.css
@@ -1,13 +1,20 @@
-.track {
-  --toggle-track-width: 40px;
-  --toggle-track-height: 24px;
-  --toggle-knob-size: 16px;
+.track-wrapper {
+  --toggle-track-width: var(--cui-spacings-peta);
+  --toggle-track-height: var(--cui-spacings-giga);
+  --toggle-knob-size: var(--cui-spacings-mega);
   --toggle-animation-timing: var(--cui-transitions-default);
 
   position: relative;
   flex: 0 0 var(--toggle-track-width);
   width: var(--toggle-track-width);
   height: var(--toggle-track-height);
+}
+
+.track {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   padding: 0;
   margin: 0;
   overflow: visible;
@@ -30,29 +37,28 @@
   border: 1px solid var(--cui-border-normal-pressed);
 }
 
-.track[aria-checked="true"] {
+.track:checked {
   background-color: var(--cui-bg-strong);
   border: 1px solid var(--cui-bg-strong);
 }
 
-.track[aria-checked="true"]:hover {
+.track:checked:hover {
   background-color: var(--cui-bg-strong-hovered);
   border: 1px solid var(--cui-bg-strong-hovered);
 }
 
-.track[aria-checked="true"]:active {
+.track:checked:active {
   background-color: var(--cui-bg-strong-pressed);
   border: 1px solid var(--cui-bg-strong-pressed);
 }
 
-.track:disabled,
-.track[disabled] {
+.track:disabled {
+  cursor: default;
   background-color: var(--cui-bg-normal);
   border: 1px solid var(--cui-border-subtle-disabled);
 }
 
-.track[aria-checked="true"]:disabled,
-.track[aria-checked="true"][disabled] {
+.track:checked:disabled {
   background-color: var(--cui-bg-accent-strong-disabled);
   border: 1px solid transparent;
 }
@@ -63,6 +69,7 @@
   display: block;
   width: var(--toggle-knob-size);
   height: var(--toggle-knob-size);
+  pointer-events: none;
   background-color: var(--cui-fg-subtle);
   border-radius: var(--toggle-knob-size);
   transform: translate3d(var(--cui-spacings-bit), -50%, 0);
@@ -71,7 +78,8 @@
     background-color var(--toggle-animation-timing);
 }
 
-[aria-checked="true"] .knob {
+.track:checked ~ .knob {
+  background-color: var(--cui-fg-on-strong);
   transform: translate3d(
     calc(
       var(--toggle-track-width) -
@@ -83,14 +91,11 @@
   );
 }
 
-[disabled] .knob,
-[data-disabled="true"] .knob {
+.track:disabled ~ .knob {
   background-color: var(--cui-bg-subtle-disabled);
 }
 
-.track[aria-checked="true"] .knob,
-.track[aria-checked="true"]:disabled .knob,
-.track[aria-checked="true"][disabled] .knob {
+.track:checked:disabled ~ .knob {
   background-color: var(--cui-fg-on-strong);
 }
 

--- a/packages/circuit-ui/components/Toggle/Toggle.module.css
+++ b/packages/circuit-ui/components/Toggle/Toggle.module.css
@@ -53,7 +53,6 @@
 }
 
 .track:disabled {
-  cursor: default;
   background-color: var(--cui-bg-normal);
   border: 1px solid var(--cui-border-subtle-disabled);
 }

--- a/packages/circuit-ui/components/Toggle/Toggle.module.css
+++ b/packages/circuit-ui/components/Toggle/Toggle.module.css
@@ -1,4 +1,4 @@
-.track-wrapper {
+.base-wrapper {
   --toggle-track-width: var(--cui-spacings-peta);
   --toggle-track-height: var(--cui-spacings-giga);
   --toggle-knob-size: var(--cui-spacings-mega);
@@ -10,7 +10,7 @@
   height: var(--toggle-track-height);
 }
 
-.track {
+.base {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -27,37 +27,37 @@
   transition: background-color var(--toggle-animation-timing);
 }
 
-.track:hover {
+.base:hover {
   background-color: var(--cui-bg-normal-hovered);
   border: 1px solid var(--cui-border-normal-hovered);
 }
 
-.track:active {
+.base:active {
   background-color: var(--cui-bg-normal-pressed);
   border: 1px solid var(--cui-border-normal-pressed);
 }
 
-.track:checked {
+.base:checked {
   background-color: var(--cui-bg-strong);
   border: 1px solid var(--cui-bg-strong);
 }
 
-.track:checked:hover {
+.base:checked:hover {
   background-color: var(--cui-bg-strong-hovered);
   border: 1px solid var(--cui-bg-strong-hovered);
 }
 
-.track:checked:active {
+.base:checked:active {
   background-color: var(--cui-bg-strong-pressed);
   border: 1px solid var(--cui-bg-strong-pressed);
 }
 
-.track:disabled {
+.base:disabled {
   background-color: var(--cui-bg-normal);
   border: 1px solid var(--cui-border-subtle-disabled);
 }
 
-.track:checked:disabled {
+.base:checked:disabled {
   background-color: var(--cui-bg-accent-strong-disabled);
   border: 1px solid transparent;
 }
@@ -77,7 +77,7 @@
     background-color var(--toggle-animation-timing);
 }
 
-.track:checked ~ .knob {
+.base:checked ~ .knob {
   background-color: var(--cui-fg-on-strong);
   transform: translate3d(
     calc(
@@ -90,11 +90,11 @@
   );
 }
 
-.track:disabled ~ .knob {
+.base:disabled ~ .knob {
   background-color: var(--cui-bg-subtle-disabled);
 }
 
-.track:checked:disabled ~ .knob {
+.base:checked:disabled ~ .knob {
   background-color: var(--cui-fg-on-strong);
 }
 

--- a/packages/circuit-ui/components/Toggle/Toggle.spec.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.spec.tsx
@@ -36,10 +36,10 @@ describe('Toggle', () => {
   });
 
   it('should forward a ref', () => {
-    const ref = createRef<HTMLButtonElement>();
+    const ref = createRef<HTMLInputElement>();
     const { container } = render(<Toggle {...defaultProps} ref={ref} />);
-    const button = container.querySelector('button');
-    expect(ref.current).toBe(button);
+    const input = container.querySelector('input');
+    expect(ref.current).toBe(input);
   });
 
   it('should call the change handler when toggled', async () => {
@@ -67,6 +67,14 @@ describe('Toggle', () => {
     expect(toggleEl).toHaveAccessibleDescription(
       `${customDescription} ${defaultProps.description}`,
     );
+  });
+
+  it('should support uncontrolled usage via defaultChecked', async () => {
+    render(<Toggle {...defaultProps} defaultChecked />);
+    const toggleEl = screen.getByRole('switch');
+    expect(toggleEl).toBeChecked();
+    await userEvent.click(toggleEl);
+    expect(toggleEl).not.toBeChecked();
   });
 
   // See https://inclusive-components.design/toggle-button/

--- a/packages/circuit-ui/components/Toggle/Toggle.spec.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.spec.tsx
@@ -69,14 +69,6 @@ describe('Toggle', () => {
     );
   });
 
-  it('should support uncontrolled usage via defaultChecked', async () => {
-    render(<Toggle {...defaultProps} defaultChecked />);
-    const toggleEl = screen.getByRole('switch');
-    expect(toggleEl).toBeChecked();
-    await userEvent.click(toggleEl);
-    expect(toggleEl).not.toBeChecked();
-  });
-
   // See https://inclusive-components.design/toggle-button/
   it('should have no accessibility violations', async () => {
     const { container } = render(<Toggle {...defaultProps} />);

--- a/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
@@ -60,15 +60,6 @@ WithDescription.args = {
   description: 'Some more detailed text of what this means',
 };
 
-export const Uncontrolled = (args: ToggleProps) => (
-  <Stack vertical>
-    <Toggle {...args} />
-    <Toggle {...args} defaultChecked />
-  </Stack>
-);
-
-Uncontrolled.args = baseArgs;
-
 export const Disabled = (args: ToggleProps) => (
   <Stack vertical>
     <Toggle {...args} />

--- a/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.stories.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import { type ChangeEvent, useState } from 'react';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 
@@ -33,8 +33,8 @@ const baseArgs = {
 export const Base = (args: ToggleProps) => {
   const [checked, setChecked] = useState(false);
 
-  const handleChange = () => {
-    setChecked((prev) => !prev);
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setChecked(e.target.checked);
   };
   return (
     <Stack vertical>
@@ -49,8 +49,8 @@ Base.args = baseArgs;
 export const WithDescription = (args: ToggleProps) => {
   const [checked, setChecked] = useState(false);
 
-  const handleChange = () => {
-    setChecked((prev) => !prev);
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setChecked(e.target.checked);
   };
   return <Toggle {...args} checked={checked} onChange={handleChange} />;
 };
@@ -59,6 +59,15 @@ WithDescription.args = {
   ...baseArgs,
   description: 'Some more detailed text of what this means',
 };
+
+export const Uncontrolled = (args: ToggleProps) => (
+  <Stack vertical>
+    <Toggle {...args} />
+    <Toggle {...args} defaultChecked />
+  </Stack>
+);
+
+Uncontrolled.args = baseArgs;
 
 export const Disabled = (args: ToggleProps) => (
   <Stack vertical>

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -21,6 +21,7 @@ import {
   AccessibilityError,
   isSufficientlyLabelled,
 } from '../../util/errors.js';
+import { idx } from '../../util/idx.js';
 import { FieldDescription, FieldWrapper } from '../Field/index.js';
 import { clsx } from '../../styles/clsx.js';
 import { utilClasses } from '../../styles/utility.js';
@@ -55,10 +56,6 @@ export function Toggle({
   const labelId = useId();
   const descriptionId = useId();
 
-  const descriptionIds = [describedBy, description && descriptionId]
-    .filter(Boolean)
-    .join(' ');
-
   if (
     process.env.NODE_ENV !== 'production' &&
     process.env.NODE_ENV !== 'test' &&
@@ -76,7 +73,7 @@ export function Toggle({
       className={clsx(classes.wrapper, className)}
       style={style}
     >
-      <span className={classes['track-wrapper']}>
+      <span className={classes['base-wrapper']}>
         <input
           type="checkbox"
           // All browsers in our support matrix handle this correctly. See https://www.w3.org/WAI/ARIA/apg/patterns/switch/
@@ -84,8 +81,8 @@ export function Toggle({
           role="switch"
           id={switchId}
           aria-labelledby={labelId}
-          aria-describedby={descriptionIds || undefined}
-          className={clsx(classes.track, utilClasses.focusVisible)}
+          aria-describedby={idx(describedBy, description && descriptionId)}
+          className={clsx(classes.base, utilClasses.focusVisible)}
           {...props}
           ref={ref}
         />

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -15,27 +15,20 @@
 
 'use client';
 
-import { useId, type Ref, type ButtonHTMLAttributes } from 'react';
+import { useId, type Ref, type InputHTMLAttributes } from 'react';
 
 import {
   AccessibilityError,
   isSufficientlyLabelled,
 } from '../../util/errors.js';
-import type { ClickEvent } from '../../types/events.js';
 import { FieldDescription, FieldWrapper } from '../Field/index.js';
 import { clsx } from '../../styles/clsx.js';
 import { utilClasses } from '../../styles/utility.js';
 
 import classes from './Toggle.module.css';
 
-export interface ToggleProps
-  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
-  ref?: Ref<HTMLButtonElement>;
-  /**
-   * Callback when the toggle state changes. Can be triggered by mouse or
-   * keyboard interactions.
-   */
-  onChange?: (event: ClickEvent<HTMLButtonElement>) => void;
+export interface ToggleProps extends InputHTMLAttributes<HTMLInputElement> {
+  ref?: Ref<HTMLInputElement>;
   /**
    * Describes the function of the toggle. Should not change depending on the state.
    */
@@ -44,10 +37,6 @@ export interface ToggleProps
    * Further explanation of the toggle. Can change depending on the state.
    */
   description?: string;
-  /**
-   * Is the Switch on?
-   */
-  checked?: boolean;
 }
 
 /**
@@ -57,8 +46,6 @@ export function Toggle({
   label,
   description,
   'aria-describedby': describedBy,
-  checked = false,
-  onChange,
   className,
   style,
   ref,
@@ -89,20 +76,21 @@ export function Toggle({
       className={clsx(classes.wrapper, className)}
       style={style}
     >
-      <button
-        type="button"
-        onClick={onChange}
-        role="switch"
-        aria-checked={checked}
-        aria-labelledby={labelId}
-        aria-describedby={descriptionIds}
-        id={switchId}
-        className={clsx(classes.track, utilClasses.focusVisible)}
-        {...props}
-        ref={ref}
-      >
-        <span className={classes.knob} />
-      </button>
+      <span className={classes['track-wrapper']}>
+        <input
+          type="checkbox"
+          //  All browsers in our support matrix handle this correctly. See https://www.w3.org/WAI/ARIA/apg/patterns/switch/
+          // biome-ignore lint/a11y/useAriaPropsForRole: <input type="checkbox"> natively maps its checked state to aria-checked for role="switch" per the HTML-AAM spec.
+          role="switch"
+          id={switchId}
+          aria-labelledby={labelId}
+          aria-describedby={descriptionIds || undefined}
+          className={clsx(classes.track, utilClasses.focusVisible)}
+          {...props}
+          ref={ref}
+        />
+        <span className={classes.knob} aria-hidden="true" />
+      </span>
       <label className={classes.label} id={labelId} htmlFor={switchId}>
         {label}
         {description && (

--- a/packages/circuit-ui/components/Toggle/Toggle.tsx
+++ b/packages/circuit-ui/components/Toggle/Toggle.tsx
@@ -79,7 +79,7 @@ export function Toggle({
       <span className={classes['track-wrapper']}>
         <input
           type="checkbox"
-          //  All browsers in our support matrix handle this correctly. See https://www.w3.org/WAI/ARIA/apg/patterns/switch/
+          // All browsers in our support matrix handle this correctly. See https://www.w3.org/WAI/ARIA/apg/patterns/switch/
           // biome-ignore lint/a11y/useAriaPropsForRole: <input type="checkbox"> natively maps its checked state to aria-checked for role="switch" per the HTML-AAM spec.
           role="switch"
           id={switchId}


### PR DESCRIPTION
Addresses [DSYS-1708](https://sumupteam.atlassian.net/browse/DSYS-1708)

## Purpose

Toggle used a `<button role="switch">` and wired `onChange` to `onClick`, meaning the callback fired a `ClickEvent<HTMLButtonElement>`. This is semantically wrong; a prop named `onChange` should fire a `ChangeEvent`. This refactor replaces the button with `<input type="checkbox" role="switch">` so `onChange` fires a native `ChangeEvent<HTMLInputElement>`, matching what consumers expect from a controlled input API.

## Approach and changes

- Toggle.tsx:  `ToggleProps` now extends `InputHTMLAttributes<HTMLInputElement>` instead of `Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'>`. The `<button>` is replaced with `<input type="checkbox" role="switch">` wrapped in a `<span class="track-wrapper">` to provide the positioning context the knob needs (inputs are void elements and cannot have children).

- `role="switch"` is kept because a toggle is semantically different from a checkbox; screen readers should announce "switch, on/off", not "checkbox, checked/unchecked". Both patterns are valid per the [W3C APG switch pattern](https://www.w3.org/WAI/ARIA/apg/patterns/switch/). The biome lint rule `(useAriaPropsForRole)` is suppressed with a comment because `<input type="checkbox">` natively maps its checked state to `aria-checked` per the HTML-AAM spec, and all browsers in our support matrix (Chrome 85+, Firefox 79+, Safari 14+, Edge 85+) handle this correctly.

- `pointer-events: none` is added to `.knob` so clicks pass through the decorative span to the underlying input. The knob is absolutely positioned on top of the input inside `track-wrapper`; without this, clicks on the knob would hit the span instead of toggling the checkbox.

## Notable side-effect

`checked` (and' defaultChecked', ' name', and' value') no longer appear in the Storybook props table; they're inherited from `InputHTMLAttributes` rather than explicitly declared. The old `checked` showed up because it had to be declared explicitly for the button-based implementation. These props work correctly; they're just not surfaced in controls. We can document them in the MDX if needed (LMK).

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
