### PR TITLE
add button ref into shared props

### DIFF
--- a/packages/circuit-ui/components/Button/base.tsx
+++ b/packages/circuit-ui/components/Button/base.tsx
@@ -99,6 +99,8 @@ export type SharedButtonProps = LinkElProps &
      * Defaults to `navigator.language` in supported environments.
      */
     locale?: Locale;
+    // biome-ignore lint/suspicious/noExplicitAny: Polymorphic component supports button, anchor, and custom elements (including consumer-provided ones such as Next.js Link)
+    ref?: Ref<any>;
   };
 
 type CreateButtonComponentProps = SharedButtonProps & {
@@ -132,13 +134,14 @@ export const legacyButtonSizeMap: Record<string, 's' | 'm'> = {
   giga: 'm',
 };
 
-export function createButtonComponent<Props>(
+export function createButtonComponent<
+  Props extends Pick<SharedButtonProps, 'ref'>,
+>(
   componentName: string,
   // TODO: Refactor to `mapClassName` once the deprecations have been removed.
   mapProps: (props: Props) => CreateButtonComponentProps,
 ) {
-  // biome-ignore lint/suspicious/noExplicitAny: Polymorphic component supports button, anchor, and custom elements
-  function Button({ ref, ...rest }: Props & { ref?: Ref<any> }) {
+  function Button({ ref, ...rest }: Props) {
     const {
       children,
       onClick,


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

Move the `ref` declaration from the inline type intersection in createButtonComponent into SharedButtonProps so it's part of the documented props surface and consistent with how other props are declared.

## Approach and changes

- added `ref?: Ref<any>` to `SharedButtonProps`

```
// Before
function Button({ ref, ...rest }: Props & { ref?: Ref<any> }) {

// After: ref lives in SharedButtonProps
function Button({ ref, ...rest }: Props) {
```

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
