### PR TITLE
pin node version in CI to 24.18.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [22, 24]
+        node: [22, 24.18.0]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Create release PR or publish to npm
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/canary' || startsWith(github.ref, 'refs/heads/release')) && matrix.node == 24
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/canary' || startsWith(github.ref, 'refs/heads/release')) && matrix.node == '24.18.0'
         uses: changesets/action@v1
         with:
           publish: npm run release


### PR DESCRIPTION
## Purpose

Recently we noticed issues in CI with node 24.17.x, 
`🦋  error Error: Failed to parse data from GitHub
🦋  error Invalid response body while trying to fetch https://api.github.com/graphql: Premature close`

The issue is related to node-fetch@2 reporting false ERR_STREAM_PREMATURE_CLOSE errors, causing our CI to fail unexpectedly. v24.18.0 was released 7 days ago so it passes our 7-day wait rule.

## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
