### PR TITLE
feat(circuit-ui): Callout component

### DIFF
--- a/.changeset/curvy-plums-call.md
+++ b/.changeset/curvy-plums-call.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': minor
+---
+
+Added the experimental Callout component for static inline guidance or emphasis.

--- a/packages/circuit-ui/components/Callout/Callout.mdx
+++ b/packages/circuit-ui/components/Callout/Callout.mdx
@@ -16,7 +16,7 @@ The `Callout` component renders static guidance or emphasis content within the c
 
 Use callouts to highlight persistent guidance, contextual tips, or extra information that belongs next to related content.
 
-Keep callout copy concise and static. For semantic feedback to user actions, use [`NotificationInline`](Notifications/NotificationInline). For dismissible content or content with a call to action, use [`NotificationBanner`](Notifications/NotificationBanner).
+Keep callout copy concise and static. For semantic feedback in response to user actions, such as success or error messages, use the [`NotificationInline`](Notifications/NotificationInline) component. For dismissible content or content with a call to action, use the [`NotificationBanner`](Notifications/NotificationBanner) component.
 
 ## How to use it
 
@@ -25,25 +25,10 @@ Keep callout copy concise and static. For semantic feedback to user actions, use
 <Story of={Stories.Variants} />
 
 - Use the 'info' variant for informational, neutral messages.
-- Use the 'success' variant for successful messages.
-- Use the 'warning' variant for warning messages, and other information a user should be aware of.
-- Use the 'danger' variant for error messages. Be descriptive and give users clear next steps.
 - Use the 'promo' variant for promotional or upgrade-related messages.
 
-### Links
+### Content
 
-The callout body supports links to related content. Avoid placing other interactive content inside a callout.
+The body of the Callout should be static and purely informational. Keep the content limited to text and links to related resources, and avoid placing other interactive elements such as buttons, form controls, or custom actions.
 
 <Story of={Stories.WithRichContent} />
-
-## Accessibility
-
-### Best practices
-
-#### Place callouts close to their related content
-
-Callouts are part of the content flow, and should be placed near their related content. Make use of headings and semantic markup to programmatically group content into meaningful sections.
-
-#### Avoid dynamically rendering a callout
-
-The `Callout` component is meant for static content. If you need to render a message dynamically, you most likely want to use the [`NotificationInline`](Notifications/NotificationInline) component instead.

--- a/packages/circuit-ui/components/Callout/Callout.mdx
+++ b/packages/circuit-ui/components/Callout/Callout.mdx
@@ -1,0 +1,43 @@
+import { Meta, Status, Props, Story } from '../../../../.storybook/components';
+import * as Stories from './Callout.stories';
+
+<Meta of={Stories} />
+
+# Callout
+
+<Status variant="experimental" />
+
+The `Callout` component renders static inline guidance or emphasis within the content flow.
+
+<Story of={Stories.Base} />
+<Props />
+
+## Component variations
+
+### Callout variants
+
+<Story of={Stories.Variants} />
+
+- Use the 'info' variant for informational, neutral messages.
+- Use the 'success' variant for successful messages.
+- Use the 'warning' variant for warning messages, and other information a user should be aware of.
+- Use the 'danger' variant for error messages. Be descriptive and give users clear next steps.
+- Use the 'promo' variant for promotional or upgrade-related messages.
+
+### Callouts with rich content
+
+The callout body supports arbitrary React nodes.
+
+<Story of={Stories.WithRichContent} />
+
+## Accessibility
+
+### Best practices
+
+#### Place callouts close to their related content
+
+Callouts are part of the content flow, and should be placed near their related content. Make use of headings and semantic markup to programmatically group content into meaningful sections.
+
+#### Avoid dynamically rendering a callout
+
+The `Callout` component is meant for static content. If you need to render a message dynamically, you most likely want to use the [`NotificationInline`](Notifications/NotificationInline) component instead.

--- a/packages/circuit-ui/components/Callout/Callout.mdx
+++ b/packages/circuit-ui/components/Callout/Callout.mdx
@@ -20,12 +20,12 @@ Keep callout copy concise and static. For semantic feedback in response to user 
 
 ## How to use it
 
-### Variants
+### Colors
 
-<Story of={Stories.Variants} />
+<Story of={Stories.Colors} />
 
-- Use the 'info' variant for informational, neutral messages.
-- Use the 'promo' variant for promotional or upgrade-related messages.
+- Use the 'info' color for informational, neutral messages.
+- Use the 'promo' color for promotional or upgrade-related messages.
 
 ### Content
 

--- a/packages/circuit-ui/components/Callout/Callout.mdx
+++ b/packages/circuit-ui/components/Callout/Callout.mdx
@@ -7,14 +7,20 @@ import * as Stories from './Callout.stories';
 
 <Status variant="experimental" />
 
-The `Callout` component renders static inline guidance or emphasis within the content flow.
+The `Callout` component renders static guidance or emphasis content within the content flow.
 
 <Story of={Stories.Base} />
 <Props />
 
-## Component variations
+## When to use it
 
-### Callout variants
+Use callouts to highlight persistent guidance, contextual tips, or extra information that belongs next to related content.
+
+Keep callout copy concise and static. For semantic feedback to user actions, use [`NotificationInline`](Notifications/NotificationInline). For dismissible content or content with a call to action, use [`NotificationBanner`](Notifications/NotificationBanner).
+
+## How to use it
+
+### Variants
 
 <Story of={Stories.Variants} />
 
@@ -24,9 +30,9 @@ The `Callout` component renders static inline guidance or emphasis within the co
 - Use the 'danger' variant for error messages. Be descriptive and give users clear next steps.
 - Use the 'promo' variant for promotional or upgrade-related messages.
 
-### Callouts with rich content
+### Links
 
-The callout body supports arbitrary React nodes.
+The callout body supports links to related content. Avoid placing other interactive content inside a callout.
 
 <Story of={Stories.WithRichContent} />
 

--- a/packages/circuit-ui/components/Callout/Callout.mdx
+++ b/packages/circuit-ui/components/Callout/Callout.mdx
@@ -24,7 +24,10 @@ Keep callout copy concise and static. For semantic feedback in response to user 
 
 <Story of={Stories.Colors} />
 
-- Use the 'info' color for informational, neutral messages.
+- Use the 'confirm' color for positive guidance.
+- Use the 'neutral' color for informational, neutral messages.
+- Use the 'notify' color for cautionary guidance.
+- Use the 'alert' color for urgent or critical guidance.
 - Use the 'promo' color for promotional or upgrade-related messages.
 
 ### Content

--- a/packages/circuit-ui/components/Callout/Callout.module.css
+++ b/packages/circuit-ui/components/Callout/Callout.module.css
@@ -27,35 +27,35 @@
 
 /* Colors */
 
-.info {
-  background-color: var(--cui-bg-subtle);
-}
-
-.info .icon {
-  color: var(--cui-fg-accent);
-}
-
-.success {
+.confirm {
   background-color: var(--cui-bg-success);
 }
 
-.success .icon {
+.confirm .icon {
   color: var(--cui-fg-success);
 }
 
-.warning {
+.neutral {
+  background-color: var(--cui-bg-neutral);
+}
+
+.neutral .icon {
+  color: var(--cui-fg-neutral);
+}
+
+.notify {
   background-color: var(--cui-bg-warning);
 }
 
-.warning .icon {
+.notify .icon {
   color: var(--cui-fg-warning);
 }
 
-.danger {
+.alert {
   background-color: var(--cui-bg-danger);
 }
 
-.danger .icon {
+.alert .icon {
   color: var(--cui-fg-danger);
 }
 

--- a/packages/circuit-ui/components/Callout/Callout.module.css
+++ b/packages/circuit-ui/components/Callout/Callout.module.css
@@ -25,7 +25,7 @@
   letter-spacing: var(--cui-letter-spacing);
 }
 
-/* Variants */
+/* Colors */
 
 .info {
   background-color: var(--cui-bg-subtle);

--- a/packages/circuit-ui/components/Callout/Callout.module.css
+++ b/packages/circuit-ui/components/Callout/Callout.module.css
@@ -19,6 +19,10 @@
   flex-direction: column;
   align-items: flex-start;
   padding-left: var(--cui-spacings-mega);
+  font-size: var(--cui-body-m-font-size);
+  font-weight: var(--cui-font-weight-regular);
+  line-height: var(--cui-body-m-line-height);
+  letter-spacing: var(--cui-letter-spacing);
 }
 
 /* Variants */

--- a/packages/circuit-ui/components/Callout/Callout.module.css
+++ b/packages/circuit-ui/components/Callout/Callout.module.css
@@ -1,0 +1,64 @@
+.base {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: var(--cui-spacings-kilo) var(--cui-spacings-mega);
+  border-radius: var(--cui-border-radius-kilo);
+}
+
+.icon {
+  position: relative;
+  flex-grow: 0;
+  flex-shrink: 0;
+  align-self: flex-start;
+  line-height: 0;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding-left: var(--cui-spacings-mega);
+}
+
+/* Variants */
+
+.info {
+  background-color: var(--cui-bg-subtle);
+}
+
+.info .icon {
+  color: var(--cui-fg-accent);
+}
+
+.success {
+  background-color: var(--cui-bg-success);
+}
+
+.success .icon {
+  color: var(--cui-fg-success);
+}
+
+.warning {
+  background-color: var(--cui-bg-warning);
+}
+
+.warning .icon {
+  color: var(--cui-fg-warning);
+}
+
+.danger {
+  background-color: var(--cui-bg-danger);
+}
+
+.danger .icon {
+  color: var(--cui-fg-danger);
+}
+
+.promo {
+  background-color: var(--cui-bg-promo);
+}
+
+.promo .icon {
+  color: var(--cui-fg-promo);
+}

--- a/packages/circuit-ui/components/Callout/Callout.spec.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.spec.tsx
@@ -35,18 +35,6 @@ describe('Callout', () => {
     expect(screen.getByText('This is a callout')).toBeVisible();
   });
 
-  it.each([
-    'confirm',
-    'neutral',
-    'notify',
-    'alert',
-    'promo',
-  ] as const)('should render the %s color', (color) => {
-    const { container } = renderCallout({ ...baseProps, color });
-
-    expect(container.firstElementChild?.className).toContain(`_${color}_`);
-  });
-
   it('should render a custom icon', () => {
     const CustomIcon = (props: IconProps) => (
       <svg {...props} data-testid="custom-icon" />

--- a/packages/circuit-ui/components/Callout/Callout.spec.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.spec.tsx
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2026, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import type { IconProps } from '@sumup-oss/icons';
+
+import { axe, render, screen } from '../../util/test-utils.js';
+
+import { Callout, type CalloutProps } from './Callout.js';
+
+describe('Callout', () => {
+  const renderCallout = (props: CalloutProps) => render(<Callout {...props} />);
+
+  const baseProps: CalloutProps = {
+    body: 'This is a callout',
+  };
+
+  it('should render the callout', () => {
+    renderCallout(baseProps);
+
+    expect(screen.getByText('This is a callout')).toBeVisible();
+  });
+
+  it.each([
+    'info',
+    'success',
+    'warning',
+    'danger',
+    'promo',
+  ] as const)('should render the %s variant', (variant) => {
+    const { container } = renderCallout({ ...baseProps, variant });
+
+    expect(container.firstElementChild?.className).toContain(`_${variant}_`);
+  });
+
+  it('should render a custom icon', () => {
+    const CustomIcon = (props: IconProps) => (
+      <svg {...props} data-testid="custom-icon" />
+    );
+
+    renderCallout({ ...baseProps, icon: CustomIcon });
+
+    const icon = screen.getByTestId('custom-icon');
+
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('should render the icon label visually hidden', () => {
+    renderCallout({ ...baseProps, iconLabel: 'Information' });
+
+    expect(screen.getByText('Information')).toBeInTheDocument();
+  });
+
+  it('should forward a ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    const { container } = render(<Callout ref={ref} {...baseProps} />);
+
+    expect(ref.current).toBe(container.firstChild);
+  });
+
+  it('should have no accessibility violations', async () => {
+    const { container } = renderCallout(baseProps);
+    const actual = await axe(container);
+
+    expect(actual).toHaveNoViolations();
+  });
+});

--- a/packages/circuit-ui/components/Callout/Callout.spec.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.spec.tsx
@@ -36,10 +36,10 @@ describe('Callout', () => {
   });
 
   it.each([
-    'info',
-    'success',
-    'warning',
-    'danger',
+    'confirm',
+    'neutral',
+    'notify',
+    'alert',
     'promo',
   ] as const)('should render the %s color', (color) => {
     const { container } = renderCallout({ ...baseProps, color });

--- a/packages/circuit-ui/components/Callout/Callout.spec.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.spec.tsx
@@ -41,10 +41,10 @@ describe('Callout', () => {
     'warning',
     'danger',
     'promo',
-  ] as const)('should render the %s variant', (variant) => {
-    const { container } = renderCallout({ ...baseProps, variant });
+  ] as const)('should render the %s color', (color) => {
+    const { container } = renderCallout({ ...baseProps, color });
 
-    expect(container.firstElementChild?.className).toContain(`_${variant}_`);
+    expect(container.firstElementChild?.className).toContain(`_${color}_`);
   });
 
   it('should render a custom icon', () => {

--- a/packages/circuit-ui/components/Callout/Callout.stories.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.stories.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { Info, Sparkles } from '@sumup-oss/icons';
+
 import { Stack } from '../../../../.storybook/components/index.js';
 import { Anchor } from '../Anchor/Anchor.js';
 
@@ -24,32 +26,34 @@ export default {
   tags: ['status:experimental'],
 };
 
-const variants = ['info', 'promo'] as const;
+const colors = ['info', 'promo'] as const;
 
 export const Base = (args: CalloutProps) => <Callout {...args} />;
 
 Base.args = {
   body: 'Callout is a newly available component for static inline guidance or emphasis.',
-  variant: 'promo',
+  color: 'promo',
+  icon: Sparkles,
 } as CalloutProps;
 
 Base.parameters = {
   chromatic: {
-    // covered in the Variants story
+    // covered in the Colors story
     disableSnapshot: true,
   },
 };
 
-export const Variants = (args: CalloutProps) => (
+export const Colors = (args: CalloutProps) => (
   <Stack vertical>
-    {variants.map((variant) => (
-      <Callout key={variant} {...args} variant={variant} />
+    {colors.map((color) => (
+      <Callout key={color} {...args} color={color} />
     ))}
   </Stack>
 );
 
-Variants.args = {
+Colors.args = {
   body: 'This is a callout message',
+  icon: Info,
 } as CalloutProps;
 
 export const WithRichContent = (args: CalloutProps) => <Callout {...args} />;
@@ -61,5 +65,6 @@ WithRichContent.args = {
       <Anchor href="#callout-rich-content">links to related content</Anchor>.
     </div>
   ),
-  variant: 'promo',
+  color: 'promo',
+  icon: Sparkles,
 } as CalloutProps;

--- a/packages/circuit-ui/components/Callout/Callout.stories.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.stories.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2026, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Stack } from '../../../../.storybook/components/index.js';
+import { Anchor } from '../Anchor/Anchor.js';
+import { List } from '../List/List.js';
+
+import { Callout, type CalloutProps } from './Callout.js';
+
+export default {
+  title: 'Components/Callout',
+  component: Callout,
+  tags: ['status:experimental'],
+};
+
+const variants = ['info', 'success', 'warning', 'danger', 'promo'] as const;
+
+export const Base = (args: CalloutProps) => <Callout {...args} />;
+
+Base.args = {
+  body: 'Callout is a newly available component for static inline guidance or emphasis.',
+  variant: 'promo',
+} as CalloutProps;
+
+Base.parameters = {
+  chromatic: {
+    // covered in the Variants story
+    disableSnapshot: true,
+  },
+};
+
+export const Variants = (args: CalloutProps) => (
+  <Stack vertical>
+    {variants.map((variant) => (
+      <Callout key={variant} {...args} variant={variant} />
+    ))}
+  </Stack>
+);
+
+Variants.args = {
+  body: 'This is a callout message',
+} as CalloutProps;
+
+export const WithRichContent = (args: CalloutProps) => <Callout {...args} />;
+
+WithRichContent.args = {
+  body: (
+    <div id="callout-rich-content">
+      Callouts can include{' '}
+      <Anchor href="#callout-rich-content">links to related content</Anchor> and
+      lists:
+      <List>
+        <li>Keep the content static.</li>
+        <li>Place it near the related interface.</li>
+      </List>
+    </div>
+  ),
+  variant: 'promo',
+} as CalloutProps;

--- a/packages/circuit-ui/components/Callout/Callout.stories.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.stories.tsx
@@ -19,12 +19,12 @@ import { Anchor } from '../Anchor/Anchor.js';
 import { Callout, type CalloutProps } from './Callout.js';
 
 export default {
-  title: 'Notifications/Callout',
+  title: 'Notification/Callout',
   component: Callout,
   tags: ['status:experimental'],
 };
 
-const variants = ['info', 'success', 'warning', 'danger', 'promo'] as const;
+const variants = ['info', 'promo'] as const;
 
 export const Base = (args: CalloutProps) => <Callout {...args} />;
 

--- a/packages/circuit-ui/components/Callout/Callout.stories.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.stories.tsx
@@ -26,7 +26,7 @@ export default {
   tags: ['status:experimental'],
 };
 
-const colors = ['info', 'promo'] as const;
+const colors = ['confirm', 'neutral', 'notify', 'alert', 'promo'] as const;
 
 export const Base = (args: CalloutProps) => <Callout {...args} />;
 

--- a/packages/circuit-ui/components/Callout/Callout.stories.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.stories.tsx
@@ -15,12 +15,11 @@
 
 import { Stack } from '../../../../.storybook/components/index.js';
 import { Anchor } from '../Anchor/Anchor.js';
-import { List } from '../List/List.js';
 
 import { Callout, type CalloutProps } from './Callout.js';
 
 export default {
-  title: 'Components/Callout',
+  title: 'Notifications/Callout',
   component: Callout,
   tags: ['status:experimental'],
 };
@@ -59,12 +58,7 @@ WithRichContent.args = {
   body: (
     <div id="callout-rich-content">
       Callouts can include{' '}
-      <Anchor href="#callout-rich-content">links to related content</Anchor> and
-      lists:
-      <List>
-        <li>Keep the content static.</li>
-        <li>Place it near the related interface.</li>
-      </List>
+      <Anchor href="#callout-rich-content">links to related content</Anchor>.
     </div>
   ),
   variant: 'promo',

--- a/packages/circuit-ui/components/Callout/Callout.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.tsx
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2026, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+
+import {
+  Alert,
+  Confirm,
+  Info,
+  Notify,
+  Sparkles,
+  type IconComponentType,
+} from '@sumup-oss/icons';
+
+import { Body } from '../Body/index.js';
+import { clsx } from '../../styles/clsx.js';
+import { utilClasses } from '../../styles/utility.js';
+
+import classes from './Callout.module.css';
+
+export type CalloutVariant =
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  | 'promo';
+
+const CALLOUT_ICONS: Record<CalloutVariant, IconComponentType<'24'>> = {
+  info: Info,
+  success: Confirm,
+  warning: Notify,
+  danger: Alert,
+  promo: Sparkles,
+};
+
+export interface CalloutProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * The callout's variant.
+   * @default 'info'
+   */
+  variant?: CalloutVariant;
+  /**
+   * The callout's body content.
+   */
+  body: ReactNode;
+  /**
+   * The icon displayed next to the body.
+   */
+  icon?: IconComponentType<'24'>;
+  /**
+   * A text replacement for the icon in the context of the callout, if its body
+   * copy isn't self-explanatory. Defaults to an empty string.
+   */
+  iconLabel?: string;
+}
+
+/**
+ * The `Callout` component renders static inline guidance or emphasis within
+ * the content flow.
+ */
+export const Callout = forwardRef<HTMLDivElement, CalloutProps>(
+  (
+    { variant = 'info', body, icon, iconLabel = '', className, ...props },
+    ref,
+  ) => {
+    const Icon = icon || CALLOUT_ICONS[variant];
+
+    return (
+      <div
+        ref={ref}
+        className={clsx(classes.base, classes[variant], className)}
+        {...props}
+      >
+        <div className={classes.icon}>
+          <Icon aria-hidden="true" size="24" />
+        </div>
+        <span className={utilClasses.hideVisually}>{iconLabel}</span>
+        <Body as="div" className={classes.content}>
+          {body}
+        </Body>
+      </div>
+    );
+  },
+);
+
+Callout.displayName = 'Callout';

--- a/packages/circuit-ui/components/Callout/Callout.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.tsx
@@ -22,12 +22,7 @@ import { utilClasses } from '../../styles/utility.js';
 
 import classes from './Callout.module.css';
 
-export type CalloutColor =
-  | 'confirm'
-  | 'neutral'
-  | 'notify'
-  | 'alert'
-  | 'promo';
+export type CalloutColor = 'confirm' | 'neutral' | 'notify' | 'alert' | 'promo';
 
 export interface CalloutProps extends HTMLAttributes<HTMLDivElement> {
   /**

--- a/packages/circuit-ui/components/Callout/Callout.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.tsx
@@ -22,12 +22,17 @@ import { utilClasses } from '../../styles/utility.js';
 
 import classes from './Callout.module.css';
 
-export type CalloutColor = 'info' | 'success' | 'warning' | 'danger' | 'promo';
+export type CalloutColor =
+  | 'confirm'
+  | 'neutral'
+  | 'notify'
+  | 'alert'
+  | 'promo';
 
 export interface CalloutProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * The callout's color.
-   * @default 'info'
+   * @default 'neutral'
    */
   color?: CalloutColor;
   /**
@@ -52,7 +57,7 @@ export interface CalloutProps extends HTMLAttributes<HTMLDivElement> {
 export const Callout = forwardRef<HTMLDivElement, CalloutProps>(
   (
     {
-      color = 'info',
+      color = 'neutral',
       body,
       icon: Icon = Info,
       iconLabel = '',

--- a/packages/circuit-ui/components/Callout/Callout.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.tsx
@@ -24,7 +24,6 @@ import {
   type IconComponentType,
 } from '@sumup-oss/icons';
 
-import { Body } from '../Body/index.js';
 import { clsx } from '../../styles/clsx.js';
 import { utilClasses } from '../../styles/utility.js';
 
@@ -87,9 +86,7 @@ export const Callout = forwardRef<HTMLDivElement, CalloutProps>(
           <Icon aria-hidden="true" size="24" />
         </div>
         <span className={utilClasses.hideVisually}>{iconLabel}</span>
-        <Body as="div" className={classes.content}>
-          {body}
-        </Body>
+        <div className={classes.content}>{body}</div>
       </div>
     );
   },

--- a/packages/circuit-ui/components/Callout/Callout.tsx
+++ b/packages/circuit-ui/components/Callout/Callout.tsx
@@ -15,41 +15,21 @@
 
 import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
 
-import {
-  Alert,
-  Confirm,
-  Info,
-  Notify,
-  Sparkles,
-  type IconComponentType,
-} from '@sumup-oss/icons';
+import { Info, type IconComponentType } from '@sumup-oss/icons';
 
 import { clsx } from '../../styles/clsx.js';
 import { utilClasses } from '../../styles/utility.js';
 
 import classes from './Callout.module.css';
 
-export type CalloutVariant =
-  | 'info'
-  | 'success'
-  | 'warning'
-  | 'danger'
-  | 'promo';
-
-const CALLOUT_ICONS: Record<CalloutVariant, IconComponentType<'24'>> = {
-  info: Info,
-  success: Confirm,
-  warning: Notify,
-  danger: Alert,
-  promo: Sparkles,
-};
+export type CalloutColor = 'info' | 'success' | 'warning' | 'danger' | 'promo';
 
 export interface CalloutProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * The callout's variant.
+   * The callout's color.
    * @default 'info'
    */
-  variant?: CalloutVariant;
+  color?: CalloutColor;
   /**
    * The callout's body content.
    */
@@ -71,25 +51,28 @@ export interface CalloutProps extends HTMLAttributes<HTMLDivElement> {
  */
 export const Callout = forwardRef<HTMLDivElement, CalloutProps>(
   (
-    { variant = 'info', body, icon, iconLabel = '', className, ...props },
+    {
+      color = 'info',
+      body,
+      icon: Icon = Info,
+      iconLabel = '',
+      className,
+      ...props
+    },
     ref,
-  ) => {
-    const Icon = icon || CALLOUT_ICONS[variant];
-
-    return (
-      <div
-        ref={ref}
-        className={clsx(classes.base, classes[variant], className)}
-        {...props}
-      >
-        <div className={classes.icon}>
-          <Icon aria-hidden="true" size="24" />
-        </div>
-        <span className={utilClasses.hideVisually}>{iconLabel}</span>
-        <div className={classes.content}>{body}</div>
+  ) => (
+    <div
+      ref={ref}
+      className={clsx(classes.base, classes[color], className)}
+      {...props}
+    >
+      <div className={classes.icon}>
+        <Icon aria-hidden="true" size="24" />
       </div>
-    );
-  },
+      <span className={utilClasses.hideVisually}>{iconLabel}</span>
+      <div className={classes.content}>{body}</div>
+    </div>
+  ),
 );
 
 Callout.displayName = 'Callout';

--- a/packages/circuit-ui/components/Callout/index.tsx
+++ b/packages/circuit-ui/components/Callout/index.tsx
@@ -14,4 +14,4 @@
  */
 
 export { Callout } from './Callout.js';
-export type { CalloutProps, CalloutVariant } from './Callout.js';
+export type { CalloutColor, CalloutProps } from './Callout.js';

--- a/packages/circuit-ui/components/Callout/index.tsx
+++ b/packages/circuit-ui/components/Callout/index.tsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2026, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { Callout } from './Callout.js';
+export type { CalloutProps, CalloutVariant } from './Callout.js';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -86,6 +86,11 @@ export type { SelectorGroupProps } from './components/SelectorGroup/index.js';
 export type { ClickEvent } from './types/events.js';
 
 // Notifications
+export { Callout } from './components/Callout/index.js';
+export type {
+  CalloutProps,
+  CalloutVariant,
+} from './components/Callout/index.js';
 export { NotificationBanner } from './components/NotificationBanner/index.js';
 export type { NotificationBannerProps } from './components/NotificationBanner/index.js';
 export { NotificationFullscreen } from './components/NotificationFullscreen/index.js';

--- a/packages/circuit-ui/index.ts
+++ b/packages/circuit-ui/index.ts
@@ -88,8 +88,8 @@ export type { ClickEvent } from './types/events.js';
 // Notifications
 export { Callout } from './components/Callout/index.js';
 export type {
+  CalloutColor,
   CalloutProps,
-  CalloutVariant,
 } from './components/Callout/index.js';
 export { NotificationBanner } from './components/NotificationBanner/index.js';
 export type { NotificationBannerProps } from './components/NotificationBanner/index.js';

--- a/skills/circuit-ui/references/components.md
+++ b/skills/circuit-ui/references/components.md
@@ -91,6 +91,7 @@
 
 | Component | Status | Package | Source export | Usage reference |
 | --- | --- | --- | --- | --- |
+| `Callout` | `experimental` | `@sumup-oss/circuit-ui` | `./components/Callout/index.js` | [Read MDX reference](components/Callout.mdx) |
 | `NotificationBanner` | `stable` | `@sumup-oss/circuit-ui` | `./components/NotificationBanner/index.js` | [Read MDX reference](components/NotificationBanner.mdx) |
 | `NotificationFullscreen` | `stable` | `@sumup-oss/circuit-ui` | `./components/NotificationFullscreen/index.js` | [Read MDX reference](components/NotificationFullscreen.mdx) |
 | `NotificationInline` | `stable` | `@sumup-oss/circuit-ui` | `./components/NotificationInline/index.js` | [Read MDX reference](components/NotificationInline.mdx) |

--- a/skills/circuit-ui/references/components/Callout.mdx
+++ b/skills/circuit-ui/references/components/Callout.mdx
@@ -16,7 +16,7 @@ The `Callout` component renders static guidance or emphasis content within the c
 
 Use callouts to highlight persistent guidance, contextual tips, or extra information that belongs next to related content.
 
-Keep callout copy concise and static. For semantic feedback to user actions, use [`NotificationInline`](Notifications/NotificationInline). For dismissible content or content with a call to action, use [`NotificationBanner`](Notifications/NotificationBanner).
+Keep callout copy concise and static. For semantic feedback in response to user actions, such as success or error messages, use the [`NotificationInline`](Notifications/NotificationInline) component. For dismissible content or content with a call to action, use the [`NotificationBanner`](Notifications/NotificationBanner) component.
 
 ## How to use it
 
@@ -25,25 +25,10 @@ Keep callout copy concise and static. For semantic feedback to user actions, use
 <Story of={Stories.Variants} />
 
 - Use the 'info' variant for informational, neutral messages.
-- Use the 'success' variant for successful messages.
-- Use the 'warning' variant for warning messages, and other information a user should be aware of.
-- Use the 'danger' variant for error messages. Be descriptive and give users clear next steps.
 - Use the 'promo' variant for promotional or upgrade-related messages.
 
-### Links
+### Content
 
-The callout body supports links to related content. Avoid placing other interactive content inside a callout.
+The body of the Callout should be static and purely informational. Keep the content limited to text and links to related resources, and avoid placing other interactive elements such as buttons, form controls, or custom actions.
 
 <Story of={Stories.WithRichContent} />
-
-## Accessibility
-
-### Best practices
-
-#### Place callouts close to their related content
-
-Callouts are part of the content flow, and should be placed near their related content. Make use of headings and semantic markup to programmatically group content into meaningful sections.
-
-#### Avoid dynamically rendering a callout
-
-The `Callout` component is meant for static content. If you need to render a message dynamically, you most likely want to use the [`NotificationInline`](Notifications/NotificationInline) component instead.

--- a/skills/circuit-ui/references/components/Callout.mdx
+++ b/skills/circuit-ui/references/components/Callout.mdx
@@ -1,0 +1,43 @@
+import { Meta, Status, Props, Story } from '../../../../.storybook/components';
+import * as Stories from './Callout.stories';
+
+<Meta of={Stories} />
+
+# Callout
+
+<Status variant="experimental" />
+
+The `Callout` component renders static inline guidance or emphasis within the content flow.
+
+<Story of={Stories.Base} />
+<Props />
+
+## Component variations
+
+### Callout variants
+
+<Story of={Stories.Variants} />
+
+- Use the 'info' variant for informational, neutral messages.
+- Use the 'success' variant for successful messages.
+- Use the 'warning' variant for warning messages, and other information a user should be aware of.
+- Use the 'danger' variant for error messages. Be descriptive and give users clear next steps.
+- Use the 'promo' variant for promotional or upgrade-related messages.
+
+### Callouts with rich content
+
+The callout body supports arbitrary React nodes.
+
+<Story of={Stories.WithRichContent} />
+
+## Accessibility
+
+### Best practices
+
+#### Place callouts close to their related content
+
+Callouts are part of the content flow, and should be placed near their related content. Make use of headings and semantic markup to programmatically group content into meaningful sections.
+
+#### Avoid dynamically rendering a callout
+
+The `Callout` component is meant for static content. If you need to render a message dynamically, you most likely want to use the [`NotificationInline`](Notifications/NotificationInline) component instead.

--- a/skills/circuit-ui/references/components/Callout.mdx
+++ b/skills/circuit-ui/references/components/Callout.mdx
@@ -20,12 +20,12 @@ Keep callout copy concise and static. For semantic feedback in response to user 
 
 ## How to use it
 
-### Variants
+### Colors
 
-<Story of={Stories.Variants} />
+<Story of={Stories.Colors} />
 
-- Use the 'info' variant for informational, neutral messages.
-- Use the 'promo' variant for promotional or upgrade-related messages.
+- Use the 'info' color for informational, neutral messages.
+- Use the 'promo' color for promotional or upgrade-related messages.
 
 ### Content
 

--- a/skills/circuit-ui/references/components/Callout.mdx
+++ b/skills/circuit-ui/references/components/Callout.mdx
@@ -7,14 +7,20 @@ import * as Stories from './Callout.stories';
 
 <Status variant="experimental" />
 
-The `Callout` component renders static inline guidance or emphasis within the content flow.
+The `Callout` component renders static guidance or emphasis content within the content flow.
 
 <Story of={Stories.Base} />
 <Props />
 
-## Component variations
+## When to use it
 
-### Callout variants
+Use callouts to highlight persistent guidance, contextual tips, or extra information that belongs next to related content.
+
+Keep callout copy concise and static. For semantic feedback to user actions, use [`NotificationInline`](Notifications/NotificationInline). For dismissible content or content with a call to action, use [`NotificationBanner`](Notifications/NotificationBanner).
+
+## How to use it
+
+### Variants
 
 <Story of={Stories.Variants} />
 
@@ -24,9 +30,9 @@ The `Callout` component renders static inline guidance or emphasis within the co
 - Use the 'danger' variant for error messages. Be descriptive and give users clear next steps.
 - Use the 'promo' variant for promotional or upgrade-related messages.
 
-### Callouts with rich content
+### Links
 
-The callout body supports arbitrary React nodes.
+The callout body supports links to related content. Avoid placing other interactive content inside a callout.
 
 <Story of={Stories.WithRichContent} />
 

--- a/skills/circuit-ui/references/components/Callout.mdx
+++ b/skills/circuit-ui/references/components/Callout.mdx
@@ -24,7 +24,10 @@ Keep callout copy concise and static. For semantic feedback in response to user 
 
 <Story of={Stories.Colors} />
 
-- Use the 'info' color for informational, neutral messages.
+- Use the 'confirm' color for positive guidance.
+- Use the 'neutral' color for informational, neutral messages.
+- Use the 'notify' color for cautionary guidance.
+- Use the 'alert' color for urgent or critical guidance.
 - Use the 'promo' color for promotional or upgrade-related messages.
 
 ### Content


### PR DESCRIPTION
## Purpose

On text-heavy websites we sometimes want to call out a specific feature, warning, and similar. One example being our developer portal: https://developer.sumup.com/online-payments/testing. This use-case doesn't align well with the existing `InlineNotification` which comes the closest in desired style but has different purpose that shouldn't be overloaded.

## Approach and changes

Adds a new `Callout` component that is close in implementation to `InlineNotification` but:

- supports `promo` variant
- has configurable `icon`
- doesn't support `action`

Related (internal Slack thread): https://sumup.slack.com/archives/CURHLN94K/p1782128993767939

## Definition of done

* [x] Development completed
* [ ] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [ ] Meets accessibility requirements
