### PR TITLE
[HotFix] Icon Package

### DIFF
--- a/.changeset/fix-icon-build-case-collision.md
+++ b/.changeset/fix-icon-build-case-collision.md
@@ -1,5 +1,0 @@
----
-"@sumup-oss/icons": patch
----
-
-Fixed a build script bug where two icon component names that differ only in case (`SumUpCard` from `sum_up_card` and `SumupCard` from `sumup_card`) would corrupt each other's generated `.js` file on macOS's case-insensitive filesystem (HFS+/APFS). The build script now detects case-insensitive filename collisions and combines the affected components into a single file, ensuring both exports are available and the generated output is always syntactically valid.

--- a/.changeset/fix-icon-build-case-collision.md
+++ b/.changeset/fix-icon-build-case-collision.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/icons": patch
+---
+
+Fixed a build script bug where two icon component names that differ only in case (`SumUpCard` from `sum_up_card` and `SumupCard` from `sumup_card`) would corrupt each other's generated `.js` file on macOS's case-insensitive filesystem (HFS+/APFS). The build script now detects case-insensitive filename collisions and combines the affected components into a single file, ensuring both exports are available and the generated output is always syntactically valid.

--- a/.changeset/hip-boxes-give.md
+++ b/.changeset/hip-boxes-give.md
@@ -2,4 +2,4 @@
 "@sumup-oss/icons": patch
 ---
 
-Fixed a broken case-insensitive filename collision on icons package `v6.10.0` (`SumupCard.js` vs `SumUpCard.js`) that caused the build to produce only one of the two files, resulting in "Module not found: Can't resolve './SumUpCard.js'" for consumers. Both `SumUpCard` and `SumupCard` continue to work as before.
+Fixed a broken case-insensitive filename collision on icons package `v6.10.0` (`SumupCard.js` vs `SumUpCard.js`) that caused the build to produce only one of the two files, resulting in "Module not found: Can't resolve './SumUpCard.js'" for consumers. Both `SumUpCard` and `SumupCard` can be imported safely.

--- a/.changeset/hip-boxes-give.md
+++ b/.changeset/hip-boxes-give.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/icons": patch
+---
+
+Fixed a broken case-insensitive filename collision on icons package `v6.10.0`  (`SumupCard.js` vs `SumUpCard.js`) that caused the build to produce only one of the two files. 

--- a/.changeset/hip-boxes-give.md
+++ b/.changeset/hip-boxes-give.md
@@ -2,4 +2,4 @@
 "@sumup-oss/icons": patch
 ---
 
-Fixed a broken case-insensitive filename collision on icons package `v6.10.0`  (`SumupCard.js` vs `SumUpCard.js`) that caused the build to produce only one of the two files. 
+Fixed a broken case-insensitive filename collision on icons package `v6.10.0` (`SumupCard.js` vs `SumUpCard.js`) that caused the build to produce only one of the two files, resulting in "Module not found: Can't resolve './SumUpCard.js'" for consumers. Both `SumUpCard` and `SumupCard` continue to work as before.

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -97,6 +97,9 @@ function buildComponentFile(component: Component): string {
   );
   const sizes = icons.map((icon) => Number.parseInt(icon.size, 10)).sort();
   const defaultSize = sizes.includes(24) ? '24' : Math.min(...sizes).toString();
+  // Use a component-scoped variable name to avoid collisions when multiple
+  // components are combined into a single file (case-insensitive FS).
+  const sizeMapVar = `${component.name}SizeMap`;
   const sizeMap = icons.map((icon) => `'${icon.size}': ${icon.name},`);
   const invalidSizeWarning = `The '\${size}' size is not supported by the '${
     component.name
@@ -105,18 +108,18 @@ function buildComponentFile(component: Component): string {
   return `
     ${iconImports.join('\n')}
 
-    const sizeMap = {
+    const ${sizeMapVar} = {
       ${sizeMap.join('\n')}
     }
 
     ${createDeprecationComment(component)}
     export function ${component.name}({ size = '${defaultSize}', ...props }) {
-      const Icon = sizeMap[size] || sizeMap['${defaultSize}'];
+      const Icon = ${sizeMapVar}[size] || ${sizeMapVar}['${defaultSize}'];
 
       if (
         process.env.NODE_ENV !== 'production' &&
         process.env.NODE_ENV !== 'test' &&
-        !sizeMap[size]
+        !${sizeMapVar}[size]
       ) {
         console.warn(new Error(\`${invalidSizeWarning}\`));
       }
@@ -134,9 +137,15 @@ function buildHelpersFile(): string {
   `;
 }
 
-function buildIndexFile(components: Component[]): string {
+function buildIndexFile(
+  components: Component[],
+  canonicalNames: Map<string, string>,
+): string {
   const componentExports = components
-    .map(({ name }) => `export { ${name} } from './${name}.js';`)
+    .map(({ name }) => {
+      const fileName = canonicalNames.get(name) ?? name;
+      return `export { ${name} } from './${fileName}.js';`;
+    })
     .join('\n');
   const helpersExport = `export * from './helpers.js';`;
   return `
@@ -268,14 +277,36 @@ async function main() {
     )
     .filter(({ icons }) => icons.some((icon) => !icon.skipComponentFile));
 
-  const indexRaw = buildIndexFile(components);
+  // Group components by lowercase name to detect case-insensitive collisions
+  // (e.g. SumUpCard / SumupCard on macOS HFS+/APFS).  Components that share a
+  // lowercase name are combined into a single file so concurrent writes to the
+  // same physical inode don't corrupt each other.
+  const collisionGroups = new Map<string, Component[]>();
+  for (const component of components) {
+    const key = component.name.toLowerCase();
+    collisionGroups.set(key, [...(collisionGroups.get(key) ?? []), component]);
+  }
+
+  // Map each component name → the canonical filename it will be exported from.
+  const canonicalNames = new Map<string, string>();
+  for (const group of collisionGroups.values()) {
+    // Sort alphabetically; the first entry becomes the canonical filename.
+    const sorted = [...group].sort((a, b) => a.name.localeCompare(b.name));
+    const canonicalName = sorted[0].name;
+    for (const component of group) {
+      canonicalNames.set(component.name, canonicalName);
+    }
+  }
+
+  const indexRaw = buildIndexFile(components, canonicalNames);
   const helpersRaw = buildHelpersFile();
   const declarationFile = buildDeclarationFile(components);
 
   await Promise.all(
-    components.map((component) => {
-      const componentFileName = `${component.name}.js`;
-      const componentRaw = buildComponentFile(component);
+    [...collisionGroups.values()].map((group) => {
+      const sorted = [...group].sort((a, b) => a.name.localeCompare(b.name));
+      const componentFileName = `${sorted[0].name}.js`;
+      const componentRaw = group.map((c) => buildComponentFile(c)).join('\n\n');
       return transpileModule(componentFileName, componentRaw);
     }),
   );

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -98,7 +98,7 @@ function buildComponentFile(component: Component): string {
   const sizes = icons.map((icon) => Number.parseInt(icon.size, 10)).sort();
   const defaultSize = sizes.includes(24) ? '24' : Math.min(...sizes).toString();
   // Use a component-scoped variable name to avoid collisions when multiple
-  // components are combined into a single file (case-insensitive FS).
+  // components are combined into a single file (case-insensitive FS)
   const sizeMapVar = `${component.name}SizeMap`;
   const sizeMap = icons.map((icon) => `'${icon.size}': ${icon.name},`);
   const invalidSizeWarning = `The '\${size}' size is not supported by the '${
@@ -277,17 +277,19 @@ async function main() {
     )
     .filter(({ icons }) => icons.some((icon) => !icon.skipComponentFile));
 
-  // Group components by lowercase name to detect case-insensitive collisions
-  // (e.g. SumUpCard / SumupCard on macOS HFS+/APFS).  Components that share a
-  // lowercase name are combined into a single file so concurrent writes to the
-  // same physical inode don't corrupt each other.
+  // Group components by lowercase name to detect case-insensitive filename
+  // collisions (e.g. SumUpCard / SumupCard).  When two names differ only in
+  // case, a build on a case-insensitive filesystem produces only one physical
+  // file, leaving the other reference in index.js unresolvable for consumers.
+  // Merging colliding components into a single canonical file avoids the issue
+  // regardless of the filesystem the build runs on.
   const collisionGroups = new Map<string, Component[]>();
   for (const component of components) {
     const key = component.name.toLowerCase();
     collisionGroups.set(key, [...(collisionGroups.get(key) ?? []), component]);
   }
 
-  // Map each component name → the canonical filename it will be exported from.
+  // Map each component name to the canonical filename it will be exported from.
   const canonicalNames = new Map<string, string>();
   for (const group of collisionGroups.values()) {
     // Sort alphabetically; the first entry becomes the canonical filename.


### PR DESCRIPTION
## Purpose

Fix consumers hitting `Module not found: Can't resolve './SumUpCard.js'` after upgrading to `@sumup-oss/icons@6.10.0`

## Approach and changes

The `sumup_card icon` added in [#3698](https://github.com/sumup-oss/circuit-ui/pull/3698) (SumupCard) shares a case-insensitive filename with the existing `sum_up_card icon` (SumUpCard). When the package was built on a case-insensitive filesystem, only one physical file was produced, so `SumUpCard.js` was never included in the published tarball. The build script now detects case-insensitive filename collisions and merges affected components into a single canonical file that exports both named symbols. Both `SumUpCard` and `SumupCard` remain fully functional.

- Renamed the internal `sizeMap` variable in generated files to `${ComponentName}SizeMap` to avoid `const` redeclaration conflicts when multiple components share a file.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
