### PR TITLE
add eslint rule to replace deprecated icons

### DIFF
--- a/.changeset/happy-nails-strive.md
+++ b/.changeset/happy-nails-strive.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/eslint-plugin-circuit-ui": minor
+---
+
+Added a `no-deprecated-icons` rule to flag and replace depracted icons with their suggested alternatives.

--- a/.changeset/happy-nails-strive.md
+++ b/.changeset/happy-nails-strive.md
@@ -2,4 +2,4 @@
 "@sumup-oss/eslint-plugin-circuit-ui": minor
 ---
 
-Added a `no-deprecated-icons` rule to flag and replace deprecatedeslint icons with their suggested alternatives.
+Added a `no-deprecated-icons` rule to flag and replace deprecated icons with their suggested alternatives.

--- a/.changeset/happy-nails-strive.md
+++ b/.changeset/happy-nails-strive.md
@@ -2,4 +2,4 @@
 "@sumup-oss/eslint-plugin-circuit-ui": minor
 ---
 
-Added a `no-deprecated-icons` rule to flag and replace depracted icons with their suggested alternatives.
+Added a `no-deprecated-icons` rule to flag and replace deprecatedeslint icons with their suggested alternatives.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,7 @@ export default defineConfig([
       'circuit-ui/no-deprecated-props': 'error',
       'circuit-ui/no-renamed-props': 'error',
       'circuit-ui/prefer-custom-properties': 'warn',
+      'circuit-ui/no-deprecated-icons': 'warn',
     },
   },
   configs.browser,

--- a/package-lock.json
+++ b/package-lock.json
@@ -35509,13 +35509,7 @@
       },
       "peerDependencies": {
         "@sumup-oss/circuit-ui": ">=10.0.0",
-        "@sumup-oss/design-tokens": ">=9.0.0",
-        "@sumup-oss/icons": ">=6.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@sumup-oss/icons": {
-          "optional": true
-        }
+        "@sumup-oss/design-tokens": ">=9.0.0"
       }
     },
     "packages/eslint-plugin-circuit-ui/node_modules/@typescript-eslint/project-service": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11971,6 +11971,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -11980,6 +11981,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -35507,7 +35509,13 @@
       },
       "peerDependencies": {
         "@sumup-oss/circuit-ui": ">=10.0.0",
-        "@sumup-oss/design-tokens": ">=9.0.0"
+        "@sumup-oss/design-tokens": ">=9.0.0",
+        "@sumup-oss/icons": ">=6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@sumup-oss/icons": {
+          "optional": true
+        }
       }
     },
     "packages/eslint-plugin-circuit-ui/node_modules/@typescript-eslint/project-service": {
@@ -36459,24 +36467,6 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-testing-library": "^7.16.2",
         "typescript": "^6.0.3"
-      }
-    },
-    "templates/astro/node_modules/@types/react": {
-      "version": "19.2.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
-      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
-    },
-    "templates/astro/node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
       }
     },
     "templates/nextjs": {

--- a/packages/eslint-plugin-circuit-ui/index.ts
+++ b/packages/eslint-plugin-circuit-ui/index.ts
@@ -27,6 +27,7 @@ import { noRenamedProps } from './no-renamed-props/index.js';
 import { preferCustomProperties } from './prefer-custom-properties/index.js';
 import { noRenamedComponents } from './no-renamed-components/index.js';
 import { noDeprecatedSpacingMixin } from './no-deprecated-spacing-mixin/index.js';
+import { noDeprecatedIcons } from './no-deprecated-icons/index.js';
 
 export const rules = {
   'component-lifecycle-imports': componentLifecycleImports,
@@ -38,6 +39,7 @@ export const rules = {
   'prefer-custom-properties': preferCustomProperties,
   'no-renamed-components': noRenamedComponents,
   'no-deprecated-spacing-mixin': noDeprecatedSpacingMixin,
+  'no-deprecated-icons': noDeprecatedIcons,
 };
 
 const namespace = 'circuit-ui';

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/README.md
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/README.md
@@ -1,0 +1,35 @@
+# Update deprecated icons (`no-deprecated-icons`)
+
+Circuit UI's icon library evolves along with our visual identity. Over time, some icons can become obsolete or renamed. This rule flags outdated icon imports and usages and can automatically update them with the suggested alternatives.
+
+## Rule Details
+Icons are marked as deprecated in minor releases to be later removed in major releases.
+Set this rule to warn (or 1) to get a warning when using deprecated icons with minor releases.
+When upgrading Circuit UI to the next major, set the rule's error level to error (or 2) to help migrate deprecated icons.
+
+Examples of **incorrect** code for this rule:
+
+```tsx
+import { Add } from '@sumup-oss/icons'
+function Component() {
+  return <Add />;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```tsx
+import { FlagFr } from '@sumup-oss/icons';
+function Component() {
+  return <FlagFr />
+}
+```
+
+### Options
+
+n/a
+
+## Further Reading
+
+- [Migration guide](https://github.com/sumup-oss/circuit-ui/blob/main/MIGRATION.md)
+- [Circuit UI release notes](https://github.com/sumup-oss/circuit-ui/blob/main/packages/circuit-ui/CHANGELOG.md)

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/README.md
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/README.md
@@ -7,6 +7,10 @@ Icons are marked as deprecated in minor releases to be later removed in major re
 Set this rule to warn (or 1) to get a warning when using deprecated icons with minor releases.
 When upgrading Circuit UI to the next major, set the rule's error level to error (or 2) to help migrate deprecated icons.
 
+- If the icon has no direct replacement, show the deprecation message as is, no fixes are applied.
+- If the icon has a direct replacement, the rule warns about/replaces the icon import and usages with the proposed alternative.
+- If the icon has multiple direct alternatives, propose suggestions for all of them; no fixes are applied.
+
 Examples of **incorrect** code for this rule:
 
 ```tsx

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.spec.ts
@@ -1,5 +1,6 @@
 // We disable the rule in this file because we explicitly test invalid cases
 
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -7,14 +8,32 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 
 import { noDeprecatedIcons } from './index.js';
 
-const testDir = path.dirname(fileURLToPath(import.meta.url));
-const circuitUiFilename = path.join(
-  testDir,
-  '../../circuit-ui/src/example.tsx',
+function resolveMonorepoPackagePath(
+  packageName: string,
+  filePath: string,
+): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+
+  while (dir !== path.dirname(dir)) {
+    const packageJsonPath = path.join(dir, packageName, 'package.json');
+
+    if (existsSync(packageJsonPath)) {
+      return path.join(dir, packageName, filePath);
+    }
+
+    dir = path.dirname(dir);
+  }
+
+  throw new Error(`Could not find monorepo package "${packageName}"`);
+}
+
+const circuitUiFilename = resolveMonorepoPackagePath(
+  'circuit-ui',
+  'src/example.tsx',
 );
-const stylelintPluginFilename = path.join(
-  testDir,
-  '../../stylelint-plugin-circuit-ui/src/example.tsx',
+const stylelintPluginFilename = resolveMonorepoPackagePath(
+  'stylelint-plugin-circuit-ui',
+  'src/example.tsx',
 );
 
 const ruleTester = new RuleTester({

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.spec.ts
@@ -1,0 +1,158 @@
+// We disable the rule in this file because we explicitly test invalid cases
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { noDeprecatedIcons } from './index.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
+  valid: [
+    {
+      name: 'Non deprecated icon from Circuit UI',
+      code: `
+        import { Add } from '@sumup-oss/icons';
+      `,
+    },
+    {
+      name: 'matched icon name from different package',
+      code: `
+        import { Copy } from 'material-ui';
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'matched multiple deprecated icons from Circuit UI',
+      code: `
+        import { Copy, EmailChat, Home } from '@sumup-oss/icons';
+        function Component() {
+          return (<>
+          <Copy />
+          <EmailChat/>
+          </>)
+        }
+      `,
+      output: `
+        import { CopyPaste, Email, Home } from '@sumup-oss/icons';
+        function Component() {
+          return (<>
+          <CopyPaste />
+          <Email/>
+          </>)
+        }
+      `,
+      errors: [
+        { messageId: 'deprecated' },
+        { messageId: 'deprecated' },
+        { messageId: 'deprecated' },
+        { messageId: 'deprecated' },
+      ],
+    },
+    {
+      name: 'matched multiple deprecated icons from Circuit UI in different import statements',
+      code: `
+        import { Copy, Home } from '@sumup-oss/icons';
+        import { EmailChat } from '@sumup-oss/icons';
+        function Component() {
+          return (<>
+          <Copy />
+          <EmailChat/>
+          </>)
+        }
+      `,
+      output: `
+        import { CopyPaste, Home } from '@sumup-oss/icons';
+        import { Email } from '@sumup-oss/icons';
+        function Component() {
+          return (<>
+          <CopyPaste />
+          <Email/>
+          </>)
+        }
+      `,
+      errors: [
+        { messageId: 'deprecated' },
+        { messageId: 'deprecated' },
+        { messageId: 'deprecated' },
+        { messageId: 'deprecated' },
+      ],
+    },
+    {
+      name: 'matched country flag icon from Circuit UI',
+      code: `
+        import { FlagFr } from '@sumup-oss/icons';
+        function Component() {
+          return <FlagFr />
+        }
+      `,
+      output: `
+        import { Flag } from '@sumup-oss/icons';
+        function Component() {
+          return <Flag countryCode="FR" width="16" />
+        }
+      `,
+      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+    },
+    {
+      name: 'matched locally renamed icon from Circuit UI',
+      code: `
+         import { FlagFr as FrenchFlag } from '@sumup-oss/icons';
+         function Component() {
+           return <FrenchFlag />
+         }
+       `,
+      output: `
+         import { Flag as FrenchFlag } from '@sumup-oss/icons';
+         function Component() {
+           return <FrenchFlag countryCode="FR" width="16" />
+         }
+       `,
+      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+    },
+    {
+      name: 'matched deprecated icon in object expression',
+      code: `
+        import { Copy } from '@sumup-oss/icons';
+        const myObject = {
+          name: 'home',
+          icon: Copy,
+        };
+      `,
+      output: `
+        import { CopyPaste } from '@sumup-oss/icons';
+        const myObject = {
+          name: 'home',
+          icon: CopyPaste,
+        };
+      `,
+      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+    },
+    {
+      name: 'matched renamed deprecated icon in object expression',
+      code: `
+        import { Copy as CopyIcon } from '@sumup-oss/icons';
+        const myObject = {
+          name: 'home',
+          icon: CopyIcon,
+        };
+      `,
+      output: `
+        import { CopyPaste as CopyIcon } from '@sumup-oss/icons';
+        const myObject = {
+          name: 'home',
+          icon: CopyIcon,
+        };
+      `,
+      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.spec.ts
@@ -116,16 +116,16 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
       code: `
         import { FlagFr } from '@sumup-oss/icons';
         function Component() {
-          return <FlagFr />
+          return <FlagFr>France</FlagFr>
         }
       `,
       output: `
         import { Flag } from '@sumup-oss/icons';
         function Component() {
-          return <Flag countryCode="FR" width="16" />
+          return <Flag countryCode="FR" width="16">France</Flag>
         }
       `,
-      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }, { messageId: 'deprecated' }],
     },
     {
       name: 'matched locally renamed icon from Circuit UI',

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.spec.ts
@@ -44,7 +44,7 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
       `,
     },
     {
-      name: 'skips when icons is not a declared dependency',
+      name: 'skips when the icons package is not a declared dependency',
       filename: stylelintPluginFilename,
       code: `
         import { Copy } from '@sumup-oss/icons';
@@ -74,10 +74,10 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
         }
       `,
       errors: [
-        { messageId: 'deprecated' },
-        { messageId: 'deprecated' },
-        { messageId: 'deprecated' },
-        { messageId: 'deprecated' },
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
       ],
     },
     {
@@ -104,10 +104,10 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
         }
       `,
       errors: [
-        { messageId: 'deprecated' },
-        { messageId: 'deprecated' },
-        { messageId: 'deprecated' },
-        { messageId: 'deprecated' },
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
       ],
     },
     {
@@ -125,7 +125,11 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
           return <Flag countryCode="FR" width="16">France</Flag>
         }
       `,
-      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }, { messageId: 'deprecated' }],
+      errors: [
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
+      ],
     },
     {
       name: 'matched locally renamed icon from Circuit UI',
@@ -133,16 +137,49 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
       code: `
          import { FlagFr as FrenchFlag } from '@sumup-oss/icons';
          function Component() {
-           return <FrenchFlag />
+           return <div><FrenchFlag /><FlagFr/></div>
          }
        `,
       output: `
          import { Flag as FrenchFlag } from '@sumup-oss/icons';
          function Component() {
-           return <FrenchFlag countryCode="FR" width="16" />
+           return <div><FrenchFlag countryCode="FR" width="16" /><FlagFr/></div>
          }
        `,
-      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+      errors: [
+        {
+          messageId: 'deprecatedWithAlternative',
+        },
+        { messageId: 'deprecatedWithAlternative' },
+      ],
+    },
+    {
+      name: 'does not confuse a deprecated icon from Circuit UI with another of the same name from a different package',
+      filename: circuitUiFilename,
+      code: `
+         import { FlagFr as FrenchFlag } from '@sumup-oss/icons';
+         import { FlagFr } from 'flags-package';
+         function Component() {
+           return (<div>
+             <FrenchFlag />
+             <FlagFr/>
+           </div>)
+         }
+       `,
+      output: `
+         import { Flag as FrenchFlag } from '@sumup-oss/icons';
+         import { FlagFr } from 'flags-package';
+         function Component() {
+           return (<div>
+             <FrenchFlag countryCode="FR" width="16" />
+             <FlagFr/>
+           </div>)
+         }
+       `,
+      errors: [
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
+      ],
     },
     {
       name: 'matched deprecated icon in object expression',
@@ -161,7 +198,10 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
           icon: CopyPaste,
         };
       `,
-      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+      errors: [
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
+      ],
     },
     {
       name: 'matched renamed deprecated icon in object expression',
@@ -180,7 +220,104 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
           icon: CopyIcon,
         };
       `,
-      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+      errors: [
+        { messageId: 'deprecatedWithAlternative' },
+        { messageId: 'deprecatedWithAlternative' },
+      ],
+    },
+    {
+      name: 'matched deprecated icon with multiple alternatives',
+      filename: circuitUiFilename,
+      code: `
+        import { AddItems } from '@sumup-oss/icons';
+        function Component() {
+          return <AddItems/>
+        }
+      `,
+      errors: [
+        {
+          messageId: 'deprecatedWithSuggestion',
+          suggestions: [
+            {
+              messageId: 'deprecatedWithSuggestion',
+              data: {
+                name: 'AddItems',
+                alternative: 'Add',
+              },
+              output: `
+        import { Add } from '@sumup-oss/icons';
+        function Component() {
+          return <AddItems/>
+        }
+      `,
+            },
+            {
+              messageId: 'deprecatedWithSuggestion',
+              data: {
+                name: 'AddItems',
+                alternative: 'Items',
+              },
+              output: `
+        import { Items } from '@sumup-oss/icons';
+        function Component() {
+          return <AddItems/>
+        }
+      `,
+            },
+          ],
+        },
+        {
+          messageId: 'deprecatedWithAlternative',
+          suggestions: [
+            {
+              messageId: 'deprecatedWithSuggestion',
+              data: {
+                name: 'AddItems',
+                alternative: 'Add',
+              },
+              output: `
+        import { AddItems } from '@sumup-oss/icons';
+        function Component() {
+          return <Add/>
+        }
+      `,
+            },
+            {
+              messageId: 'deprecatedWithSuggestion',
+              data: {
+                name: 'AddItems',
+                alternative: 'Items',
+              },
+              output: `
+        import { AddItems } from '@sumup-oss/icons';
+        function Component() {
+          return <Items/>
+        }
+      `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'matched deprecated icon with out direct alternative',
+      filename: circuitUiFilename,
+      code: `
+        import { SumUpLogo } from '@sumup-oss/icons';
+        function Component() {
+          return <SumUpLogo/>
+        }
+      `,
+      errors: [
+        {
+          messageId: 'deprecated',
+          data: {
+            name: 'SumUpLogo',
+            deprecation:
+              "Use the SumUpLogo component from '@sumup-oss/circuit-ui' instead.",
+          },
+        },
+      ],
     },
   ],
 });

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.spec.ts
@@ -1,8 +1,21 @@
 // We disable the rule in this file because we explicitly test invalid cases
 
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { RuleTester } from '@typescript-eslint/rule-tester';
 
 import { noDeprecatedIcons } from './index.js';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const circuitUiFilename = path.join(
+  testDir,
+  '../../circuit-ui/src/example.tsx',
+);
+const stylelintPluginFilename = path.join(
+  testDir,
+  '../../stylelint-plugin-circuit-ui/src/example.tsx',
+);
 
 const ruleTester = new RuleTester({
   languageOptions: {
@@ -18,20 +31,30 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
   valid: [
     {
       name: 'Non deprecated icon from Circuit UI',
+      filename: circuitUiFilename,
       code: `
         import { Add } from '@sumup-oss/icons';
       `,
     },
     {
       name: 'matched icon name from different package',
+      filename: circuitUiFilename,
       code: `
         import { Copy } from 'material-ui';
+      `,
+    },
+    {
+      name: 'skips when icons is not a declared dependency',
+      filename: stylelintPluginFilename,
+      code: `
+        import { Copy } from '@sumup-oss/icons';
       `,
     },
   ],
   invalid: [
     {
       name: 'matched multiple deprecated icons from Circuit UI',
+      filename: circuitUiFilename,
       code: `
         import { Copy, EmailChat, Home } from '@sumup-oss/icons';
         function Component() {
@@ -59,6 +82,7 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
     },
     {
       name: 'matched multiple deprecated icons from Circuit UI in different import statements',
+      filename: circuitUiFilename,
       code: `
         import { Copy, Home } from '@sumup-oss/icons';
         import { EmailChat } from '@sumup-oss/icons';
@@ -88,6 +112,7 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
     },
     {
       name: 'matched country flag icon from Circuit UI',
+      filename: circuitUiFilename,
       code: `
         import { FlagFr } from '@sumup-oss/icons';
         function Component() {
@@ -104,6 +129,7 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
     },
     {
       name: 'matched locally renamed icon from Circuit UI',
+      filename: circuitUiFilename,
       code: `
          import { FlagFr as FrenchFlag } from '@sumup-oss/icons';
          function Component() {
@@ -120,6 +146,7 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
     },
     {
       name: 'matched deprecated icon in object expression',
+      filename: circuitUiFilename,
       code: `
         import { Copy } from '@sumup-oss/icons';
         const myObject = {
@@ -138,6 +165,7 @@ ruleTester.run('no-deprecated-icons', noDeprecatedIcons, {
     },
     {
       name: 'matched renamed deprecated icon in object expression',
+      filename: circuitUiFilename,
       code: `
         import { Copy as CopyIcon } from '@sumup-oss/icons';
         const myObject = {

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.ts
@@ -8,9 +8,9 @@ import path from 'node:path';
 type DeprecatedIcon = {
   name: string;
   deprecation: string;
-  alternative: string;
+  alternative: string[];
   alternativeProps?: Record<string, string>;
-}
+};
 
 const ICONS_PACKAGE = '@sumup-oss/icons';
 
@@ -33,9 +33,7 @@ function getProjectRoot(cwd: string, filename?: string): string {
   return findPackageRoot(filename ? path.dirname(filename) : cwd);
 }
 
-function hasDeclaredDependency(
-  projectRoot: string,
-): boolean {
+function hasDeclaredDependency(projectRoot: string): boolean {
   try {
     const pkg = JSON.parse(
       readFileSync(path.join(projectRoot, 'package.json'), 'utf8'),
@@ -57,6 +55,17 @@ function hasDeclaredDependency(
   }
 }
 
+function formatAlternativeText(alternative: string[]): string {
+  if (alternative.length === 1) {
+    return alternative[0];
+  }
+  if (alternative.length === 2) {
+    return `${alternative[0]} or ${alternative[1]}`;
+  }
+  const commaSeparated = alternative.slice(0, -1).join(', ');
+  return `${commaSeparated} or ${alternative[alternative.length - 1]}`;
+}
+
 function getDeprecatedIcons(projectRoot: string): DeprecatedIcon[] {
   if (iconsCache.has(projectRoot)) {
     return iconsCache.get(projectRoot)!;
@@ -74,7 +83,7 @@ function getDeprecatedIcons(projectRoot: string): DeprecatedIcon[] {
       icons: DeprecatedIcon[];
     };
     const icons = manifest.icons
-      .filter(({ deprecation, alternative }) => Boolean(deprecation) && Boolean(alternative))
+      .filter(({ deprecation }) => Boolean(deprecation))
       .map(({ name, ...rest }) => ({
         name: getIconReactName(name),
         ...rest,
@@ -106,7 +115,8 @@ type TrackedImport = {
   key: string;
   node: TSESTree.Node;
   specifier: TSESTree.ImportSpecifier;
-  alternative: string;
+  alternative?: string[];
+  deprecation?: string;
   localName: string;
   alternativeProps?: Record<string, string>;
 };
@@ -114,14 +124,15 @@ type TrackedImport = {
 type TrackedUsage = {
   key: string;
   node: TSESTree.Node;
-  alternative: string;
+  alternative?: string[];
+  deprecation?: string;
   localName: string;
   alternativeProps?: Record<string, string>;
   kind: 'jsx' | 'expression';
 };
 
 function referencesImportBinding(
-  node: TSESTree.Identifier,
+  node: TSESTree.Identifier | TSESTree.JSXIdentifier,
   specifier: TSESTree.ImportSpecifier,
   localName: string,
   sourceCode: Readonly<TSESLint.SourceCode>,
@@ -145,13 +156,17 @@ export const noDeprecatedIcons = createRule({
     type: 'suggestion',
     fixable: 'code',
     schema: [],
+    hasSuggestions: true,
     docs: {
       description: 'Deprecated icons should be removed or replaced',
       recommended: 'warn',
     },
     messages: {
-      deprecated:
+      deprecated: 'The {{name}} icon has been deprecated. {{deprecation}}',
+      deprecatedWithAlternative:
         'The {{name}} icon has been deprecated. Use the {{alternative}} icon instead',
+      deprecatedWithSuggestion:
+        'Replace the deprecated {{name}} icon with the {{alternative}} icon',
     },
   },
   create(context) {
@@ -195,6 +210,7 @@ export const noDeprecatedIcons = createRule({
                 alternative: renamedIcon.alternative,
                 localName: specifier.local.name ?? importedName,
                 alternativeProps: renamedIcon.alternativeProps,
+                deprecation: renamedIcon.deprecation,
               });
             }
           });
@@ -203,8 +219,9 @@ export const noDeprecatedIcons = createRule({
       JSXIdentifier(node) {
         // Check if the JSX element matches the tracked icon
         for (const value of Array.from(trackedImports.values()).flat()) {
-          const { key, alternative, localName, alternativeProps } = value;
-          if (node.name === key || node.name === localName) {
+          const { key, alternative, localName, alternativeProps, specifier } =
+            value;
+          if (referencesImportBinding(node, specifier, localName, sourceCode)) {
             trackedUsages.push({
               key,
               node,
@@ -253,55 +270,139 @@ export const noDeprecatedIcons = createRule({
         }
         for (const [_, imports] of trackedImports) {
           // Report each tracked import
-          imports.forEach(({ key, node, alternative, specifier }) => {
-            context.report({
-              node,
-              data: {
-                name: key,
-                alternative,
-              },
-              messageId: 'deprecated',
-              fix(fixer) {
-                return fixer.replaceText(specifier?.imported, alternative);
-              },
-            });
-          });
+          imports.forEach(
+            ({ key, node, alternative, deprecation, specifier }) => {
+              if (!alternative) {
+                context.report({
+                  node,
+                  data: {
+                    name: key,
+                    deprecation,
+                  },
+                  messageId: 'deprecated',
+                });
+              } else {
+                const hasMultipleAlternatives =
+                  alternative?.length && alternative.length > 1;
+                const alternativeName = formatAlternativeText(alternative);
+                context.report({
+                  node,
+                  data: {
+                    name: key,
+                    alternative: alternativeName,
+                  },
+                  suggest: hasMultipleAlternatives
+                    ? alternative.map((alt) => ({
+                        messageId: 'deprecatedWithSuggestion',
+                        data: {
+                          name: key,
+                          alternative: alt,
+                        },
+                        fix(fixer) {
+                          return fixer.replaceText(specifier?.imported, alt);
+                        },
+                      }))
+                    : undefined,
+                  messageId: hasMultipleAlternatives
+                    ? 'deprecatedWithSuggestion'
+                    : 'deprecatedWithAlternative',
+                  fix: hasMultipleAlternatives
+                    ? undefined
+                    : (fixer) =>
+                        fixer.replaceText(specifier?.imported, alternativeName),
+                });
+              }
+            },
+          );
         }
 
         // replace icons and add potential props
         trackedUsages.forEach(
           ({ node, key, alternative, localName, alternativeProps, kind }) => {
+            if (!alternative) {
+              return;
+            }
+            const hasMultipleAlternatives =
+              alternative?.length && alternative.length > 1;
+            const alternativeName = formatAlternativeText(alternative);
             context.report({
               node,
               data: {
                 name: key,
-                alternative,
+                alternative: alternativeName,
               },
-              messageId: 'deprecated',
-              fix(fixer) {
-                const fixes =
-                  localName === key
-                    ? [
-                        fixer.replaceText(
-                          node,
-                          sourceCode.getText(node).replace(key, alternative),
-                        ),
-                      ]
-                    : [];
+              messageId: 'deprecatedWithAlternative',
+              suggest: hasMultipleAlternatives
+                ? alternative.map((alt) => ({
+                    messageId: 'deprecatedWithSuggestion',
+                    data: {
+                      name: key,
+                      alternative: alt,
+                    },
+                    fix(fixer) {
+                      const fixes =
+                        localName === key
+                          ? [
+                              fixer.replaceText(
+                                node,
+                                sourceCode.getText(node).replace(key, alt),
+                              ),
+                            ]
+                          : [];
 
-                // insert alternative props for JSX usages only
-                if (kind === 'jsx' && alternativeProps && node.parent?.type === TSESTree.AST_NODE_TYPES.JSXOpeningElement) {
-                  fixes.push(
-                    fixer.insertTextAfter(
-                      node,
-                      ` ${Object.entries(alternativeProps)
-                        .map(([name, value]) => `${name}="${value}"`)
-                        .join(' ')}`,
-                    ),
-                  );
-                }
-                return fixes;
-              },
+                      // insert alternative props for JSX usages only
+                      if (
+                        kind === 'jsx' &&
+                        alternativeProps &&
+                        node.parent?.type ===
+                          TSESTree.AST_NODE_TYPES.JSXOpeningElement
+                      ) {
+                        fixes.push(
+                          fixer.insertTextAfter(
+                            node,
+                            ` ${Object.entries(alternativeProps)
+                              .map(([name, value]) => `${name}="${value}"`)
+                              .join(' ')}`,
+                          ),
+                        );
+                      }
+                      return fixes;
+                    },
+                  }))
+                : undefined,
+              fix: hasMultipleAlternatives
+                ? undefined
+                : (fixer) => {
+                    const fixes =
+                      localName === key
+                        ? [
+                            fixer.replaceText(
+                              node,
+                              sourceCode
+                                .getText(node)
+                                .replace(key, alternativeName),
+                            ),
+                          ]
+                        : [];
+
+                    // insert alternative props for JSX usages only
+                    if (
+                      kind === 'jsx' &&
+                      alternativeProps &&
+                      node.parent?.type ===
+                        TSESTree.AST_NODE_TYPES.JSXOpeningElement
+                    ) {
+                      fixes.push(
+                        fixer.insertTextAfter(
+                          node,
+                          ` ${Object.entries(alternativeProps)
+                            .map(([name, value]) => `${name}="${value}"`)
+                            .join(' ')}`,
+                        ),
+                      );
+                    }
+                    return fixes;
+                  },
             });
           },
         );

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.ts
@@ -290,7 +290,7 @@ export const noDeprecatedIcons = createRule({
                     : [];
 
                 // insert alternative props for JSX usages only
-                if (kind === 'jsx' && alternativeProps) {
+                if (kind === 'jsx' && alternativeProps && node.parent?.type === TSESTree.AST_NODE_TYPES.JSXOpeningElement) {
                   fixes.push(
                     fixer.insertTextAfter(
                       node,

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.ts
@@ -1,0 +1,234 @@
+import { ESLintUtils, type TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { RuleDocs } from '../utils/meta.js';
+import iconsManifest from '@sumup-oss/icons/manifest.json' with {
+  type: 'json',
+};
+
+function getIconReactName(name: string): string {
+  // Split on non-word characters
+  const words = name.split(/[^a-z0-9]/i);
+  // Uppercase the first letter and lowercase the rest
+  const pascalCased = words.map(
+    (part) => part.charAt(0).toUpperCase() + part.substring(1).toLowerCase(),
+  );
+  return pascalCased.join('');
+}
+
+const createRule = ESLintUtils.RuleCreator<RuleDocs>(
+  (name) =>
+    `https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/${name}`,
+);
+
+type TrackedImport = {
+  key: string;
+  node: TSESTree.Node;
+  specifier: TSESTree.ImportSpecifier;
+  alternative: string;
+  localName: string;
+  alternativeProps?: Record<string, string>;
+};
+
+type TrackedUsage = {
+  key: string;
+  node: TSESTree.Node;
+  alternative: string;
+  localName: string;
+  alternativeProps?: Record<string, string>;
+  kind: 'jsx' | 'expression';
+};
+
+function referencesImportBinding(
+  node: TSESTree.Identifier,
+  specifier: TSESTree.ImportSpecifier,
+  localName: string,
+  sourceCode: Readonly<TSESLint.SourceCode>,
+): boolean {
+  if (node.name !== localName) {
+    return false;
+  }
+
+  const variables = sourceCode.getDeclaredVariables(specifier);
+  const binding = variables.find((variable) => variable.name === localName);
+
+  return (
+    binding?.references.some((reference) => reference.identifier === node) ??
+    false
+  );
+}
+
+const icons = iconsManifest.icons
+  .filter(
+    ({ deprecation, alternative }) =>
+      Boolean(deprecation) && Boolean(alternative),
+  )
+  .map(({ name, ...rest }) => ({
+    name: getIconReactName(name),
+    ...rest,
+  })) as {
+  name: string;
+  alternative: string;
+  alternativeProps?: Record<string, string>;
+}[];
+
+export const noDeprecatedIcons = createRule({
+  name: 'no-deprecated-icons',
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [],
+    docs: {
+      description: 'Deprecated icons should be removed or replaced',
+      recommended: 'warn',
+    },
+    messages: {
+      deprecated:
+        'The {{name}} icon has been deprecated. Use the {{alternative}} icon instead',
+    },
+  },
+  create(context) {
+    const trackedImports = new Map<TSESTree.Node, TrackedImport[]>(); // Track imported icons and their sources.
+    const trackedUsages: TrackedUsage[] = [];
+    const { sourceCode } = context;
+
+    return {
+      ImportDeclaration(node) {
+        //check source
+        if (node.source.value === '@sumup-oss/icons') {
+          node.specifiers.forEach((specifier) => {
+            if (specifier.type === TSESTree.AST_NODE_TYPES.ImportSpecifier) {
+              const importedName =
+                specifier.imported.type === TSESTree.AST_NODE_TYPES.Identifier
+                  ? specifier.imported.name
+                  : specifier.imported.value;
+              const renamedIcon = icons.find(
+                (icon) => icon.name === importedName,
+              );
+              if (!renamedIcon) {
+                return;
+              }
+
+              // group imports by node
+              if (!trackedImports.has(node)) {
+                trackedImports.set(node, []);
+              }
+              trackedImports.get(node)!.push({
+                node,
+                specifier,
+                key: renamedIcon.name,
+                alternative: renamedIcon.alternative,
+                localName: specifier.local.name ?? importedName,
+                alternativeProps: renamedIcon.alternativeProps,
+              });
+            }
+          });
+        }
+      },
+      JSXIdentifier(node) {
+        // Check if the JSX element matches the tracked icon
+        for (const value of Array.from(trackedImports.values()).flat()) {
+          const { key, alternative, localName, alternativeProps } = value;
+          if (node.name === key || node.name === localName) {
+            trackedUsages.push({
+              key,
+              node,
+              alternative,
+              localName,
+              alternativeProps,
+              kind: 'jsx',
+            });
+          }
+        }
+      },
+      Identifier(node) {
+        if (
+          node.parent?.type === TSESTree.AST_NODE_TYPES.ImportSpecifier ||
+          (node.parent?.type === TSESTree.AST_NODE_TYPES.MemberExpression &&
+            node.parent.property === node &&
+            !node.parent.computed) ||
+          (node.parent?.type === TSESTree.AST_NODE_TYPES.Property &&
+            node.parent.key === node &&
+            !node.parent.method &&
+            !node.parent.shorthand &&
+            node.parent.value !== node)
+        ) {
+          return;
+        }
+
+        for (const value of Array.from(trackedImports.values()).flat()) {
+          const { key, alternative, localName, alternativeProps, specifier } =
+            value;
+
+          if (referencesImportBinding(node, specifier, localName, sourceCode)) {
+            trackedUsages.push({
+              key,
+              node,
+              alternative,
+              localName,
+              alternativeProps,
+              kind: 'expression',
+            });
+          }
+        }
+      },
+      'Program:exit': () => {
+        if (trackedImports.size === 0) {
+          return;
+        }
+        for (const [_, imports] of trackedImports) {
+          // Report each tracked import
+          imports.forEach(({ key, node, alternative, specifier }) => {
+            context.report({
+              node,
+              data: {
+                name: key,
+                alternative,
+              },
+              messageId: 'deprecated',
+              fix(fixer) {
+                return fixer.replaceText(specifier?.imported, alternative);
+              },
+            });
+          });
+        }
+
+        // replace icons and add potential props
+        trackedUsages.forEach(
+          ({ node, key, alternative, localName, alternativeProps, kind }) => {
+            context.report({
+              node,
+              data: {
+                name: key,
+                alternative,
+              },
+              messageId: 'deprecated',
+              fix(fixer) {
+                const fixes =
+                  localName === key
+                    ? [
+                        fixer.replaceText(
+                          node,
+                          sourceCode.getText(node).replace(key, alternative),
+                        ),
+                      ]
+                    : [];
+
+                // insert alternative props for JSX usages only
+                if (kind === 'jsx' && alternativeProps) {
+                  fixes.push(
+                    fixer.insertTextAfter(
+                      node,
+                      ` ${Object.entries(alternativeProps)
+                        .map(([name, value]) => `${name}="${value}"`)
+                        .join(' ')}`,
+                    ),
+                  );
+                }
+                return fixes;
+              },
+            });
+          },
+        );
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-icons/index.ts
@@ -1,8 +1,91 @@
 import { ESLintUtils, type TSESLint, TSESTree } from '@typescript-eslint/utils';
 import type { RuleDocs } from '../utils/meta.js';
-import iconsManifest from '@sumup-oss/icons/manifest.json' with {
-  type: 'json',
-};
+
+import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+type DeprecatedIcon = {
+  name: string;
+  deprecation: string;
+  alternative: string;
+  alternativeProps?: Record<string, string>;
+}
+
+const ICONS_PACKAGE = '@sumup-oss/icons';
+
+const iconsCache = new Map<string, DeprecatedIcon[]>();
+
+function findPackageRoot(startDir: string): string {
+  let dir = startDir;
+
+  while (dir !== path.dirname(dir)) {
+    if (existsSync(path.join(dir, 'package.json'))) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+  }
+
+  return startDir;
+}
+
+function getProjectRoot(cwd: string, filename?: string): string {
+  return findPackageRoot(filename ? path.dirname(filename) : cwd);
+}
+
+function hasDeclaredDependency(
+  projectRoot: string,
+): boolean {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(path.join(projectRoot, 'package.json'), 'utf8'),
+    ) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    };
+
+    return [
+      pkg.dependencies,
+      pkg.devDependencies,
+      pkg.peerDependencies,
+      pkg.optionalDependencies,
+    ].some((deps) => deps && ICONS_PACKAGE in deps);
+  } catch {
+    return false;
+  }
+}
+
+function getDeprecatedIcons(projectRoot: string): DeprecatedIcon[] {
+  if (iconsCache.has(projectRoot)) {
+    return iconsCache.get(projectRoot)!;
+  }
+
+  if (!hasDeclaredDependency(projectRoot)) {
+    iconsCache.set(projectRoot, []);
+    return [];
+  }
+
+  try {
+    const require = createRequire(path.join(projectRoot, 'package.json'));
+    // eslint-disable-next-line import-x/no-dynamic-require
+    const manifest = require(`${ICONS_PACKAGE}/manifest.json`) as {
+      icons: DeprecatedIcon[];
+    };
+    const icons = manifest.icons
+      .filter(({ deprecation, alternative }) => Boolean(deprecation) && Boolean(alternative))
+      .map(({ name, ...rest }) => ({
+        name: getIconReactName(name),
+        ...rest,
+      }));
+    iconsCache.set(projectRoot, icons);
+    return icons;
+  } catch {
+    iconsCache.set(projectRoot, []);
+    return [];
+  }
+}
 
 function getIconReactName(name: string): string {
   // Split on non-word characters
@@ -56,20 +139,6 @@ function referencesImportBinding(
   );
 }
 
-const icons = iconsManifest.icons
-  .filter(
-    ({ deprecation, alternative }) =>
-      Boolean(deprecation) && Boolean(alternative),
-  )
-  .map(({ name, ...rest }) => ({
-    name: getIconReactName(name),
-    ...rest,
-  })) as {
-  name: string;
-  alternative: string;
-  alternativeProps?: Record<string, string>;
-}[];
-
 export const noDeprecatedIcons = createRule({
   name: 'no-deprecated-icons',
   meta: {
@@ -86,6 +155,14 @@ export const noDeprecatedIcons = createRule({
     },
   },
   create(context) {
+    const projectRoot = getProjectRoot(context.cwd, context.filename);
+    const icons = getDeprecatedIcons(projectRoot);
+
+    // skip if the current project does not depend on the icons package
+    if (icons.length === 0) {
+      return {};
+    }
+
     const trackedImports = new Map<TSESTree.Node, TrackedImport[]>(); // Track imported icons and their sources.
     const trackedUsages: TrackedUsage[] = [];
     const { sourceCode } = context;

--- a/packages/eslint-plugin-circuit-ui/package.json
+++ b/packages/eslint-plugin-circuit-ui/package.json
@@ -44,12 +44,6 @@
   },
   "peerDependencies": {
     "@sumup-oss/circuit-ui": ">=10.0.0",
-    "@sumup-oss/design-tokens": ">=9.0.0",
-    "@sumup-oss/icons": ">=6.8.0"
-  },
-  "peerDependenciesMeta": {
-    "@sumup-oss/icons": {
-      "optional": true
-    }
+    "@sumup-oss/design-tokens": ">=9.0.0"
   }
 }

--- a/packages/eslint-plugin-circuit-ui/package.json
+++ b/packages/eslint-plugin-circuit-ui/package.json
@@ -44,6 +44,7 @@
   },
   "peerDependencies": {
     "@sumup-oss/circuit-ui": ">=10.0.0",
-    "@sumup-oss/design-tokens": ">=9.0.0"
+    "@sumup-oss/design-tokens": ">=9.0.0",
+    "@sumup-oss/icons": ">=6.8.0"
   }
 }

--- a/packages/eslint-plugin-circuit-ui/package.json
+++ b/packages/eslint-plugin-circuit-ui/package.json
@@ -46,5 +46,10 @@
     "@sumup-oss/circuit-ui": ">=10.0.0",
     "@sumup-oss/design-tokens": ">=9.0.0",
     "@sumup-oss/icons": ">=6.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@sumup-oss/icons": {
+      "optional": true
+    }
   }
 }

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -19,7 +19,7 @@
       "name": "add_items",
       "category": "Action",
       "size": "24",
-      "alternative": "Add",
+      "alternative": ["Add", "Items"],
       "deprecation": "Use the `Add` or `Items` icons instead."
     },
     {
@@ -81,7 +81,7 @@
       "name": "copy",
       "category": "Action",
       "size": "24",
-      "alternative": "CopyPaste",
+      "alternative": ["CopyPaste"],
       "deprecation": "Use the `CopyPaste` icon instead."
     },
     {
@@ -438,19 +438,19 @@
       "name": "sum_up_logo",
       "category": "Brand",
       "size": "24",
-      "deprecation": "Use the `SumUpLogo` component instead."
+      "deprecation": "Use the SumUpLogo component from '@sumup-oss/circuit-ui' instead."
     },
     {
       "name": "sum_up_logomark",
       "category": "Brand",
       "size": "24",
-      "deprecation": "Use the `SumUpLogo` component's 'short' variant instead."
+      "deprecation": "Use the SumUpLogo component from '@sumup-oss/circuit-ui' in its 'short' variant instead."
     },
     {
       "name": "sum_up_logomark",
       "category": "Brand",
       "size": "32",
-      "deprecation": "Use the `SumUpLogo` component's 'short' variant instead."
+      "deprecation": "Use the SumUpLogo component from '@sumup-oss/circuit-ui' in its 'short' variant instead."
     },
     {
       "name": "plus_tier",
@@ -486,7 +486,7 @@
       "name": "apm",
       "category": "Card scheme",
       "size": "32",
-      "alternative": "AlternativePaymentMethod",
+      "alternative": ["AlternativePaymentMethod"],
       "deprecation": "Use the `AlternativePaymentMethod` icon instead."
     },
     {
@@ -673,7 +673,7 @@
       "name": "email_chat",
       "category": "Communication",
       "size": "24",
-      "alternative": "Email",
+      "alternative": ["Email"],
       "deprecation": "Use the `Email` icon instead."
     },
     {
@@ -690,7 +690,7 @@
       "name": "phone_chat",
       "category": "Communication",
       "size": "24",
-      "alternative": "Phone",
+      "alternative": ["Phone"],
       "deprecation": "Use the `Phone` icon instead."
     },
     {
@@ -698,7 +698,7 @@
       "category": "Country flag",
       "keywords": ["United Arab Emirates"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "AE",
         "width": "16"
@@ -710,7 +710,7 @@
       "category": "Country flag",
       "keywords": ["Argentina"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "AR",
         "width": "16"
@@ -722,7 +722,7 @@
       "category": "Country flag",
       "keywords": ["Austria"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "AT",
         "width": "16"
@@ -734,7 +734,7 @@
       "category": "Country flag",
       "keywords": ["Australia"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "AU",
         "width": "16"
@@ -746,7 +746,7 @@
       "category": "Country flag",
       "keywords": ["Belgium"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "BE",
         "width": "16"
@@ -758,7 +758,7 @@
       "category": "Country flag",
       "keywords": ["Bulgaria"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "BG",
         "width": "16"
@@ -770,7 +770,7 @@
       "category": "Country flag",
       "keywords": ["Brazil"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "BR",
         "width": "16"
@@ -782,7 +782,7 @@
       "category": "Country flag",
       "keywords": ["Canada"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "CA",
         "width": "16"
@@ -794,7 +794,7 @@
       "category": "Country flag",
       "keywords": ["Switzerland"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "CH",
         "width": "16"
@@ -806,7 +806,7 @@
       "category": "Country flag",
       "keywords": ["Chile"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "CL",
         "width": "16"
@@ -818,7 +818,7 @@
       "category": "Country flag",
       "keywords": ["Colombia"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "CO",
         "width": "16"
@@ -830,7 +830,7 @@
       "category": "Country flag",
       "keywords": ["Cypress"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "CY",
         "width": "16"
@@ -842,7 +842,7 @@
       "category": "Country flag",
       "keywords": ["Czech Republic"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "CZ",
         "width": "16"
@@ -854,7 +854,7 @@
       "category": "Country flag",
       "keywords": ["Germany"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "DE",
         "width": "16"
@@ -866,7 +866,7 @@
       "category": "Country flag",
       "keywords": ["Denmark"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "DK",
         "width": "16"
@@ -878,7 +878,7 @@
       "category": "Country flag",
       "keywords": ["Estonia"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "EE",
         "width": "16"
@@ -890,7 +890,7 @@
       "category": "Country flag",
       "keywords": ["Spain"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "ES",
         "width": "16"
@@ -902,7 +902,7 @@
       "category": "Country flag",
       "keywords": ["Finland"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "FI",
         "width": "16"
@@ -914,7 +914,7 @@
       "category": "Country flag",
       "keywords": ["France"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "FR",
         "width": "16"
@@ -926,7 +926,7 @@
       "category": "Country flag",
       "keywords": ["Great Britain", "United Kingdom", "UK", "England"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "GB",
         "width": "16"
@@ -938,7 +938,7 @@
       "category": "Country flag",
       "keywords": ["Greece"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "GR",
         "width": "16"
@@ -950,7 +950,7 @@
       "category": "Country flag",
       "keywords": ["Hong Kong"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "HK",
         "width": "16"
@@ -962,7 +962,7 @@
       "category": "Country flag",
       "keywords": ["Croatia"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "HR",
         "width": "16"
@@ -974,7 +974,7 @@
       "category": "Country flag",
       "keywords": ["Hungary"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "HU",
         "width": "16"
@@ -986,7 +986,7 @@
       "category": "Country flag",
       "keywords": ["Ireland"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "IE",
         "width": "16"
@@ -998,7 +998,7 @@
       "category": "Country flag",
       "keywords": ["Italy"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "IT",
         "width": "16"
@@ -1010,7 +1010,7 @@
       "category": "Country flag",
       "keywords": ["Japan"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "JP",
         "width": "16"
@@ -1022,7 +1022,7 @@
       "category": "Country flag",
       "keywords": ["Japan"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "JP",
         "width": "16"
@@ -1034,7 +1034,7 @@
       "category": "Country flag",
       "keywords": ["Lithuania"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "LT",
         "width": "16"
@@ -1046,7 +1046,7 @@
       "category": "Country flag",
       "keywords": ["Luxembourg"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "LU",
         "width": "16"
@@ -1058,7 +1058,7 @@
       "category": "Country flag",
       "keywords": ["Latvia"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "LV",
         "width": "16"
@@ -1070,7 +1070,7 @@
       "category": "Country flag",
       "keywords": ["Montenegro"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "MT",
         "width": "16"
@@ -1082,7 +1082,7 @@
       "category": "Country flag",
       "keywords": ["Mexico"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "MX",
         "width": "16"
@@ -1094,7 +1094,7 @@
       "category": "Country flag",
       "keywords": ["Malaysia"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "MY",
         "width": "16"
@@ -1106,7 +1106,7 @@
       "category": "Country flag",
       "keywords": ["Netherlands"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "NL",
         "width": "16"
@@ -1118,7 +1118,7 @@
       "category": "Country flag",
       "keywords": ["Norway"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "NO",
         "width": "16"
@@ -1130,7 +1130,7 @@
       "category": "Country flag",
       "keywords": ["New Zeland"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "NZ",
         "width": "16"
@@ -1142,7 +1142,7 @@
       "category": "Country flag",
       "keywords": ["Peru"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "PE",
         "width": "16"
@@ -1154,7 +1154,7 @@
       "category": "Country flag",
       "keywords": ["Poland"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "PL",
         "width": "16"
@@ -1166,7 +1166,7 @@
       "category": "Country flag",
       "keywords": ["Portugal"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "PT",
         "width": "16"
@@ -1178,7 +1178,7 @@
       "category": "Country flag",
       "keywords": ["Romania"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "RO",
         "width": "16"
@@ -1190,7 +1190,7 @@
       "category": "Country flag",
       "keywords": ["Sweden"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "SE",
         "width": "16"
@@ -1202,7 +1202,7 @@
       "category": "Country flag",
       "keywords": ["Singapore"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "SG",
         "width": "16"
@@ -1214,7 +1214,7 @@
       "category": "Country flag",
       "keywords": ["Slovenia"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "SI",
         "width": "16"
@@ -1226,7 +1226,7 @@
       "category": "Country flag",
       "keywords": ["Slovakia"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "SK",
         "width": "16"
@@ -1238,7 +1238,7 @@
       "category": "Country flag",
       "keywords": ["United States of America", "USA"],
       "size": "16",
-      "alternative": "Flag",
+      "alternative": ["Flag"],
       "alternativeProps": {
         "countryCode": "US",
         "width": "16"
@@ -3091,7 +3091,7 @@
       "name": "mobile_phone",
       "category": "Device",
       "size": "24",
-      "alternative": "Mobile",
+      "alternative": ["Mobile"],
       "deprecation": "Use the 'Mobile' icon instead."
     },
     {
@@ -3400,7 +3400,7 @@
       "name": "color_correction",
       "category": "Miscellaneous",
       "size": "24",
-      "alternative": "ColorPicker",
+      "alternative": ["ColorPicker"],
       "deprecation": "Use the `ColorPicker` icon instead."
     },
     {
@@ -3428,7 +3428,7 @@
       "name": "cookie_preferences",
       "category": "Miscellaneous",
       "size": "24",
-      "alternative": "Cookie",
+      "alternative": ["Cookie"],
       "deprecation": "Use the `Cookie` icon instead."
     },
     {
@@ -3440,7 +3440,7 @@
       "name": "customize",
       "category": "Miscellaneous",
       "size": "24",
-      "alternative": "Customise",
+      "alternative": ["Customise"],
       "deprecation": "Use the `Customise` icon instead."
     },
     {
@@ -3452,7 +3452,7 @@
       "name": "favorite",
       "category": "Miscellaneous",
       "size": "24",
-      "alternative": "Favourite",
+      "alternative": ["Favourite"],
       "deprecation": "Use the `Favourite` icon instead."
     },
     {
@@ -3464,7 +3464,7 @@
       "name": "favorite",
       "category": "Miscellaneous",
       "size": "16",
-      "alternative": "Favourite",
+      "alternative": ["Favourite"],
       "deprecation": "Use the `Favourite` icon instead."
     },
     {
@@ -3561,7 +3561,7 @@
       "name": "no_sim",
       "category": "Miscellaneous",
       "size": "24",
-      "alternative": "NoSimcard",
+      "alternative": ["NoSimcard"],
       "deprecation": "Use the `NoSimcard` icon instead."
     },
     {
@@ -3608,7 +3608,7 @@
       "name": "print_failed",
       "category": "Miscellaneous",
       "size": "24",
-      "alternative": "PrinterFailed",
+      "alternative": ["PrinterFailed"],
       "deprecation": "Use the `PrinterFailed` icon instead."
     },
     {
@@ -3620,7 +3620,7 @@
       "name": "print_failed",
       "category": "Miscellaneous",
       "size": "16",
-      "alternative": "PrinterFailed",
+      "alternative": ["PrinterFailed"],
       "deprecation": "Use the `PrinterFailed` icon instead."
     },
     {
@@ -3729,7 +3729,7 @@
       "name": "unfavorite",
       "category": "Miscellaneous",
       "size": "24",
-      "alternative": "Unfavourite",
+      "alternative": ["Unfavourite"],
       "deprecation": "Use the `Unfavourite` icon instead."
     },
     {
@@ -3746,7 +3746,7 @@
       "name": "contractors",
       "category": "Miscellaneous",
       "size": "16",
-      "alternative": "Contractor",
+      "alternative": ["Contractor"],
       "deprecation": "Use the `Contractor` icon instead."
     },
     {
@@ -3758,7 +3758,7 @@
       "name": "contractors",
       "category": "Miscellaneous",
       "size": "24",
-      "alternative": "Contractor",
+      "alternative": ["Contractor"],
       "deprecation": "Use the `Contractor` icon instead."
     },
     {
@@ -3933,14 +3933,14 @@
       "name": "notify_circle",
       "category": "Notification",
       "size": "24",
-      "alternative": "Notify",
+      "alternative": ["Notify"],
       "deprecation": "Use the `Notify` icon instead."
     },
     {
       "name": "notify_circle",
       "category": "Notification",
       "size": "16",
-      "alternative": "Notify",
+      "alternative": ["Notify"],
       "deprecation": "Use the `Notify` icon instead."
     },
     {
@@ -4326,7 +4326,7 @@
     {
       "name": "general_settings",
       "category": "Product and feature",
-      "alternative": "Settings",
+      "alternative": ["Settings"],
       "deprecation": "Use the `Settings` icon instead.",
       "size": "24"
     },
@@ -4334,7 +4334,7 @@
       "name": "gift_card",
       "category": "Product and feature",
       "size": "24",
-      "alternative": "GiftCards",
+      "alternative": ["GiftCards"],
       "deprecation": "Use the `GiftCards` icon instead."
     },
     {
@@ -4484,7 +4484,7 @@
       "name": "payment_link",
       "category": "Product and feature",
       "size": "24",
-      "alternative": "PaymentLinks",
+      "alternative": ["PaymentLinks"],
       "deprecation": "Use the `PaymentLinks` icon instead."
     },
     {
@@ -4603,7 +4603,7 @@
       "name": "refer",
       "category": "Product and feature",
       "size": "24",
-      "alternative": "ReferAFriend",
+      "alternative": ["ReferAFriend", "Reward"],
       "deprecation": "Use the `ReferAFriend` or `Reward` icons instead."
     },
     {
@@ -4632,7 +4632,7 @@
       "name": "sales",
       "category": "Product and feature",
       "size": "24",
-      "alternative": "Receipt",
+      "alternative": ["Receipt"],
       "deprecation": "Use the `Receipt` icon instead."
     },
     {
@@ -4750,7 +4750,7 @@
       "name": "messenger",
       "category": "Social media",
       "size": "24",
-      "alternative": "FacebookMessenger",
+      "alternative": ["FacebookMessenger"],
       "deprecation": "Use the `FacebookMessenger` icon instead."
     },
     {

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -19,6 +19,7 @@
       "name": "add_items",
       "category": "Action",
       "size": "24",
+      "alternative": "Add",
       "deprecation": "Use the `Add` or `Items` icons instead."
     },
     {
@@ -80,6 +81,7 @@
       "name": "copy",
       "category": "Action",
       "size": "24",
+      "alternative": "CopyPaste",
       "deprecation": "Use the `CopyPaste` icon instead."
     },
     {
@@ -484,6 +486,7 @@
       "name": "apm",
       "category": "Card scheme",
       "size": "32",
+      "alternative": "AlternativePaymentMethod",
       "deprecation": "Use the `AlternativePaymentMethod` icon instead."
     },
     {
@@ -670,6 +673,7 @@
       "name": "email_chat",
       "category": "Communication",
       "size": "24",
+      "alternative": "Email",
       "deprecation": "Use the `Email` icon instead."
     },
     {
@@ -686,6 +690,7 @@
       "name": "phone_chat",
       "category": "Communication",
       "size": "24",
+      "alternative": "Phone",
       "deprecation": "Use the `Phone` icon instead."
     },
     {
@@ -693,6 +698,11 @@
       "category": "Country flag",
       "keywords": ["United Arab Emirates"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "AE",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -700,6 +710,11 @@
       "category": "Country flag",
       "keywords": ["Argentina"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "AR",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -707,6 +722,11 @@
       "category": "Country flag",
       "keywords": ["Austria"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "AT",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -714,6 +734,11 @@
       "category": "Country flag",
       "keywords": ["Australia"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "AU",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -721,6 +746,11 @@
       "category": "Country flag",
       "keywords": ["Belgium"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "BE",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -728,6 +758,11 @@
       "category": "Country flag",
       "keywords": ["Bulgaria"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "BG",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -735,6 +770,11 @@
       "category": "Country flag",
       "keywords": ["Brazil"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "BR",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -742,6 +782,11 @@
       "category": "Country flag",
       "keywords": ["Canada"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "CA",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -749,6 +794,11 @@
       "category": "Country flag",
       "keywords": ["Switzerland"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "CH",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -756,6 +806,11 @@
       "category": "Country flag",
       "keywords": ["Chile"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "CL",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -763,6 +818,11 @@
       "category": "Country flag",
       "keywords": ["Colombia"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "CO",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -770,6 +830,11 @@
       "category": "Country flag",
       "keywords": ["Cypress"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "CY",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -777,6 +842,11 @@
       "category": "Country flag",
       "keywords": ["Czech Republic"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "CZ",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -784,6 +854,11 @@
       "category": "Country flag",
       "keywords": ["Germany"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "DE",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -791,6 +866,11 @@
       "category": "Country flag",
       "keywords": ["Denmark"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "DK",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -798,6 +878,11 @@
       "category": "Country flag",
       "keywords": ["Estonia"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "EE",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -805,6 +890,11 @@
       "category": "Country flag",
       "keywords": ["Spain"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "ES",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -812,6 +902,11 @@
       "category": "Country flag",
       "keywords": ["Finland"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "FI",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -819,6 +914,11 @@
       "category": "Country flag",
       "keywords": ["France"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "FR",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -826,6 +926,11 @@
       "category": "Country flag",
       "keywords": ["Great Britain", "United Kingdom", "UK", "England"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "GB",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -833,6 +938,11 @@
       "category": "Country flag",
       "keywords": ["Greece"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "GR",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -840,6 +950,11 @@
       "category": "Country flag",
       "keywords": ["Hong Kong"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "HK",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -847,6 +962,11 @@
       "category": "Country flag",
       "keywords": ["Croatia"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "HR",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -854,6 +974,11 @@
       "category": "Country flag",
       "keywords": ["Hungary"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "HU",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -861,6 +986,11 @@
       "category": "Country flag",
       "keywords": ["Ireland"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "IE",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -868,6 +998,11 @@
       "category": "Country flag",
       "keywords": ["Italy"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "IT",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -875,6 +1010,11 @@
       "category": "Country flag",
       "keywords": ["Japan"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "JP",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -882,6 +1022,11 @@
       "category": "Country flag",
       "keywords": ["Japan"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "JP",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -889,6 +1034,11 @@
       "category": "Country flag",
       "keywords": ["Lithuania"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "LT",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -896,6 +1046,11 @@
       "category": "Country flag",
       "keywords": ["Luxembourg"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "LU",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -903,6 +1058,11 @@
       "category": "Country flag",
       "keywords": ["Latvia"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "LV",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -910,6 +1070,11 @@
       "category": "Country flag",
       "keywords": ["Montenegro"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "MT",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -917,6 +1082,11 @@
       "category": "Country flag",
       "keywords": ["Mexico"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "MX",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -924,6 +1094,11 @@
       "category": "Country flag",
       "keywords": ["Malaysia"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "MY",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -931,6 +1106,11 @@
       "category": "Country flag",
       "keywords": ["Netherlands"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "NL",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -938,6 +1118,11 @@
       "category": "Country flag",
       "keywords": ["Norway"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "NO",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -945,6 +1130,11 @@
       "category": "Country flag",
       "keywords": ["New Zeland"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "NZ",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -952,6 +1142,11 @@
       "category": "Country flag",
       "keywords": ["Peru"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "PE",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -959,6 +1154,11 @@
       "category": "Country flag",
       "keywords": ["Poland"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "PL",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -966,6 +1166,11 @@
       "category": "Country flag",
       "keywords": ["Portugal"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "PT",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -973,6 +1178,11 @@
       "category": "Country flag",
       "keywords": ["Romania"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "RO",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -980,6 +1190,11 @@
       "category": "Country flag",
       "keywords": ["Sweden"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "SE",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -987,6 +1202,11 @@
       "category": "Country flag",
       "keywords": ["Singapore"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "SG",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -994,6 +1214,11 @@
       "category": "Country flag",
       "keywords": ["Slovenia"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "SI",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -1001,6 +1226,11 @@
       "category": "Country flag",
       "keywords": ["Slovakia"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "SK",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
     {
@@ -1008,6 +1238,11 @@
       "category": "Country flag",
       "keywords": ["United States of America", "USA"],
       "size": "16",
+      "alternative": "Flag",
+      "alternativeProps": {
+        "countryCode": "US",
+        "width": "16"
+      },
       "deprecation": "Use the Flag component instead."
     },
 
@@ -2856,6 +3091,7 @@
       "name": "mobile_phone",
       "category": "Device",
       "size": "24",
+      "alternative": "Mobile",
       "deprecation": "Use the 'Mobile' icon instead."
     },
     {
@@ -3164,6 +3400,7 @@
       "name": "color_correction",
       "category": "Miscellaneous",
       "size": "24",
+      "alternative": "ColorPicker",
       "deprecation": "Use the `ColorPicker` icon instead."
     },
     {
@@ -3191,6 +3428,7 @@
       "name": "cookie_preferences",
       "category": "Miscellaneous",
       "size": "24",
+      "alternative": "Cookie",
       "deprecation": "Use the `Cookie` icon instead."
     },
     {
@@ -3202,6 +3440,7 @@
       "name": "customize",
       "category": "Miscellaneous",
       "size": "24",
+      "alternative": "Customise",
       "deprecation": "Use the `Customise` icon instead."
     },
     {
@@ -3213,6 +3452,7 @@
       "name": "favorite",
       "category": "Miscellaneous",
       "size": "24",
+      "alternative": "Favourite",
       "deprecation": "Use the `Favourite` icon instead."
     },
     {
@@ -3224,6 +3464,7 @@
       "name": "favorite",
       "category": "Miscellaneous",
       "size": "16",
+      "alternative": "Favourite",
       "deprecation": "Use the `Favourite` icon instead."
     },
     {
@@ -3320,6 +3561,7 @@
       "name": "no_sim",
       "category": "Miscellaneous",
       "size": "24",
+      "alternative": "NoSimcard",
       "deprecation": "Use the `NoSimcard` icon instead."
     },
     {
@@ -3366,6 +3608,7 @@
       "name": "print_failed",
       "category": "Miscellaneous",
       "size": "24",
+      "alternative": "PrinterFailed",
       "deprecation": "Use the `PrinterFailed` icon instead."
     },
     {
@@ -3377,6 +3620,7 @@
       "name": "print_failed",
       "category": "Miscellaneous",
       "size": "16",
+      "alternative": "PrinterFailed",
       "deprecation": "Use the `PrinterFailed` icon instead."
     },
     {
@@ -3485,6 +3729,7 @@
       "name": "unfavorite",
       "category": "Miscellaneous",
       "size": "24",
+      "alternative": "Unfavourite",
       "deprecation": "Use the `Unfavourite` icon instead."
     },
     {
@@ -3501,6 +3746,7 @@
       "name": "contractors",
       "category": "Miscellaneous",
       "size": "16",
+      "alternative": "Contractor",
       "deprecation": "Use the `Contractor` icon instead."
     },
     {
@@ -3512,6 +3758,7 @@
       "name": "contractors",
       "category": "Miscellaneous",
       "size": "24",
+      "alternative": "Contractor",
       "deprecation": "Use the `Contractor` icon instead."
     },
     {
@@ -3686,12 +3933,14 @@
       "name": "notify_circle",
       "category": "Notification",
       "size": "24",
+      "alternative": "Notify",
       "deprecation": "Use the `Notify` icon instead."
     },
     {
       "name": "notify_circle",
       "category": "Notification",
       "size": "16",
+      "alternative": "Notify",
       "deprecation": "Use the `Notify` icon instead."
     },
     {
@@ -4077,6 +4326,7 @@
     {
       "name": "general_settings",
       "category": "Product and feature",
+      "alternative": "Settings",
       "deprecation": "Use the `Settings` icon instead.",
       "size": "24"
     },
@@ -4084,6 +4334,7 @@
       "name": "gift_card",
       "category": "Product and feature",
       "size": "24",
+      "alternative": "GiftCards",
       "deprecation": "Use the `GiftCards` icon instead."
     },
     {
@@ -4233,6 +4484,7 @@
       "name": "payment_link",
       "category": "Product and feature",
       "size": "24",
+      "alternative": "PaymentLinks",
       "deprecation": "Use the `PaymentLinks` icon instead."
     },
     {
@@ -4351,6 +4603,7 @@
       "name": "refer",
       "category": "Product and feature",
       "size": "24",
+      "alternative": "ReferAFriend",
       "deprecation": "Use the `ReferAFriend` or `Reward` icons instead."
     },
     {
@@ -4379,6 +4632,7 @@
       "name": "sales",
       "category": "Product and feature",
       "size": "24",
+      "alternative": "Receipt",
       "deprecation": "Use the `Receipt` icon instead."
     },
     {
@@ -4496,6 +4750,7 @@
       "name": "messenger",
       "category": "Social media",
       "size": "24",
+      "alternative": "FacebookMessenger",
       "deprecation": "Use the `FacebookMessenger` icon instead."
     },
     {


### PR DESCRIPTION
Addresses [DSYS-1716](https://sumupteam.atlassian.net/browse/DSYS-1716)

## Purpose

Deprecated icons will be removed in the next major. This PR introduces a new eslint rule to replace them with suggested alternatives.

## Approach and changes

- Add an `alternative` property (and an optional `alternativeProps`  property) to icon manifest declaration for deprecated icons
- Add new eslint rule `no-deprecated-icons` to replace icons based on the `alternative` property

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
