### PR TITLE
PhoneNumberInput flag size

### DIFF
--- a/.changeset/hip-needles-design.md
+++ b/.changeset/hip-needles-design.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Made PhoneNumberInput default flag size responsive to the input size.

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -199,13 +199,20 @@ export interface PhoneNumberInputProps
   };
 }
 
-const DefaultPrefix: ComponentType<{
+type DefaultPrefixProps = {
   value?: string | number;
   className?: string;
-}> = ({ value, ...rest }) =>
+  size?: FieldSize;
+};
+
+const DefaultPrefix = ({ value, ...rest }: DefaultPrefixProps) =>
   value ? (
     <Flag countryCode={value as FlagProps['countryCode']} alt="" {...rest} />
   ) : null;
+
+const getDefaultPrefix = (size: FieldSize) => (args: DefaultPrefixProps) => (
+  <DefaultPrefix size={size} {...args} />
+);
 
 /**
  * Provides a straightforward way for users to type their phone number in an
@@ -404,6 +411,7 @@ export function PhoneNumberInput({
               (({ value: inputValue, ...rest }) => (
                 <DefaultPrefix
                   value={getCountry(countryCode.options, inputValue as string)}
+                  size={size}
                   {...rest}
                 />
               ))
@@ -434,7 +442,7 @@ export function PhoneNumberInput({
               countryCodeRef as RefObject<HTMLSelectElement | null>,
               countryCode.ref as ForwardedRef<HTMLSelectElement>,
             )}
-            renderPrefix={countryCode.renderPrefix ?? DefaultPrefix}
+            renderPrefix={countryCode.renderPrefix ?? getDefaultPrefix(size)}
           />
         )}
         <Input


### PR DESCRIPTION
Addresses [DSYS-1762](https://sumupteam.atlassian.net/browse/DSYS-1762)

## Purpose

#3711 introduced the `size` prop in the Flag component. Since we also recently support sizes in input fields, we can make the flag size in the PhoneNumberInput component responsive to the input's size.

## Approach and changes

Use PhoneNumberInput's size to adjust default prefix flag size accordingly.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
