### PR TITLE
feat(circuit-ui): make Timestamp delegate to Body

### DIFF
--- a/.changeset/violet-hotels-switch.md
+++ b/.changeset/violet-hotels-switch.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added more props to Timestamp component, supporting the same set of styling options as Body.

--- a/packages/circuit-ui/components/Timestamp/Timestamp.spec.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.spec.tsx
@@ -19,9 +19,11 @@ import { createRef } from 'react';
 
 import { render, screen, axe, act } from '../../util/test-utils.js';
 
+import bodyClasses from '../Body/Body.module.css';
+
 import { Timestamp } from './Timestamp.js';
 
-describe('Calendar', () => {
+describe('Timestamp', () => {
   beforeEach(() => {
     MockDate.set('2020-01-01T01:00+01:00');
   });
@@ -35,6 +37,15 @@ describe('Calendar', () => {
     render(<Timestamp {...baseProps} className={className} />);
     const element = screen.getByRole('time');
     expect(element?.className).toContain(className);
+  });
+
+  it('should accept Body props', () => {
+    render(<Timestamp {...baseProps} size="s" weight="bold" color="accent" />);
+
+    const element = screen.getByRole('time');
+    expect(element.className).toContain(bodyClasses.s);
+    expect(element.className).toContain(bodyClasses.bold);
+    expect(element.className).toContain(bodyClasses.accent);
   });
 
   it('should forward a ref to the outer element', () => {

--- a/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
@@ -20,10 +20,39 @@ import { Stack, Matrix } from '../../../../.storybook/components/index.js';
 
 import { Timestamp, type TimestampProps } from './Timestamp.js';
 
+const sizes = ['l', 'm', 's'] as const;
+const weights = ['regular', 'semibold', 'bold'] as const;
+const colors = [
+  'normal',
+  'subtle',
+  'placeholder',
+  'on-strong',
+  'on-strong-subtle',
+  'accent',
+  'success',
+  'warning',
+  'danger',
+  'promo',
+] as const;
+
 export default {
   title: 'Components/Timestamp',
   component: Timestamp,
   tags: ['status:stable'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: sizes,
+    },
+    weight: {
+      control: 'select',
+      options: weights,
+    },
+    color: {
+      control: 'select',
+      options: colors,
+    },
+  },
   chromatic: {
     modes: {
       // the theme does not impact the component
@@ -55,6 +84,9 @@ export const Base = (args: TimestampProps) => <Timestamp {...args} />;
 
 Base.args = {
   datetime: getDatetimes('relative')[2].toString(),
+  size: 'm',
+  weight: 'regular',
+  color: 'normal',
 };
 
 Base.parameters = {

--- a/packages/circuit-ui/components/Timestamp/Timestamp.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.tsx
@@ -15,16 +15,26 @@
 
 'use client';
 
-import { forwardRef, useEffect, useState, type HTMLAttributes } from 'react';
+import {
+  forwardRef,
+  useEffect,
+  useState,
+  type Ref,
+  type TimeHTMLAttributes,
+} from 'react';
 import { Temporal } from 'temporal-polyfill';
 
 import type { Locale } from '../../util/i18n.js';
 import { clsx } from '../../styles/clsx.js';
+import { Body, type BodyProps } from '../Body/Body.js';
 
 import { getInitialState, getState } from './TimestampService.js';
 import classes from './Timestamp.module.css';
 
-export interface TimestampProps extends HTMLAttributes<HTMLTimeElement> {
+type TimestampBodyProps = Omit<BodyProps, 'as' | 'children' | 'variant'> &
+  Omit<TimeHTMLAttributes<HTMLTimeElement>, 'children'>;
+
+export interface TimestampProps extends TimestampBodyProps {
   /**
    * A datetime in the [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601)
    * format (`YYYY-MM-DDThh:mm:ss.sss[time-zone-id]`). Must include an
@@ -121,8 +131,9 @@ export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
     }, [state.interval, datetime, variant, formatStyle, locale, includeTime]);
 
     return (
-      <time
-        ref={ref}
+      <Body
+        ref={ref as Ref<HTMLParagraphElement>}
+        as="time"
         dateTime={zonedDateTime.toString({ timeZoneName: 'never' })}
         title={zonedDateTime.toLocaleString(locale, {
           year: 'numeric',
@@ -136,7 +147,9 @@ export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
         {...props}
       >
         {state.label}
-      </time>
+      </Body>
     );
   },
 );
+
+Timestamp.displayName = 'Timestamp';


### PR DESCRIPTION
## Purpose

Make `Timestamp` component delegate to `Body` to provide the same set of styling props on `Timestamp` as we do on `Body` (e.g. weight, colour, etc.).

## Approach and changes

Updates `Timestamp` to use `Body` under the hood.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
