### PR TITLE
Fix the SidePanel's onBack callback

### DIFF
--- a/.changeset/major-cows-remain.md
+++ b/.changeset/major-cows-remain.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed calling the `onBack` callback when navigating back from a stacked SidePanel.

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.spec.tsx
@@ -86,13 +86,11 @@ describe('SidePanelContext', () => {
 
   describe('SidePanelProvider', () => {
     const getPanel = () => ({
-      backButtonLabel: 'Back',
       children: <p data-testid="children">Side panel content</p>,
       closeButtonLabel: 'Close',
       group: 'primary',
       headline: 'Side panel title',
       id: uniqueId(),
-      onClose: undefined,
     });
 
     const renderComponent = (Trigger: ComponentType, props = {}) =>
@@ -202,6 +200,36 @@ describe('SidePanelContext', () => {
         await userEvent.click(screen.getByText('Open second panel'));
 
         expect(screen.getAllByRole('dialog')).toHaveLength(2);
+      });
+
+      it('should call the onBack callback when closing a stacked side panel', async () => {
+        const onBack = vi.fn();
+        const Trigger = () => {
+          const { setSidePanel } = useContext(SidePanelContext);
+          return (
+            <>
+              {renderOpenButton(setSidePanel)}
+              {renderOpenButton(
+                setSidePanel,
+                { group: 'secondary', onBack },
+                'Open second panel',
+              )}
+            </>
+          );
+        };
+
+        renderComponent(Trigger);
+
+        await userEvent.click(screen.getByText('Open panel'));
+        await userEvent.click(screen.getByText('Open second panel'));
+        await userEvent.click(screen.getByText('Back'));
+        act(() => {
+          vi.runAllTimers();
+        });
+
+        await waitFor(() => {
+          expect(onBack).toHaveBeenCalled();
+        });
       });
 
       it('should close all stacked side panels when opening a panel from a lower group', async () => {

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.spec.tsx
@@ -232,6 +232,37 @@ describe('SidePanelContext', () => {
         });
       });
 
+      it('should not call the onBack callback when closing of a stacked side panel is cancelled', async () => {
+        const onBack = vi.fn();
+        const onClose = vi.fn().mockRejectedValue(false);
+        const Trigger = () => {
+          const { setSidePanel } = useContext(SidePanelContext);
+          return (
+            <>
+              {renderOpenButton(setSidePanel)}
+              {renderOpenButton(
+                setSidePanel,
+                { group: 'secondary', onBack, onClose },
+                'Open second panel',
+              )}
+            </>
+          );
+        };
+
+        renderComponent(Trigger);
+
+        await userEvent.click(screen.getByText('Open panel'));
+        await userEvent.click(screen.getByText('Open second panel'));
+        await userEvent.click(screen.getByText('Back'));
+        act(() => {
+          vi.runAllTimers();
+        });
+
+        await waitFor(() => {
+          expect(onBack).not.toHaveBeenCalled();
+        });
+      });
+
       it('should close all stacked side panels when opening a panel from a lower group', async () => {
         const Trigger = () => {
           const { setSidePanel } = useContext(SidePanelContext);

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
@@ -220,6 +220,7 @@ export function SidePanelProvider({
             transition,
             isInstantOpen,
             isInstantClose,
+            onBack,
             ...sidePanelProps
           } = sidePanel;
 
@@ -229,7 +230,7 @@ export function SidePanelProvider({
             void removeSidePanel(sidePanels[0].group);
           };
           const handleBack = isStacked
-            ? () => removeSidePanel(group)
+            ? () => removeSidePanel(group).then(() => onBack?.())
             : undefined;
 
           return (

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.tsx
@@ -44,7 +44,7 @@ export type UpdateSidePanel = (
 export type RemoveSidePanel = (
   group: SidePanelHookProps['group'],
   isInstantClose?: boolean,
-) => Promise<void>;
+) => Promise<boolean>;
 
 export type SidePanelContextItem = SidePanelHookProps &
   Pick<SidePanelProps, 'onCloseEnd' | 'open'> &
@@ -61,7 +61,7 @@ type SidePanelContextValue = {
 export const SidePanelContext = createContext<SidePanelContextValue>({
   setSidePanel: () => {},
   updateSidePanel: () => {},
-  removeSidePanel: () => Promise.resolve(),
+  removeSidePanel: () => Promise.resolve(false),
   isPrimaryContentResized: false,
   transitionDuration: TRANSITION_DURATION,
 });
@@ -96,7 +96,7 @@ export function SidePanelProvider({
       const panel = findSidePanel(group);
 
       if (!panel) {
-        return;
+        return false;
       }
 
       const sidePanelIndex = sidePanelsRef.current.indexOf(panel);
@@ -145,9 +145,10 @@ export function SidePanelProvider({
             });
           });
         } catch (_error) {
-          break;
+          return false;
         }
       }
+      return true;
       /* eslint-enable no-await-in-loop */
     },
     [findSidePanel, dispatch, sidePanelsRef],
@@ -230,7 +231,12 @@ export function SidePanelProvider({
             void removeSidePanel(sidePanels[0].group);
           };
           const handleBack = isStacked
-            ? () => removeSidePanel(group).then(() => onBack?.())
+            ? () =>
+                removeSidePanel(group).then((didClose) => {
+                  if (didClose) {
+                    onBack?.();
+                  }
+                })
             : undefined;
 
           return (


### PR DESCRIPTION
## Purpose

The SidePanel's `onBack` callback is overwritten by a custom internal one, so it never fires. Thanks @martina-tonkovska for the report! 🙌🏻  

## Approach and changes

- Fire the `onBack` callback after closing the SidePanel and add a test to prevent future regressions

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
