### PR TITLE
feat(PhoneNumberInput): add shouldDisplayCountryNames prop

### DIFF
--- a/.changeset/phone-number-input-should-display-country-names.md
+++ b/.changeset/phone-number-input-should-display-country-names.md
@@ -2,4 +2,4 @@
 '@sumup-oss/circuit-ui': minor
 ---
 
-Added `shouldDisplayCountryNames` prop to `PhoneNumberInput`. Defaults to `false`, displaying calling codes from `countryCode.options` without `Intl.DisplayNames` localization. Set to `true` to opt in to localized country names in the selector labels.
+Added `shouldDisplayCountryNames` prop to `PhoneNumberInput` to opt out of `Intl.DisplayNames` localization and display calling codes from `countryCode.options` directly.

--- a/.changeset/phone-number-input-should-display-country-names.md
+++ b/.changeset/phone-number-input-should-display-country-names.md
@@ -2,4 +2,4 @@
 '@sumup-oss/circuit-ui': minor
 ---
 
-Added `shouldDisplayCountryNames` prop to `PhoneNumberInput` to opt out of `Intl.DisplayNames` localization and display calling codes from `countryCode.options` directly.
+Added `shouldDisplayCountryNames` prop to `PhoneNumberInput`. Defaults to `false`, displaying calling codes from `countryCode.options` without `Intl.DisplayNames` localization. Set to `true` to opt in to localized country names in the selector labels.

--- a/.changeset/phone-number-input-should-display-country-names.md
+++ b/.changeset/phone-number-input-should-display-country-names.md
@@ -2,4 +2,4 @@
 '@sumup-oss/circuit-ui': minor
 ---
 
-Added `shouldDisplayCountryNames` prop to `PhoneNumberInput` to opt out of `Intl.DisplayNames` localization and display calling codes from `countryCode.options` directly.
+Added a new `shouldDisplayCountryNames` prop to PhoneNumberInput to opt out of `Intl.DisplayNames` localization and display calling codes from `countryCode.options` directly.

--- a/.changeset/phone-number-input-should-display-country-names.md
+++ b/.changeset/phone-number-input-should-display-country-names.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': minor
+---
+
+Added `shouldDisplayCountryNames` prop to `PhoneNumberInput` to opt out of `Intl.DisplayNames` localization and display calling codes from `countryCode.options` directly.

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -67,6 +67,7 @@ export const Base = (args: PhoneNumberInputProps) => {
 Base.args = {
   value: '',
   label: 'Phone number',
+  shouldDisplayCountryNames: true,
   countryCode: {
     label: 'Country code',
     defaultValue: 'CA',

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -67,7 +67,6 @@ export const Base = (args: PhoneNumberInputProps) => {
 Base.args = {
   value: '',
   label: 'Phone number',
-  shouldDisplayCountryNames: true,
   countryCode: {
     label: 'Country code',
     defaultValue: 'CA',

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -168,6 +168,15 @@ export const WithPrefix = (args: PhoneNumberInputProps) => {
 
 WithPrefix.args = Base.args;
 
+export const WithoutCountryNames = (args: PhoneNumberInputProps) => (
+  <PhoneNumberInput {...args} />
+);
+
+WithoutCountryNames.args = {
+  ...Base.args,
+  shouldDisplayCountryNames: false,
+};
+
 export const Sizes = (args: PhoneNumberInputProps) => (
   <Stack>
     <PhoneNumberInput {...args} size="s" />

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -122,7 +122,7 @@ export interface PhoneNumberInputProps
    * `Intl.DisplayNames`. When `false`, displays the calling codes from
    * `countryCode.options` without localization.
    *
-   * @default false
+   * @default true
    */
   shouldDisplayCountryNames?: boolean;
   /**
@@ -240,7 +240,7 @@ export const PhoneNumberInput = forwardRef<
       readOnly,
       'aria-describedby': descriptionId,
       locale,
-      shouldDisplayCountryNames = false,
+      shouldDisplayCountryNames = true,
       size = 'm',
       className,
       style,

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -122,7 +122,7 @@ export interface PhoneNumberInputProps
    * `Intl.DisplayNames`. When `false`, displays the calling codes from
    * `countryCode.options` without localization.
    *
-   * @default true
+   * @default false
    */
   shouldDisplayCountryNames?: boolean;
   /**
@@ -240,7 +240,7 @@ export const PhoneNumberInput = forwardRef<
       readOnly,
       'aria-describedby': descriptionId,
       locale,
-      shouldDisplayCountryNames = true,
+      shouldDisplayCountryNames = false,
       size = 'm',
       className,
       style,

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -118,6 +118,14 @@ export interface PhoneNumberInputProps
    */
   locale?: string | string[];
   /**
+   * When `true`, localizes country names in the country code selector using
+   * `Intl.DisplayNames`. When `false`, displays the calling codes from
+   * `countryCode.options` without localization.
+   *
+   * @default true
+   */
+  shouldDisplayCountryNames?: boolean;
+  /**
    * Choose from 2 sizes.
    * @default m
    */
@@ -232,6 +240,7 @@ export const PhoneNumberInput = forwardRef<
       readOnly,
       'aria-describedby': descriptionId,
       locale,
+      shouldDisplayCountryNames = true,
       size = 'm',
       className,
       style,
@@ -257,8 +266,13 @@ export const PhoneNumberInput = forwardRef<
     );
 
     const options = useMemo(
-      () => mapCountryCodeOptions(countryCode.options, locale),
-      [countryCode.options, locale],
+      () =>
+        mapCountryCodeOptions(
+          countryCode.options,
+          locale,
+          shouldDisplayCountryNames,
+        ),
+      [countryCode.options, locale, shouldDisplayCountryNames],
     );
 
     const handleChange = () => {

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -118,7 +118,7 @@ export interface PhoneNumberInputProps
    */
   locale?: string | string[];
   /**
-   * When `true`, localizes country names in the country code selector using
+   * When `true`, displays the localised country name in the country code selector using
    * `Intl.DisplayNames`. When `false`, displays the calling codes from
    * `countryCode.options` without localization.
    *

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -135,8 +135,8 @@ describe('PhoneNumberInputService', () => {
       const locale = undefined;
       const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].value).toBe('CA');
-      expect(actual[1].value).toBe('DE');
-      expect(actual[2].value).toBe('US');
+      expect(actual[1].value).toBe('US');
+      expect(actual[2].value).toBe('DE');
     });
 
     it('should use the country name and code as the option label', () => {
@@ -146,7 +146,7 @@ describe('PhoneNumberInputService', () => {
         { country: 'DE', code: '+49' },
       ];
       const locale = undefined;
-      const actual = mapCountryCodeOptions(options, locale);
+      const actual = mapCountryCodeOptions(options, locale, true);
       expect(actual[0].label).toBe('Canada (+1)');
       expect(actual[1].label).toBe('Germany (+49)');
       expect(actual[2].label).toBe('United States (+1)');
@@ -155,7 +155,7 @@ describe('PhoneNumberInputService', () => {
     it('should omit the country name when it is not available', () => {
       const options = [{ country: '', code: '+49' }];
       const locale = undefined;
-      const actual = mapCountryCodeOptions(options, locale);
+      const actual = mapCountryCodeOptions(options, locale, true);
       expect(actual[0].label).toBe('+49');
     });
 
@@ -166,7 +166,7 @@ describe('PhoneNumberInputService', () => {
         { country: 'DE', code: '+49' },
       ];
       const locale = undefined;
-      const actual = mapCountryCodeOptions(options, locale);
+      const actual = mapCountryCodeOptions(options, locale, true);
       expect(actual[0].label).toBe('Canada (+1)');
       expect(actual[1].label).toBe('Germany (+49)');
       expect(actual[2].label).toBe('United States (+1)');
@@ -179,17 +179,17 @@ describe('PhoneNumberInputService', () => {
         { country: 'DE', code: '+49' },
       ];
       const locale = 'DE';
-      const actual = mapCountryCodeOptions(options, locale);
+      const actual = mapCountryCodeOptions(options, locale, true);
       expect(actual[0].value).toBe('DE');
     });
 
-    it('should use calling codes as labels when shouldDisplayCountryNames is false', () => {
+    it('should use calling codes as labels by default', () => {
       const options = [
         { country: 'CA', code: '+1' },
         { country: 'US', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const actual = mapCountryCodeOptions(options, undefined, false);
+      const actual = mapCountryCodeOptions(options, undefined);
       expect(actual[0].label).toBe('+1');
       expect(actual[0].value).toBe('CA');
       expect(actual[1].label).toBe('+1');
@@ -198,13 +198,13 @@ describe('PhoneNumberInputService', () => {
       expect(actual[2].value).toBe('DE');
     });
 
-    it('should sort calling code labels when shouldDisplayCountryNames is false', () => {
+    it('should sort calling code labels by default', () => {
       const options = [
         { country: 'DE', code: '+49' },
         { country: 'CA', code: '+1' },
         { country: 'US', code: '+1' },
       ];
-      const actual = mapCountryCodeOptions(options, undefined, false);
+      const actual = mapCountryCodeOptions(options, undefined);
       expect(actual.map(({ label }) => label)).toEqual(['+1', '+1', '+49']);
     });
   });

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -182,5 +182,30 @@ describe('PhoneNumberInputService', () => {
       const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].value).toBe('DE');
     });
+
+    it('should use calling codes as labels when shouldDisplayCountryNames is false', () => {
+      const options = [
+        { country: 'CA', code: '+1' },
+        { country: 'US', code: '+1' },
+        { country: 'DE', code: '+49' },
+      ];
+      const actual = mapCountryCodeOptions(options, undefined, false);
+      expect(actual[0].label).toBe('+1');
+      expect(actual[0].value).toBe('CA');
+      expect(actual[1].label).toBe('+1');
+      expect(actual[1].value).toBe('US');
+      expect(actual[2].label).toBe('+49');
+      expect(actual[2].value).toBe('DE');
+    });
+
+    it('should sort calling code labels when shouldDisplayCountryNames is false', () => {
+      const options = [
+        { country: 'DE', code: '+49' },
+        { country: 'CA', code: '+1' },
+        { country: 'US', code: '+1' },
+      ];
+      const actual = mapCountryCodeOptions(options, undefined, false);
+      expect(actual.map(({ label }) => label)).toEqual(['+1', '+1', '+49']);
+    });
   });
 });

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -135,8 +135,8 @@ describe('PhoneNumberInputService', () => {
       const locale = undefined;
       const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].value).toBe('CA');
-      expect(actual[1].value).toBe('US');
-      expect(actual[2].value).toBe('DE');
+      expect(actual[1].value).toBe('DE');
+      expect(actual[2].value).toBe('US');
     });
 
     it('should use the country name and code as the option label', () => {
@@ -146,7 +146,7 @@ describe('PhoneNumberInputService', () => {
         { country: 'DE', code: '+49' },
       ];
       const locale = undefined;
-      const actual = mapCountryCodeOptions(options, locale, true);
+      const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].label).toBe('Canada (+1)');
       expect(actual[1].label).toBe('Germany (+49)');
       expect(actual[2].label).toBe('United States (+1)');
@@ -155,7 +155,7 @@ describe('PhoneNumberInputService', () => {
     it('should omit the country name when it is not available', () => {
       const options = [{ country: '', code: '+49' }];
       const locale = undefined;
-      const actual = mapCountryCodeOptions(options, locale, true);
+      const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].label).toBe('+49');
     });
 
@@ -166,7 +166,7 @@ describe('PhoneNumberInputService', () => {
         { country: 'DE', code: '+49' },
       ];
       const locale = undefined;
-      const actual = mapCountryCodeOptions(options, locale, true);
+      const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].label).toBe('Canada (+1)');
       expect(actual[1].label).toBe('Germany (+49)');
       expect(actual[2].label).toBe('United States (+1)');
@@ -179,17 +179,17 @@ describe('PhoneNumberInputService', () => {
         { country: 'DE', code: '+49' },
       ];
       const locale = 'DE';
-      const actual = mapCountryCodeOptions(options, locale, true);
+      const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].value).toBe('DE');
     });
 
-    it('should use calling codes as labels by default', () => {
+    it('should use calling codes as labels when shouldDisplayCountryNames is false', () => {
       const options = [
         { country: 'CA', code: '+1' },
         { country: 'US', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const actual = mapCountryCodeOptions(options, undefined);
+      const actual = mapCountryCodeOptions(options, undefined, false);
       expect(actual[0].label).toBe('+1');
       expect(actual[0].value).toBe('CA');
       expect(actual[1].label).toBe('+1');
@@ -198,13 +198,13 @@ describe('PhoneNumberInputService', () => {
       expect(actual[2].value).toBe('DE');
     });
 
-    it('should sort calling code labels by default', () => {
+    it('should sort calling code labels when shouldDisplayCountryNames is false', () => {
       const options = [
         { country: 'DE', code: '+49' },
         { country: 'CA', code: '+1' },
         { country: 'US', code: '+1' },
       ];
-      const actual = mapCountryCodeOptions(options, undefined);
+      const actual = mapCountryCodeOptions(options, undefined, false);
       expect(actual.map(({ label }) => label)).toEqual(['+1', '+1', '+49']);
     });
   });

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
@@ -132,7 +132,17 @@ export function normalizePhoneNumber(
 export function mapCountryCodeOptions(
   countryCodeOptions: CountryCodeOption[],
   locale: Locale | undefined,
+  shouldDisplayCountryNames = true,
 ): Required<SelectProps>['options'] {
+  if (!shouldDisplayCountryNames) {
+    return countryCodeOptions
+      .map(({ code, country }) => ({
+        label: code,
+        value: country,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }
+
   const getCountryName = (country: string) => {
     // eslint-disable-next-line compat/compat
     const isIntlDisplayNamesSupported = typeof Intl.DisplayNames === 'function';

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
@@ -132,7 +132,7 @@ export function normalizePhoneNumber(
 export function mapCountryCodeOptions(
   countryCodeOptions: CountryCodeOption[],
   locale: Locale | undefined,
-  shouldDisplayCountryNames = false,
+  shouldDisplayCountryNames = true,
 ): Required<SelectProps>['options'] {
   if (!shouldDisplayCountryNames) {
     return countryCodeOptions

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
@@ -132,7 +132,7 @@ export function normalizePhoneNumber(
 export function mapCountryCodeOptions(
   countryCodeOptions: CountryCodeOption[],
   locale: Locale | undefined,
-  shouldDisplayCountryNames = true,
+  shouldDisplayCountryNames = false,
 ): Required<SelectProps>['options'] {
   if (!shouldDisplayCountryNames) {
     return countryCodeOptions


### PR DESCRIPTION
## Summary

- Adds a new optional `shouldDisplayCountryNames` prop to `PhoneNumberInput` (defaults to `true`, preserving current behavior).
- When `true`, country selector labels continue to use `Intl.DisplayNames` for localized country names (e.g. `Canada (+1)`).
- When `false`, labels use the calling codes from `countryCode.options` directly (e.g. `+1`, `+49`), skipping `Intl.DisplayNames` entirely.

This lets consumers choose whether the country code selector displays localized country names or calling codes only.

## Motivation

`Intl.DisplayNames` can return different labels on the server and client for the same region code, which causes hydration mismatches in Next.js applications. For example, with Node.js 22.22.2 and Chrome 149.0.0.0, `FK` (`+500`) resolves to `Falkland Islands` on the server and `Falkland Islands (Islas Malvinas)` on the client.

Setting `shouldDisplayCountryNames={false}` avoids this by not calling `Intl.DisplayNames` for selector labels.

A follow-up PR on the website project will describe the issue and integration in more detail.

## Test plan

- [x] Unit tests for `mapCountryCodeOptions` with `shouldDisplayCountryNames={false}`
- [x] Verified in Storybook (`WithoutCountryNames` story)
- [x] Verified locally in website-builder via linked package


Made with [Cursor](https://cursor.com)