### PR TITLE
Migrate SideNavigation's badge prop from BadgeProps to StatusProps

### DIFF
--- a/.changeset/public-geese-see.md
+++ b/.changeset/public-geese-see.md
@@ -1,0 +1,6 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Migrated the SideNavigation component's `badge` prop from the deprecated `Badge` component's props to the `Status` component's props. On primary links, `badge.variant` has been renamed to `badge.color`. On secondary links, `badge` is now typed as `StatusProps` instead of `BadgeProps`: replace `variant` with `color`, and replace `circle` with `variant="badge"`.
+

--- a/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
+++ b/packages/circuit-ui/components/SideNavigation/SideNavigation.stories.tsx
@@ -59,7 +59,7 @@ export const baseArgs: SideNavigationProps = {
       href: '/shop',
       onClick: action('Shop'),
       isActive: true,
-      badge: { variant: 'promo', children: 'New items' },
+      badge: { color: 'promo', children: 'New items' },
       secondaryGroups: [
         {
           secondaryLinks: [

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.module.css
@@ -128,15 +128,15 @@
   border-radius: var(--cui-border-radius-circle);
 }
 
-.success::after {
+.confirm::after {
   background-color: var(--cui-bg-success-strong);
 }
 
-.warning::after {
+.notify::after {
   background-color: var(--cui-bg-warning-strong);
 }
 
-.danger::after {
+.alert::after {
   background-color: var(--cui-bg-danger-strong);
 }
 
@@ -146,6 +146,10 @@
 
 .promo::after {
   background-color: var(--cui-bg-promo-strong);
+}
+
+.special::after {
+  background-color: var(--cui-fg-normal);
 }
 
 .suffix {

--- a/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/PrimaryLink/PrimaryLink.tsx
@@ -105,7 +105,7 @@ export function PrimaryLink({
           className={clsx(
             classes.icon,
             badge && classes.badge,
-            badge && classes[badge.variant || 'promo'],
+            badge && classes[badge.color || 'promo'],
           )}
         >
           <Icon aria-hidden="true" size="24" />

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -69,7 +69,7 @@ function SecondaryLink({
             {label}
           </Body>
         </Skeleton>
-        {badge && <Status color="promo" as="span" {...badge} />}
+        {badge && <Status color="promo" as="span" {...badge} variant="pill" />}
         {tier && <TierIndicator {...tier} size="s" />}
       </Element>
     </li>

--- a/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
+++ b/packages/circuit-ui/components/SideNavigation/components/SecondaryLinks/SecondaryLinks.tsx
@@ -23,7 +23,7 @@ import {
   type FocusProps,
 } from '../../../../hooks/useFocusList/index.js';
 import { Body } from '../../../Body/index.js';
-import { Badge } from '../../../Badge/index.js';
+import { Status } from '../../../Status/index.js';
 import { useComponents } from '../../../ComponentsContext/index.js';
 import { Skeleton } from '../../../Skeleton/index.js';
 import type { SecondaryGroupProps, SecondaryLinkProps } from '../../types.js';
@@ -69,7 +69,7 @@ function SecondaryLink({
             {label}
           </Body>
         </Skeleton>
-        {badge && <Badge variant="promo" as="span" {...badge} />}
+        {badge && <Status color="promo" as="span" {...badge} />}
         {tier && <TierIndicator {...tier} size="s" />}
       </Element>
     </li>

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -101,7 +101,7 @@ export interface SecondaryLinkProps {
    * An optional badge to highlight the secondary link, e.g. to promote
    * a new link or to indicate new content.
    */
-  badge?: StatusProps;
+  badge?: Omit<StatusProps, 'variant'>;
   /**
    * An optional badge to highlight elements belonging to a specific tier.
    */

--- a/packages/circuit-ui/components/SideNavigation/types.ts
+++ b/packages/circuit-ui/components/SideNavigation/types.ts
@@ -16,7 +16,7 @@
 import type { MouseEvent, KeyboardEvent, AnchorHTMLAttributes } from 'react';
 import type { IconComponentType } from '@sumup-oss/icons';
 
-import type { BadgeProps } from '../Badge/index.js';
+import type { StatusProps } from '../Status/index.js';
 import type { TierIndicatorProps } from '../TierIndicator/TierIndicator.js';
 
 export interface PrimaryLinkProps
@@ -52,11 +52,11 @@ export interface PrimaryLinkProps
    */
   badge?: {
     /**
-     * Choose the style variant.
+     * The semantic color of the badge.
      *
      * @default 'promo'
      */
-    variant?: BadgeProps['variant'];
+    color?: StatusProps['color'];
     /**
      * A clear and concise description of the badge's meaning.
      */
@@ -101,7 +101,7 @@ export interface SecondaryLinkProps {
    * An optional badge to highlight the secondary link, e.g. to promote
    * a new link or to indicate new content.
    */
-  badge?: BadgeProps;
+  badge?: StatusProps;
   /**
    * An optional badge to highlight elements belonging to a specific tier.
    */


### PR DESCRIPTION
Addresses [DSYS-1839](https://sumupteam.atlassian.net/browse/DSYS-1839)

## Purpose

`Badge` has been deprecated in favor of `Status`. `SideNavigation's` badge prop on both `PrimaryLink and SecondaryLink` was still typed against the deprecated Badge component's props and rendered <Badge> internally. This PR migrates it to Status. 

## Approach and changes

- `SecondaryLinkProps.badge`: retyped from BadgeProps to StatusProps. 
- `PrimaryLinkProps.badge`: Renamed the field to color: StatusProps['color'] for consistency with the new prop names
- `PrimaryLink.module.css`: Renamed the classes to match Status's color prop names. 

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
