### PR TITLE
Warn about non-string-like Button children

### DIFF
--- a/.changeset/moody-experts-film.md
+++ b/.changeset/moody-experts-film.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Added a development-time error to the Button component when passing children that aren't a string or a number. This will be enforced by the prop types in the next major.

--- a/packages/circuit-ui/components/Button/base.tsx
+++ b/packages/circuit-ui/components/Button/base.tsx
@@ -187,7 +187,11 @@ export function BaseButton(props: BaseButtonProps) {
     );
   }
 
-  if (process.env.NODE_ENV !== 'production' && !isStringChildren(children)) {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
+    !isStringChildren(children)
+  ) {
     throw new CircuitError(
       componentName,
       'The `children` prop must be a string.',

--- a/packages/circuit-ui/components/Button/base.tsx
+++ b/packages/circuit-ui/components/Button/base.tsx
@@ -28,6 +28,7 @@ import type { AsPropType } from '../../types/prop-types.js';
 import { useComponents } from '../ComponentsContext/index.js';
 import {
   AccessibilityError,
+  CircuitError,
   isSufficientlyLabelled,
 } from '../../util/errors.js';
 import { utilClasses } from '../../styles/utility.js';
@@ -37,6 +38,7 @@ import type { Locale } from '../../util/i18n.js';
 
 import classes from './base.module.css';
 import { translations } from './translations/index.js';
+import { isStringChildren } from '../../util/type-check.js';
 
 type LinkElProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick'>;
 type ButtonElProps = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'>;
@@ -182,6 +184,13 @@ export function BaseButton(props: BaseButtonProps) {
     throw new AccessibilityError(
       componentName,
       'The `children` prop is missing or invalid.',
+    );
+  }
+
+  if (process.env.NODE_ENV !== 'production' && !isStringChildren(children)) {
+    throw new CircuitError(
+      componentName,
+      'The `children` prop must be a string.',
     );
   }
 

--- a/packages/circuit-ui/util/type-check.spec.ts
+++ b/packages/circuit-ui/util/type-check.spec.ts
@@ -25,6 +25,7 @@ import {
   isObject,
   isReactComponent,
   isString,
+  isStringChildren,
 } from './type-check.js';
 
 describe('type check', () => {
@@ -289,6 +290,108 @@ describe('type check', () => {
 
     it('should return false for an integer', () => {
       const actual = isReactComponent(1);
+      expect(actual).toBeFalsy();
+    });
+  });
+
+  describe('isStringChildren', () => {
+    it('should return true for a string', () => {
+      const actual = isStringChildren('Hello world');
+      expect(actual).toBeTruthy();
+    });
+
+    it('should return true for a number', () => {
+      const actual = isStringChildren(42);
+      expect(actual).toBeTruthy();
+    });
+
+    it('should return true for an empty string', () => {
+      const actual = isStringChildren('');
+      expect(actual).toBeTruthy();
+    });
+
+    it('should return true for an array of strings', () => {
+      const actual = isStringChildren(['Hello', 'world']);
+      expect(actual).toBeTruthy();
+    });
+
+    it('should return true for an array of numbers', () => {
+      const actual = isStringChildren([1, 2, 3]);
+      expect(actual).toBeTruthy();
+    });
+
+    it('should return true for an array of strings and numbers', () => {
+      const actual = isStringChildren(['Hello', 42]);
+      expect(actual).toBeTruthy();
+    });
+
+    it('should return true for a nested array of strings and numbers', () => {
+      const actual = isStringChildren(['Hello', [42, 'world']]);
+      expect(actual).toBeTruthy();
+    });
+
+    it('should return true for an empty array', () => {
+      const actual = isStringChildren([]);
+      expect(actual).toBeTruthy();
+    });
+
+    it('should return false for an object', () => {
+      const actual = isStringChildren({ foo: 'bar' });
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for null', () => {
+      const actual = isStringChildren(null);
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for undefined', () => {
+      const actual = isStringChildren(undefined);
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for a boolean', () => {
+      const actual = isStringChildren(true);
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for a function', () => {
+      const actual = isStringChildren(vi.fn());
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for an HTML element', () => {
+      const actual = isStringChildren(document.createElement('div'));
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for a React component', () => {
+      const actual = isStringChildren(() => 'Hello world');
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for an array containing an object', () => {
+      const actual = isStringChildren(['Hello', { foo: 'bar' }]);
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for an array containing null', () => {
+      const actual = isStringChildren(['Hello', null]);
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for an array containing undefined', () => {
+      const actual = isStringChildren(['Hello', undefined]);
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for an array containing a React component', () => {
+      const actual = isStringChildren(['Hello', () => 'world']);
+      expect(actual).toBeFalsy();
+    });
+
+    it('should return false for a nested array containing invalid children', () => {
+      const actual = isStringChildren(['Hello', [42, true]]);
       expect(actual).toBeFalsy();
     });
   });

--- a/packages/circuit-ui/util/type-check.ts
+++ b/packages/circuit-ui/util/type-check.ts
@@ -68,3 +68,12 @@ export function isReactComponent(
 
   return false;
 }
+
+export function isStringChildren(value?: unknown): value is string {
+  if (isArray(value)) {
+    // @ts-expect-error This is a boolean and you know it.
+    return value.reduce((acc, chunk) => acc && isStringChildren(chunk), true);
+  }
+
+  return isString(value) || isNumber(value);
+}


### PR DESCRIPTION
Relates to https://github.com/sumup-oss/circuit-ui/pull/3745#discussion_r3543430974.

## Purpose

Buttons labels should be plain strings (or string-like such as a number or an array of strings). Other usages are likely a mistake, such as passing an icon instead of using the `icon` prop.

## Approach and changes

- Throw an error during development when a Button receives non-string-like children

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
