### PR TITLE
mark Badge as deprecated in docs

### DIFF
--- a/packages/circuit-ui/components/Badge/Badge.mdx
+++ b/packages/circuit-ui/components/Badge/Badge.mdx
@@ -5,7 +5,7 @@ import * as Stories from './Badge.stories';
 
 # Badge
 
-<Status variant="stable" />
+<Status variant="deprecated" />
 
 Badges are non-actionable elements in the UI, used to indicate the status of an object.
 

--- a/skills/circuit-ui/references/components.md
+++ b/skills/circuit-ui/references/components.md
@@ -44,7 +44,7 @@
 | `ActionMenu` | `stable` | `@sumup-oss/circuit-ui` | `./components/ActionMenu/index.js` | [Read MDX reference](components/ActionMenu.mdx) |
 | `AspectRatio` | `stable` | `@sumup-oss/circuit-ui` | `./components/AspectRatio/index.js` | Not available |
 | `Avatar` | `stable` | `@sumup-oss/circuit-ui` | `./components/Avatar/index.js` | [Read MDX reference](components/Avatar.mdx) |
-| `Badge` | `stable` | `@sumup-oss/circuit-ui` | `./components/Badge/index.js` | [Read MDX reference](components/Badge.mdx) |
+| `Badge` | `deprecated` | `@sumup-oss/circuit-ui` | `./components/Badge/index.js` | [Read MDX reference](components/Badge.mdx) |
 | `Card` | `stable` | `@sumup-oss/circuit-ui` | `./components/Card/index.js` | [Read MDX reference](components/Card.mdx) |
 | `CardFooter` | `stable` | `@sumup-oss/circuit-ui` | `./components/Card/index.js` | [Read MDX reference](components/CardFooter.mdx) |
 | `CardHeader` | `stable` | `@sumup-oss/circuit-ui` | `./components/Card/index.js` | [Read MDX reference](components/CardHeader.mdx) |

--- a/skills/circuit-ui/references/components/Badge.mdx
+++ b/skills/circuit-ui/references/components/Badge.mdx
@@ -5,7 +5,7 @@ import * as Stories from './Badge.stories';
 
 # Badge
 
-<Status variant="stable" />
+<Status variant="deprecated" />
 
 Badges are non-actionable elements in the UI, used to indicate the status of an object.
 


### PR DESCRIPTION
## Purpose

The badge component has become deprecated in [v11.5.0](https://github.com/sumup-oss/circuit-ui/releases/tag/%40sumup-oss%2Fcircuit-ui%4011.5.0) but still has a "stable" status in docs instead of "deprecated"

## Approach and changes

Update lifecycle status of the Badge component.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
