### PR TITLE
Remove deprecated IconButton API

### DIFF
--- a/.changeset/cute-glasses-clap.md
+++ b/.changeset/cute-glasses-clap.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed the deprecated `label` prop from the IconButton component. Use the `children` prop for the label and the `icon` prop for the icon instead.

--- a/packages/circuit-ui/components/Button/Button.tsx
+++ b/packages/circuit-ui/components/Button/Button.tsx
@@ -24,7 +24,7 @@ import { deprecate } from '../../util/logger.js';
 
 import classes from './Button.module.css';
 import {
-  createButtonComponent,
+  BaseButton,
   legacyButtonSizeMap,
   type SharedButtonProps,
 } from './base.js';
@@ -59,43 +59,49 @@ export type ButtonProps = SharedButtonProps & {
  * The Button component enables the user to perform an action or navigate
  * to a different screen.
  */
-export const Button = createButtonComponent<ButtonProps>(
-  'Button',
-  ({ className, size: legacySize = 'm', stretch, variant, ...props }) => {
-    const size = legacyButtonSizeMap[legacySize] || legacySize;
+export function Button({
+  className,
+  size: legacySize = 'm',
+  stretch,
+  variant,
+  ...props
+}: ButtonProps) {
+  const size = legacyButtonSizeMap[legacySize] || legacySize;
 
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      process.env.NODE_ENV !== 'test' &&
-      props.icon &&
-      props.navigationIcon
-    ) {
-      throw new CircuitError(
-        'Button',
-        'The leading and trailing icons cannot be used at the same time. Remove either the `icon` or the `navigationIcon` prop.',
-      );
-    }
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    props.icon &&
+    props.navigationIcon
+  ) {
+    throw new CircuitError(
+      'Button',
+      'The leading and trailing icons cannot be used at the same time. Remove either the `icon` or the `navigationIcon` prop.',
+    );
+  }
 
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      legacyButtonSizeMap[legacySize]
-    ) {
-      deprecate(
-        'Button',
-        `The \`${legacySize}\` size has been deprecated. Use the \`${legacyButtonSizeMap[legacySize]}\` size instead.`,
-      );
-    }
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    legacyButtonSizeMap[legacySize]
+  ) {
+    deprecate(
+      'Button',
+      `The \`${legacySize}\` size has been deprecated. Use the \`${legacyButtonSizeMap[legacySize]}\` size instead.`,
+    );
+  }
 
-    return {
-      className: clsx(
+  return (
+    <BaseButton
+      componentName="Button"
+      className={clsx(
         className,
         classes[size],
         stretch && classes.stretch,
         variant === 'tertiary' && classes.tertiary,
-      ),
-      variant,
-      size,
-      ...props,
-    };
-  },
-);
+      )}
+      variant={variant}
+      size={size}
+      {...props}
+    />
+  );
+}

--- a/packages/circuit-ui/components/Button/IconButton.spec.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.spec.tsx
@@ -31,20 +31,6 @@ describe('IconButton', () => {
     expect(icon).toBeVisible();
   });
 
-  /**
-   * @deprecated
-   */
-  it('should render an icon passed as children', () => {
-    render(
-      // eslint-disable-next-line circuit-ui/no-renamed-props
-      <IconButton label="Close">
-        <svg data-testid="icon" />
-      </IconButton>,
-    );
-    const icon = screen.getByTestId('icon');
-    expect(icon).toBeVisible();
-  });
-
   it('should render a visually hidden label', () => {
     render(<IconButton icon={Close}>Close</IconButton>);
     const label = screen.getByText('Close');

--- a/packages/circuit-ui/components/Button/IconButton.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.tsx
@@ -22,7 +22,7 @@ import { CircuitError } from '../../util/errors.js';
 import { deprecate } from '../../util/logger.js';
 
 import {
-  createButtonComponent,
+  BaseButton,
   legacyButtonSizeMap,
   type SharedButtonProps,
 } from './base.js';
@@ -47,31 +47,35 @@ export type IconButtonProps = SharedButtonProps & {
  * The IconButton component enables the user to perform an action or navigate
  * to a different screen.
  */
-export const IconButton = createButtonComponent<IconButtonProps>(
-  'IconButton',
-  ({ className, size: legacySize = 'm', ...props }) => {
-    const size = legacyButtonSizeMap[legacySize] || legacySize;
+export function IconButton({
+  className,
+  size: legacySize = 'm',
+  ...props
+}: IconButtonProps) {
+  const size = legacyButtonSizeMap[legacySize] || legacySize;
 
-    if (process.env.NODE_ENV !== 'production' && !props.icon) {
-      throw new CircuitError('IconButton', 'The `icon` prop is missing.');
-    }
+  if (process.env.NODE_ENV !== 'production' && !props.icon) {
+    throw new CircuitError('IconButton', 'The `icon` prop is missing.');
+  }
 
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      legacyButtonSizeMap[legacySize]
-    ) {
-      deprecate(
-        'IconButton',
-        `The \`${legacySize}\` size has been deprecated. Use the \`${legacyButtonSizeMap[legacySize]}\` size instead.`,
-      );
-    }
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    legacyButtonSizeMap[legacySize]
+  ) {
+    deprecate(
+      'IconButton',
+      `The \`${legacySize}\` size has been deprecated. Use the \`${legacyButtonSizeMap[legacySize]}\` size instead.`,
+    );
+  }
 
-    return {
-      className: clsx(classes.base, classes[size], className),
-      size,
-      title: props.children,
-      'aria-label': props.children,
-      ...props,
-    };
-  },
-);
+  return (
+    <BaseButton
+      componentName="IconButton"
+      className={clsx(classes.base, classes[size], className)}
+      size={size}
+      title={props.children}
+      aria-label={props.children}
+      {...props}
+    />
+  );
+}

--- a/packages/circuit-ui/components/Button/IconButton.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.tsx
@@ -15,13 +15,11 @@
 
 'use client';
 
-import { Children, cloneElement, type ReactElement } from 'react';
-import type { IconComponentType, IconProps } from '@sumup-oss/icons';
+import type { IconComponentType } from '@sumup-oss/icons';
 
 import { clsx } from '../../styles/clsx.js';
 import { CircuitError } from '../../util/errors.js';
 import { deprecate } from '../../util/logger.js';
-import { isString } from '../../util/type-check.js';
 
 import {
   createButtonComponent,
@@ -37,18 +35,12 @@ export type IconButtonProps = SharedButtonProps & {
    * one-word object if needed to clarify.
    * Displayed on hover and accessible to screen readers.
    */
-  children?: ReactElement<IconProps> | string;
-  /**
-   * @deprecated
-   *
-   * Use the `children` prop instead.
-   */
-  label?: string;
+  children: string;
   /**
    * The icon provides context for the button, such as a “search” icon for a
    * search field submission.
    */
-  icon?: IconComponentType;
+  icon: IconComponentType;
 };
 
 /**
@@ -57,36 +49,11 @@ export type IconButtonProps = SharedButtonProps & {
  */
 export const IconButton = createButtonComponent<IconButtonProps>(
   'IconButton',
-  ({
-    className,
-    icon: Icon,
-    label,
-    children,
-    size: legacySize = 'm',
-    ...props
-  }) => {
+  ({ className, size: legacySize = 'm', ...props }) => {
     const size = legacyButtonSizeMap[legacySize] || legacySize;
 
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      !Icon &&
-      Children.count(children) !== 1
-    ) {
+    if (process.env.NODE_ENV !== 'production' && !props.icon) {
       throw new CircuitError('IconButton', 'The `icon` prop is missing.');
-    }
-
-    if (process.env.NODE_ENV !== 'production' && !isString(children)) {
-      deprecate(
-        'IconButton',
-        'The `children` prop has been deprecated for passing the icon. Use the `icon` prop instead.',
-      );
-    }
-
-    if (process.env.NODE_ENV !== 'production' && label) {
-      deprecate(
-        'IconButton',
-        'The `label` prop has been deprecated. Use the `children` prop instead.',
-      );
     }
 
     if (
@@ -101,22 +68,9 @@ export const IconButton = createButtonComponent<IconButtonProps>(
 
     return {
       className: clsx(classes.base, classes[size], className),
-      icon: (iconProps: IconProps) => {
-        if (Icon) {
-          return <Icon {...iconProps} />;
-        }
-        // biome-ignore lint/style/noNonNullAssertion: We check for the existence of children above
-        const child = Children.only(children)!;
-        // TODO: Remove with the next major
-        if (isString(child)) {
-          return null;
-        }
-        return cloneElement(child, iconProps);
-      },
       size,
-      children: isString(children) ? children : label,
-      title: isString(children) ? children : label,
-      'aria-label': isString(children) ? children : label,
+      title: props.children,
+      'aria-label': props.children,
       ...props,
     };
   },

--- a/packages/circuit-ui/components/Button/IconButton.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.tsx
@@ -18,7 +18,6 @@
 import type { IconComponentType } from '@sumup-oss/icons';
 
 import { clsx } from '../../styles/clsx.js';
-import { CircuitError } from '../../util/errors.js';
 import { deprecate } from '../../util/logger.js';
 
 import {
@@ -53,10 +52,6 @@ export function IconButton({
   ...props
 }: IconButtonProps) {
   const size = legacyButtonSizeMap[legacySize] || legacySize;
-
-  if (process.env.NODE_ENV !== 'production' && !props.icon) {
-    throw new CircuitError('IconButton', 'The `icon` prop is missing.');
-  }
 
   if (
     process.env.NODE_ENV !== 'production' &&

--- a/packages/circuit-ui/components/Button/base.spec.tsx
+++ b/packages/circuit-ui/components/Button/base.spec.tsx
@@ -18,12 +18,15 @@ import { createRef } from 'react';
 
 import { render, axe, userEvent, screen } from '../../util/test-utils.js';
 
-import { createButtonComponent, type SharedButtonProps } from './base.js';
+import { BaseButton, type SharedButtonProps } from './base.js';
 
-const Button = createButtonComponent<SharedButtonProps>(
-  'TestButton',
-  (props) => ({ ...props, children: 'Button', size: 'm' }),
-);
+function Button({ size, ...props }: SharedButtonProps) {
+  return (
+    <BaseButton componentName="TestButton" size="m" {...props}>
+      Button
+    </BaseButton>
+  );
+}
 
 describe('Button', () => {
   it('should merge a custom class name with the default ones', () => {

--- a/packages/circuit-ui/components/Button/base.tsx
+++ b/packages/circuit-ui/components/Button/base.tsx
@@ -99,9 +99,11 @@ export type SharedButtonProps = LinkElProps &
      * Defaults to `navigator.language` in supported environments.
      */
     locale?: Locale;
+    // biome-ignore lint/suspicious/noExplicitAny: Polymorphic component supports button, anchor, and custom elements
+    ref?: Ref<any>;
   };
 
-type CreateButtonComponentProps = SharedButtonProps & {
+type BaseButtonProps = SharedButtonProps & {
   /**
    * Communicates the action that will be performed when the user interacts
    * with the button. Use one strong, clear imperative verb and follow with a
@@ -125,6 +127,7 @@ type CreateButtonComponentProps = SharedButtonProps & {
    * context for the button.
    */
   navigationIcon?: IconComponentType;
+  componentName: string;
 };
 
 export const legacyButtonSizeMap: Record<string, 's' | 'm'> = {
@@ -132,113 +135,104 @@ export const legacyButtonSizeMap: Record<string, 's' | 'm'> = {
   giga: 'm',
 };
 
-export function createButtonComponent<Props>(
-  componentName: string,
-  // TODO: Refactor to `mapClassName` once the deprecations have been removed.
-  mapProps: (props: Props) => CreateButtonComponentProps,
-) {
-  // biome-ignore lint/suspicious/noExplicitAny: Polymorphic component supports button, anchor, and custom elements
-  function Button({ ref, ...rest }: Props & { ref?: Ref<any> }) {
-    const {
-      children,
-      onClick,
-      disabled,
-      destructive,
-      size = 'm',
-      variant = 'secondary',
-      isLoading,
-      loadingLabel,
-      className,
-      icon: LeadingIcon,
-      navigationIcon: TrailingIcon,
-      as,
-      locale,
-      ...sharedProps
-    } = useI18n(mapProps(rest as Props), translations);
+export function BaseButton(props: BaseButtonProps) {
+  const {
+    ref,
+    componentName,
+    children,
+    onClick,
+    disabled,
+    destructive,
+    size = 'm',
+    variant = 'secondary',
+    isLoading,
+    loadingLabel,
+    className,
+    icon: LeadingIcon,
+    navigationIcon: TrailingIcon,
+    as,
+    locale,
+    ...sharedProps
+  } = useI18n(props, translations);
 
-    const components = useComponents();
-    const Link = components.Link as AsPropType;
+  const components = useComponents();
+  const Link = components.Link as AsPropType;
 
-    const isLink = Boolean(sharedProps.href);
+  const isLink = Boolean(sharedProps.href);
 
-    const Element = as || (isLink ? Link : 'button');
+  const Element = as || (isLink ? Link : 'button');
 
-    const leadingIconSize = size === 's' ? '16' : '24';
-    const trailingIconSize = '16';
+  const leadingIconSize = size === 's' ? '16' : '24';
+  const trailingIconSize = '16';
 
-    const hasLoadingState = typeof isLoading !== 'undefined';
+  const hasLoadingState = typeof isLoading !== 'undefined';
 
-    const isDisabled = Boolean(disabled || isLoading);
-    const onDisabledClick = (event: ClickEvent) => {
-      event.preventDefault();
-      event.stopPropagation();
-      event.nativeEvent.stopImmediatePropagation();
-    };
+  const isDisabled = Boolean(disabled || isLoading);
+  const onDisabledClick = (event: ClickEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    event.nativeEvent.stopImmediatePropagation();
+  };
 
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      process.env.NODE_ENV !== 'test' &&
-      !isSufficientlyLabelled(children as string, sharedProps)
-    ) {
-      throw new AccessibilityError(
-        componentName,
-        'The `children` prop is missing or invalid.',
-      );
-    }
-
-    return (
-      <Element
-        {...sharedProps}
-        {...(hasLoadingState && {
-          'aria-live': 'polite',
-          'aria-busy': Boolean(isLoading),
-        })}
-        {...(isDisabled && {
-          'aria-disabled': true,
-        })}
-        onClick={isDisabled ? onDisabledClick : onClick}
-        className={clsx(
-          classes.base,
-          classes[variant],
-          classes[size],
-          destructive && classes.destructive,
-          utilClasses.focusVisible,
-          className,
-        )}
-        ref={ref}
-      >
-        <span className={classes.loader} aria-hidden={!isLoading}>
-          <span className={classes.dot} />
-          <span className={classes.dot} />
-          <span className={classes.dot} />
-          <span className={utilClasses.hideVisually}>{loadingLabel}</span>
-        </span>
-        <span className={classes.content}>
-          {LeadingIcon && (
-            <LeadingIcon
-              aria-hidden="true"
-              className={classes['leading-icon']}
-              size={leadingIconSize}
-              width={leadingIconSize}
-              height={leadingIconSize}
-            />
-          )}
-          <span className={classes.label}>{children}</span>
-          {TrailingIcon && (
-            <TrailingIcon
-              aria-hidden="true"
-              className={classes['trailing-icon']}
-              size={trailingIconSize}
-              width={trailingIconSize}
-              height={trailingIconSize}
-            />
-          )}
-        </span>
-      </Element>
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !isSufficientlyLabelled(children as string, sharedProps)
+  ) {
+    throw new AccessibilityError(
+      componentName,
+      'The `children` prop is missing or invalid.',
     );
   }
 
-  Button.displayName = componentName;
-
-  return Button;
+  return (
+    <Element
+      {...sharedProps}
+      {...(hasLoadingState && {
+        'aria-live': 'polite',
+        'aria-busy': Boolean(isLoading),
+      })}
+      {...(isDisabled && {
+        'aria-disabled': true,
+      })}
+      onClick={isDisabled ? onDisabledClick : onClick}
+      className={clsx(
+        classes.base,
+        classes[variant],
+        classes[size],
+        destructive && classes.destructive,
+        utilClasses.focusVisible,
+        className,
+      )}
+      ref={ref}
+    >
+      <span className={classes.loader} aria-hidden={!isLoading}>
+        <span className={classes.dot} />
+        <span className={classes.dot} />
+        <span className={classes.dot} />
+        <span className={utilClasses.hideVisually}>{loadingLabel}</span>
+      </span>
+      <span className={classes.content}>
+        {LeadingIcon && (
+          <LeadingIcon
+            aria-hidden="true"
+            className={classes['leading-icon']}
+            size={leadingIconSize}
+            width={leadingIconSize}
+            height={leadingIconSize}
+          />
+        )}
+        <span className={classes.label}>{children}</span>
+        {TrailingIcon && (
+          <TrailingIcon
+            aria-hidden="true"
+            className={classes['trailing-icon']}
+            size={trailingIconSize}
+            width={trailingIconSize}
+            height={trailingIconSize}
+          />
+        )}
+      </span>
+    </Element>
+  );
 }

--- a/packages/circuit-ui/components/Carousel/components/Slide/Slide.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Slide/Slide.tsx
@@ -18,7 +18,11 @@ import type { HTMLAttributes, ReactNode } from 'react';
 import { ANIMATION_DURATION, SlideDirection } from '../../constants.js';
 import { clsx } from '../../../../styles/clsx.js';
 
-import * as SlideService from './SlideService.js';
+import {
+  getStackOrder,
+  shouldAnimate,
+  getDynamicWidth,
+} from './SlideService.js';
 import classes from './Slide.module.css';
 
 export interface SlideProps extends HTMLAttributes<HTMLDivElement> {
@@ -66,20 +70,11 @@ export function Slide({
   style = {},
   ...props
 }: SlideProps) {
-  const stackOrder = SlideService.getStackOrder(
-    index,
-    step,
-    prevStep,
-    slideDirection,
+  const stackOrder = getStackOrder(index, step, prevStep, slideDirection);
+  const dynamicWidth = getDynamicWidth(slideSize.width);
+  const isAnimating = Boolean(
+    slideSize.width && shouldAnimate(index, step, prevStep, slideDirection),
   );
-  const shouldAnimate = SlideService.shouldAnimate(
-    index,
-    step,
-    prevStep,
-    slideDirection,
-  );
-  const dynamicWidth = SlideService.getDynamicWidth(slideSize.width);
-  const isAnimating = Boolean(slideSize.width && shouldAnimate);
 
   return (
     <div

--- a/packages/circuit-ui/components/CloseButton/CloseButton.spec.tsx
+++ b/packages/circuit-ui/components/CloseButton/CloseButton.spec.tsx
@@ -24,7 +24,7 @@ describe('CloseButton', () => {
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
     const { container } = render(
-      <CloseButton label="Close" className={className} />,
+      <CloseButton className={className}>Close</CloseButton>,
     );
     const button = container.querySelector('button');
     expect(button?.className).toContain(className);
@@ -32,13 +32,13 @@ describe('CloseButton', () => {
 
   it('should forward a ref', () => {
     const ref = createRef<HTMLHRElement>();
-    const { container } = render(<CloseButton label="Close" ref={ref} />);
+    const { container } = render(<CloseButton ref={ref}>Close</CloseButton>);
     const button = container.querySelector('button');
     expect(ref.current).toBe(button);
   });
 
   it('should meet accessibility guidelines', async () => {
-    const { container } = render(<CloseButton label="Close" />);
+    const { container } = render(<CloseButton>Close</CloseButton>);
     const actual = await axe(container);
     expect(actual).toHaveNoViolations();
   });

--- a/packages/circuit-ui/components/CloseButton/CloseButton.tsx
+++ b/packages/circuit-ui/components/CloseButton/CloseButton.tsx
@@ -28,8 +28,7 @@ export type CloseButtonProps = Omit<IconButtonProps, 'icon'> & {
  */
 
 export function CloseButton({
-  label = 'Close',
-  children = label,
+  children = 'Close',
   ref,
   ...props
 }: CloseButtonProps) {

--- a/packages/circuit-ui/components/Hamburger/Hamburger.tsx
+++ b/packages/circuit-ui/components/Hamburger/Hamburger.tsx
@@ -30,7 +30,7 @@ import { clsx } from '../../styles/clsx.js';
 import classes from './Hamburger.module.css';
 
 export interface HamburgerProps
-  extends Omit<IconButtonProps, 'ref' | 'children' | 'label' | 'type'> {
+  extends Omit<IconButtonProps, 'ref' | 'children' | 'icon' | 'type'> {
   // biome-ignore lint/suspicious/noExplicitAny: ref can target button or anchor
   ref?: React.Ref<any>;
   /**

--- a/packages/circuit-ui/components/ImageInput/ImageInput.tsx
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.tsx
@@ -294,6 +294,7 @@ export const ImageInput = ({
             {clearButtonLabel}
           </IconButton>
         ) : (
+          // @ts-expect-error The button is purely presentational and thus doesn't need a label.
           <IconButton
             type="button"
             size="s"

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -124,6 +124,7 @@ export function NotificationToast({
           <Body>{body}</Body>
         </div>
 
+        {/* @ts-expect-error FIXME: */}
         <CloseButton
           className={classes.close}
           aria-hidden="true"

--- a/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
+++ b/packages/circuit-ui/components/NotificationToast/NotificationToast.tsx
@@ -124,7 +124,7 @@ export function NotificationToast({
           <Body>{body}</Body>
         </div>
 
-        {/* @ts-expect-error FIXME: */}
+        {/* @ts-expect-error The button isn't meant to be accessible to screen reader users and thus doesn't need a label. */}
         <CloseButton
           className={classes.close}
           aria-hidden="true"

--- a/packages/circuit-ui/components/Pagination/Pagination.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.tsx
@@ -27,7 +27,7 @@ import { clsx } from '../../styles/clsx.js';
 
 import { PageSelect } from './components/PageSelect/index.js';
 import { PageList } from './components/PageList/index.js';
-import * as PaginationService from './PaginationService.js';
+import { generatePages } from './PaginationService.js';
 import classes from './Pagination.module.css';
 
 export interface PaginationProps
@@ -112,7 +112,7 @@ export const Pagination = ({
   }
 
   const showList = totalPages <= 5;
-  const pages = PaginationService.generatePages(totalPages);
+  const pages = generatePages(totalPages);
 
   return (
     <nav

--- a/packages/circuit-ui/components/Step/StepService.spec.ts
+++ b/packages/circuit-ui/components/Step/StepService.spec.ts
@@ -136,23 +136,6 @@ describe('StepService', () => {
       expect(actions.previous).toHaveBeenCalledTimes(1);
     });
 
-    it('should add aria-labels to elements', () => {
-      const getters = StepService.generatePropGetters(actions);
-
-      expect(getters.getPlayControlProps()).toMatchObject({
-        'aria-label': 'play',
-      });
-      expect(getters.getPauseControlProps()).toMatchObject({
-        'aria-label': 'pause',
-      });
-      expect(getters.getNextControlProps()).toMatchObject({
-        'aria-label': 'next',
-      });
-      expect(getters.getPreviousControlProps()).toMatchObject({
-        'aria-label': 'previous',
-      });
-    });
-
     it('should pass custom props to elements', () => {
       const getters = StepService.generatePropGetters(actions);
       const customProps = {

--- a/packages/circuit-ui/components/Step/StepService.ts
+++ b/packages/circuit-ui/components/Step/StepService.ts
@@ -79,28 +79,24 @@ export function generatePropGetters(actions: Actions): PropGetters {
     // @ts-expect-error The type will be inferred correctly as long as the
     // generic type isn't manually overridden.
     getPlayControlProps: (props = {}) => ({
-      'aria-label': 'play',
       ...props,
       'onClick': eachFn([props.onClick, actions.play]),
     }),
     // @ts-expect-error The type will be inferred correctly as long as the
     // generic type isn't manually overridden.
     getPauseControlProps: (props = {}) => ({
-      'aria-label': 'pause',
       ...props,
       'onClick': eachFn([props.onClick, actions.pause]),
     }),
     // @ts-expect-error The type will be inferred correctly as long as the
     // generic type isn't manually overridden.
     getNextControlProps: (props = {}) => ({
-      'aria-label': 'next',
       ...props,
       'onClick': eachFn([props.onClick, actions.next]),
     }),
     // @ts-expect-error The type will be inferred correctly as long as the
     // generic type isn't manually overridden.
     getPreviousControlProps: (props = {}) => ({
-      'aria-label': 'previous',
       ...props,
       'onClick': eachFn([props.onClick, actions.previous]),
     }),

--- a/packages/circuit-ui/components/Step/hooks/useStep.ts
+++ b/packages/circuit-ui/components/Step/hooks/useStep.ts
@@ -17,7 +17,12 @@ import { useReducer, useEffect, useRef } from 'react';
 
 import { CircuitError } from '../../../util/errors.js';
 import { isFunction } from '../../../util/type-check.js';
-import * as StepService from '../StepService.js';
+import {
+  calculatePreviousStep,
+  calculateNextStep,
+  generatePropGetters,
+  reducer,
+} from '../StepService.js';
 import type { Duration, StateAndHelpers, StepOptions } from '../types.js';
 
 export function useStep({
@@ -49,7 +54,7 @@ export function useStep({
 
   const initialState = {
     step: initialStep,
-    previousStep: StepService.calculatePreviousStep({
+    previousStep: calculatePreviousStep({
       step: initialStep,
       totalSteps,
       stepInterval,
@@ -57,7 +62,7 @@ export function useStep({
     }),
     paused: !autoPlay,
   };
-  const [state, dispatch] = useReducer(StepService.reducer, initialState);
+  const [state, dispatch] = useReducer(reducer, initialState);
   const playingInterval = useRef<ReturnType<typeof setInterval> | null>(null);
   const animationEndCallback = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -78,7 +83,7 @@ export function useStep({
 
   // ACTIONS
   function next() {
-    const newStep = StepService.calculateNextStep({
+    const newStep = calculateNextStep({
       step: state.step,
       stepInterval,
       totalSteps,
@@ -93,7 +98,7 @@ export function useStep({
   }
 
   function previous() {
-    const newStep = StepService.calculatePreviousStep({
+    const newStep = calculatePreviousStep({
       step: state.step,
       stepInterval,
       totalSteps,
@@ -210,7 +215,7 @@ export function useStep({
       play,
       pause,
     };
-    const propGetters = StepService.generatePropGetters(actions);
+    const propGetters = generatePropGetters(actions);
 
     return {
       state: {


### PR DESCRIPTION
Addresses [DSYS-1667](https://sumupteam.atlassian.net/browse/DSYS-1667)

## Purpose

The IconButton’s API was updated to match the Button component and to make it easier to pass props to the icon component.

## Approach and changes

- Remove the deprecated `label` prop in favor of `children` and force passing the icon using the `icon` prop
- Remove unlocalized `aria-label`s from the carousel buttons
- Replace star imports (`import * as`) to improve tree-shaking

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
