### PR TITLE
Deprecated --cui-bg-accent-strong-* and --cui-z-index-toast design tokens

### DIFF
--- a/.changeset/cute-fans-admire.md
+++ b/.changeset/cute-fans-admire.md
@@ -2,4 +2,4 @@
 "@sumup-oss/design-tokens": minor
 ---
 
-Deprecated the `--cui-bg-accent-strong-*` token family and `--cui-z-index-toast`. The `--cui-bg-accent-strong-*` tokens are near-identical to `--cui-bg-strong-*` and are being consolidated.
+Deprecated the `--cui-bg-accent-strong-*` token family, use the `--cui-bg-strong-*` tokens instead.

--- a/.changeset/cute-fans-admire.md
+++ b/.changeset/cute-fans-admire.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/design-tokens": minor
+---
+
+Deprecated the `--cui-bg-accent-strong-*` token family and `--cui-z-index-toast`. The `--cui-bg-accent-strong-*` tokens are near-identical to `--cui-bg-strong-*` and are being consolidated.

--- a/.changeset/proud-signs-check.md
+++ b/.changeset/proud-signs-check.md
@@ -1,5 +1,5 @@
 ---
-"@sumup-oss/design-tokens": patch
+"@sumup-oss/design-tokens": minor
 ---
 
 Deprecated the `--cui-z-index-toast` token, no direct replacement, update z-index based on the context manually.

--- a/.changeset/proud-signs-check.md
+++ b/.changeset/proud-signs-check.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/design-tokens": patch
+---
+
+Deprecated the `--cui-z-index-toast` token, no direct replacement, update z-index based on the context manually.

--- a/.changeset/silent-snails-shave.md
+++ b/.changeset/silent-snails-shave.md
@@ -2,4 +2,4 @@
 "@sumup-oss/stylelint-plugin-circuit-ui": patch
 ---
 
-Updated the `no-deprecated-custom-properties` rule to support deprecated tokens that have no direct replacement. A guidance message when an auto-fixable replacement is not available can now be provided.
+Updated the `no-deprecated-custom-properties` rule to support deprecated tokens that have no direct replacement. The rule now requires an additional message for deprecated tokens with no direct replacement.

--- a/.changeset/silent-snails-shave.md
+++ b/.changeset/silent-snails-shave.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/stylelint-plugin-circuit-ui": patch
+---
+
+Updated the `no-deprecated-custom-properties` rule to support deprecated tokens that have no direct replacement. A guidance message when an auto-fixable replacement is not available can now be provided.

--- a/.changeset/tangy-results-ask.md
+++ b/.changeset/tangy-results-ask.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/eslint-plugin-circuit-ui": patch
+---
+
+Updated the `no-deprecated-custom-properties` rule to support deprecated tokens that have no direct replacement. A guidance message when an auto-fixable replacement is not available can now be provided.

--- a/.changeset/tangy-results-ask.md
+++ b/.changeset/tangy-results-ask.md
@@ -1,5 +1,0 @@
----
-"@sumup-oss/eslint-plugin-circuit-ui": patch
----
-
-Updated the `no-deprecated-custom-properties` rule to support deprecated tokens that have no direct replacement. A guidance message when an auto-fixable replacement is not available can now be provided.

--- a/.changeset/twelve-donkeys-sleep.md
+++ b/.changeset/twelve-donkeys-sleep.md
@@ -1,5 +1,6 @@
 ---
 "@sumup-oss/stylelint-plugin-circuit-ui": patch
+"@sumup-oss/eslint-plugin-circuit-ui": patch
 ---
 
 Updated the `no-deprecated-custom-properties` rule to support deprecated tokens that have no direct replacement. The rule now requires an additional message for deprecated tokens with no direct replacement.

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -106,4 +106,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr edit $PR_NUMBER --remove-label "preview"
+          gh pr edit "$PR_NUMBER" --remove-label "preview"

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Publish packages
-        run: npx pkg-pr-new publish './packages/circuit-ui'  './packages/design-tokens'  './packages/icons' './packages/eslint-plugin-circuit-ui' './packages/eslint-plugin-circuit-ui' --json output.json --comment=off
+        run: npx pkg-pr-new publish './packages/circuit-ui'  './packages/design-tokens'  './packages/icons' './packages/eslint-plugin-circuit-ui' './packages/stylelint-plugin-circuit-ui' --json output.json --comment=off
 
       - name: Post or update comment
         uses: actions/github-script@v9

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Publish packages
-        run: npx pkg-pr-new publish './packages/circuit-ui'  './packages/design-tokens'  './packages/icons' './packages/eslint-plugin-circuit-ui' --json output.json --comment=off
+        run: npx pkg-pr-new publish './packages/circuit-ui'  './packages/design-tokens'  './packages/icons' './packages/eslint-plugin-circuit-ui' './packages/eslint-plugin-circuit-ui' --json output.json --comment=off
 
       - name: Post or update comment
         uses: actions/github-script@v9

--- a/.storybook/components/Theme.tsx
+++ b/.storybook/components/Theme.tsx
@@ -35,7 +35,9 @@ type CustomPropertyValue = string;
 type CustomProperty = {
   name: CustomPropertyName;
   value: CustomPropertyValue;
-  deprecation?: { replacement: CustomPropertyName };
+  deprecation?:
+    | { replacement: CustomPropertyName }
+    | { additionalInfo: string };
 };
 type CustomProperties = CustomProperty[];
 
@@ -101,7 +103,11 @@ function getRows(
             {deprecation && (
               <Tooltip
                 type="description"
-                label={`Use the \`${deprecation.replacement}\` custom property instead.`}
+                label={
+                  'replacement' in deprecation
+                    ? `Use the \`${deprecation.replacement}\` custom property instead.`
+                    : deprecation.additionalInfo
+                }
                 component={(props) => (
                   <Badge
                     {...props}
@@ -196,7 +202,7 @@ export function BorderRadius({ name }: PreviewProps) {
             ? 'var(--cui-spacings-mega)'
             : 'var(--cui-spacings-tera)',
         borderRadius: `var(${name})`,
-        backgroundColor: 'var(--cui-bg-accent-strong)',
+        backgroundColor: 'var(--cui-bg-strong)',
       }}
     />
   );
@@ -285,7 +291,7 @@ export function Spacing({ name }: PreviewProps) {
         display: 'inline-block',
         width: `var(${name})`,
         height: `var(${name})`,
-        backgroundColor: 'var(--cui-bg-accent-strong)',
+        backgroundColor: 'var(--cui-bg-strong)',
       }}
     />
   );
@@ -310,7 +316,7 @@ export function Transition({ name }: PreviewProps) {
         display: 'inline-block',
         width: 'var(--cui-spacings-tera)',
         height: 'var(--cui-spacings-tera)',
-        backgroundColor: 'var(--cui-bg-accent-strong)',
+        backgroundColor: 'var(--cui-bg-strong)',
         borderRadius: 'var(--cui-border-radius-circle)',
         transition: `transform var(${name})`,
         transform: `scale(${scale}%)`,

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -189,13 +189,13 @@
 /* Variants */
 .primary {
   color: var(--cui-fg-on-strong);
-  background-color: var(--cui-bg-accent-strong);
+  background-color: var(--cui-bg-strong);
   border-color: transparent;
 }
 
 .primary:hover {
   color: var(--cui-fg-on-strong-hovered);
-  background-color: var(--cui-bg-accent-strong-hovered);
+  background-color: var(--cui-bg-strong-hovered);
   border-color: transparent;
 }
 
@@ -203,7 +203,7 @@
 .primary[aria-expanded="true"],
 .primary[aria-pressed="true"] {
   color: var(--cui-fg-on-strong-pressed);
-  background-color: var(--cui-bg-accent-strong-pressed);
+  background-color: var(--cui-bg-strong-pressed);
   border-color: transparent;
 }
 

--- a/packages/circuit-ui/components/Calendar/Calendar.module.css
+++ b/packages/circuit-ui/components/Calendar/Calendar.module.css
@@ -141,19 +141,19 @@
 [aria-pressed="true"].range-end {
   font-weight: var(--cui-font-weight-bold);
   color: var(--cui-fg-on-strong);
-  background: var(--cui-bg-accent-strong);
+  background: var(--cui-bg-strong);
 }
 
 .selected:hover,
 [aria-pressed="true"].range-start:hover,
 [aria-pressed="true"].range-end:hover {
-  background: var(--cui-bg-accent-strong-hovered);
+  background: var(--cui-bg-strong-hovered);
 }
 
 .selected:active,
 .range-start:active,
 .range-end:active {
-  background: var(--cui-bg-accent-strong-pressed);
+  background: var(--cui-bg-strong-pressed);
 }
 
 .range-start::before,
@@ -217,7 +217,7 @@ td:not(:last-of-type) .range-end.last-day::before {
 .day[aria-disabled="true"].range-start,
 .day[aria-disabled="true"].range-end {
   color: var(--cui-fg-on-strong-disabled);
-  background: var(--cui-bg-accent-strong-disabled);
+  background: var(--cui-bg-strong-disabled);
 }
 
 .day[aria-disabled="true"].range-start::before,

--- a/packages/circuit-ui/components/Checkbox/CheckboxInput.module.css
+++ b/packages/circuit-ui/components/Checkbox/CheckboxInput.module.css
@@ -81,7 +81,7 @@
 
 .base:checked + .label::before,
 .base:indeterminate + .label::before {
-  background-color: var(--cui-bg-accent-strong);
+  background-color: var(--cui-bg-strong);
   border-color: var(--cui-border-accent);
 }
 
@@ -89,7 +89,7 @@
 .base:checked[disabled] + .label::before,
 .base:indeterminate:disabled + .label::before,
 .base:indeterminate[disabled] + .label::before {
-  background-color: var(--cui-bg-accent-strong-disabled);
+  background-color: var(--cui-bg-strong-disabled);
   border-color: var(--cui-border-accent-disabled);
 }
 
@@ -135,6 +135,6 @@
 
 .base:disabled:checked + .label::before,
 .base[disabled]:checked + .label::before {
-  background-color: var(--cui-bg-accent-strong-disabled);
+  background-color: var(--cui-bg-strong-disabled);
   border-color: var(--cui-border-accent-disabled);
 }

--- a/packages/circuit-ui/components/ProgressBar/ProgressBar.module.css
+++ b/packages/circuit-ui/components/ProgressBar/ProgressBar.module.css
@@ -21,7 +21,7 @@
   width: 1px;
   height: 100%;
   content: "";
-  background-color: var(--cui-bg-accent-strong);
+  background-color: var(--cui-bg-strong);
   transition: width 0.05s ease-out;
 }
 

--- a/packages/circuit-ui/components/Tag/Tag.module.css
+++ b/packages/circuit-ui/components/Tag/Tag.module.css
@@ -31,7 +31,7 @@
 
 .selected .content {
   color: var(--cui-fg-on-strong);
-  background-color: var(--cui-bg-accent-strong);
+  background-color: var(--cui-bg-strong);
   border-color: var(--cui-border-accent);
 }
 
@@ -61,14 +61,14 @@ button.content:active {
 .selected a.content:hover,
 .selected button.content:hover {
   color: var(--cui-fg-on-strong-hovered);
-  background-color: var(--cui-bg-accent-strong-hovered);
+  background-color: var(--cui-bg-strong-hovered);
   border-color: var(--cui-border-accent-hovered);
 }
 
 .selected a.content:active,
 .selected button.content:active {
   color: var(--cui-fg-on-strong-pressed);
-  background-color: var(--cui-bg-accent-strong-pressed);
+  background-color: var(--cui-bg-strong-pressed);
   border-color: var(--cui-border-accent-pressed);
 }
 

--- a/packages/circuit-ui/components/Toggle/Toggle.module.css
+++ b/packages/circuit-ui/components/Toggle/Toggle.module.css
@@ -53,7 +53,7 @@
 
 .track[aria-checked="true"]:disabled,
 .track[aria-checked="true"][disabled] {
-  background-color: var(--cui-bg-accent-strong-disabled);
+  background-color: var(--cui-bg-strong-disabled);
   border: 1px solid transparent;
 }
 

--- a/packages/design-tokens/themes/consumer.ts
+++ b/packages/design-tokens/themes/consumer.ts
@@ -116,6 +116,7 @@ export const consumer = [
     value: 'rgba(58, 16, 55, 0.6000)',
     type: 'color',
   },
+  /* eslint-disable circuit-ui/no-deprecated-custom-properties */
   {
     name: '--cui-bg-accent-strong',
     value: '#fbfbf9',
@@ -136,6 +137,7 @@ export const consumer = [
     value: 'rgba(251, 251, 249, 0.1500)',
     type: 'color',
   },
+  /* eslint-enable circuit-ui/no-deprecated-custom-properties */
   {
     name: '--cui-bg-neutral',
     value: 'rgba(104, 79, 98, 0.3500)',

--- a/packages/design-tokens/themes/dark.ts
+++ b/packages/design-tokens/themes/dark.ts
@@ -116,6 +116,7 @@ export const dark = [
     value: 'rgba(26, 24, 22, 0.6000)',
     type: 'color',
   },
+  /* eslint-disable circuit-ui/no-deprecated-custom-properties */
   {
     name: '--cui-bg-accent-strong',
     value: '#f5f4ed',
@@ -136,6 +137,7 @@ export const dark = [
     value: 'rgba(245, 244, 237, 0.1000)',
     type: 'color',
   },
+  /* eslint-enable circuit-ui/no-deprecated-custom-properties */
   {
     name: '--cui-bg-neutral',
     value: '#2b2927',

--- a/packages/design-tokens/themes/light.ts
+++ b/packages/design-tokens/themes/light.ts
@@ -116,6 +116,7 @@ export const light = [
     value: 'rgba(227, 226, 214, 0.6000)',
     type: 'color',
   },
+  /* eslint-disable circuit-ui/no-deprecated-custom-properties */
   {
     name: '--cui-bg-accent-strong',
     value: '#1e1c1c',
@@ -136,6 +137,7 @@ export const light = [
     value: 'rgba(30, 28, 28, 0.1000)',
     type: 'color',
   },
+  /* eslint-enable circuit-ui/no-deprecated-custom-properties */
   {
     name: '--cui-bg-neutral',
     value: '#f0eee7',

--- a/packages/design-tokens/themes/schema.ts
+++ b/packages/design-tokens/themes/schema.ts
@@ -38,10 +38,28 @@ export const schema = [
   { name: '--cui-bg-accent-hovered', type: 'color' },
   { name: '--cui-bg-accent-pressed', type: 'color' },
   { name: '--cui-bg-accent-disabled', type: 'color' },
-  { name: '--cui-bg-accent-strong', type: 'color' },
-  { name: '--cui-bg-accent-strong-hovered', type: 'color' },
-  { name: '--cui-bg-accent-strong-pressed', type: 'color' },
-  { name: '--cui-bg-accent-strong-disabled', type: 'color' },
+  /* eslint-disable circuit-ui/no-deprecated-custom-properties */
+  {
+    name: '--cui-bg-accent-strong',
+    type: 'color',
+    deprecation: { replacement: '--cui-bg-strong' },
+  },
+  {
+    name: '--cui-bg-accent-strong-hovered',
+    type: 'color',
+    deprecation: { replacement: '--cui-bg-strong-hovered' },
+  },
+  {
+    name: '--cui-bg-accent-strong-pressed',
+    type: 'color',
+    deprecation: { replacement: '--cui-bg-strong-pressed' },
+  },
+  {
+    name: '--cui-bg-accent-strong-disabled',
+    type: 'color',
+    deprecation: { replacement: '--cui-bg-strong-disabled' },
+  },
+  /* eslint-enable circuit-ui/no-deprecated-custom-properties */
   /* Neutral backgrounds */
   { name: '--cui-bg-neutral', type: 'color' },
   { name: '--cui-bg-neutral-hovered', type: 'color' },
@@ -458,9 +476,18 @@ export const schema = [
   { name: '--cui-z-index-tooltip', type: 'number' },
   { name: '--cui-z-index-header', type: 'number' },
   { name: '--cui-z-index-navigation', type: 'number' },
-  { name: '--cui-z-index-toast', type: 'number' },
+
+  /* eslint-disable circuit-ui/no-deprecated-custom-properties */
+  {
+    name: '--cui-z-index-toast',
+    type: 'number',
+    deprecation: {
+      additionalInfo: 'Use one of the existing z-index tokens instead.',
+    },
+  },
+  /* eslint-enable circuit-ui/no-deprecated-custom-properties */
 ] satisfies {
   name: TokenName;
   type: TokenType;
-  deprecation?: { replacement: TokenName };
+  deprecation?: { replacement: TokenName } | { additionalInfo: string };
 }[];

--- a/packages/design-tokens/themes/shared.ts
+++ b/packages/design-tokens/themes/shared.ts
@@ -546,11 +546,13 @@ export const shared = [
     value: 800,
     type: 'number',
   },
+  /* eslint-disable circuit-ui/no-deprecated-custom-properties */
   {
     name: '--cui-z-index-toast',
     value: 1100,
     type: 'number',
   },
+  /* eslint-enable circuit-ui/no-deprecated-custom-properties */
 ] satisfies Token[];
 
 export const sharedUntilGiga = [

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-custom-properties/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-custom-properties/index.spec.ts
@@ -135,6 +135,38 @@ ruleTester.run(
           },
         ],
       },
+      {
+        name: 'deprecated custom property with a replacement token',
+        code: `
+          const styles = css\`
+            background-color: var(--cui-bg-accent-strong);
+          \`;
+        `,
+        output: `
+          const styles = css\`
+            background-color: var(--cui-bg-strong);
+          \`;
+        `,
+        errors: [
+          {
+            messageId: 'deprecated',
+          },
+        ],
+      },
+      {
+        name: 'deprecated custom property with no replacement token',
+        code: `
+          const styles = css\`
+            z-index: var(--cui-z-index-toast);
+          \`;
+        `,
+        output: null,
+        errors: [
+          {
+            messageId: 'deprecatedNoReplacement',
+          },
+        ],
+      },
     ],
   },
 );

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
@@ -20,9 +20,9 @@ import type { RuleDocs } from '../utils/meta.js';
 const DEPRECATED_CUSTOM_PROPERTIES = schema.filter(({ deprecation }) =>
   Boolean(deprecation),
 );
-const REGEX_STRING = DEPRECATED_CUSTOM_PROPERTIES.map(({ name }) => name).join(
-  '|',
-);
+const REGEX_STRING = DEPRECATED_CUSTOM_PROPERTIES.map(({ name }) => name)
+  .sort((a, b) => b.length - a.length)
+  .join('|');
 
 const createRule = ESLintUtils.RuleCreator<RuleDocs>(
   (name) =>
@@ -82,9 +82,7 @@ export const noDeprecatedCustomProperties = createRule({
                 },
               });
             } else {
-              const additionalInfo = String(
-                (deprecation as { additionalInfo: string }).additionalInfo,
-              );
+              const additionalInfo = String(deprecation.additionalInfo);
               context.report({
                 node,
                 loc,

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
@@ -42,6 +42,8 @@ export const noDeprecatedCustomProperties = createRule({
     messages: {
       deprecated:
         'The `{{name}}` custom property has been deprecated. Use the `{{replacement}}` custom property instead.',
+      deprecatedNoReplacement:
+        'The `{{name}}` custom property has been deprecated. {{additionalInfo}}',
     },
   },
   defaultOptions: [],
@@ -55,33 +57,41 @@ export const noDeprecatedCustomProperties = createRule({
           // biome-ignore lint/suspicious/noAssignInExpressions: This is fine
           while ((match = regex.exec(line)) !== null) {
             const name = match[0];
-            const { replacement } = DEPRECATED_CUSTOM_PROPERTIES.find(
+            const deprecation = DEPRECATED_CUSTOM_PROPERTIES.find(
               (token) => token.name === name,
             )!.deprecation!;
-            context.report({
-              node,
-              loc: {
-                start: {
-                  line: index + 1,
-                  column: match.index,
+            const loc = {
+              start: { line: index + 1, column: match.index },
+              end: {
+                line: index + 1,
+                column: match.index + match[0].length,
+              },
+            };
+            if ('replacement' in deprecation) {
+              const replacement = String(deprecation.replacement);
+              context.report({
+                node,
+                loc,
+                messageId: 'deprecated',
+                data: { name, replacement },
+                fix(fixer) {
+                  return fixer.replaceText(
+                    node,
+                    context.sourceCode.getText(node).replace(name, replacement),
+                  );
                 },
-                end: {
-                  line: index + 1,
-                  column: match.index + match[0].length,
-                },
-              },
-              messageId: 'deprecated',
-              data: {
-                name,
-                replacement,
-              },
-              fix(fixer) {
-                return fixer.replaceText(
-                  node,
-                  context.sourceCode.getText(node).replace(name, replacement),
-                );
-              },
-            });
+              });
+            } else {
+              const additionalInfo = String(
+                (deprecation as { additionalInfo: string }).additionalInfo,
+              );
+              context.report({
+                node,
+                loc,
+                messageId: 'deprecatedNoReplacement',
+                data: { name, additionalInfo },
+              });
+            }
           }
         });
       },

--- a/packages/stylelint-plugin-circuit-ui/no-deprecated-custom-properties/index.spec.ts
+++ b/packages/stylelint-plugin-circuit-ui/no-deprecated-custom-properties/index.spec.ts
@@ -109,5 +109,19 @@ testRule({
         },
       ],
     },
+    {
+      code: `.class {
+        z-index: var(--cui-z-index-toast);
+      }`,
+      description: 'Disallow deprecated custom property with no replacement',
+      message: messages.deprecatedNoReplacement(
+        '--cui-z-index-toast',
+        'Use one of the existing z-index tokens instead.',
+      ),
+      line: 2,
+      column: 9,
+      endLine: 2,
+      endColumn: 41,
+    },
   ],
 });

--- a/packages/stylelint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
+++ b/packages/stylelint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
@@ -19,9 +19,9 @@ import { schema } from '@sumup-oss/design-tokens';
 const DEPRECATED_CUSTOM_PROPERTIES = schema.filter(({ deprecation }) =>
   Boolean(deprecation),
 );
-const REGEX_STRING = DEPRECATED_CUSTOM_PROPERTIES.map(({ name }) => name).join(
-  '|',
-);
+const REGEX_STRING = DEPRECATED_CUSTOM_PROPERTIES.map(({ name }) => name)
+  .sort((a, b) => b.length - a.length)
+  .join('|');
 
 export const ruleName = 'circuit-ui/no-deprecated-custom-properties';
 
@@ -65,9 +65,7 @@ const rule: Rule = (enabled, _options, context) => (root, result) => {
           ruleName,
         });
       } else {
-        const additionalInfo = String(
-          (deprecation as { additionalInfo: string }).additionalInfo,
-        );
+        const additionalInfo = String(deprecation.additionalInfo);
         stylelint.utils.report({
           message: messages.deprecatedNoReplacement(name, additionalInfo),
           node: decl,

--- a/packages/stylelint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
+++ b/packages/stylelint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
@@ -37,7 +37,7 @@ export const messages = stylelint.utils.ruleMessages(ruleName, {
     `The \`${name}\` custom property has been deprecated. ${additionalInfo}`,
 });
 
-const rule: Rule = (enabled, _options, context) => (root, result) => {
+const rule: Rule = (enabled) => (root, result) => {
   if (!enabled || DEPRECATED_CUSTOM_PROPERTIES.length === 0) {
     return;
   }
@@ -55,14 +55,14 @@ const rule: Rule = (enabled, _options, context) => (root, result) => {
 
       if ('replacement' in deprecation) {
         const replacement = String(deprecation.replacement);
-        if (context?.fix) {
-          decl.value = decl.value.replace(name, replacement);
-        }
         stylelint.utils.report({
           message: messages.deprecated(name, replacement),
           node: decl,
           result,
           ruleName,
+          fix: () => {
+            decl.value = decl.value.replace(name, replacement);
+          },
         });
       } else {
         const additionalInfo = String(deprecation.additionalInfo);

--- a/packages/stylelint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
+++ b/packages/stylelint-plugin-circuit-ui/no-deprecated-custom-properties/index.ts
@@ -33,6 +33,8 @@ const meta = {
 export const messages = stylelint.utils.ruleMessages(ruleName, {
   deprecated: (name: string, replacement: string) =>
     `The \`${name}\` custom property has been deprecated. Use the \`${replacement}\` custom property instead.`,
+  deprecatedNoReplacement: (name: string, additionalInfo: string) =>
+    `The \`${name}\` custom property has been deprecated. ${additionalInfo}`,
 });
 
 const rule: Rule = (enabled, _options, context) => (root, result) => {
@@ -47,20 +49,32 @@ const rule: Rule = (enabled, _options, context) => (root, result) => {
     while ((match = regex.exec(decl.value)) !== null) {
       const name = match[0];
       // biome-ignore lint/style/noNonNullAssertion: Each item is guaranteed to have a deprecation.
-      const { replacement } = DEPRECATED_CUSTOM_PROPERTIES.find(
+      const deprecation = DEPRECATED_CUSTOM_PROPERTIES.find(
         (token) => token.name === name,
       )!.deprecation!;
 
-      if (context?.fix) {
-        decl.value = decl.value.replace(name, replacement);
+      if ('replacement' in deprecation) {
+        const replacement = String(deprecation.replacement);
+        if (context?.fix) {
+          decl.value = decl.value.replace(name, replacement);
+        }
+        stylelint.utils.report({
+          message: messages.deprecated(name, replacement),
+          node: decl,
+          result,
+          ruleName,
+        });
+      } else {
+        const additionalInfo = String(
+          (deprecation as { additionalInfo: string }).additionalInfo,
+        );
+        stylelint.utils.report({
+          message: messages.deprecatedNoReplacement(name, additionalInfo),
+          node: decl,
+          result,
+          ruleName,
+        });
       }
-
-      stylelint.utils.report({
-        message: messages.deprecated(name, replacement),
-        node: decl,
-        result,
-        ruleName,
-      });
     }
   });
 };

--- a/scripts/generate-skills.js
+++ b/scripts/generate-skills.js
@@ -38,7 +38,7 @@ const componentReferencesDir = path.join(referencesDir, 'components');
 const hookReferencesDir = path.join(referencesDir, 'hooks');
 
 const TOKEN_SCHEMA_PATTERN =
-  /\{\s*name:\s*'([^']+)'\s*,\s*type:\s*'([^']+)'\s*(?:,\s*deprecation:\s*\{\s*replacement:\s*'([^']+)'\s*\}\s*)?\}/gms;
+  /\{\s*name:\s*'([^']+)'\s*,\s*type:\s*'([^']+)'\s*(?:,\s*deprecation:\s*(\{[^}]*\}),?\s*)?\}/gms;
 const TOKEN_VALUE_PATTERN =
   /\{\s*name:\s*'([^']+)'\s*,\s*value:\s*(?:'((?:\\'|[^'])*)'|(-?\d+(?:\.\d+)?))\s*,\s*type:\s*'([^']+)'\s*,?\s*\}/gms;
 const EXPORT_STATEMENT_PATTERN =
@@ -50,10 +50,13 @@ function parseTokens(schemaSource) {
   const tokens = [];
   let match = TOKEN_SCHEMA_PATTERN.exec(schemaSource);
   while (match !== null) {
+    const deprecationStr = match[3] ?? null;
+    const replacementMatch = deprecationStr?.match(/replacement:\s*'([^']+)'/);
     tokens.push({
       name: match[1],
       type: match[2],
-      replacement: match[3] ?? null,
+      deprecated: deprecationStr !== null,
+      replacement: replacementMatch?.[1] ?? null,
     });
     match = TOKEN_SCHEMA_PATTERN.exec(schemaSource);
   }
@@ -310,7 +313,7 @@ function renderTokensMarkdown(tokens, lightValues, darkValues, sharedValues) {
 
   const tokenRows = tokens
     .map((token) => {
-      const deprecated = token.replacement ? 'yes' : 'no';
+      const deprecated = token.deprecated ? 'yes' : 'no';
       const replacement = token.replacement ? `\`${token.replacement}\`` : '';
       const light =
         lightValues.get(token.name) ?? sharedValues.get(token.name) ?? '';

--- a/skills/circuit-ui/references/design-tokens.md
+++ b/skills/circuit-ui/references/design-tokens.md
@@ -24,6 +24,10 @@ CSS variables provided by the Circuit UI design system and their values.
 | `--cui-bg-accent-hovered` | `color` | no |  | `#e8e6dc` | `#222018` |
 | `--cui-bg-accent-pressed` | `color` | no |  | `#d9d6c7` | `#2a2820` |
 | `--cui-bg-accent-disabled` | `color` | no |  | `rgba(227, 226, 214, 0.6000)` | `rgba(26, 24, 22, 0.6000)` |
+| `--cui-bg-accent-strong` | `color` | yes | `--cui-bg-strong` | `#1e1c1c` | `#f5f4ed` |
+| `--cui-bg-accent-strong-hovered` | `color` | yes | `--cui-bg-strong-hovered` | `#332f2f` | `#e8e6dc` |
+| `--cui-bg-accent-strong-pressed` | `color` | yes | `--cui-bg-strong-pressed` | `#4d4949` | `#d9d6c7` |
+| `--cui-bg-accent-strong-disabled` | `color` | yes | `--cui-bg-strong-disabled` | `rgba(30, 28, 28, 0.1000)` | `rgba(245, 244, 237, 0.1000)` |
 | `--cui-bg-neutral` | `color` | no |  | `#f0eee7` | `#2b2927` |
 | `--cui-bg-neutral-hovered` | `color` | no |  | `#e8e6dc` | `#201f1e` |
 | `--cui-bg-neutral-pressed` | `color` | no |  | `#d9d6c7` | `#282726` |
@@ -230,6 +234,30 @@ CSS variables provided by the Circuit UI design system and their values.
 | `--cui-numeral-s-line-height` | `dimension` | no |  | `1.5rem` | `1.5rem` |
 | `--cui-letter-spacing` | `dimension` | no |  | `0rem` | `0rem` |
 | `--cui-letter-spacing-tight` | `dimension` | no |  | `0rem` | `0rem` |
+| `--cui-typography-headline-one-font-size` | `dimension` | yes | `--cui-headline-l-font-size` | `2.0625rem` | `2.0625rem` |
+| `--cui-typography-headline-one-line-height` | `dimension` | yes | `--cui-headline-l-line-height` | `2.125rem` | `2.125rem` |
+| `--cui-typography-headline-two-font-size` | `dimension` | yes | `--cui-headline-m-font-size` | `1.5625rem` | `1.5625rem` |
+| `--cui-typography-headline-two-line-height` | `dimension` | yes | `--cui-headline-m-line-height` | `1.625rem` | `1.625rem` |
+| `--cui-typography-headline-three-font-size` | `dimension` | yes | `--cui-headline-m-font-size` | `1.5625rem` | `1.5625rem` |
+| `--cui-typography-headline-three-line-height` | `dimension` | yes | `--cui-headline-m-line-height` | `1.625rem` | `1.625rem` |
+| `--cui-typography-headline-four-font-size` | `dimension` | yes | `--cui-headline-s-font-size` | `1.1875rem` | `1.1875rem` |
+| `--cui-typography-headline-four-line-height` | `dimension` | yes | `--cui-headline-s-line-height` | `1.375rem` | `1.375rem` |
+| `--cui-typography-title-one-font-size` | `dimension` | yes | `--cui-display-l-font-size` | `4rem` | `4rem` |
+| `--cui-typography-title-one-line-height` | `dimension` | yes | `--cui-display-l-line-height` | `4.5rem` | `4.5rem` |
+| `--cui-typography-title-two-font-size` | `dimension` | yes | `--cui-display-m-font-size` | `3rem` | `3rem` |
+| `--cui-typography-title-two-line-height` | `dimension` | yes | `--cui-display-m-line-height` | `3.5rem` | `3.5rem` |
+| `--cui-typography-title-three-font-size` | `dimension` | yes | `--cui-display-m-font-size` | `3rem` | `3rem` |
+| `--cui-typography-title-three-line-height` | `dimension` | yes | `--cui-display-m-line-height` | `3.5rem` | `3.5rem` |
+| `--cui-typography-title-four-font-size` | `dimension` | yes | `--cui-display-s-font-size` | `2.5rem` | `2.5rem` |
+| `--cui-typography-title-four-line-height` | `dimension` | yes | `--cui-display-s-line-height` | `2.875rem` | `2.875rem` |
+| `--cui-typography-sub-headline-font-size` | `dimension` | yes | `--cui-headline-s-font-size` | `1.125rem` | `1.125rem` |
+| `--cui-typography-sub-headline-line-height` | `dimension` | yes | `--cui-headline-s-line-height` | `1.375rem` | `1.375rem` |
+| `--cui-typography-body-one-font-size` | `dimension` | yes | `--cui-body-m-font-size` | `1.0625rem` | `1.0625rem` |
+| `--cui-typography-body-one-line-height` | `dimension` | yes | `--cui-body-m-line-height` | `1.5rem` | `1.5rem` |
+| `--cui-typography-body-two-font-size` | `dimension` | yes | `--cui-body-s-font-size` | `0.9375rem` | `0.9375rem` |
+| `--cui-typography-body-two-line-height` | `dimension` | yes | `--cui-body-s-line-height` | `1.25rem` | `1.25rem` |
+| `--cui-typography-body-large-font-size` | `dimension` | yes | `--cui-body-l-font-size` | `1.3125rem` | `1.3125rem` |
+| `--cui-typography-body-large-line-height` | `dimension` | yes | `--cui-body-l-line-height` | `1.625rem` | `1.625rem` |
 | `--cui-z-index-default` | `number` | no |  | `0` | `0` |
 | `--cui-z-index-absolute` | `number` | no |  | `1` | `1` |
 | `--cui-z-index-input` | `number` | no |  | `20` | `20` |
@@ -238,3 +266,4 @@ CSS variables provided by the Circuit UI design system and their values.
 | `--cui-z-index-tooltip` | `number` | no |  | `40` | `40` |
 | `--cui-z-index-header` | `number` | no |  | `600` | `600` |
 | `--cui-z-index-navigation` | `number` | no |  | `800` | `800` |
+| `--cui-z-index-toast` | `number` | yes |  | `1100` | `1100` |

--- a/skills/circuit-ui/references/design-tokens.md
+++ b/skills/circuit-ui/references/design-tokens.md
@@ -24,10 +24,6 @@ CSS variables provided by the Circuit UI design system and their values.
 | `--cui-bg-accent-hovered` | `color` | no |  | `#e8e6dc` | `#222018` |
 | `--cui-bg-accent-pressed` | `color` | no |  | `#d9d6c7` | `#2a2820` |
 | `--cui-bg-accent-disabled` | `color` | no |  | `rgba(227, 226, 214, 0.6000)` | `rgba(26, 24, 22, 0.6000)` |
-| `--cui-bg-accent-strong` | `color` | no |  | `#1e1c1c` | `#f5f4ed` |
-| `--cui-bg-accent-strong-hovered` | `color` | no |  | `#332f2f` | `#e8e6dc` |
-| `--cui-bg-accent-strong-pressed` | `color` | no |  | `#4d4949` | `#d9d6c7` |
-| `--cui-bg-accent-strong-disabled` | `color` | no |  | `rgba(30, 28, 28, 0.1000)` | `rgba(245, 244, 237, 0.1000)` |
 | `--cui-bg-neutral` | `color` | no |  | `#f0eee7` | `#2b2927` |
 | `--cui-bg-neutral-hovered` | `color` | no |  | `#e8e6dc` | `#201f1e` |
 | `--cui-bg-neutral-pressed` | `color` | no |  | `#d9d6c7` | `#282726` |
@@ -242,4 +238,3 @@ CSS variables provided by the Circuit UI design system and their values.
 | `--cui-z-index-tooltip` | `number` | no |  | `40` | `40` |
 | `--cui-z-index-header` | `number` | no |  | `600` | `600` |
 | `--cui-z-index-navigation` | `number` | no |  | `800` | `800` |
-| `--cui-z-index-toast` | `number` | no |  | `1100` | `1100` |


### PR DESCRIPTION
Addresses [DSYS-1689](https://sumupteam.atlassian.net/browse/DSYS-1689)

## Purpose

Deprecate design tokens `--cui-z-index-toast` and the `accent-strong` color family 

## Approach and changes

- Deprecates the `--cui-bg-accent-strong-*` token family (4 tokens) in `@sumup-oss/design-tokens`, replacing them with the equivalent `--cui-bg-strong-*` tokens. The two families are nearly identical and are being consolidated.
- Deprecates `--cui-z-index-toast` in `@sumup-oss/design-tokens` (no direct replacement, consumers should update z-index based on the context manually).
- Updates the `no-deprecated-custom-properties` rule in both `@sumup-oss/eslint-plugin-circuit-ui and @sumup-oss/stylelint-plugin-circuit-ui` to support tokens that have no auto-fixable replacement, surfacing a guidance message instead.
- Migrates all internal Circuit UI component styles `(Button, Calendar, Checkbox, ProgressBar, Tag, Toggle)` off the deprecated `--cui-bg-accent-strong-*` tokens.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
