### PR TITLE
Upgrade to temporal-polyfill@1.x

### DIFF
--- a/.changeset/chubby-melons-rush.md
+++ b/.changeset/chubby-melons-rush.md
@@ -1,0 +1,6 @@
+---
+"next-app": minor
+"@sumup-oss/astro-template-circuit-ui": minor
+---
+
+Upgraded to `temporal-polyfill@1.x`.

--- a/.changeset/icy-windows-ring.md
+++ b/.changeset/icy-windows-ring.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Declared support for `temporal-polyfill@1.x` in the peer dependency range.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11159,15 +11159,15 @@
       "link": true
     },
     "node_modules/@sumup-oss/intl": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@sumup-oss/intl/-/intl-3.3.0.tgz",
-      "integrity": "sha512-f4GmD0gYRu+UBr1bcHGLFsh2n54kzgOrCcdA/tIRHo/PdQM+dAc4OXnDME/5VQGnxCtqEyp8oT+9mlK5OhgI7A==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@sumup-oss/intl/-/intl-3.5.0.tgz",
+      "integrity": "sha512-uOtDLg2jIIyd5tNAzwH/IEVb5e1C9RJPQSavjEHop0/6nXNvK2UuLhWzhRzbJejJsBKY4VC9pKS0StF55jDfbA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "temporal-polyfill": ">= 0.2.0 <0.4.0"
+        "temporal-polyfill": ">= 0.2.0 <2.0.0"
       }
     },
     "node_modules/@sumup-oss/stylelint-plugin-circuit-ui": {
@@ -31466,19 +31466,26 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.2.tgz",
+      "integrity": "sha512-pTyp/7kfStJQbJ8YOHmcJItkxvOGCZHu3PaVgLvLnxFS7O12EPiWLElnRre/rw77z4TGZX/gvdqMXWn6ispQvA==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "0.3.1"
+        "temporal-spec": "1.0.1",
+        "temporal-utils": "1.0.1"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.1.tgz",
+      "integrity": "sha512-wxVoanmDeavXie1vu2JaQ3WIc3JZnWAOYFBsJyATaVsXsycKYUflGsyBmrRSnoCpZJpwPyr38VpgSUlQ8CbFxg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/temporal-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
+      "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
+      "license": "MIT"
     },
     "node_modules/term-size": {
       "version": "2.2.1",
@@ -35153,7 +35160,7 @@
         "@emotion/styled": "^11.14.1",
         "@sumup-oss/design-tokens": "^10.0.0",
         "@sumup-oss/icons": "^6.13.0",
-        "@sumup-oss/intl": "^3.3.0",
+        "@sumup-oss/intl": "^3.5.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -35168,7 +35175,7 @@
         "react-dom": "^19.2.6",
         "react-swipeable": "^7.0.2",
         "rollup-plugin-preserve-directives": "^0.4.0",
-        "temporal-polyfill": "^0.3.0",
+        "temporal-polyfill": "^1.0.2",
         "typescript": "^6.0.3",
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^7.3.5",
@@ -35187,7 +35194,7 @@
         "@sumup-oss/intl": "^3.1.1",
         "react": ">=18.0.0 <20.0.0",
         "react-dom": ">=18.0.0 <20.0.0",
-        "temporal-polyfill": ">= 0.2.0 < 0.4.0"
+        "temporal-polyfill": ">= 0.2.0"
       }
     },
     "packages/design-tokens": {
@@ -36197,7 +36204,7 @@
     },
     "packages/icons": {
       "name": "@sumup-oss/icons",
-      "version": "6.13.0",
+      "version": "6.14.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.29.7",
@@ -36472,13 +36479,13 @@
         "@sumup-oss/circuit-ui": "^11.0.0",
         "@sumup-oss/design-tokens": "^10.0.0",
         "@sumup-oss/icons": "^6.0.0",
-        "@sumup-oss/intl": "^3.3.0",
+        "@sumup-oss/intl": "^3.5.0",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "astro": "^6.4.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "temporal-polyfill": "^0.3.2"
+        "temporal-polyfill": "^1.0.2"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -36558,11 +36565,11 @@
         "@sumup-oss/circuit-ui": "^11.0.0",
         "@sumup-oss/design-tokens": "^10.0.0",
         "@sumup-oss/icons": "^6.0.0",
-        "@sumup-oss/intl": "^3.3.0",
+        "@sumup-oss/intl": "^3.5.0",
         "next": "^16.2.11",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "temporal-polyfill": "^0.3.2"
+        "temporal-polyfill": "^1.0.2"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^16.2.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11159,9 +11159,9 @@
       "link": true
     },
     "node_modules/@sumup-oss/intl": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@sumup-oss/intl/-/intl-3.5.0.tgz",
-      "integrity": "sha512-uOtDLg2jIIyd5tNAzwH/IEVb5e1C9RJPQSavjEHop0/6nXNvK2UuLhWzhRzbJejJsBKY4VC9pKS0StF55jDfbA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@sumup-oss/intl/-/intl-3.5.1.tgz",
+      "integrity": "sha512-u7vJy0CQXS8nSmvxZGWhKs5RQ/X/nocCf7B7d/ATfUvrkUgE7V8mcHdZSAyGGqMzSbNnz9jQW7XFPIUL8FsyFA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -35160,7 +35160,7 @@
         "@emotion/styled": "^11.14.1",
         "@sumup-oss/design-tokens": "^10.0.0",
         "@sumup-oss/icons": "^6.13.0",
-        "@sumup-oss/intl": "^3.5.0",
+        "@sumup-oss/intl": "^3.5.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -36479,7 +36479,7 @@
         "@sumup-oss/circuit-ui": "^11.0.0",
         "@sumup-oss/design-tokens": "^10.0.0",
         "@sumup-oss/icons": "^6.0.0",
-        "@sumup-oss/intl": "^3.5.0",
+        "@sumup-oss/intl": "^3.5.1",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "astro": "^6.4.6",
@@ -36565,7 +36565,7 @@
         "@sumup-oss/circuit-ui": "^11.0.0",
         "@sumup-oss/design-tokens": "^10.0.0",
         "@sumup-oss/icons": "^6.0.0",
-        "@sumup-oss/intl": "^3.5.0",
+        "@sumup-oss/intl": "^3.5.1",
         "next": "^16.2.11",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35194,7 +35194,7 @@
         "@sumup-oss/intl": "^3.1.1",
         "react": ">=18.0.0 <20.0.0",
         "react-dom": ">=18.0.0 <20.0.0",
-        "temporal-polyfill": ">= 0.2.0"
+        "temporal-polyfill": ">=0.2.0 <2.0.0"
       }
     },
     "packages/design-tokens": {

--- a/packages/circuit-ui/components/Timestamp/TimestampService.ts
+++ b/packages/circuit-ui/components/Timestamp/TimestampService.ts
@@ -67,7 +67,7 @@ const UNITS = [
     interval: 1000, // 1 second
   },
 ] satisfies {
-  name: Temporal.SmallestUnit<Temporal.DateTimeUnit>;
+  name: Temporal.PluralizeUnit<Temporal.DateUnit | Temporal.TimeUnit>;
   duration: Temporal.Duration;
   interval: number; // in milliseconds
 }[];

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -72,7 +72,7 @@
     "@emotion/styled": "^11.14.1",
     "@sumup-oss/design-tokens": "^10.0.0",
     "@sumup-oss/icons": "^6.13.0",
-    "@sumup-oss/intl": "^3.5.0",
+    "@sumup-oss/intl": "^3.5.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -72,7 +72,7 @@
     "@emotion/styled": "^11.14.1",
     "@sumup-oss/design-tokens": "^10.0.0",
     "@sumup-oss/icons": "^6.13.0",
-    "@sumup-oss/intl": "^3.3.0",
+    "@sumup-oss/intl": "^3.5.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -87,7 +87,7 @@
     "react-dom": "^19.2.6",
     "react-swipeable": "^7.0.2",
     "rollup-plugin-preserve-directives": "^0.4.0",
-    "temporal-polyfill": "^0.3.0",
+    "temporal-polyfill": "^1.0.2",
     "typescript": "^6.0.3",
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^7.3.5",
@@ -102,7 +102,7 @@
     "@sumup-oss/intl": "^3.1.1",
     "react": ">=18.0.0 <20.0.0",
     "react-dom": ">=18.0.0 <20.0.0",
-    "temporal-polyfill": ">= 0.2.0 < 0.4.0"
+    "temporal-polyfill": ">= 0.2.0"
   },
   "engines": {
     "node": ">=22",

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -102,7 +102,7 @@
     "@sumup-oss/intl": "^3.1.1",
     "react": ">=18.0.0 <20.0.0",
     "react-dom": ">=18.0.0 <20.0.0",
-    "temporal-polyfill": ">= 0.2.0"
+    "temporal-polyfill": ">=0.2.0 <2.0.0"
   },
   "engines": {
     "node": ">=22",

--- a/templates/astro/package.json
+++ b/templates/astro/package.json
@@ -19,13 +19,13 @@
     "@sumup-oss/circuit-ui": "^11.0.0",
     "@sumup-oss/design-tokens": "^10.0.0",
     "@sumup-oss/icons": "^6.0.0",
-    "@sumup-oss/intl": "^3.3.0",
+    "@sumup-oss/intl": "^3.5.0",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "astro": "^6.4.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "temporal-polyfill": "^0.3.2"
+    "temporal-polyfill": "^1.0.2"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",

--- a/templates/astro/package.json
+++ b/templates/astro/package.json
@@ -19,7 +19,7 @@
     "@sumup-oss/circuit-ui": "^11.0.0",
     "@sumup-oss/design-tokens": "^10.0.0",
     "@sumup-oss/icons": "^6.0.0",
-    "@sumup-oss/intl": "^3.5.0",
+    "@sumup-oss/intl": "^3.5.1",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "astro": "^6.4.6",

--- a/templates/nextjs/template/package.json
+++ b/templates/nextjs/template/package.json
@@ -19,11 +19,11 @@
     "@sumup-oss/circuit-ui": "^11.0.0",
     "@sumup-oss/design-tokens": "^10.0.0",
     "@sumup-oss/icons": "^6.0.0",
-    "@sumup-oss/intl": "^3.3.0",
+    "@sumup-oss/intl": "^3.5.0",
     "next": "^16.2.11",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "temporal-polyfill": "^0.3.2"
+    "temporal-polyfill": "^1.0.2"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.9",

--- a/templates/nextjs/template/package.json
+++ b/templates/nextjs/template/package.json
@@ -19,7 +19,7 @@
     "@sumup-oss/circuit-ui": "^11.0.0",
     "@sumup-oss/design-tokens": "^10.0.0",
     "@sumup-oss/icons": "^6.0.0",
-    "@sumup-oss/intl": "^3.5.0",
+    "@sumup-oss/intl": "^3.5.1",
     "next": "^16.2.11",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",


### PR DESCRIPTION
Relates to https://github.com/sumup-oss/intl-js/pull/384.

## Purpose

The first stable version of `temporal-polyfill` was released not long ago and aligns it with the latest Temporal spec. The breaking changes do not affect Circuit UI.

## Approach and changes

- Upgrade to `@sumup-oss/intl@3.5.0` and `temporal-polyfill@1.0.2`
- Update some Temporal types

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
