### PR TITLE
[SLP-3524] Add sumup_card icon and update sumup_scheme to pink

### DIFF
--- a/.changeset/five-ducks-count.md
+++ b/.changeset/five-ducks-count.md
@@ -2,4 +2,4 @@
 "@sumup-oss/icons": minor
 ---
 
-Add sumup_card card-scheme icon (SLP-3524)
+Added SumupCard icon in size 32

--- a/.changeset/five-ducks-count.md
+++ b/.changeset/five-ducks-count.md
@@ -2,4 +2,4 @@
 "@sumup-oss/icons": minor
 ---
 
-Add sumup_card card-scheme icon; update sumup_scheme to pink design (SLP-3524)
+Add sumup_card card-scheme icon (SLP-3524)

--- a/.changeset/five-ducks-count.md
+++ b/.changeset/five-ducks-count.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/icons": minor
+---
+
+Add sumup_card card-scheme icon; update sumup_scheme to pink design (SLP-3524)

--- a/.changeset/pink-schemes-smile.md
+++ b/.changeset/pink-schemes-smile.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/icons": patch
+---
+
+Update sumup_scheme card-scheme icon to pink design (SLP-3524)

--- a/.changeset/pink-schemes-smile.md
+++ b/.changeset/pink-schemes-smile.md
@@ -2,4 +2,4 @@
 "@sumup-oss/icons": patch
 ---
 
-Update sumup_scheme card-scheme icon to pink design (SLP-3524)
+Updated the size 32 of the SumupScheme icon to the pink design

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -607,6 +607,21 @@
       "size": "32"
     },
     {
+      "name": "sumup_card",
+      "category": "Card scheme",
+      "size": "32"
+    },
+    {
+      "name": "sumup_pay",
+      "category": "Card scheme",
+      "size": "32"
+    },
+    {
+      "name": "sumup_scheme",
+      "category": "Card scheme",
+      "size": "32"
+    },
+    {
       "name": "swile",
       "category": "Card scheme",
       "size": "32"
@@ -638,21 +653,6 @@
     },
     {
       "name": "vr",
-      "category": "Card scheme",
-      "size": "32"
-    },
-    {
-      "name": "sumup_card",
-      "category": "Card scheme",
-      "size": "32"
-    },
-    {
-      "name": "sumup_pay",
-      "category": "Card scheme",
-      "size": "32"
-    },
-    {
-      "name": "sumup_scheme",
       "category": "Card scheme",
       "size": "32"
     },

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -642,6 +642,11 @@
       "size": "32"
     },
     {
+      "name": "sumup_card",
+      "category": "Card scheme",
+      "size": "32"
+    },
+    {
       "name": "sumup_pay",
       "category": "Card scheme",
       "size": "32"

--- a/packages/icons/web/v2/sumup_card_32.svg
+++ b/packages/icons/web/v2/sumup_card_32.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="24" fill="none" viewBox="0 0 32 24">
+    <g clip-path="url(#sumup_card_32_svg__a)">
+        <rect width="31" height="23" x=".5" y=".5" fill="#ff61f2" stroke="#d0cdc3" rx="3.5"/>
+        <circle cx="24" cy="16" r="4" fill="#f79e1b"/>
+        <circle cx="19" cy="16" r="4" fill="#eb001b"/>
+        <path fill="#ff5f00" d="M21.5 12.878A4 4 0 0 1 23 16a4 4 0 0 1-1.5 3.121A4 4 0 0 1 20 16c0-1.263.586-2.389 1.5-3.122"/>
+    </g>
+    <defs>
+        <clipPath id="sumup_card_32_svg__a">
+            <rect width="32" height="24" fill="#fff" rx="4"/>
+        </clipPath>
+    </defs>
+</svg>

--- a/packages/icons/web/v2/sumup_scheme_32.svg
+++ b/packages/icons/web/v2/sumup_scheme_32.svg
@@ -1,8 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="24" fill="none" viewBox="0 0 32 24">
     <g clip-path="url(#sumup_scheme_32_svg__a)">
-        <rect width="32" height="24" fill="#fff" rx="4"/>
-        <rect width="31" height="23" x=".5" y=".5" fill="#000" stroke="#ccc" rx="3.5"/>
-        <path fill="#fff" d="M11.5 17.507a5.06 5.06 0 0 0 7.18 0 5.11 5.11 0 0 0 0-7.207zm8.808-11.014a5.06 5.06 0 0 0-7.18 0 5.11 5.11 0 0 0 0 7.207z"/>
+        <rect width="31" height="23" x=".5" y=".5" fill="#ff61f2" stroke="#d0cdc3" rx="3.5"/>
+        <path fill="#1e1c1c" d="M11.5 17.507a5.06 5.06 0 0 0 7.18 0 5.11 5.11 0 0 0 0-7.207zm8.808-11.014a5.06 5.06 0 0 0-7.18 0 5.11 5.11 0 0 0 0 7.207z"/>
     </g>
     <defs>
         <clipPath id="sumup_scheme_32_svg__a">


### PR DESCRIPTION
Addresses [SLP-3524](https://sumupteam.atlassian.net/browse/SLP-3524)

## Purpose

Adds `sumup_card` to `@sumup-oss/icons` and updates `sumup_scheme` to the new pink card-scheme asset for SLP-3524

## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
