### PR TITLE
Remove the deprecated Flag's width and height props

### DIFF
--- a/.changeset/weak-paths-cheat.md
+++ b/.changeset/weak-paths-cheat.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Remove the deprecated `width` and `height` props from the Flag component. Use the `size` prop instead.

--- a/packages/circuit-ui/components/Flag/Flag.mdx
+++ b/packages/circuit-ui/components/Flag/Flag.mdx
@@ -17,7 +17,7 @@ The Flag component is used to display a country flag given its ISO 3166-1 alpha-
 ## How to use
 
 - The Flag component accepts a `countryCode` prop, which should be a valid ISO 3166-1 alpha-2 code (e.g. `US`, `FR`, `DE`). The component will render the corresponding flag.
-- Choose one of the three available sizes: `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) . Flags have a 4:3 aspect ratio by default. If you need to render a flag in different dimensions, import the svg file directly using the `getIconURL` [helper](https://circuit.sumup.com/?path=/docs/packages-icons--docs&globals=theme:light#load-from-a-url). Avoid using `height` and `width` props as they are deprecated and will be removed soon.
+- Choose one of the three available sizes: `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) (default m). Flags have a 4:3 aspect ratio by default. If you need to render a flag in different dimensions, import the svg file directly using the `getIconURL` [helper](https://circuit.sumup.com/?path=/docs/packages-icons--docs&globals=theme:light#load-from-a-url). 
 
 ## Accessibility
 

--- a/packages/circuit-ui/components/Flag/Flag.mdx
+++ b/packages/circuit-ui/components/Flag/Flag.mdx
@@ -17,7 +17,7 @@ The Flag component is used to display a country flag given its ISO 3166-1 alpha-
 ## How to use
 
 - The Flag component accepts a `countryCode` prop, which should be a valid ISO 3166-1 alpha-2 code (e.g. `US`, `FR`, `DE`). The component will render the corresponding flag.
-- Choose one of the three available sizes: `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) (default m). Flags have a 4:3 aspect ratio by default. If you need to render a flag in different dimensions, import the svg file directly using the `getIconURL` [helper](https://circuit.sumup.com/?path=/docs/packages-icons--docs&globals=theme:light#load-from-a-url). 
+- Choose one of the three available sizes: `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px). Flags have a 4:3 aspect ratio by default. If you need to render a flag in different dimensions, import the svg file directly using the `getIconURL` [helper](https://circuit.sumup.com/?path=/docs/packages-icons--docs&globals=theme:light#load-from-a-url). 
 
 ## Accessibility
 

--- a/packages/circuit-ui/components/Flag/Flag.module.css
+++ b/packages/circuit-ui/components/Flag/Flag.module.css
@@ -1,5 +1,5 @@
 .wrapper {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: center;
 }

--- a/packages/circuit-ui/components/Flag/Flag.module.css
+++ b/packages/circuit-ui/components/Flag/Flag.module.css
@@ -5,23 +5,8 @@
 }
 
 .base {
-  border: var(--cui-border-width-kilo) solid var(--cui-border-strong);
-  border-radius: var(--cui-border-radius-bit);
-}
-
-.s {
-  width: calc(var(--cui-icon-sizes-kilo) * 4 / 3);
-  height: var(--cui-icon-sizes-kilo);
-}
-
-.m {
-  width: calc(var(--cui-icon-sizes-mega) * 4 / 3);
-  height: var(--cui-icon-sizes-mega);
-}
-
-.l {
-  width: calc(var(--cui-icon-sizes-giga) * 4 / 3);
-  height: var(--cui-icon-sizes-giga);
+  border: 0.5px solid #ccc;
+  border-radius: 2px;
 }
 
 .s {

--- a/packages/circuit-ui/components/Flag/Flag.module.css
+++ b/packages/circuit-ui/components/Flag/Flag.module.css
@@ -9,17 +9,17 @@
   border-radius: var(--cui-border-radius-bit);
 }
 
-.size-16 {
+.s {
   width: calc(var(--cui-icon-sizes-kilo) * 4 / 3);
   height: var(--cui-icon-sizes-kilo);
 }
 
-.size-24 {
+.m {
   width: calc(var(--cui-icon-sizes-mega) * 4 / 3);
   height: var(--cui-icon-sizes-mega);
 }
 
-.size-32 {
+.l {
   width: calc(var(--cui-icon-sizes-giga) * 4 / 3);
   height: var(--cui-icon-sizes-giga);
 }

--- a/packages/circuit-ui/components/Flag/Flag.module.css
+++ b/packages/circuit-ui/components/Flag/Flag.module.css
@@ -1,24 +1,27 @@
 .wrapper {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
 }
 
-@supports not (aspect-ratio: 1 / 1) {
-  .wrapper {
-    height: var(--flag-wrapper-height);
-  }
-}
-
-@supports (aspect-ratio: 1 / 1) {
-  .wrapper {
-    aspect-ratio: 1 / 1;
-  }
-}
-
 .base {
-  border: 0.5px solid #ccc;
-  border-radius: 2px;
+  border: var(--cui-border-width-kilo) solid var(--cui-border-strong);
+  border-radius: var(--cui-border-radius-bit);
+}
+
+.size-16 {
+  width: calc(var(--cui-icon-sizes-kilo) * 4 / 3);
+  height: var(--cui-icon-sizes-kilo);
+}
+
+.size-24 {
+  width: calc(var(--cui-icon-sizes-mega) * 4 / 3);
+  height: var(--cui-icon-sizes-mega);
+}
+
+.size-32 {
+  width: calc(var(--cui-icon-sizes-giga) * 4 / 3);
+  height: var(--cui-icon-sizes-giga);
 }
 
 .s {

--- a/packages/circuit-ui/components/Flag/Flag.spec.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.spec.tsx
@@ -37,21 +37,6 @@ describe('Flag', () => {
     expect(ref.current).toBe(image);
   });
 
-  it('should render with size 16', () => {
-    render(<Flag {...baseProps} size="16" />);
-    expect(screen.getByRole('img')).toBeInTheDocument();
-  });
-
-  it('should render with size 24', () => {
-    render(<Flag {...baseProps} size="24" />);
-    expect(screen.getByRole('img')).toBeInTheDocument();
-  });
-
-  it('should render with size 32', () => {
-    render(<Flag {...baseProps} size="32" />);
-    expect(screen.getByRole('img')).toBeInTheDocument();
-  });
-
   it('should have no accessibility violations', async () => {
     const { container } = render(<Flag {...baseProps} />);
     const actual = await axe(container);

--- a/packages/circuit-ui/components/Flag/Flag.spec.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.spec.tsx
@@ -37,16 +37,19 @@ describe('Flag', () => {
     expect(ref.current).toBe(image);
   });
 
-  it('should size the image correctly when given a width', () => {
-    render(<Flag countryCode="DE" alt="Germany" width={100} />);
-    const image = screen.getByAltText('Germany');
-    expect(image.getAttribute('height')).toBe('75px');
+  it('should render with size 16', () => {
+    render(<Flag {...baseProps} size="16" />);
+    expect(screen.getByRole('img')).toBeInTheDocument();
   });
 
-  it('should size the image correctly when given a height', () => {
-    render(<Flag countryCode="DE" alt="Germany" height={120} />);
-    const image = screen.getByAltText('Germany');
-    expect(image.getAttribute('width')).toBe('160px');
+  it('should render with size 24', () => {
+    render(<Flag {...baseProps} size="24" />);
+    expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+
+  it('should render with size 32', () => {
+    render(<Flag {...baseProps} size="32" />);
+    expect(screen.getByRole('img')).toBeInTheDocument();
   });
 
   it('should have no accessibility violations', async () => {

--- a/packages/circuit-ui/components/Flag/Flag.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.tsx
@@ -61,14 +61,6 @@ export type FlagProps = HTMLAttributes<HTMLImageElement> & {
    */
   alt: string;
   /**
-<<<<<<< HEAD
-=======
-   * The size of the flag. Matches the standard icon sizes.
-   * @default 'm'
-   */
-  size?: 's' | 'm' | 'l';
-  /**
->>>>>>> a8a295c4 (update styles to use tshirt sizes)
    * Additional class name to apply to the flag wrapper.
    */
   className?: string;
@@ -86,10 +78,6 @@ const ASPECT_RATIO = 4 / 3;
 export function Flag({
   countryCode,
   alt,
-<<<<<<< HEAD
-=======
-  size = 'm',
->>>>>>> a8a295c4 (update styles to use tshirt sizes)
   className,
   imageClassName,
   size,
@@ -140,11 +128,7 @@ export function Flag({
     <div className={clsx(classes.wrapper, className)}>
       <img
         ref={ref}
-<<<<<<< HEAD
         className={clsx(classes.base, imageClassName)}
-=======
-        className={clsx(classes.base, classes[size], imageClassName)}
->>>>>>> a8a295c4 (update styles to use tshirt sizes)
         src={getIconURL(flagName)}
         {...props}
         alt={alt}

--- a/packages/circuit-ui/components/Flag/Flag.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.tsx
@@ -61,6 +61,14 @@ export type FlagProps = HTMLAttributes<HTMLImageElement> & {
    */
   alt: string;
   /**
+<<<<<<< HEAD
+=======
+   * The size of the flag. Matches the standard icon sizes.
+   * @default 'm'
+   */
+  size?: 's' | 'm' | 'l';
+  /**
+>>>>>>> a8a295c4 (update styles to use tshirt sizes)
    * Additional class name to apply to the flag wrapper.
    */
   className?: string;
@@ -78,6 +86,10 @@ const ASPECT_RATIO = 4 / 3;
 export function Flag({
   countryCode,
   alt,
+<<<<<<< HEAD
+=======
+  size = 'm',
+>>>>>>> a8a295c4 (update styles to use tshirt sizes)
   className,
   imageClassName,
   size,
@@ -128,7 +140,11 @@ export function Flag({
     <div className={clsx(classes.wrapper, className)}>
       <img
         ref={ref}
+<<<<<<< HEAD
         className={clsx(classes.base, imageClassName)}
+=======
+        className={clsx(classes.base, classes[size], imageClassName)}
+>>>>>>> a8a295c4 (update styles to use tshirt sizes)
         src={getIconURL(flagName)}
         {...props}
         alt={alt}

--- a/packages/circuit-ui/components/Flag/Flag.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.tsx
@@ -125,17 +125,10 @@ export function Flag({
   }
 
   return (
-    <div
-      className={clsx(classes.wrapper, className)}
-      style={{
-        '--flag-wrapper-height': `${dimensions.width}px`,
-      }}
-    >
+    <div className={clsx(classes.wrapper, className)}>
       <img
         ref={ref}
         className={clsx(classes.base, imageClassName)}
-        height={`${dimensions.height}px`}
-        width={`${dimensions.width}px`}
         src={getIconURL(flagName)}
         {...props}
         alt={alt}

--- a/packages/circuit-ui/components/Flag/Flag.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.tsx
@@ -17,41 +17,11 @@ import type { HTMLAttributes, Ref } from 'react';
 import { getIconURL, type IconName } from '@sumup-oss/icons';
 
 import { clsx } from '../../styles/clsx.js';
-import { deprecate } from '../../util/logger.js';
 
 import classes from './Flag.module.css';
 import type { FLAGS } from './constants.js';
 
 type CountryCode = (typeof FLAGS)[number];
-
-type WithSize = {
-  /**
-   * Choose from 3 sizes.
-   */
-  size?: 's' | 'm' | 'l';
-  width?: never;
-  height?: never;
-};
-
-type WithHeightWidth =
-  | {
-      /**
-       * The width of the flag image.
-       * @deprecated Use the `size` prop instead.
-       */
-      width?: number;
-      height?: never;
-      size?: never;
-    }
-  | {
-      /**
-       * The height of the flag image.
-       * @deprecated Use the `size` prop instead.
-       */
-      height?: number;
-      width?: never;
-      size?: never;
-    };
 
 export type FlagProps = HTMLAttributes<HTMLImageElement> & {
   ref?: Ref<HTMLImageElement>;
@@ -68,9 +38,12 @@ export type FlagProps = HTMLAttributes<HTMLImageElement> & {
    * Additional class name to apply to the flag's inner image.
    */
   imageClassName?: string;
-} & (WithSize | WithHeightWidth);
-
-const ASPECT_RATIO = 4 / 3;
+  /**
+   * Choose from 3 sizes.
+   * @default m
+   */
+  size?: 's' | 'm' | 'l';
+};
 
 /**
  * Renders an SVG icon of a flag. Flags are sourced from: https://flagicons.lipis.dev/
@@ -80,55 +53,17 @@ export function Flag({
   alt,
   className,
   imageClassName,
-  size,
-  width,
-  height,
+  size = 'm',
   ref,
   ...props
 }: FlagProps) {
   const flagName = `flag_${countryCode.toLowerCase()}` as IconName;
 
-  if (process.env.NODE_ENV !== 'production' && (width || height)) {
-    deprecate(
-      'Flag',
-      'The `width` and `height` props are deprecated. Use the `size` prop instead.',
-    );
-  }
-
-  if (size) {
-    return (
-      <div className={clsx(classes.wrapper, className)}>
-        <img
-          ref={ref}
-          className={clsx(classes.base, classes[size], imageClassName)}
-          src={getIconURL(flagName)}
-          {...props}
-          alt={alt}
-        />
-      </div>
-    );
-  }
-
-  // default dimensions
-  const dimensions = {
-    width: 16,
-    height: 12,
-  };
-  // for a consistent aspect ratio
-  if (height) {
-    dimensions.height = height;
-    dimensions.width = height * ASPECT_RATIO;
-  }
-  if (width) {
-    dimensions.width = width;
-    dimensions.height = width / ASPECT_RATIO;
-  }
-
   return (
     <div className={clsx(classes.wrapper, className)}>
       <img
         ref={ref}
-        className={clsx(classes.base, imageClassName)}
+        className={clsx(classes.base, classes[size], imageClassName)}
         src={getIconURL(flagName)}
         {...props}
         alt={alt}

--- a/skills/circuit-ui/references/components/Flag.mdx
+++ b/skills/circuit-ui/references/components/Flag.mdx
@@ -17,7 +17,7 @@ The Flag component is used to display a country flag given its ISO 3166-1 alpha-
 ## How to use
 
 - The Flag component accepts a `countryCode` prop, which should be a valid ISO 3166-1 alpha-2 code (e.g. `US`, `FR`, `DE`). The component will render the corresponding flag.
-- Choose one of the three available sizes: `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) . Flags have a 4:3 aspect ratio by default. If you need to render a flag in different dimensions, import the svg file directly using the `getIconURL` [helper](https://circuit.sumup.com/?path=/docs/packages-icons--docs&globals=theme:light#load-from-a-url). Avoid using `height` and `width` props as they are deprecated and will be removed soon.
+- Choose one of the three available sizes: `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px). Flags have a 4:3 aspect ratio by default. If you need to render a flag in different dimensions, import the svg file directly using the `getIconURL` [helper](https://circuit.sumup.com/?path=/docs/packages-icons--docs&globals=theme:light#load-from-a-url). 
 
 ## Accessibility
 


### PR DESCRIPTION
Addresses [DSYS-1684](https://sumupteam.atlassian.net/browse/DSYS-1684)

## Purpose

Remove the deprecated `width` and `height` props from the Flag component now that the `size` prop is available.

## Approach and changes

- Deleted the `Dimensions` discriminated union type and all dimension calculation logic from `Flag.tsx`
- Removed `width` and `height` props and updated size (defaulting to `m`) as the only valid sizing prop

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
