### PR TITLE
Fix: Pin `temporal-polyfill` on templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7246,9 +7246,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7264,9 +7261,6 @@
       "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7284,9 +7278,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7302,9 +7293,6 @@
       "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -11905,6 +11893,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -11914,6 +11903,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -36442,7 +36432,7 @@
         "astro": "^6.4.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "temporal-polyfill": "^1.0.2"
+        "temporal-polyfill": "^0.3.2"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -36454,6 +36444,21 @@
         "eslint-plugin-testing-library": "^7.16.2",
         "typescript": "^6.0.3"
       }
+    },
+    "templates/astro/node_modules/temporal-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.1"
+      }
+    },
+    "templates/astro/node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
     },
     "templates/nextjs": {
       "name": "@sumup-oss/cna-template",
@@ -36514,6 +36519,21 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "templates/nextjs/node_modules/temporal-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.1"
+      }
+    },
+    "templates/nextjs/node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
+    },
     "templates/nextjs/template": {
       "name": "next-app",
       "version": "2.1.0",
@@ -36526,7 +36546,7 @@
         "next": "^16.2.11",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "temporal-polyfill": "^1.0.2"
+        "temporal-polyfill": "^0.3.2"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^16.2.9",

--- a/templates/astro/package.json
+++ b/templates/astro/package.json
@@ -25,7 +25,7 @@
     "astro": "^6.4.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "temporal-polyfill": "^1.0.2"
+    "temporal-polyfill": "^0.3.2"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",

--- a/templates/nextjs/template/package.json
+++ b/templates/nextjs/template/package.json
@@ -23,7 +23,7 @@
     "next": "^16.2.11",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "temporal-polyfill": "^1.0.2"
+    "temporal-polyfill": "^0.3.2"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.9",


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose
`templates/nextjs/template` and `templates/astro` pin `temporal-polyfill@^1.0.2` (bumped in #3784), but `temporal-polyfill@1.x` dropped its CommonJS export condition; it ships ESM-only. Any CJS/Jest consumer of `@sumup-oss/circuit-ui` that transitively requires `temporal-polyfill` can't resolve it, breaking the Next.js template's own test suite: see failing CI: https://github.com/sumup-oss/circuit-ui/actions/runs/30451884493/job/90575646490

## Approach and changes

- Pin `temporal-polyfill` back to `^0.3.2` (last dual CJS/ESM release) in `templates/nextjs/template/package.json` and `templates/astro/package.json`.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
