### PR TITLE
feat(PhoneNumberInput): custom country dropdown rendering

### DIFF
--- a/.changeset/phone-input-render-option.md
+++ b/.changeset/phone-input-render-option.md
@@ -1,0 +1,5 @@
+---
+'@sumup-oss/circuit-ui': minor
+---
+
+Added opt-in `countryCode.renderOption` and `countryCode.getOptionLabel` props to PhoneNumberInput for custom country dropdown rendering and SSR-stable option labels.

--- a/packages/circuit-ui/components/PhoneNumberInput/CountryCodeDropdown.module.css
+++ b/packages/circuit-ui/components/PhoneNumberInput/CountryCodeDropdown.module.css
@@ -1,0 +1,47 @@
+.panel[hidden] {
+  display: none;
+}
+
+.panel {
+  z-index: calc(var(--cui-z-index-input) + 4);
+  max-height: var(--country-code-dropdown-max-height, 240px);
+  margin: 0;
+  padding: var(--cui-spacings-bit) 0;
+  overflow-y: auto;
+  list-style: none;
+  background-color: var(--cui-bg-normal);
+  border: 1px solid var(--cui-border-normal);
+  border-radius: var(--field-input-border-radius);
+  box-shadow: var(--cui-shadows-single);
+}
+
+.option {
+  display: flex;
+  gap: var(--cui-spacings-kilo);
+  align-items: center;
+  padding: var(--cui-spacings-kilo) var(--cui-spacings-mega);
+  color: var(--cui-fg-normal);
+  cursor: pointer;
+}
+
+.option:hover,
+.option.focused {
+  background-color: var(--cui-bg-subtle);
+}
+
+.option.selected {
+  font-weight: var(--cui-font-weight-semibold);
+}
+
+.trigger {
+  font-family: inherit;
+  font-weight: inherit;
+  text-align: left;
+}
+
+.trigger-content {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/circuit-ui/components/PhoneNumberInput/CountryCodeDropdown.module.css
+++ b/packages/circuit-ui/components/PhoneNumberInput/CountryCodeDropdown.module.css
@@ -5,8 +5,8 @@
 .panel {
   z-index: calc(var(--cui-z-index-input) + 4);
   max-height: var(--country-code-dropdown-max-height, 240px);
-  margin: 0;
   padding: var(--cui-spacings-bit) 0;
+  margin: 0;
   overflow-y: auto;
   list-style: none;
   background-color: var(--cui-bg-normal);

--- a/packages/circuit-ui/components/PhoneNumberInput/CountryCodeDropdown.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/CountryCodeDropdown.tsx
@@ -1,0 +1,395 @@
+/**
+ * Copyright 2024, SumUp Ltd.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use client';
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ComponentType,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import {
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useFloating,
+} from '@floating-ui/react-dom';
+import { ChevronDown } from '@sumup-oss/icons';
+
+import {
+  FieldLabel,
+  FieldLabelText,
+  FieldWrapper,
+  type FieldSize,
+} from '../Field/index.js';
+import type { SelectOption } from '../Select/Select.js';
+import { clsx } from '../../styles/clsx.js';
+import { applyMultipleRefs } from '../../util/refs.js';
+import { useClickOutside } from '../../hooks/useClickOutside/index.js';
+import { useEscapeKey } from '../../hooks/useEscapeKey/index.js';
+import { changeInputValue } from '../../util/input-value.js';
+import {
+  isArrowDown,
+  isArrowUp,
+  isEnter,
+  isEscape,
+  isSpacebar,
+} from '../../util/key-codes.js';
+
+import type { CountryCodeOption } from './PhoneNumberInputService.js';
+import selectClasses from '../Select/Select.module.css';
+import classes from './CountryCodeDropdown.module.css';
+
+export interface CountryCodeDropdownProps {
+  label: string;
+  hideLabel?: boolean;
+  options: CountryCodeOption[];
+  mappedOptions: SelectOption[];
+  value?: string;
+  disabled?: boolean;
+  required?: boolean;
+  invalid?: boolean;
+  size?: FieldSize;
+  className?: string;
+  style?: CSSProperties;
+  'aria-describedby'?: string;
+  renderOption: (
+    option: CountryCodeOption,
+    meta: { selected: boolean },
+  ) => ReactNode;
+  renderPrefix?: ComponentType<{
+    value?: string | number;
+    className?: string;
+  }>;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const CountryCodeDropdown = forwardRef<
+  HTMLInputElement,
+  CountryCodeDropdownProps
+>(
+  (
+    {
+      label,
+      hideLabel,
+      options,
+      mappedOptions,
+      value,
+      disabled,
+      required,
+      invalid,
+      size = 'm',
+      className,
+      style,
+      'aria-describedby': descriptionId,
+      renderOption,
+      renderPrefix: RenderPrefix,
+      onChange,
+    },
+    ref,
+  ) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [activeIndex, setActiveIndex] = useState<number>();
+    const hiddenInputRef = useRef<HTMLInputElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const wrapperRef = useRef<HTMLDivElement>(null);
+    const listboxId = useId();
+    const triggerId = useId();
+
+    const sortedOptions = useMemo(
+      () =>
+        mappedOptions
+          .map((mapped) => {
+            const option = options.find(
+              ({ country }) => country === mapped.value,
+            );
+            return option ? { option, label: mapped.label } : null;
+          })
+          .filter((item): item is { option: CountryCodeOption; label: string } =>
+            Boolean(item),
+          ),
+      [mappedOptions, options],
+    );
+
+    const selectedCountry = value;
+    const selectedIndex = sortedOptions.findIndex(
+      ({ option }) => option.country === selectedCountry,
+    );
+
+    const { refs, floatingStyles } = useFloating({
+      placement: 'bottom-start',
+      whileElementsMounted: autoUpdate,
+      middleware: [offset(4), flip(), shift({ padding: 8 })],
+    });
+
+    const close = useCallback((returnFocus = false) => {
+      setIsOpen(false);
+      setActiveIndex(undefined);
+      if (returnFocus) {
+        triggerRef.current?.focus();
+      }
+    }, []);
+
+    const selectOption = useCallback(
+      (option: CountryCodeOption) => {
+        changeInputValue(hiddenInputRef.current, option.country);
+        hiddenInputRef.current?.dispatchEvent(
+          new Event('change', { bubbles: true }),
+        );
+        onChange?.({
+          target: hiddenInputRef.current,
+        } as ChangeEvent<HTMLInputElement>);
+        close();
+        triggerRef.current?.focus();
+      },
+      [close, onChange],
+    );
+
+    useClickOutside([wrapperRef, refs.floating], () => close(), isOpen);
+    useEscapeKey(() => close(true), isOpen);
+
+    useEffect(() => {
+      if (isOpen) {
+        setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
+      }
+    }, [isOpen, selectedIndex]);
+
+    useEffect(() => {
+      if (!isOpen || activeIndex === undefined) {
+        return;
+      }
+
+      document
+        .getElementById(`${listboxId}-option-${activeIndex}`)
+        ?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    }, [activeIndex, isOpen, listboxId]);
+
+    const handleTriggerKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (disabled) {
+        return;
+      }
+
+      if (isEscape(event) && isOpen) {
+        event.preventDefault();
+        close(true);
+        return;
+      }
+
+      if (isSpacebar(event)) {
+        event.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+          return;
+        }
+        if (activeIndex !== undefined) {
+          const selected = sortedOptions[activeIndex];
+          if (selected) {
+            selectOption(selected.option);
+          }
+        }
+        return;
+      }
+
+      if (isArrowDown(event) || isArrowUp(event)) {
+        event.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+          return;
+        }
+      }
+
+      if (!isOpen) {
+        return;
+      }
+
+      if (isArrowDown(event)) {
+        setActiveIndex((current = -1) =>
+          current < sortedOptions.length - 1 ? current + 1 : 0,
+        );
+      }
+
+      if (isArrowUp(event)) {
+        setActiveIndex((current = sortedOptions.length) =>
+          current > 0 ? current - 1 : sortedOptions.length - 1,
+        );
+      }
+
+      if (isEnter(event) && activeIndex !== undefined) {
+        const selected = sortedOptions[activeIndex];
+        if (selected) {
+          selectOption(selected.option);
+        }
+      }
+    };
+
+    const handleListboxKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+      if (isEscape(event)) {
+        event.preventDefault();
+        close(true);
+        return;
+      }
+
+      if (isArrowDown(event)) {
+        event.preventDefault();
+        setActiveIndex((current = -1) =>
+          current < sortedOptions.length - 1 ? current + 1 : 0,
+        );
+      }
+
+      if (isArrowUp(event)) {
+        event.preventDefault();
+        setActiveIndex((current = sortedOptions.length) =>
+          current > 0 ? current - 1 : sortedOptions.length - 1,
+        );
+      }
+
+      if (isEnter(event) && activeIndex !== undefined) {
+        event.preventDefault();
+        const selected = sortedOptions[activeIndex];
+        if (selected) {
+          selectOption(selected.option);
+        }
+      }
+    };
+
+    const prefix = RenderPrefix && (
+      <RenderPrefix
+        className={selectClasses.prefix}
+        value={selectedCountry}
+      />
+    );
+    const hasPrefix = Boolean(prefix);
+
+    const activeOptionId =
+      activeIndex !== undefined
+        ? `${listboxId}-option-${activeIndex}`
+        : undefined;
+
+    const selectedOption =
+      selectedIndex >= 0 ? sortedOptions[selectedIndex] : undefined;
+
+    return (
+      <FieldWrapper
+        disabled={disabled}
+        size={size}
+        className={className}
+        style={style}
+      >
+        <FieldLabel htmlFor={triggerId}>
+          <FieldLabelText label={label} hideLabel={hideLabel} required={required} />
+        </FieldLabel>
+        <input
+          type="hidden"
+          ref={applyMultipleRefs(ref, hiddenInputRef)}
+          value={value ?? ''}
+          disabled={disabled}
+          required={required}
+          tabIndex={-1}
+          aria-hidden="true"
+        />
+        <div
+          ref={wrapperRef}
+          className={clsx(selectClasses.wrapper, selectClasses[size])}
+        >
+          {prefix}
+          <button
+            id={triggerId}
+            type="button"
+            ref={applyMultipleRefs(triggerRef, refs.setReference)}
+            disabled={disabled}
+            autoComplete="tel-country-code"
+            aria-haspopup="listbox"
+            aria-expanded={isOpen}
+            aria-controls={listboxId}
+            aria-describedby={descriptionId}
+            aria-invalid={invalid && 'true'}
+            aria-required={required || undefined}
+            aria-autocomplete="none"
+            aria-activedescendant={isOpen ? activeOptionId : undefined}
+            role="combobox"
+            className={clsx(
+              selectClasses.base,
+              classes.trigger,
+              hasPrefix && selectClasses['has-prefix'],
+            )}
+            onClick={() => {
+              if (!disabled) {
+                setIsOpen((open) => !open);
+              }
+            }}
+            onKeyDown={handleTriggerKeyDown}
+          >
+            <span className={classes['trigger-content']}>
+              {selectedOption?.label}
+            </span>
+          </button>
+          <ChevronDown
+            className={selectClasses.icon}
+            size={size === 's' ? '16' : '24'}
+            aria-hidden="true"
+          />
+          <ul
+            ref={refs.setFloating}
+            id={listboxId}
+            role="listbox"
+            aria-labelledby={triggerId}
+            hidden={!isOpen}
+            tabIndex={-1}
+            style={isOpen ? floatingStyles : undefined}
+            className={classes.panel}
+            onKeyDown={handleListboxKeyDown}
+          >
+            {sortedOptions.map(({ option, label: optionLabel }, index) => {
+              const isSelected = option.country === selectedCountry;
+              const isFocused = index === activeIndex;
+
+              return (
+                // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard selection handled on listbox
+                <li
+                  key={option.country}
+                  id={`${listboxId}-option-${index}`}
+                  role="option"
+                  aria-selected={isSelected}
+                  aria-label={optionLabel}
+                  className={clsx(
+                    classes.option,
+                    isSelected && classes.selected,
+                    isFocused && classes.focused,
+                  )}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => selectOption(option)}
+                >
+                  {renderOption(option, { selected: isSelected })}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </FieldWrapper>
+    );
+  },
+);
+
+CountryCodeDropdown.displayName = 'CountryCodeDropdown';

--- a/packages/circuit-ui/components/PhoneNumberInput/CountryCodeDropdown.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/CountryCodeDropdown.tsx
@@ -127,8 +127,9 @@ export const CountryCodeDropdown = forwardRef<
             );
             return option ? { option, label: mapped.label } : null;
           })
-          .filter((item): item is { option: CountryCodeOption; label: string } =>
-            Boolean(item),
+          .filter(
+            (item): item is { option: CountryCodeOption; label: string } =>
+              Boolean(item),
           ),
       [mappedOptions, options],
     );
@@ -275,10 +276,7 @@ export const CountryCodeDropdown = forwardRef<
     };
 
     const prefix = RenderPrefix && (
-      <RenderPrefix
-        className={selectClasses.prefix}
-        value={selectedCountry}
-      />
+      <RenderPrefix className={selectClasses.prefix} value={selectedCountry} />
     );
     const hasPrefix = Boolean(prefix);
 
@@ -298,7 +296,11 @@ export const CountryCodeDropdown = forwardRef<
         style={style}
       >
         <FieldLabel htmlFor={triggerId}>
-          <FieldLabelText label={label} hideLabel={hideLabel} required={required} />
+          <FieldLabelText
+            label={label}
+            hideLabel={hideLabel}
+            required={required}
+          />
         </FieldLabel>
         <input
           type="hidden"
@@ -352,6 +354,7 @@ export const CountryCodeDropdown = forwardRef<
           <ul
             ref={refs.setFloating}
             id={listboxId}
+            // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: list element has all necessary attributes to be interactive
             role="listbox"
             aria-labelledby={triggerId}
             hidden={!isOpen}
@@ -366,9 +369,11 @@ export const CountryCodeDropdown = forwardRef<
 
               return (
                 // biome-ignore lint/a11y/useKeyWithClickEvents: keyboard selection handled on listbox
+                // biome-ignore lint/a11y/useFocusableInteractive: options are reached via combobox aria-activedescendant
                 <li
                   key={option.country}
                   id={`${listboxId}-option-${index}`}
+                  // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: list element has all necessary attributes to be interactive
                   role="option"
                   aria-selected={isSelected}
                   aria-label={optionLabel}

--- a/packages/circuit-ui/components/PhoneNumberInput/CountryCodeDropdown.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/CountryCodeDropdown.tsx
@@ -319,7 +319,6 @@ export const CountryCodeDropdown = forwardRef<
             type="button"
             ref={applyMultipleRefs(triggerRef, refs.setReference)}
             disabled={disabled}
-            autoComplete="tel-country-code"
             aria-haspopup="listbox"
             aria-expanded={isOpen}
             aria-controls={listboxId}

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.mdx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.mdx
@@ -59,3 +59,15 @@ You should use only when the value is a critical information from the user that 
 Use the `renderPrefix` prop to add a small prefix to the country code selected input field. By default, the component will display the selected country's [Flag](Components/Flag/Docs). You can override that behavior by providing your own prefix component.
 
 <Story of={Stories.WithPrefix} />
+
+## Custom option labels
+
+Pass pre-computed labels via `countryCode.options[].label` or `countryCode.getOptionLabel` to avoid SSR/client mismatches from `Intl.DisplayNames` in server-rendered apps. Labels are used for native `<select>` options and as accessible names in the custom dropdown.
+
+<Story of={Stories.WithCustomLabels} />
+
+## Custom dropdown
+
+Pass `countryCode.renderOption` to replace the native country code select with a custom listbox dropdown. Use this when options need rich content such as flags or emojis that native `<option>` elements cannot render. Combine with pre-computed labels for hydration-safe country names.
+
+<Story of={Stories.WithCustomDropdown} />

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
@@ -17,7 +17,8 @@
   }
 
   .wrapper .country-code.country-code select,
-  .wrapper .country-code .country-code-input.country-code-input {
+  .wrapper .country-code .country-code-input.country-code-input,
+  .wrapper .country-code button[role='combobox'] {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
@@ -35,7 +36,8 @@
   }
 
   .wrapper .country-code.country-code select,
-  .wrapper .country-code .country-code-input.country-code-input {
+  .wrapper .country-code .country-code-input.country-code-input,
+  .wrapper .country-code button[role='combobox'] {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
@@ -66,9 +68,14 @@
   flex-grow: 1;
 }
 
+.country-code.country-code {
+  flex-shrink: 0;
+}
+
 /* Elevate the country code select above the subscriber number input on hover and focus */
 .country-code.country-code:hover,
 .country-code.country-code:focus,
+.country-code.country-code:focus-within,
 .country-code-input.country-code-input:hover,
 .country-code-input.country-code-input:focus {
   position: relative;

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.module.css
@@ -18,7 +18,7 @@
 
   .wrapper .country-code.country-code select,
   .wrapper .country-code .country-code-input.country-code-input,
-  .wrapper .country-code button[role='combobox'] {
+  .wrapper .country-code button[role="combobox"] {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
@@ -37,7 +37,7 @@
 
   .wrapper .country-code.country-code select,
   .wrapper .country-code .country-code-input.country-code-input,
-  .wrapper .country-code button[role='combobox'] {
+  .wrapper .country-code button[role="combobox"] {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
@@ -378,6 +378,170 @@ describe('PhoneNumberInput', () => {
     expect(actual).toHaveNoViolations();
   });
 
+  it('should meet accessibility guidelines with a custom country dropdown', async () => {
+    const { container } = render(
+      <PhoneNumberInput
+        {...defaultProps}
+        countryCode={{
+          ...defaultProps.countryCode,
+          options: defaultProps.countryCode.options.map((option) => ({
+            ...option,
+            label: `Label ${option.country}`,
+          })),
+          renderOption: (option) => option.label ?? option.country,
+        }}
+      />,
+    );
+    const actual = await axe(container);
+    expect(actual).toHaveNoViolations();
+  });
+
+  it('should use getOptionLabel for native select option labels', () => {
+    const getOptionLabel = ({ country, code }: { country: string; code: string }) =>
+      `Custom ${country} (${code})`;
+    render(
+      <PhoneNumberInput
+        {...defaultProps}
+        countryCode={{
+          ...defaultProps.countryCode,
+          getOptionLabel,
+        }}
+      />,
+    );
+    expect(screen.getByRole('option', { name: 'Custom CA (+1)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Custom DE (+49)' })).toBeInTheDocument();
+  });
+
+  it('should use option.label for native select option labels', () => {
+    render(
+      <PhoneNumberInput
+        {...defaultProps}
+        countryCode={{
+          ...defaultProps.countryCode,
+          options: defaultProps.countryCode.options.map((option) => ({
+            ...option,
+            label: `Label ${option.country}`,
+          })),
+        }}
+      />,
+    );
+    expect(screen.getByRole('option', { name: 'Label CA' })).toBeInTheDocument();
+  });
+
+  describe('custom country dropdown', () => {
+    const renderOption = (option: { country: string; code: string }) =>
+      `${option.country} ${option.code}`;
+
+    const customDropdownProps = {
+      ...defaultProps,
+      countryCode: {
+        ...defaultProps.countryCode,
+        renderOption,
+      },
+    };
+
+    it('should render a combobox when renderOption is provided', () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      const combobox = screen.getByRole('combobox', { name: 'Country code' });
+      expect(combobox).toBeInTheDocument();
+      expect(combobox).toHaveAttribute('aria-autocomplete', 'none');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    it('should expose required and invalid state on the combobox', () => {
+      render(
+        <PhoneNumberInput
+          {...customDropdownProps}
+          required
+          invalid
+        />,
+      );
+      const combobox = screen.getByRole('combobox', { name: 'Country code' });
+      expect(combobox).toHaveAttribute('aria-required', 'true');
+      expect(combobox).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('should open the listbox on arrow down and close on escape with focus returned', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      const combobox = screen.getByRole('combobox', { name: 'Country code' });
+      combobox.focus();
+      await userEvent.keyboard('{ArrowDown}');
+      expect(combobox).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('listbox')).toBeVisible();
+      await userEvent.keyboard('{Escape}');
+      expect(combobox).toHaveAttribute('aria-expanded', 'false');
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(combobox).toHaveFocus();
+    });
+
+    it('should expose option accessible names independent of renderOption content', async () => {
+      render(
+        <PhoneNumberInput
+          {...customDropdownProps}
+          countryCode={{
+            ...customDropdownProps.countryCode,
+            options: defaultProps.countryCode.options.map((option) => ({
+              ...option,
+              label: `Accessible ${option.country}`,
+            })),
+            renderOption: () => <span aria-hidden="true">decorative</span>,
+          }}
+        />,
+      );
+      await userEvent.click(screen.getByRole('combobox', { name: 'Country code' }));
+      expect(
+        screen.getByRole('option', { name: 'Accessible DE' }),
+      ).toBeInTheDocument();
+    });
+
+    it('should open the custom dropdown and select a country', async () => {
+      const onChange = vi.fn();
+      render(
+        <PhoneNumberInput
+          {...customDropdownProps}
+          onChange={onChange}
+        />,
+      );
+      await userEvent.click(screen.getByRole('combobox'));
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('option', { name: 'Germany (+49)' }));
+      expect(onChange).toHaveBeenCalled();
+      expect(screen.getByRole('combobox')).toHaveTextContent('Germany (+49)');
+    });
+
+    it('should update the hidden phone number input when selecting a country', async () => {
+      const { container } = render(<PhoneNumberInput {...customDropdownProps} />);
+      await userEvent.click(screen.getByRole('combobox'));
+      await userEvent.click(screen.getByRole('option', { name: 'Germany (+49)' }));
+      const subscriberNumber = screen.getByLabelText(/Subscriber number/);
+      await userEvent.type(subscriberNumber, '12345678');
+      expect(getHiddenInput(container)).toHaveValue('+4912345678');
+    });
+
+    it('should distinguish countries that share a calling code', async () => {
+      render(
+        <PhoneNumberInput
+          {...customDropdownProps}
+          countryCode={{
+            ...customDropdownProps.countryCode,
+            options: defaultProps.countryCode.options.map((option) => ({
+              ...option,
+              label:
+                option.country === 'CA'
+                  ? 'Canada (+1)'
+                  : option.country === 'US'
+                    ? 'United States (+1)'
+                    : `Germany (${option.code})`,
+            })),
+          }}
+        />,
+      );
+      await userEvent.click(screen.getByRole('combobox'));
+      await userEvent.click(screen.getByRole('option', { name: 'United States (+1)' }));
+      expect(screen.getByRole('combobox')).toHaveTextContent('United States (+1)');
+    });
+  });
+
   it('should set aria-describedby when there is an error message', () => {
     const props = {
       ...defaultProps,

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
@@ -397,8 +397,13 @@ describe('PhoneNumberInput', () => {
   });
 
   it('should use getOptionLabel for native select option labels', () => {
-    const getOptionLabel = ({ country, code }: { country: string; code: string }) =>
-      `Custom ${country} (${code})`;
+    const getOptionLabel = ({
+      country,
+      code,
+    }: {
+      country: string;
+      code: string;
+    }) => `Custom ${country} (${code})`;
     render(
       <PhoneNumberInput
         {...defaultProps}
@@ -408,8 +413,12 @@ describe('PhoneNumberInput', () => {
         }}
       />,
     );
-    expect(screen.getByRole('option', { name: 'Custom CA (+1)' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Custom DE (+49)' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Custom CA (+1)' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Custom DE (+49)' }),
+    ).toBeInTheDocument();
   });
 
   it('should use option.label for native select option labels', () => {
@@ -425,7 +434,9 @@ describe('PhoneNumberInput', () => {
         }}
       />,
     );
-    expect(screen.getByRole('option', { name: 'Label CA' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Label CA' }),
+    ).toBeInTheDocument();
   });
 
   describe('custom country dropdown', () => {
@@ -449,13 +460,7 @@ describe('PhoneNumberInput', () => {
     });
 
     it('should expose required and invalid state on the combobox', () => {
-      render(
-        <PhoneNumberInput
-          {...customDropdownProps}
-          required
-          invalid
-        />,
-      );
+      render(<PhoneNumberInput {...customDropdownProps} required invalid />);
       const combobox = screen.getByRole('combobox', { name: 'Country code' });
       expect(combobox).toHaveAttribute('aria-required', 'true');
       expect(combobox).toHaveAttribute('aria-invalid', 'true');
@@ -488,7 +493,9 @@ describe('PhoneNumberInput', () => {
           }}
         />,
       );
-      await userEvent.click(screen.getByRole('combobox', { name: 'Country code' }));
+      await userEvent.click(
+        screen.getByRole('combobox', { name: 'Country code' }),
+      );
       expect(
         screen.getByRole('option', { name: 'Accessible DE' }),
       ).toBeInTheDocument();
@@ -496,23 +503,24 @@ describe('PhoneNumberInput', () => {
 
     it('should open the custom dropdown and select a country', async () => {
       const onChange = vi.fn();
-      render(
-        <PhoneNumberInput
-          {...customDropdownProps}
-          onChange={onChange}
-        />,
-      );
+      render(<PhoneNumberInput {...customDropdownProps} onChange={onChange} />);
       await userEvent.click(screen.getByRole('combobox'));
       expect(screen.getByRole('listbox')).toBeInTheDocument();
-      await userEvent.click(screen.getByRole('option', { name: 'Germany (+49)' }));
+      await userEvent.click(
+        screen.getByRole('option', { name: 'Germany (+49)' }),
+      );
       expect(onChange).toHaveBeenCalled();
       expect(screen.getByRole('combobox')).toHaveTextContent('Germany (+49)');
     });
 
     it('should update the hidden phone number input when selecting a country', async () => {
-      const { container } = render(<PhoneNumberInput {...customDropdownProps} />);
+      const { container } = render(
+        <PhoneNumberInput {...customDropdownProps} />,
+      );
       await userEvent.click(screen.getByRole('combobox'));
-      await userEvent.click(screen.getByRole('option', { name: 'Germany (+49)' }));
+      await userEvent.click(
+        screen.getByRole('option', { name: 'Germany (+49)' }),
+      );
       const subscriberNumber = screen.getByLabelText(/Subscriber number/);
       await userEvent.type(subscriberNumber, '12345678');
       expect(getHiddenInput(container)).toHaveValue('+4912345678');
@@ -537,8 +545,12 @@ describe('PhoneNumberInput', () => {
         />,
       );
       await userEvent.click(screen.getByRole('combobox'));
-      await userEvent.click(screen.getByRole('option', { name: 'United States (+1)' }));
-      expect(screen.getByRole('combobox')).toHaveTextContent('United States (+1)');
+      await userEvent.click(
+        screen.getByRole('option', { name: 'United States (+1)' }),
+      );
+      expect(screen.getByRole('combobox')).toHaveTextContent(
+        'United States (+1)',
+      );
     });
   });
 

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
@@ -17,7 +17,7 @@ import { describe, it, vi, expect } from 'vitest';
 import { createRef, useState, type ChangeEvent } from 'react';
 import { getIconURL } from '@sumup-oss/icons';
 
-import { axe, render, screen, userEvent } from '../../util/test-utils.js';
+import { axe, fireEvent, render, screen, userEvent } from '../../util/test-utils.js';
 
 import {
   PhoneNumberInput,
@@ -550,6 +550,143 @@ describe('PhoneNumberInput', () => {
       );
       expect(screen.getByRole('combobox')).toHaveTextContent(
         'United States (+1)',
+      );
+    });
+
+    it('should call countryCode.onChange when selecting a country', async () => {
+      const onCountryChange = vi.fn();
+      render(
+        <PhoneNumberInput
+          {...customDropdownProps}
+          countryCode={{
+            ...customDropdownProps.countryCode,
+            onChange: onCountryChange,
+          }}
+        />,
+      );
+      await userEvent.click(screen.getByRole('combobox'));
+      await userEvent.click(
+        screen.getByRole('option', { name: 'Germany (+49)' }),
+      );
+      expect(onCountryChange).toHaveBeenCalled();
+    });
+
+    it('should close the dropdown when clicking outside', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      await userEvent.click(screen.getByRole('combobox'));
+      expect(screen.getByRole('listbox')).toBeVisible();
+      await userEvent.click(document.body);
+      expect(screen.getByRole('combobox')).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      );
+    });
+
+    it('should not toggle the dropdown when disabled', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} disabled />);
+      await userEvent.click(screen.getByRole('combobox'));
+      expect(screen.getByRole('combobox')).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      );
+    });
+
+    it('should open the dropdown with arrow up', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      const combobox = screen.getByRole('combobox', { name: 'Country code' });
+      combobox.focus();
+      await userEvent.keyboard('{ArrowUp}');
+      expect(combobox).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should navigate options with arrow keys and select with enter', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      const combobox = screen.getByRole('combobox', { name: 'Country code' });
+      combobox.focus();
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('{Enter}');
+      expect(combobox).toHaveTextContent('Germany (+49)');
+    });
+
+    it('should wrap arrow up navigation to the last option', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      const combobox = screen.getByRole('combobox', { name: 'Country code' });
+      combobox.focus();
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('{ArrowUp}');
+      expect(combobox).toHaveAttribute('aria-activedescendant', expect.stringMatching(/-option-2$/));
+    });
+
+    it('should select the active option with space', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      const combobox = screen.getByRole('combobox', { name: 'Country code' });
+      combobox.focus();
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard('{ArrowDown}');
+      await userEvent.keyboard(' ');
+      expect(combobox).toHaveTextContent('Germany (+49)');
+    });
+
+    it('should open the dropdown with space when closed', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      const combobox = screen.getByRole('combobox', { name: 'Country code' });
+      combobox.focus();
+      await userEvent.keyboard(' ');
+      expect(combobox).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('should support keyboard navigation on the listbox', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      await userEvent.click(screen.getByRole('combobox'));
+      const listbox = screen.getByRole('listbox');
+      fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+      fireEvent.keyDown(listbox, { key: 'Enter' });
+      expect(screen.getByRole('combobox')).toHaveTextContent('Germany (+49)');
+    });
+
+    it('should close the listbox on escape from listbox keyboard events', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      const combobox = screen.getByRole('combobox', { name: 'Country code' });
+      await userEvent.click(combobox);
+      fireEvent.keyDown(screen.getByRole('listbox'), { key: 'Escape' });
+      expect(combobox).toHaveAttribute('aria-expanded', 'false');
+      expect(combobox).toHaveFocus();
+    });
+
+    it('should ignore keyboard input when disabled', () => {
+      render(<PhoneNumberInput {...customDropdownProps} disabled />);
+      const combobox = screen.getByRole('combobox');
+      fireEvent.keyDown(combobox, { key: 'ArrowDown' });
+      expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should ignore enter when the dropdown is closed', () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      const combobox = screen.getByRole('combobox', { name: 'Country code' });
+      fireEvent.keyDown(combobox, { key: 'Enter' });
+      expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should navigate the listbox with arrow up', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      await userEvent.click(screen.getByRole('combobox'));
+      fireEvent.keyDown(screen.getByRole('listbox'), { key: 'ArrowUp' });
+      expect(screen.getByRole('combobox')).toHaveAttribute(
+        'aria-activedescendant',
+        expect.stringMatching(/-option-2$/),
+      );
+    });
+
+    it('should highlight options on mouse enter', async () => {
+      render(<PhoneNumberInput {...customDropdownProps} />);
+      await userEvent.click(screen.getByRole('combobox'));
+      await userEvent.hover(
+        screen.getByRole('option', { name: 'Germany (+49)' }),
+      );
+      expect(screen.getByRole('combobox')).toHaveAttribute(
+        'aria-activedescendant',
+        expect.stringMatching(/-option-1$/),
       );
     });
   });

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.spec.tsx
@@ -17,7 +17,13 @@ import { describe, it, vi, expect } from 'vitest';
 import { createRef, useState, type ChangeEvent } from 'react';
 import { getIconURL } from '@sumup-oss/icons';
 
-import { axe, fireEvent, render, screen, userEvent } from '../../util/test-utils.js';
+import {
+  axe,
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+} from '../../util/test-utils.js';
 
 import {
   PhoneNumberInput,
@@ -615,7 +621,10 @@ describe('PhoneNumberInput', () => {
       combobox.focus();
       await userEvent.keyboard('{ArrowDown}');
       await userEvent.keyboard('{ArrowUp}');
-      expect(combobox).toHaveAttribute('aria-activedescendant', expect.stringMatching(/-option-2$/));
+      expect(combobox).toHaveAttribute(
+        'aria-activedescendant',
+        expect.stringMatching(/-option-2$/),
+      );
     });
 
     it('should select the active option with space', async () => {

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -16,6 +16,7 @@
 import {
   Alert,
   Checkmark,
+  Flag,
   Notify,
   type IconComponentType,
 } from '@sumup-oss/icons';
@@ -180,6 +181,77 @@ export const WithoutCountryNames = (args: PhoneNumberInputProps) => (
 WithoutCountryNames.args = {
   ...Base.args,
   shouldDisplayCountryNames: false,
+};
+
+const precomputedCountryLabels: Record<string, string> = {
+  CA: 'Canada (+1)',
+  US: 'United States (+1)',
+  DE: 'Germany (+49)',
+};
+
+export const WithCustomLabels = (args: PhoneNumberInputProps) => (
+  <StatefulPhoneNumberInput {...args} />
+);
+
+WithCustomLabels.args = {
+  ...Base.args,
+  countryCode: {
+    ...Base.args.countryCode,
+    options: Base.args.countryCode.options.map((option) => ({
+      ...option,
+      label: precomputedCountryLabels[option.country],
+    })),
+  },
+};
+
+export const WithCustomDropdown = (args: PhoneNumberInputProps) => (
+  <StatefulPhoneNumberInput
+    {...args}
+    countryCode={{
+      ...args.countryCode,
+      options: args.countryCode.options.map((option) => ({
+        ...option,
+        label: precomputedCountryLabels[option.country],
+      })),
+      renderOption: (option) => (
+        <>
+          <Flag countryCode={option.country as 'CA' | 'US' | 'DE'} alt="" />
+          <span>{option.label}</span>
+        </>
+      ),
+    }}
+  />
+);
+
+WithCustomDropdown.args = Base.args;
+
+WithCustomDropdown.parameters = {
+  docs: {
+    source: {
+      code: `<PhoneNumberInput
+  label="Phone number"
+  countryCode={{
+    label: 'Country code',
+    defaultValue: 'CA',
+    options: [
+      { country: 'CA', code: '+1', label: 'Canada (+1)' },
+      { country: 'US', code: '+1', label: 'United States (+1)' },
+      { country: 'DE', code: '+49', label: 'Germany (+49)' },
+    ],
+    renderOption: (option) => (
+      <>
+        <Flag countryCode={option.country} alt="" />
+        <span>{option.label}</span>
+      </>
+    ),
+  }}
+  subscriberNumber={{
+    label: 'Subscriber number',
+    placeholder: '202 555 0132',
+  }}
+/>`,
+    },
+  },
 };
 
 export const Sizes = (args: PhoneNumberInputProps) => (

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -26,11 +26,12 @@ import {
   type ComponentType,
   type InputHTMLAttributes,
   type ForwardedRef,
+  type ReactNode,
   type RefObject,
 } from 'react';
 import { Flag, type FlagProps } from '@sumup-oss/icons';
 
-import { Select, type SelectProps } from '../Select/index.js';
+import { Select } from '../Select/index.js';
 import { Input, type InputProps } from '../Input/index.js';
 import {
   FieldLabelText,
@@ -51,12 +52,14 @@ import { idx } from '../../util/idx.js';
 
 import {
   getCountryCode,
+  getCountryCodeFieldWidth,
   mapCountryCodeOptions,
   normalizePhoneNumber,
   parsePhoneNumber,
   type CountryCodeOption,
   getCountry,
 } from './PhoneNumberInputService.js';
+import { CountryCodeDropdown } from './CountryCodeDropdown.js';
 import classes from './PhoneNumberInput.module.css';
 
 export interface PhoneNumberInputProps
@@ -143,6 +146,19 @@ export interface PhoneNumberInputProps
      */
     options: CountryCodeOption[];
     /**
+     * When provided, replaces the native country code select with a custom
+     * dropdown that renders each option via this render prop.
+     */
+    renderOption?: (
+      option: CountryCodeOption,
+      meta: { selected: boolean },
+    ) => ReactNode;
+    /**
+     * Optional SSR-stable label override per option. Used by both the native
+     * select and the custom dropdown for accessible option text.
+     */
+    getOptionLabel?: (option: CountryCodeOption) => string;
+    /**
      * Triggers error styles on the component. Important for accessibility.
      */
     invalid?: boolean;
@@ -157,7 +173,7 @@ export interface PhoneNumberInputProps
     /**
      * Callback when the country code changes.
      */
-    onChange?: SelectProps['onChange'];
+    onChange?: (event: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => void;
     /**
      * The ref to the country code selector HTML DOM element.
      */
@@ -251,6 +267,12 @@ export const PhoneNumberInput = forwardRef<
     const hiddenInputRef = useRef<HTMLInputElement>(null);
     const countryCodeRef = useRef<HTMLSelectElement | HTMLInputElement>(null);
     const subscriberNumberRef = useRef<HTMLInputElement>(null);
+    const {
+      renderOption,
+      getOptionLabel,
+      options: countryCodeOptions,
+      ...countryCodeFieldProps
+    } = countryCode;
 
     // This state is used to trigger a re-render when selecting a different
     // country with the same country code as the current one (e.g. Canada → USA).
@@ -268,11 +290,29 @@ export const PhoneNumberInput = forwardRef<
     const options = useMemo(
       () =>
         mapCountryCodeOptions(
-          countryCode.options,
+          countryCodeOptions,
           locale,
           shouldDisplayCountryNames,
+          getOptionLabel,
         ),
-      [countryCode.options, locale, shouldDisplayCountryNames],
+      [
+        countryCodeOptions,
+        locale,
+        shouldDisplayCountryNames,
+        getOptionLabel,
+      ],
+    );
+
+    const countryCodeFieldWidth = useMemo(
+      () =>
+        renderOption
+          ? getCountryCodeFieldWidth(
+              options,
+              size,
+              Boolean(countryCode.renderPrefix ?? true),
+            )
+          : undefined,
+      [options, size, countryCode.renderPrefix, renderOption],
     );
 
     const handleChange = () => {
@@ -284,7 +324,7 @@ export const PhoneNumberInput = forwardRef<
       if (!selectedCountry) {
         return;
       }
-      const code = countryCode.options.find(
+      const code = countryCodeOptions.find(
         ({ country }) => country === selectedCountry,
       )?.code;
 
@@ -314,7 +354,7 @@ export const PhoneNumberInput = forwardRef<
 
       const pastedPhoneNumber = parsePhoneNumber(
         event.clipboardData.getData('text/plain'),
-        countryCode.options,
+        countryCodeOptions,
         countryCodeRef.current.value,
       );
 
@@ -331,13 +371,19 @@ export const PhoneNumberInput = forwardRef<
 
     const parsedValue = parsePhoneNumber(
       value,
-      countryCode.options,
+      countryCodeOptions,
       countryCodeRef.current?.value,
     );
     const parsedDefaultValue = parsePhoneNumber(
       defaultValue,
-      countryCode.options,
+      countryCodeOptions,
     );
+
+    const selectedCountryCode =
+      parsedValue.countryCode ??
+      countryCodeRef.current?.value ??
+      parsedDefaultValue.countryCode ??
+      countryCode.defaultValue;
 
     if (
       process.env.NODE_ENV !== 'production' &&
@@ -408,13 +454,13 @@ export const PhoneNumberInput = forwardRef<
               size={size}
               className={classes['country-code']}
               inputClassName={classes['country-code-input']}
-              {...countryCode}
+              {...countryCodeFieldProps}
               value={getCountryCode(
-                countryCode.options,
+                countryCodeOptions,
                 parsedValue.countryCode,
               )}
               defaultValue={getCountryCode(
-                countryCode.options,
+                countryCodeOptions,
                 parsedDefaultValue.countryCode ?? countryCode.defaultValue,
               )}
               invalid={invalid || countryCode.invalid}
@@ -429,13 +475,42 @@ export const PhoneNumberInput = forwardRef<
                 (({ value: inputValue, ...rest }) => (
                   <DefaultPrefix
                     value={getCountry(
-                      countryCode.options,
+                      countryCodeOptions,
                       inputValue as string,
                     )}
                     {...rest}
                   />
                 ))
               }
+            />
+          ) : renderOption ? (
+            <CountryCodeDropdown
+              hideLabel
+              aria-describedby={descriptionIds}
+              required={required}
+              disabled={disabled}
+              size={size}
+              className={classes['country-code']}
+              style={
+                countryCodeFieldWidth
+                  ? { width: countryCodeFieldWidth }
+                  : undefined
+              }
+              label={countryCode.label}
+              options={countryCodeOptions}
+              mappedOptions={options}
+              value={selectedCountryCode}
+              invalid={invalid || countryCode.invalid}
+              renderOption={renderOption}
+              renderPrefix={countryCode.renderPrefix ?? DefaultPrefix}
+              onChange={eachFn<[ChangeEvent<HTMLInputElement>]>([
+                countryCode.onChange,
+                handleChange,
+              ])}
+              ref={applyMultipleRefs(
+                countryCodeRef as RefObject<HTMLInputElement>,
+                countryCode.ref as ForwardedRef<HTMLInputElement>,
+              )}
             />
           ) : (
             <Select
@@ -446,7 +521,7 @@ export const PhoneNumberInput = forwardRef<
               disabled={disabled}
               size={size}
               className={classes['country-code']}
-              {...countryCode}
+              {...countryCodeFieldProps}
               value={parsedValue.countryCode}
               defaultValue={
                 parsedDefaultValue.countryCode ?? countryCode.defaultValue

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -173,7 +173,9 @@ export interface PhoneNumberInputProps
     /**
      * Callback when the country code changes.
      */
-    onChange?: (event: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => void;
+    onChange?: (
+      event: ChangeEvent<HTMLSelectElement | HTMLInputElement>,
+    ) => void;
     /**
      * The ref to the country code selector HTML DOM element.
      */
@@ -295,12 +297,7 @@ export const PhoneNumberInput = forwardRef<
           shouldDisplayCountryNames,
           getOptionLabel,
         ),
-      [
-        countryCodeOptions,
-        locale,
-        shouldDisplayCountryNames,
-        getOptionLabel,
-      ],
+      [countryCodeOptions, locale, shouldDisplayCountryNames, getOptionLabel],
     );
 
     const countryCodeFieldWidth = useMemo(
@@ -474,10 +471,7 @@ export const PhoneNumberInput = forwardRef<
                 (countryCode.renderPrefix as InputProps['renderPrefix']) ??
                 (({ value: inputValue, ...rest }) => (
                   <DefaultPrefix
-                    value={getCountry(
-                      countryCodeOptions,
-                      inputValue as string,
-                    )}
+                    value={getCountry(countryCodeOptions, inputValue as string)}
                     {...rest}
                   />
                 ))

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -16,9 +16,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  getCountryCodeFieldWidth,
   mapCountryCodeOptions,
   normalizePhoneNumber,
   parsePhoneNumber,
+  resolveCountryCodeOptionLabel,
 } from './PhoneNumberInputService.js';
 
 describe('PhoneNumberInputService', () => {
@@ -206,6 +208,76 @@ describe('PhoneNumberInputService', () => {
       ];
       const actual = mapCountryCodeOptions(options, undefined, false);
       expect(actual.map(({ label }) => label)).toEqual(['+1', '+1', '+49']);
+    });
+
+    it('should use option.label when provided', () => {
+      const options = [
+        { country: 'CA', code: '+1', label: 'Canada (+1)' },
+        { country: 'DE', code: '+49', label: 'Germany (+49)' },
+      ];
+      const actual = mapCountryCodeOptions(options, undefined, true);
+      expect(actual[0].label).toBe('Canada (+1)');
+      expect(actual[1].label).toBe('Germany (+49)');
+    });
+
+    it('should use getOptionLabel when provided', () => {
+      const options = [
+        { country: 'CA', code: '+1' },
+        { country: 'DE', code: '+49' },
+      ];
+      const getOptionLabel = ({ country, code }: { country: string; code: string }) =>
+        `${country} ${code}`;
+      const actual = mapCountryCodeOptions(
+        options,
+        undefined,
+        true,
+        getOptionLabel,
+      );
+      expect(actual.find(({ value }) => value === 'CA')?.label).toBe('CA +1');
+      expect(actual.find(({ value }) => value === 'DE')?.label).toBe('DE +49');
+    });
+
+    it('should prefer option.label over getOptionLabel', () => {
+      const options = [{ country: 'CA', code: '+1', label: 'Custom label' }];
+      const getOptionLabel = () => 'Ignored';
+      expect(
+        resolveCountryCodeOptionLabel(
+          options[0],
+          undefined,
+          true,
+          getOptionLabel,
+        ),
+      ).toBe('Custom label');
+    });
+  });
+
+  describe('getCountryCodeFieldWidth', () => {
+    const options = [
+      { label: 'Canada (+1)' },
+      { label: 'Germany (+49)' },
+      { label: 'United States (+1)' },
+    ];
+
+    it('should size to the longest option label with prefix', () => {
+      expect(getCountryCodeFieldWidth(options, 'm', true)).toBe(
+        'calc(var(--cui-spacings-exa) + 18ch + var(--cui-spacings-exa))',
+      );
+    });
+
+    it('should use smaller spacing tokens for size s', () => {
+      expect(getCountryCodeFieldWidth(options, 's', true)).toBe(
+        'calc(var(--cui-spacings-tera) + 18ch + var(--cui-spacings-tera))',
+      );
+    });
+
+    it('should omit prefix spacing when there is no prefix', () => {
+      expect(getCountryCodeFieldWidth(options, 'm', false)).toBe(
+        'calc(var(--cui-spacings-mega) + 18ch + var(--cui-spacings-exa))',
+      );
+    });
+
+    it('should return undefined when there are no options', () => {
+      expect(getCountryCodeFieldWidth([], 'm', true)).toBeUndefined();
     });
   });
 });

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   getCountryCodeFieldWidth,

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -225,8 +225,13 @@ describe('PhoneNumberInputService', () => {
         { country: 'CA', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const getOptionLabel = ({ country, code }: { country: string; code: string }) =>
-        `${country} ${code}`;
+      const getOptionLabel = ({
+        country,
+        code,
+      }: {
+        country: string;
+        code: string;
+      }) => `${country} ${code}`;
       const actual = mapCountryCodeOptions(
         options,
         undefined,

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -285,4 +285,24 @@ describe('PhoneNumberInputService', () => {
       expect(getCountryCodeFieldWidth([], 'm', true)).toBeUndefined();
     });
   });
+
+  describe('resolveCountryCodeOptionLabel', () => {
+    it('should fall back to the country code when Intl.DisplayNames throws', () => {
+      const displayNamesSpy = vi
+        .spyOn(globalThis.Intl, 'DisplayNames')
+        .mockImplementation(() => {
+          throw new Error('Intl.DisplayNames unavailable');
+        });
+
+      expect(
+        resolveCountryCodeOptionLabel(
+          { country: 'DE', code: '+49' },
+          'en',
+          true,
+        ),
+      ).toBe('DE (+49)');
+
+      displayNamesSpy.mockRestore();
+    });
+  });
 });

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
@@ -32,7 +32,51 @@ export type CountryCodeOption = {
    * where `268` is the area code.
    */
   areaCodes?: string[];
+  /**
+   * Pre-computed option label. When set, takes precedence over
+   * `getOptionLabel`, `shouldDisplayCountryNames`, and `Intl.DisplayNames`.
+   */
+  label?: string;
 };
+
+function getCountryName(country: string, locale: Locale | undefined) {
+  // eslint-disable-next-line compat/compat
+  const isIntlDisplayNamesSupported = typeof Intl.DisplayNames === 'function';
+
+  if (!isIntlDisplayNamesSupported || !country) {
+    return country;
+  }
+
+  try {
+    // eslint-disable-next-line compat/compat
+    const displayName = new Intl.DisplayNames(locale, { type: 'region' });
+    return displayName.of(country);
+  } catch {
+    return country;
+  }
+}
+
+export function resolveCountryCodeOptionLabel(
+  option: CountryCodeOption,
+  locale: Locale | undefined,
+  shouldDisplayCountryNames = true,
+  getOptionLabel?: (option: CountryCodeOption) => string,
+): string {
+  if (option.label) {
+    return option.label;
+  }
+
+  if (getOptionLabel) {
+    return getOptionLabel(option);
+  }
+
+  if (!shouldDisplayCountryNames) {
+    return option.code;
+  }
+
+  const countryName = getCountryName(option.country, locale);
+  return countryName ? `${countryName} (${option.code})` : option.code;
+}
 
 export function parsePhoneNumber(
   value: string | undefined,
@@ -133,42 +177,18 @@ export function mapCountryCodeOptions(
   countryCodeOptions: CountryCodeOption[],
   locale: Locale | undefined,
   shouldDisplayCountryNames = true,
+  getOptionLabel?: (option: CountryCodeOption) => string,
 ): Required<SelectProps>['options'] {
-  if (!shouldDisplayCountryNames) {
-    return countryCodeOptions
-      .map(({ code, country }) => ({
-        label: code,
-        value: country,
-      }))
-      .sort((a, b) => a.label.localeCompare(b.label));
-  }
-
-  const getCountryName = (country: string) => {
-    // eslint-disable-next-line compat/compat
-    const isIntlDisplayNamesSupported = typeof Intl.DisplayNames === 'function';
-
-    // When Intl.DisplayNames is not supported, we can't provide the localized country names
-    if (!isIntlDisplayNamesSupported || !country) {
-      return country;
-    }
-
-    try {
-      // eslint-disable-next-line compat/compat
-      const displayName = new Intl.DisplayNames(locale, { type: 'region' });
-      return displayName.of(country);
-    } catch {
-      return country;
-    }
-  };
-
   return countryCodeOptions
-    .map(({ code, country }) => {
-      const countryName = getCountryName(country);
-      return {
-        label: countryName ? `${countryName} (${code})` : code,
-        value: country,
-      };
-    })
+    .map((option) => ({
+      label: resolveCountryCodeOptionLabel(
+        option,
+        locale,
+        shouldDisplayCountryNames,
+        getOptionLabel,
+      ),
+      value: option.country,
+    }))
     .sort((a, b) => a.label.localeCompare(b.label));
 }
 
@@ -186,4 +206,33 @@ export function getCountry(
 ) {
   const option = options.find((o) => o.code === code);
   return option?.country;
+}
+
+/**
+ * Matches native `<select>` sizing: width is based on the longest option label,
+ * not the currently selected one.
+ */
+export function getCountryCodeFieldWidth(
+  mappedOptions: { label: string }[],
+  size: 's' | 'm',
+  hasPrefix: boolean,
+): string | undefined {
+  const longestLabel = mappedOptions.reduce(
+    (longest, { label }) => (label.length > longest.length ? label : longest),
+    '',
+  );
+
+  if (!longestLabel) {
+    return undefined;
+  }
+
+  const chevronSpace =
+    size === 's' ? 'var(--cui-spacings-tera)' : 'var(--cui-spacings-exa)';
+  const leftPad = hasPrefix
+    ? chevronSpace
+    : size === 's'
+      ? 'var(--cui-spacings-kilo)'
+      : 'var(--cui-spacings-mega)';
+
+  return `calc(${leftPad} + ${longestLabel.length}ch + ${chevronSpace})`;
 }

--- a/skills/circuit-ui/references/components/PhoneNumberInput.mdx
+++ b/skills/circuit-ui/references/components/PhoneNumberInput.mdx
@@ -59,3 +59,15 @@ You should use only when the value is a critical information from the user that 
 Use the `renderPrefix` prop to add a small prefix to the country code selected input field. By default, the component will display the selected country's [Flag](Components/Flag/Docs). You can override that behavior by providing your own prefix component.
 
 <Story of={Stories.WithPrefix} />
+
+## Custom option labels
+
+Pass pre-computed labels via `countryCode.options[].label` or `countryCode.getOptionLabel` to avoid SSR/client mismatches from `Intl.DisplayNames` in server-rendered apps. Labels are used for native `<select>` options and as accessible names in the custom dropdown.
+
+<Story of={Stories.WithCustomLabels} />
+
+## Custom dropdown
+
+Pass `countryCode.renderOption` to replace the native country code select with a custom listbox dropdown. Use this when options need rich content such as flags or emojis that native `<option>` elements cannot render. Combine with pre-computed labels for hydration-safe country names.
+
+<Story of={Stories.WithCustomDropdown} />


### PR DESCRIPTION
## Summary

Adds opt-in `countryCode.renderOption` and `countryCode.getOptionLabel` to `PhoneNumberInput` so apps can render rich country options (flags, etc.) and pass SSR-stable labels instead of relying on `Intl.DisplayNames`.

Native `<select>` remains the default when `renderOption` is not set.

### Motivation

Website and other SSR apps hit hydration mismatches when country names come from `Intl.DisplayNames` on the client. Pre-computed labels (`option.label` / `getOptionLabel`) plus an optional custom listbox (`renderOption`) let consumers control labels and option content without fighting native `<option>` limitations.

### What's included

- `CountryCodeDropdown` — internal listbox combobox (keyboard, a11y, floating-ui positioning)
- `option.label` / `getOptionLabel` label resolution on native select and custom dropdown
- Fixed country-code field width in custom dropdown (matches native select: sized to longest option)
- Storybook stories: `WithCustomLabels`, `WithCustomDropdown`
- Docs + changeset (minor bump)

### Bundle size

+3.32 kB total (+0.39%), mainly the new `CountryCodeDropdown` module. `CountryCodeDropdown` is statically imported today — worth a team discussion if we want lazy-loading behind `renderOption`.

## CI status

- ci, size, codecov/patch, codecov/project, Chromatic build, Vercel preview — passing
- Chromatic **UI Review** — 9 visual changes pending baseline acceptance

## Test plan

- [ ] Review `WithPrefix`, `WithCustomLabels`, and `WithCustomDropdown` in [Storybook preview](https://oss-circuit-ui-git-feat-phone-input-render-option.sumup-vercel.app)
- [ ] Confirm country field width stays stable when switching countries in `WithCustomDropdown`
- [ ] Accept Chromatic baselines for the new/updated stories
- [x] `npm test -- --run packages/circuit-ui/components/PhoneNumberInput/`