### PR TITLE
Pass explicit locale to @sumup-oss/intl

### DIFF
--- a/packages/circuit-ui/components/Calendar/Calendar.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.tsx
@@ -85,13 +85,6 @@ interface SharedProps {
    */
   maxDate?: Temporal.PlainDate;
   /**
-   * One or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag)
-   * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
-   * When passing an array, the first supported locale is used.
-   * Defaults to `navigator.language` in supported environments.
-   */
-  locale?: Locale;
-  /**
    * An integer indicating the first day of the week. Can be either `1` (Monday)
    * or `7` (Sunday). Default: `1`.
    */
@@ -113,6 +106,13 @@ interface SharedProps {
 export interface CalendarProps
   extends SharedProps,
     Omit<HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  /**
+   * One or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag)
+   * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
+   * When passing an array, the first supported locale is used.
+   * Defaults to `navigator.language` in supported environments.
+   */
+  locale?: Locale;
   /**
    * A callback that is called with the visible months on the initial render and
    * whenever a user navigates to different months.
@@ -338,6 +338,7 @@ interface MonthProps extends SharedProps {
   focusedDate: Temporal.PlainDate;
   hoveredDate: Temporal.PlainDate | null;
   daysInWeek: number;
+  locale: Locale;
 }
 
 function Month({

--- a/packages/circuit-ui/components/Calendar/CalendarService.ts
+++ b/packages/circuit-ui/components/Calendar/CalendarService.ts
@@ -142,7 +142,7 @@ type Weekdays = [Weekday, Weekday, Weekday, Weekday, Weekday, Weekday, Weekday];
 export function getWeekdays(
   firstDayOfWeek: FirstDayOfWeek = 1,
   daysInWeek: DaysInWeek = 7,
-  locale?: Locale,
+  locale: Locale,
 ) {
   return Array.from(Array(daysInWeek)).map((_, index) => {
     // 1973 started with a Monday
@@ -162,7 +162,7 @@ export function getWeekdays(
 
 export function getMonthHeadline(
   yearMonth: Temporal.PlainYearMonth,
-  locale?: Locale,
+  locale: Locale,
 ) {
   // Temporal objects use the `iso8601` calendar system by default, which
   // (incorrectly?) renders the year before the month since Node 22.12

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInputService.ts
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInputService.ts
@@ -16,8 +16,8 @@
 import { formatNumber } from '@sumup-oss/intl';
 
 export function formatPlaceholder(
-  placeholder?: string | number,
-  locale?: string | string[],
+  placeholder: string | number = '',
+  locale: string | string[],
   options?: Intl.NumberFormatOptions,
 ): string | undefined {
   return typeof placeholder === 'number'

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInputService.ts
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInputService.ts
@@ -15,9 +15,11 @@
 
 import { formatNumber } from '@sumup-oss/intl';
 
+import type { Locale } from '../../util/i18n.js';
+
 export function formatPlaceholder(
-  placeholder: string | number = '',
-  locale: string | string[],
+  placeholder: string | number | undefined,
+  locale: Locale,
   options?: Intl.NumberFormatOptions,
 ): string | undefined {
   return typeof placeholder === 'number'

--- a/packages/circuit-ui/components/DateInput/DateInputService.spec.ts
+++ b/packages/circuit-ui/components/DateInput/DateInputService.spec.ts
@@ -50,14 +50,14 @@ describe('DateInputService', () => {
 
     it('should return the plain label if the date is undefined', () => {
       const date = undefined;
-      const locale = undefined;
+      const locale = 'en';
       const actual = getCalendarButtonLabel(label, date, locale);
       expect(actual).toBe(label);
     });
 
     it('should postfix the formatted date to the label', () => {
       const date = new Temporal.PlainDate(2017, 8, 28);
-      const locale = undefined;
+      const locale = 'en';
       const actual = getCalendarButtonLabel(label, date, locale);
       expect(actual).toBe(`${label}, August 28, 2017`);
     });

--- a/packages/circuit-ui/components/DateInput/DateInputService.ts
+++ b/packages/circuit-ui/components/DateInput/DateInputService.ts
@@ -20,7 +20,7 @@ import type { Locale } from '../../util/i18n.js';
 
 const TEST_VALUE = new Temporal.PlainDate(2024, 3, 8);
 
-export function getDateSegments(locale?: Locale) {
+export function getDateSegments(locale: Locale) {
   const parts = formatDateTimeToParts(TEST_VALUE, locale);
   return parts.map(({ type, value }) =>
     type === 'literal' ? { type, value } : { type },

--- a/packages/circuit-ui/components/DateInput/DateInputService.ts
+++ b/packages/circuit-ui/components/DateInput/DateInputService.ts
@@ -30,7 +30,7 @@ export function getDateSegments(locale: Locale) {
 export function getCalendarButtonLabel(
   label: string,
   date: Temporal.PlainDate | undefined,
-  locale: Locale | undefined,
+  locale: Locale,
 ) {
   if (!date) {
     return label;

--- a/packages/circuit-ui/components/DateInput/hooks/usePlainDateState.ts
+++ b/packages/circuit-ui/components/DateInput/hooks/usePlainDateState.ts
@@ -61,7 +61,7 @@ export function usePlainDateState({
   onChange: ((date: string) => void) | undefined;
   minDate: Temporal.PlainDate | undefined;
   maxDate: Temporal.PlainDate | undefined;
-  locale: Locale | undefined;
+  locale: Locale;
 }): PlainDateState {
   const [values, setValues] = useState<DateValues>(
     parseValue(defaultValue || value),

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
@@ -22,11 +22,12 @@ import { NumericFormat } from '../../vendor/react-number-format/index.js';
 import type { OnValueChange } from '../../vendor/react-number-format/types.js';
 import { clsx } from '../../styles/clsx.js';
 import { idx } from '../../util/idx.js';
+import type { Locale } from '../../util/i18n.js';
+import { useLocale } from '../../hooks/useLocale/useLocale.js';
 import { Input, type InputProps } from '../Input/index.js';
 
 import { formatPlaceholder } from './PercentageInputService.js';
 import classes from './PercentageInput.module.css';
-import { useLocale } from '../../hooks/useLocale/useLocale.js';
 
 export interface PercentageInputProps
   extends Omit<
@@ -37,7 +38,7 @@ export interface PercentageInputProps
    * One or more Unicode BCP 47 locale identifiers, such as `'de-DE'` or
    * `['GB', 'en-US']` (the first supported locale is used).
    */
-  locale?: string | string[];
+  locale?: Locale;
   /**
    * A short string that is shown inside the empty input.
    * If the placeholder is a number, it is formatted in the local format.

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
@@ -26,6 +26,7 @@ import { Input, type InputProps } from '../Input/index.js';
 
 import { formatPlaceholder } from './PercentageInputService.js';
 import classes from './PercentageInput.module.css';
+import { useLocale } from '../../hooks/useLocale/useLocale.js';
 
 export interface PercentageInputProps
   extends Omit<
@@ -70,7 +71,7 @@ export const PercentageInput = forwardRef<
 >(
   (
     {
-      locale,
+      locale: customLocale,
       placeholder = '0',
       decimalScale = 0,
       'aria-describedby': descriptionId,
@@ -78,6 +79,7 @@ export const PercentageInput = forwardRef<
     },
     ref,
   ) => {
+    const locale = useLocale(customLocale);
     const percentageSymbolId = useId();
     const descriptionIds = idx(percentageSymbolId, descriptionId);
 

--- a/packages/circuit-ui/components/PercentageInput/PercentageInputService.ts
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInputService.ts
@@ -16,8 +16,8 @@
 import { formatNumber } from '@sumup-oss/intl';
 
 export function formatPlaceholder(
-  placeholder?: string | number,
-  locale?: string | string[],
+  placeholder: string | number = '',
+  locale: string | string[],
   options?: Intl.NumberFormatOptions,
 ): string | undefined {
   return typeof placeholder === 'number'

--- a/packages/circuit-ui/components/PercentageInput/PercentageInputService.ts
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInputService.ts
@@ -15,9 +15,11 @@
 
 import { formatNumber } from '@sumup-oss/intl';
 
+import type { Locale } from '../../util/i18n.js';
+
 export function formatPlaceholder(
-  placeholder: string | number = '',
-  locale: string | string[],
+  placeholder: string | number | undefined,
+  locale: Locale,
   options?: Intl.NumberFormatOptions,
 ): string | undefined {
   return typeof placeholder === 'number'

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -48,6 +48,7 @@ import { applyMultipleRefs } from '../../util/refs.js';
 import { eachFn } from '../../util/helpers.js';
 import { changeInputValue } from '../../util/input-value.js';
 import { idx } from '../../util/idx.js';
+import { useLocale } from '../../hooks/useLocale/useLocale.js';
 import type { Locale } from '../../util/i18n.js';
 
 import {
@@ -240,7 +241,7 @@ export const PhoneNumberInput = forwardRef<
       validationHint,
       readOnly,
       'aria-describedby': descriptionId,
-      locale,
+      locale: customLocale,
       shouldDisplayCountryNames = true,
       size = 'm',
       className,
@@ -249,6 +250,7 @@ export const PhoneNumberInput = forwardRef<
     },
     ref,
   ) => {
+    const locale = useLocale(customLocale);
     const hiddenInputRef = useRef<HTMLInputElement>(null);
     const countryCodeRef = useRef<HTMLSelectElement | HTMLInputElement>(null);
     const subscriberNumberRef = useRef<HTMLInputElement>(null);

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -48,6 +48,7 @@ import { applyMultipleRefs } from '../../util/refs.js';
 import { eachFn } from '../../util/helpers.js';
 import { changeInputValue } from '../../util/input-value.js';
 import { idx } from '../../util/idx.js';
+import type { Locale } from '../../util/i18n.js';
 
 import {
   getCountryCode,
@@ -116,7 +117,7 @@ export interface PhoneNumberInputProps
    * `['GB', 'en-US']`. Used to localize the country names and determine the
    * preselected country code. Defaults to `navigator.languages`.
    */
-  locale?: string | string[];
+  locale?: Locale;
   /**
    * When `true`, displays the localised country name in the country code selector using
    * `Intl.DisplayNames`. When `false`, displays the calling codes from

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.spec.ts
@@ -132,7 +132,7 @@ describe('PhoneNumberInputService', () => {
         { country: 'US', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const locale = undefined;
+      const locale = 'en';
       const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].value).toBe('CA');
       expect(actual[1].value).toBe('DE');
@@ -145,7 +145,7 @@ describe('PhoneNumberInputService', () => {
         { country: 'US', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const locale = undefined;
+      const locale = 'en';
       const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].label).toBe('Canada (+1)');
       expect(actual[1].label).toBe('Germany (+49)');
@@ -154,7 +154,7 @@ describe('PhoneNumberInputService', () => {
 
     it('should omit the country name when it is not available', () => {
       const options = [{ country: '', code: '+49' }];
-      const locale = undefined;
+      const locale = 'en';
       const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].label).toBe('+49');
     });
@@ -165,7 +165,7 @@ describe('PhoneNumberInputService', () => {
         { country: 'US', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const locale = undefined;
+      const locale = 'en';
       const actual = mapCountryCodeOptions(options, locale);
       expect(actual[0].label).toBe('Canada (+1)');
       expect(actual[1].label).toBe('Germany (+49)');
@@ -189,7 +189,8 @@ describe('PhoneNumberInputService', () => {
         { country: 'US', code: '+1' },
         { country: 'DE', code: '+49' },
       ];
-      const actual = mapCountryCodeOptions(options, undefined, false);
+      const locale = 'en';
+      const actual = mapCountryCodeOptions(options, locale, false);
       expect(actual[0].label).toBe('+1');
       expect(actual[0].value).toBe('CA');
       expect(actual[1].label).toBe('+1');
@@ -204,7 +205,8 @@ describe('PhoneNumberInputService', () => {
         { country: 'CA', code: '+1' },
         { country: 'US', code: '+1' },
       ];
-      const actual = mapCountryCodeOptions(options, undefined, false);
+      const locale = 'en';
+      const actual = mapCountryCodeOptions(options, locale, false);
       expect(actual.map(({ label }) => label)).toEqual(['+1', '+1', '+49']);
     });
   });

--- a/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
+++ b/packages/circuit-ui/components/PhoneNumberInput/PhoneNumberInputService.ts
@@ -131,7 +131,7 @@ export function normalizePhoneNumber(
 
 export function mapCountryCodeOptions(
   countryCodeOptions: CountryCodeOption[],
-  locale: Locale | undefined,
+  locale: Locale,
   shouldDisplayCountryNames = true,
 ): Required<SelectProps>['options'] {
   if (!shouldDisplayCountryNames) {

--- a/packages/circuit-ui/components/Timestamp/Timestamp.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.tsx
@@ -23,6 +23,7 @@ import { clsx } from '../../styles/clsx.js';
 
 import { getInitialState, getState } from './TimestampService.js';
 import classes from './Timestamp.module.css';
+import { useLocale } from '../../hooks/useLocale/useLocale.js';
 
 export interface TimestampProps extends HTMLAttributes<HTMLTimeElement> {
   /**
@@ -73,12 +74,13 @@ export const Timestamp = forwardRef<HTMLTimeElement, TimestampProps>(
       variant = 'auto',
       formatStyle = 'long',
       includeTime = false,
-      locale,
+      locale: customLocale,
       className,
       ...props
     },
     ref,
   ) => {
+    const locale = useLocale(customLocale);
     const zonedDateTime = Temporal.ZonedDateTime.from(datetime);
     const [state, setState] = useState(
       getInitialState({ datetime, locale, formatStyle, includeTime }),

--- a/packages/circuit-ui/components/Timestamp/TimestampService.ts
+++ b/packages/circuit-ui/components/Timestamp/TimestampService.ts
@@ -84,7 +84,7 @@ export function getInitialState({
   includeTime,
 }: {
   datetime: string;
-  locale: Locale | undefined;
+  locale: Locale;
   formatStyle: 'long' | 'short' | 'narrow';
   includeTime: boolean;
 }): State {
@@ -109,7 +109,7 @@ export function getState({
   includeTime,
 }: {
   datetime: string;
-  locale: Locale | undefined;
+  locale: Locale;
   formatStyle: 'long' | 'short' | 'narrow';
   variant: 'auto' | 'relative' | 'absolute';
   includeTime: boolean;

--- a/packages/circuit-ui/util/date.spec.ts
+++ b/packages/circuit-ui/util/date.spec.ts
@@ -227,7 +227,7 @@ describe('CalendarService', () => {
       [11, 'November'],
       [12, 'December'],
     ])('should return the English name of the month %s', (isoMonth, name) => {
-      const actual = getMonthName(isoMonth);
+      const actual = getMonthName(isoMonth, 'en');
       expect(actual).toBe(name);
     });
 

--- a/packages/circuit-ui/util/date.ts
+++ b/packages/circuit-ui/util/date.ts
@@ -105,7 +105,7 @@ export function getLastDateOfWeek(
   });
 }
 
-export function getMonthName(month: number, locale?: Locale) {
+export function getMonthName(month: number, locale: Locale) {
   // The year can be arbitrary since the month names are the same every year
   const yearMonth = new Temporal.PlainYearMonth(2000, month, 'gregory');
   return formatDateTime(yearMonth, locale, { month: 'long' });


### PR DESCRIPTION
## Purpose

The next major version of `@sumup-oss/intl` will make the `locale` and `currency` arguments required. Currently, a deprecation warning is logged when either argument is omitted.

When no explicit locale is passed, Circuit UI components derive one from the environment using the `useLocale` hook. This can cause hydration mismatches since server and browser rarely use the same language. Solving this would require a breaking change, so will be dealt with in a separate PR.

## Approach and changes

- Always pass a `locale` and `currency` to the `@sumup-oss/intl` functions.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
