### PR TITLE
exclude multi-colored icons from React component exports

### DIFF
--- a/.changeset/brave-rivers-enter.md
+++ b/.changeset/brave-rivers-enter.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/icons": major
+---
+
+Removed multi-colored icons (payment methods, card schemes, and country flags) from the React component exports

--- a/packages/icons/manifest.json
+++ b/packages/icons/manifest.json
@@ -1310,7 +1310,6 @@
 
     {
       "category": "Flag",
-      "inactive": true,
       "keywords": ["Andorra"],
       "name": "flag_ad",
       "size": "480"

--- a/packages/icons/scripts/build.ts
+++ b/packages/icons/scripts/build.ts
@@ -46,7 +46,6 @@ type Component = {
   deprecation?: string;
 };
 
-const DEPRECATED_CATEGORIES: string[] = [];
 const URL_ONLY_CATEGORIES = ['Flag', 'Card scheme', 'Payment method'];
 
 function createDeprecationComment(component: Component) {
@@ -54,16 +53,6 @@ function createDeprecationComment(component: Component) {
     return `
     /**
      * @deprecated ${component.deprecation}
-     */`;
-  }
-  if (
-    component.icons.some((icon) =>
-      DEPRECATED_CATEGORIES.includes(icon.category),
-    )
-  ) {
-    return `
-    /**
-     * @deprecated This icon is too heavy to be inlined as a React component. [Load it from a URL instead](https://circuit.sumup.com/?path=/docs/packages-icons--docs#load-from-a-url).
      */`;
   }
   return '';
@@ -159,21 +148,18 @@ function buildIndexFile(
   `;
 }
 
-function buildDeclarationFile(allIcons: Component[]): string {
-  const componentIcons = allIcons.filter(
-    (component) =>
-      !component.icons.some((icon) =>
-        URL_ONLY_CATEGORIES.includes(icon.category),
-      ),
-  );
-  const declarationStatements = componentIcons.map((component) => {
+function buildDeclarationFile(
+  allIcons: Component[],
+  components: Component[],
+): string {
+  const declarationStatements = components.map((component) => {
     const sizes = component.icons.map(({ size }) => `'${size}'`).sort();
     const SizesType = sizes.join(' | ');
     return `
       ${createDeprecationComment(component)}
       declare const ${component.name}: IconComponentType<${SizesType}>;`;
   });
-  const exportNames = componentIcons.map((component) => component.name);
+  const exportNames = components.map((component) => component.name);
   const iconNames = allIcons.map((component) => `'${component.icons[0].name}'`);
   const iconSizes = allIcons.map((component) => {
     const iconName = component.icons[0].name;
@@ -290,9 +276,14 @@ async function main() {
     }),
   );
 
-  const components = allIcons.filter(({ icons }) =>
-    icons.some((icon) => !URL_ONLY_CATEGORIES.includes(icon.category)),
-  );
+  const components = allIcons
+    .map((component) => ({
+      ...component,
+      icons: component.icons.filter(
+        (icon) => !URL_ONLY_CATEGORIES.includes(icon.category),
+      ),
+    }))
+    .filter((component) => component.icons.length > 0);
 
   // Group components by lowercase name to detect case-insensitive filename
   // collisions (e.g. SumUpCard / SumupCard).  When two names differ only in
@@ -319,7 +310,7 @@ async function main() {
 
   const indexRaw = buildIndexFile(components, canonicalNames);
   const helpersRaw = buildHelpersFile();
-  const declarationFile = buildDeclarationFile(allIcons);
+  const declarationFile = buildDeclarationFile(allIcons, components);
 
   await Promise.all(
     [...collisionGroups.values()].map((group) => {

--- a/packages/icons/scripts/generate-constants.ts
+++ b/packages/icons/scripts/generate-constants.ts
@@ -27,6 +27,7 @@ type Icon = {
   name: string;
   category: string;
   deprecation?: string;
+  inactive?: boolean;
 };
 
 function namesForCategory(
@@ -34,7 +35,10 @@ function namesForCategory(
   transform: (name: string) => string = (name) => name,
 ): string[] {
   return (manifest.icons as Icon[])
-    .filter((icon) => icon.category === category && !icon.deprecation)
+    .filter(
+      (icon) =>
+        icon.category === category && !icon.deprecation && !icon.inactive,
+    )
     .map((icon) => transform(icon.name))
     .sort();
 }


### PR DESCRIPTION
Addresses [DSYS-1685](https://sumupteam.atlassian.net/browse/DSYS-1685)

## Purpose

This excludes multi-colored icons from `@sumup-oss/icons`'s component exports. The mechanism already existed but had a bug for names split across an excluded and a kept category.

## Approach and changes

- Fixed `card_unknown`/`pix`: they still bundled their excluded 32px Card scheme asset but had no TypeScript declaration; now a single icon-entry-level filter drives both. 
- `generate-constants.ts`: added missing `!icon.inactive` check (`'AD'` was leaking into `FLAGS`).
- Removed dead `DEPRECATED_CATEGORIES` code, superseded by `URL_ONLY_CATEGORIES`.
- Country flags needed no change already excluded via `inactive: true`.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
