### PR TITLE
Deprecate Flag width and height props

### DIFF
--- a/.changeset/angry-baths-drum.md
+++ b/.changeset/angry-baths-drum.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added a `size` prop to the Flag component (`'s'` | `'m'` | `'l'`, default `'m'`) that maps to the standard icon sizes of 16px, 24px, and 32px. The `width` and `height` props are deprecated in favour of `size`.

--- a/.changeset/angry-baths-drum.md
+++ b/.changeset/angry-baths-drum.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": minor
 ---
 
-Added a `size` prop to the Flag component (`'s'` | `'m'` | `'l'`, default `'m'`) that maps to the standard icon sizes of 16px, 24px, and 32px. The `width` and `height` props are deprecated in favour of `size`.
+Added a `size` prop to the Flag component (`'s'` | `'m'` | `'l'`) that maps to the standard icon sizes of 16px, 24px, and 32px. Depreacted the `width` and `height` props in favour of `size`.

--- a/packages/circuit-ui/components/Flag/Flag.mdx
+++ b/packages/circuit-ui/components/Flag/Flag.mdx
@@ -18,7 +18,6 @@ The Flag component is used to display a country flag given its ISO 3166-1 alpha-
 
 - The Flag component accepts a `countryCode` prop, which should be a valid ISO 3166-1 alpha-2 code (e.g. `US`, `FR`, `DE`). The component will render the corresponding flag.
 - Choose one of the three available sizes: `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) . Flags have a 4:3 aspect ratio by default. If you need to render a flag in different dimensions, import the svg file directly using the `getIconURL` [helper](https://circuit.sumup.com/?path=/docs/packages-icons--docs&globals=theme:light#load-from-a-url). Avoid using `height` and `width` props as they are deprecated and will be removed soon.
-- The `width` and `height` props are deprecated. Use the `size` prop instead.
 
 ## Accessibility
 

--- a/packages/circuit-ui/components/Flag/Flag.mdx
+++ b/packages/circuit-ui/components/Flag/Flag.mdx
@@ -17,7 +17,7 @@ The Flag component is used to display a country flag given its ISO 3166-1 alpha-
 ## How to use
 
 - The Flag component accepts a `countryCode` prop, which should be a valid ISO 3166-1 alpha-2 code (e.g. `US`, `FR`, `DE`). The component will render the corresponding flag.
-- The size of the flag is controlled with the `size` prop. The three available sizes `'s'` (16px), `'m'` (24px, default), and `'l'` (32px) match the standard icon sizes. The flag's width is automatically derived from the height to maintain the 4:3 aspect ratio.
+- The size of the flag is controlled with the `size` prop. The three available sizes `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) match the standard icon sizes. The flag's height is automatically derived from the width to maintain the 4:3 aspect ratio.
 - The `width` and `height` props are deprecated. Use the `size` prop instead.
 
 ## Accessibility

--- a/packages/circuit-ui/components/Flag/Flag.mdx
+++ b/packages/circuit-ui/components/Flag/Flag.mdx
@@ -17,7 +17,8 @@ The Flag component is used to display a country flag given its ISO 3166-1 alpha-
 ## How to use
 
 - The Flag component accepts a `countryCode` prop, which should be a valid ISO 3166-1 alpha-2 code (e.g. `US`, `FR`, `DE`). The component will render the corresponding flag.
-- The size of the flag can be controlled using either the `height` or `width` prop. By providing one of these props, the other will be automatically calculated to maintain the 4:3 aspect ratio of the flag.
+- The size of the flag is controlled with the `size` prop. The three available sizes `'s'` (16px), `'m'` (24px, default), and `'l'` (32px) match the standard icon sizes. The flag's width is automatically derived from the height to maintain the 4:3 aspect ratio.
+- The `width` and `height` props are deprecated. Use the `size` prop instead.
 
 ## Accessibility
 

--- a/packages/circuit-ui/components/Flag/Flag.mdx
+++ b/packages/circuit-ui/components/Flag/Flag.mdx
@@ -17,7 +17,7 @@ The Flag component is used to display a country flag given its ISO 3166-1 alpha-
 ## How to use
 
 - The Flag component accepts a `countryCode` prop, which should be a valid ISO 3166-1 alpha-2 code (e.g. `US`, `FR`, `DE`). The component will render the corresponding flag.
-- The size of the flag is controlled with the `size` prop. The three available sizes `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) match the standard icon sizes. The flag's height is automatically derived from the width to maintain the 4:3 aspect ratio.
+- Choose one of the three available sizes: `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) . Flags have a 4:3 aspect ratio by default. If you need to render a flag in different dimensions, import the svg file directly using the `getIconURL` [helper](https://circuit.sumup.com/?path=/docs/packages-icons--docs&globals=theme:light#load-from-a-url). Avoid using `height` and `width` props as they are deprecated and will be removed soon.
 - The `width` and `height` props are deprecated. Use the `size` prop instead.
 
 ## Accessibility

--- a/packages/circuit-ui/components/Flag/Flag.module.css
+++ b/packages/circuit-ui/components/Flag/Flag.module.css
@@ -22,16 +22,16 @@
 }
 
 .s {
-  width: calc(var(--cui-icon-sizes-kilo) * 4 / 3);
-  height: var(--cui-icon-sizes-kilo);
+  width: var(--cui-icon-sizes-kilo);
+  height: calc(var(--cui-icon-sizes-kilo) * 3 / 4);
 }
 
 .m {
-  width: calc(var(--cui-icon-sizes-mega) * 4 / 3);
-  height: var(--cui-icon-sizes-mega);
+  width: var(--cui-icon-sizes-mega);
+  height: calc(var(--cui-icon-sizes-mega) * 3 / 4);
 }
 
 .l {
-  width: calc(var(--cui-icon-sizes-giga) * 4 / 3);
-  height: var(--cui-icon-sizes-giga);
+  width: var(--cui-icon-sizes-giga);
+  height: calc(var(--cui-icon-sizes-giga) * 3 / 4);
 }

--- a/packages/circuit-ui/components/Flag/Flag.module.css
+++ b/packages/circuit-ui/components/Flag/Flag.module.css
@@ -20,3 +20,18 @@
   border: 0.5px solid #ccc;
   border-radius: 2px;
 }
+
+.s {
+  width: calc(var(--cui-icon-sizes-kilo) * 4 / 3);
+  height: var(--cui-icon-sizes-kilo);
+}
+
+.m {
+  width: calc(var(--cui-icon-sizes-mega) * 4 / 3);
+  height: var(--cui-icon-sizes-mega);
+}
+
+.l {
+  width: calc(var(--cui-icon-sizes-giga) * 4 / 3);
+  height: var(--cui-icon-sizes-giga);
+}

--- a/packages/circuit-ui/components/Flag/Flag.stories.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.stories.tsx
@@ -23,6 +23,12 @@ export default {
   title: 'Components/Flag',
   component: Flag,
   tags: ['status:stable'],
+  argTypes: {
+    size: {
+      options: ['s', 'm', 'l'],
+      control: { type: 'radio' },
+    },
+  },
 };
 
 export const Base = () => {

--- a/packages/circuit-ui/components/Flag/Flag.stories.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.stories.tsx
@@ -43,7 +43,7 @@ export const Base = () => {
     <div className={classes.list}>
       {FLAGS.map((code) => (
         <div key={code} className={classes.wrapper}>
-          <Flag key={code} countryCode={code} alt="" width={32} />
+          <Flag key={code} countryCode={code} alt="" size="l" />
           <Body>
             {formatCountryName(code)} ({code})
           </Body>
@@ -71,5 +71,5 @@ Example.parameters = {
 Example.args = {
   countryCode: 'PR',
   alt: 'Puerto Rico',
-  width: 32,
+  size: 'l',
 };

--- a/packages/circuit-ui/components/Flag/Flag.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.tsx
@@ -26,7 +26,7 @@ type CountryCode = (typeof FLAGS)[number];
 
 type WithSize = {
   /**
-   * The size of the flag. Matches the standard icon sizes.
+   * Choose from 3 sizes.
    * @default 'm'
    */
   size?: 's' | 'm' | 'l';

--- a/packages/circuit-ui/components/Flag/Flag.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.tsx
@@ -98,26 +98,12 @@ export const Flag = forwardRef<HTMLImageElement, FlagProps>(
       );
     }
 
-    if (width || height) {
-      const dimensions = { width: 16, height: 12 };
-      if (height) {
-        dimensions.height = height;
-        dimensions.width = height * ASPECT_RATIO;
-      }
-      if (width) {
-        dimensions.width = width;
-        dimensions.height = width / ASPECT_RATIO;
-      }
+    if (size) {
       return (
-        <div
-          className={clsx(classes.wrapper, className)}
-          style={{ '--flag-wrapper-height': `${dimensions.width}px` }}
-        >
+        <div className={clsx(classes.wrapper, className)}>
           <img
             ref={ref}
-            className={clsx(classes.base, imageClassName)}
-            height={`${dimensions.height}px`}
-            width={`${dimensions.width}px`}
+            className={clsx(classes.base, classes[size], imageClassName)}
             src={getIconURL(flagName)}
             {...props}
             alt={alt}
@@ -125,12 +111,27 @@ export const Flag = forwardRef<HTMLImageElement, FlagProps>(
         </div>
       );
     }
-
+    // default dimensions
+    const dimensions = { width: 16, height: 12 };
+    // for a consistent aspect ratio
+    if (height) {
+      dimensions.height = height;
+      dimensions.width = height * ASPECT_RATIO;
+    }
+    if (width) {
+      dimensions.width = width;
+      dimensions.height = width / ASPECT_RATIO;
+    }
     return (
-      <div className={clsx(classes.wrapper, className)}>
+      <div
+        className={clsx(classes.wrapper, className)}
+        style={{ '--flag-wrapper-height': `${dimensions.width}px` }}
+      >
         <img
           ref={ref}
-          className={clsx(classes.base, classes[size ?? 'm'], imageClassName)}
+          className={clsx(classes.base, imageClassName)}
+          height={`${dimensions.height}px`}
+          width={`${dimensions.width}px`}
           src={getIconURL(flagName)}
           {...props}
           alt={alt}

--- a/packages/circuit-ui/components/Flag/Flag.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.tsx
@@ -27,7 +27,6 @@ type CountryCode = (typeof FLAGS)[number];
 type WithSize = {
   /**
    * Choose from 3 sizes.
-   * @default 'm'
    */
   size?: 's' | 'm' | 'l';
   width?: never;

--- a/packages/circuit-ui/components/Flag/Flag.tsx
+++ b/packages/circuit-ui/components/Flag/Flag.tsx
@@ -17,32 +17,41 @@ import { forwardRef, type HTMLAttributes } from 'react';
 import { getIconURL, type IconName } from '@sumup-oss/icons';
 
 import { clsx } from '../../styles/clsx.js';
+import { deprecate } from '../../util/logger.js';
 
 import classes from './Flag.module.css';
 import type { FLAGS } from './constants.js';
 
 type CountryCode = (typeof FLAGS)[number];
 
-type Dimensions =
+type WithSize = {
+  /**
+   * The size of the flag. Matches the standard icon sizes.
+   * @default 'm'
+   */
+  size?: 's' | 'm' | 'l';
+  width?: never;
+  height?: never;
+};
+
+type WithHeightWidth =
   | {
       /**
-       * The width of the flag image. To size the flag correctly, either width or height must be provided.
+       * The width of the flag image.
+       * @deprecated Use the `size` prop instead.
        */
-      width?: never;
-      /**
-       * The height of the flag image. To size the flag correctly, either width or height must be provided.
-       */
-      height?: number;
+      width?: number;
+      height?: never;
+      size?: never;
     }
   | {
       /**
-       * The width of the flag image. To size the flag correctly, either width or height must be provided.
+       * The height of the flag image.
+       * @deprecated Use the `size` prop instead.
        */
-      width?: number;
-      /**
-       * The height of the flag image. To size the flag correctly, either width or height must be provided.
-       */
-      height?: never;
+      height?: number;
+      width?: never;
+      size?: never;
     };
 
 export type FlagProps = HTMLAttributes<HTMLImageElement> & {
@@ -59,7 +68,7 @@ export type FlagProps = HTMLAttributes<HTMLImageElement> & {
    * Additional class name to apply to the flag's inner image.
    */
   imageClassName?: string;
-} & Dimensions;
+} & (WithSize | WithHeightWidth);
 
 const ASPECT_RATIO = 4 / 3;
 
@@ -68,37 +77,60 @@ const ASPECT_RATIO = 4 / 3;
  */
 export const Flag = forwardRef<HTMLImageElement, FlagProps>(
   (
-    { countryCode, alt, className, imageClassName, width, height, ...props },
+    {
+      countryCode,
+      alt,
+      className,
+      imageClassName,
+      size,
+      width,
+      height,
+      ...props
+    },
     ref,
   ) => {
     const flagName = `flag_${countryCode.toLowerCase()}` as IconName;
-    // default dimensions
-    const dimensions = {
-      width: 16,
-      height: 12,
-    };
-    // for a consistent aspect ratio
-    if (height) {
-      dimensions.height = height;
-      dimensions.width = height * ASPECT_RATIO;
+
+    if (process.env.NODE_ENV !== 'production' && (width || height)) {
+      deprecate(
+        'Flag',
+        'The `width` and `height` props are deprecated. Use the `size` prop instead.',
+      );
     }
-    if (width) {
-      dimensions.width = width;
-      dimensions.height = width / ASPECT_RATIO;
+
+    if (width || height) {
+      const dimensions = { width: 16, height: 12 };
+      if (height) {
+        dimensions.height = height;
+        dimensions.width = height * ASPECT_RATIO;
+      }
+      if (width) {
+        dimensions.width = width;
+        dimensions.height = width / ASPECT_RATIO;
+      }
+      return (
+        <div
+          className={clsx(classes.wrapper, className)}
+          style={{ '--flag-wrapper-height': `${dimensions.width}px` }}
+        >
+          <img
+            ref={ref}
+            className={clsx(classes.base, imageClassName)}
+            height={`${dimensions.height}px`}
+            width={`${dimensions.width}px`}
+            src={getIconURL(flagName)}
+            {...props}
+            alt={alt}
+          />
+        </div>
+      );
     }
 
     return (
-      <div
-        className={clsx(classes.wrapper, className)}
-        style={{
-          '--flag-wrapper-height': `${dimensions.width}px`,
-        }}
-      >
+      <div className={clsx(classes.wrapper, className)}>
         <img
           ref={ref}
-          className={clsx(classes.base, imageClassName)}
-          height={`${dimensions.height}px`}
-          width={`${dimensions.width}px`}
+          className={clsx(classes.base, classes[size ?? 'm'], imageClassName)}
           src={getIconURL(flagName)}
           {...props}
           alt={alt}
@@ -107,3 +139,5 @@ export const Flag = forwardRef<HTMLImageElement, FlagProps>(
     );
   },
 );
+
+Flag.displayName = 'Flag';

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.stories.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.stories.tsx
@@ -27,6 +27,7 @@ export default {
   argTypes: {
     size: {
       options: ['s', 'm'],
+      control: { type: 'radio' },
     },
   },
 };

--- a/skills/circuit-ui/references/components/Flag.mdx
+++ b/skills/circuit-ui/references/components/Flag.mdx
@@ -17,8 +17,7 @@ The Flag component is used to display a country flag given its ISO 3166-1 alpha-
 ## How to use
 
 - The Flag component accepts a `countryCode` prop, which should be a valid ISO 3166-1 alpha-2 code (e.g. `US`, `FR`, `DE`). The component will render the corresponding flag.
-- The size of the flag is controlled with the `size` prop. The three available sizes `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) match the standard icon sizes. The flag's height is automatically derived from the width to maintain the 4:3 aspect ratio.
-- The `width` and `height` props are deprecated. Use the `size` prop instead.
+- Choose one of the three available sizes: `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) . Flags have a 4:3 aspect ratio by default. If you need to render a flag in different dimensions, import the svg file directly using the `getIconURL` [helper](https://circuit.sumup.com/?path=/docs/packages-icons--docs&globals=theme:light#load-from-a-url). Avoid using `height` and `width` props as they are deprecated and will be removed soon.
 
 ## Accessibility
 

--- a/skills/circuit-ui/references/components/Flag.mdx
+++ b/skills/circuit-ui/references/components/Flag.mdx
@@ -17,7 +17,7 @@ The Flag component is used to display a country flag given its ISO 3166-1 alpha-
 ## How to use
 
 - The Flag component accepts a `countryCode` prop, which should be a valid ISO 3166-1 alpha-2 code (e.g. `US`, `FR`, `DE`). The component will render the corresponding flag.
-- The size of the flag is controlled with the `size` prop. The three available sizes `'s'` (16px), `'m'` (24px, default), and `'l'` (32px) match the standard icon sizes. The flag's width is automatically derived from the height to maintain the 4:3 aspect ratio.
+- The size of the flag is controlled with the `size` prop. The three available sizes `'s'` (16×12px), `'m'` (24×18px), and `'l'` (32×24px) match the standard icon sizes. The flag's height is automatically derived from the width to maintain the 4:3 aspect ratio.
 - The `width` and `height` props are deprecated. Use the `size` prop instead.
 
 ## Accessibility

--- a/skills/circuit-ui/references/components/Flag.mdx
+++ b/skills/circuit-ui/references/components/Flag.mdx
@@ -17,7 +17,8 @@ The Flag component is used to display a country flag given its ISO 3166-1 alpha-
 ## How to use
 
 - The Flag component accepts a `countryCode` prop, which should be a valid ISO 3166-1 alpha-2 code (e.g. `US`, `FR`, `DE`). The component will render the corresponding flag.
-- The size of the flag can be controlled using either the `height` or `width` prop. By providing one of these props, the other will be automatically calculated to maintain the 4:3 aspect ratio of the flag.
+- The size of the flag is controlled with the `size` prop. The three available sizes `'s'` (16px), `'m'` (24px, default), and `'l'` (32px) match the standard icon sizes. The flag's width is automatically derived from the height to maintain the 4:3 aspect ratio.
+- The `width` and `height` props are deprecated. Use the `size` prop instead.
 
 ## Accessibility
 


### PR DESCRIPTION
Addresses [DSYS-1684](https://sumupteam.atlassian.net/browse/DSYS-1684)

## Purpose

The Flag component is essentially an icon and should adhere to the standard icon sizes: 16px (1rem), 24px (1.5rem), and 32px (2rem), but it accepts arbitrary `width` and `height` number props, which makes sizing inconsistent across consumers. The goal is to introduce a size prop ('s' | 'm' | 'l') that aligns with the icon size tokens and matches the proportions of the legacy default.

## Approach and changes

- Added a size prop that maps to `--cui-icon-sizes-kilo/mega/giga` (16/24/32px) for the flag width, with height derived via `calc(width * 3 / 4)` to maintain the 4:3 aspect ratio, the same calculation as the legacy width prop path `(width / ASPECT_RATIO)`. This keeps `size="s" at 16×12px`, consistent with the existing hardcoded default.

```
size="s" → 16×12px
size="m" → 24×18px
size="l" → 32×24px
```
-  The legacy `width/height` path is preserved unchanged as the fallback, so no existing consumer breaks. Both props are deprecated and will be removed in the next major release.

Before:

```
<Flag countryCode="FR" alt="France" width={32} />  // arbitrary number, no token connection
```

After: 

```
<Flag countryCode="FR" alt="France" size="l" />  // 32×24px, tied to icon size tokens
```

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
