### PR TITLE
Update Eslint plugin `no-deprecated-props` rule

### DIFF
--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.spec.ts
@@ -53,8 +53,25 @@ ruleTester.run('no-deprecated-props', noDeprecatedProps, {
         }
       `,
     },
+    {
+      name: 'Toggle without any deprecated props',
+      code: `
+        function Component() {
+          return <Toggle label="label" checked onChange={() => {}} />
+        }
+      `,
+    },
   ],
   invalid: [
+    {
+      name: 'Body with the deprecated variant prop',
+      code: `
+        function Component() {
+          return <Body variant="alert" />
+        }
+      `,
+      errors: [{ messageId: 'deprecated' }],
+    },
     {
       name: 'Body with deprecated size "one"',
       code: `
@@ -99,6 +116,24 @@ ruleTester.run('no-deprecated-props', noDeprecatedProps, {
         }
       `,
       errors: [{ messageId: 'deprecatedValue' }],
+    },
+    {
+      name: 'Toggle with the deprecated checkedLabel prop',
+      code: `
+        function Component() {
+          return <Toggle label="label" checkedLabel="on" />
+        }
+      `,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      name: 'Toggle with the deprecated uncheckedLabel prop',
+      code: `
+        function Component() {
+          return <Toggle label="label" uncheckedLabel="off" />
+        }
+      `,
+      errors: [{ messageId: 'deprecated' }],
     },
   ],
 });

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.spec.ts
@@ -30,23 +30,75 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-deprecated-props', noDeprecatedProps, {
   valid: [
     {
-      name: 'matched component without the deprecated prop',
+      name: 'Body without any deprecated prop values',
       code: `
         function Component() {
           return <Body />
         }
       `,
     },
+    {
+      name: 'Body with a valid size value',
+      code: `
+        function Component() {
+          return <Body size="m" />
+        }
+      `,
+    },
+    {
+      name: 'Body with a valid decoration value',
+      code: `
+        function Component() {
+          return <Body decoration="strikethrough" />
+        }
+      `,
+    },
   ],
   invalid: [
     {
-      name: 'matched component with the deprecated prop',
+      name: 'Body with deprecated size "one"',
       code: `
         function Component() {
-          return <Body variant="alert" />
+          return <Body size="one" />
         }
       `,
-      errors: [{ messageId: 'deprecated' }],
+      errors: [{ messageId: 'deprecatedValue' }],
+    },
+    {
+      name: 'Body with deprecated size "two"',
+      code: `
+        function Component() {
+          return <Body size="two" />
+        }
+      `,
+      errors: [{ messageId: 'deprecatedValue' }],
+    },
+    {
+      name: 'Body with deprecated size "one" as JSX expression',
+      code: `
+        function Component() {
+          return <Body size={'one'} />
+        }
+      `,
+      errors: [{ messageId: 'deprecatedValue' }],
+    },
+    {
+      name: 'Body with deprecated decoration "italic"',
+      code: `
+        function Component() {
+          return <Body decoration="italic" />
+        }
+      `,
+      errors: [{ messageId: 'deprecatedValue' }],
+    },
+    {
+      name: 'Numeral with deprecated decoration "italic"',
+      code: `
+        function Component() {
+          return <Numeral decoration="italic" />
+        }
+      `,
+      errors: [{ messageId: 'deprecatedValue' }],
     },
   ],
 });

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.spec.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.spec.ts
@@ -73,33 +73,6 @@ ruleTester.run('no-deprecated-props', noDeprecatedProps, {
       errors: [{ messageId: 'deprecated' }],
     },
     {
-      name: 'Body with deprecated size "one"',
-      code: `
-        function Component() {
-          return <Body size="one" />
-        }
-      `,
-      errors: [{ messageId: 'deprecatedValue' }],
-    },
-    {
-      name: 'Body with deprecated size "two"',
-      code: `
-        function Component() {
-          return <Body size="two" />
-        }
-      `,
-      errors: [{ messageId: 'deprecatedValue' }],
-    },
-    {
-      name: 'Body with deprecated size "one" as JSX expression',
-      code: `
-        function Component() {
-          return <Body size={'one'} />
-        }
-      `,
-      errors: [{ messageId: 'deprecatedValue' }],
-    },
-    {
       name: 'Body with deprecated decoration "italic"',
       code: `
         function Component() {

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.ts
@@ -21,18 +21,28 @@ const createRule = ESLintUtils.RuleCreator<RuleDocs>(
     `https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/${name}`,
 );
 
-type Config = {
+type ValueConfig = {
   components: string[];
-  props: [string];
+  prop: string;
+  values: string[];
   alternative: string;
 };
 
-const mappings: Config[] = [
+// TODO: When a deprecated value is removed from a component in a major version,
+// remove the corresponding entry here
+const valueMappings: ValueConfig[] = [
   {
     components: ['Body'],
-    props: ['variant'],
+    prop: 'size',
+    values: ['one', 'two'],
+    alternative: 'Use "m" instead of "one" and "s" instead of "two".',
+  },
+  {
+    components: ['Body', 'Numeral'],
+    prop: 'decoration',
+    values: ['italic'],
     alternative:
-      'Use the new `color` prop instead of the `alert`, `confirm` and `subtle` variants. Use the new `weight` prop instead of the `highlight` variant. Use custom CSS for the `quote` variant.',
+      'Since the brand refresh, italic text is no longer supported. The `italic` decoration will be removed in the next major version.',
   },
 ];
 
@@ -46,42 +56,68 @@ export const noDeprecatedProps = createRule({
       recommended: 'warn',
     },
     messages: {
-      deprecated:
-        "The {{component}}'s `{{prop}}` prop has been deprecated. {{alternative}}",
+      deprecatedValue:
+        'The {{component}}\'s `{{prop}}` prop value "{{value}}" has been deprecated. {{alternative}}',
     },
   },
   defaultOptions: [],
   create(context) {
-    return mappings.reduce((visitors, config) => {
-      config.components.forEach((component) => {
-        visitors[`JSXElement[openingElement.name.name="${component}"]`] = (
-          node: TSESTree.JSXElement,
-        ) => {
-          const { props, alternative } = config;
+    const visitors: TSESLint.RuleListener = {};
 
+    valueMappings.forEach((config) => {
+      config.components.forEach((component) => {
+        const key = `JSXElement[openingElement.name.name="${component}"]`;
+        const existing = visitors[key] as
+          | ((node: TSESTree.JSXElement) => void)
+          | undefined;
+
+        visitors[key] = (node: TSESTree.JSXElement) => {
+          existing?.(node);
           node.openingElement.attributes.forEach((attribute) => {
             if (
               attribute.type !== TSESTree.AST_NODE_TYPES.JSXAttribute ||
-              attribute.name.type !== TSESTree.AST_NODE_TYPES.JSXIdentifier
+              attribute.name.type !== TSESTree.AST_NODE_TYPES.JSXIdentifier ||
+              attribute.name.name !== config.prop
             ) {
               return;
             }
 
-            const prop = attribute.name.name;
+            let value: string | null = null;
 
-            if (!props.includes(prop)) {
+            if (
+              attribute.value?.type === TSESTree.AST_NODE_TYPES.Literal &&
+              typeof attribute.value.value === 'string'
+            ) {
+              value = attribute.value.value;
+            } else if (
+              attribute.value?.type ===
+                TSESTree.AST_NODE_TYPES.JSXExpressionContainer &&
+              attribute.value.expression.type ===
+                TSESTree.AST_NODE_TYPES.Literal &&
+              typeof attribute.value.expression.value === 'string'
+            ) {
+              value = attribute.value.expression.value;
+            }
+
+            if (value === null || !config.values.includes(value)) {
               return;
             }
 
             context.report({
               node: attribute,
-              messageId: 'deprecated',
-              data: { component, prop, alternative },
+              messageId: 'deprecatedValue',
+              data: {
+                component,
+                prop: config.prop,
+                value,
+                alternative: config.alternative,
+              },
             });
           });
         };
       });
-      return visitors;
-    }, {} as TSESLint.RuleListener);
+    });
+
+    return visitors;
   },
 });

--- a/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-deprecated-props/index.ts
@@ -21,6 +21,33 @@ const createRule = ESLintUtils.RuleCreator<RuleDocs>(
     `https://github.com/sumup-oss/circuit-ui/tree/main/packages/eslint-plugin-circuit-ui/${name}`,
 );
 
+type PropConfig = {
+  components: string[];
+  props: [string];
+  alternative: string;
+};
+
+// TODO: When a deprecated prop is removed from a component in a major version,
+// remove the corresponding entry here
+const propMappings: PropConfig[] = [
+  {
+    components: ['Body'],
+    props: ['variant'],
+    alternative:
+      'Use the new `color` prop instead of the `alert`, `confirm` and `subtle` variants. Use the new `weight` prop instead of the `highlight` variant. Use custom CSS for the `quote` variant.',
+  },
+  {
+    components: ['Toggle'],
+    props: ['checkedLabel'],
+    alternative: 'This prop is no longer needed and can be removed.',
+  },
+  {
+    components: ['Toggle'],
+    props: ['uncheckedLabel'],
+    alternative: 'This prop is no longer needed and can be removed.',
+  },
+];
+
 type ValueConfig = {
   components: string[];
   prop: string;
@@ -31,12 +58,6 @@ type ValueConfig = {
 // TODO: When a deprecated value is removed from a component in a major version,
 // remove the corresponding entry here
 const valueMappings: ValueConfig[] = [
-  {
-    components: ['Body'],
-    prop: 'size',
-    values: ['one', 'two'],
-    alternative: 'Use "m" instead of "one" and "s" instead of "two".',
-  },
   {
     components: ['Body', 'Numeral'],
     prop: 'decoration',
@@ -56,6 +77,8 @@ export const noDeprecatedProps = createRule({
       recommended: 'warn',
     },
     messages: {
+      deprecated:
+        "The {{component}}'s `{{prop}}` prop has been deprecated. {{alternative}}",
       deprecatedValue:
         'The {{component}}\'s `{{prop}}` prop value "{{value}}" has been deprecated. {{alternative}}',
     },
@@ -64,15 +87,53 @@ export const noDeprecatedProps = createRule({
   create(context) {
     const visitors: TSESLint.RuleListener = {};
 
+    const addVisitor = (
+      component: string,
+      handler: (node: TSESTree.JSXElement) => void,
+    ) => {
+      const key = `JSXElement[openingElement.name.name="${component}"]`;
+      const existing = visitors[key] as
+        | ((node: TSESTree.JSXElement) => void)
+        | undefined;
+
+      visitors[key] = (node: TSESTree.JSXElement) => {
+        existing?.(node);
+        handler(node);
+      };
+    };
+
+    propMappings.forEach((config) => {
+      config.components.forEach((component) => {
+        addVisitor(component, (node) => {
+          const { props, alternative } = config;
+
+          node.openingElement.attributes.forEach((attribute) => {
+            if (
+              attribute.type !== TSESTree.AST_NODE_TYPES.JSXAttribute ||
+              attribute.name.type !== TSESTree.AST_NODE_TYPES.JSXIdentifier
+            ) {
+              return;
+            }
+
+            const prop = attribute.name.name;
+
+            if (!props.includes(prop)) {
+              return;
+            }
+
+            context.report({
+              node: attribute,
+              messageId: 'deprecated',
+              data: { component, prop, alternative },
+            });
+          });
+        });
+      });
+    });
+
     valueMappings.forEach((config) => {
       config.components.forEach((component) => {
-        const key = `JSXElement[openingElement.name.name="${component}"]`;
-        const existing = visitors[key] as
-          | ((node: TSESTree.JSXElement) => void)
-          | undefined;
-
-        visitors[key] = (node: TSESTree.JSXElement) => {
-          existing?.(node);
+        addVisitor(component, (node) => {
           node.openingElement.attributes.forEach((attribute) => {
             if (
               attribute.type !== TSESTree.AST_NODE_TYPES.JSXAttribute ||
@@ -114,7 +175,7 @@ export const noDeprecatedProps = createRule({
               },
             });
           });
-        };
+        });
       });
     });
 


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

Ahead of the v12 migration, deprecated props `(Toggle's checkedLabel/uncheckedLabel, Body/Numeral's decoration="italic")` are being manually removed from consumer repos. Without lint enforcement, nothing stops those props from being silently reintroduced in the window between cleanup and the actual v12 removal; this PR closes that gap.

## Approach and changes

Split the rule into two independent, composable checks:

- propMappings: flags a prop regardless of value `(e.g. Toggle's checkedLabel/uncheckedLabel)`.
- valueMapping:  flags specific deprecated values on props that are otherwise still valid (e.g. `decoration="italic"` on Body and Numeral, since `strikethrough` remains valid).


## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
