### PR TITLE
Add tier indicator to the tabs component as optional

### DIFF
--- a/.changeset/three-dragons-run.md
+++ b/.changeset/three-dragons-run.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Added a `trailingComponent` prop to the Tab component to display a TierIndicator badge next to a tab's label to indicate features that are part of the plus plan.

--- a/packages/circuit-ui/components/Tabs/Tabs.mdx
+++ b/packages/circuit-ui/components/Tabs/Tabs.mdx
@@ -133,4 +133,4 @@ Set the `trailingComponent` prop on a tab to display a `TierIndicator` badge nex
 
 However, whenever possible, communicate the value and availability of paid features within the page content itself (for example, on an "Overview" page) rather than in the navigation. This helps keep navigation clear and focused.
 
-<Story of={Stories.WithTierBadge} />
+<Story of={Stories.WithTierIndicator} />

--- a/packages/circuit-ui/components/Tabs/Tabs.mdx
+++ b/packages/circuit-ui/components/Tabs/Tabs.mdx
@@ -126,3 +126,11 @@ Avoid using external links, as this can create an inconsistent user experience a
 Set the `stretched` prop to true to make all tabs expand and share the available space evenly.
 
 <Story of={Stories.Stretched} />
+
+### Paid features
+
+Set the `trailingComponent` prop on a tab to display a `TierIndicator` badge next to its label, marking that tab as gated behind a paid plan. This works the same way whether you use the `items`-array API, `TabList`'s `tabs` prop, or manual `Tab` composition.
+
+However, whenever possible, communicate the value and availability of paid features within the page content itself (for example, on an "Overview" page) rather than in the navigation. This helps keep navigation clear and focused.
+
+<Story of={Stories.WithTierBadge} />

--- a/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
@@ -17,6 +17,8 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { axe, render, screen, userEvent } from '../../util/test-utils.js';
 
+import { TierIndicator } from '../TierIndicator/TierIndicator.js';
+
 import { Tabs } from './Tabs.js';
 
 describe('Tabs', () => {
@@ -123,7 +125,7 @@ describe('Tabs', () => {
           {
             id: 'a',
             tab: 'Services',
-            trailingComponent: { variant: 'plus' },
+            trailingComponent: TierIndicator,
             panel: 'panel-a',
           },
           { id: 'b', tab: 'Items', panel: 'panel-b' },

--- a/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
@@ -115,4 +115,21 @@ describe('Tabs', () => {
     const actual = await axe(container);
     expect(actual).toHaveNoViolations();
   });
+
+  it('should render a trailing component for a tab item', () => {
+    render(
+      <Tabs
+        items={[
+          {
+            id: 'a',
+            tab: 'Services',
+            trailingComponent: { variant: 'plus' },
+            panel: 'panel-a',
+          },
+          { id: 'b', tab: 'Items', panel: 'panel-b' },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Services')).toBeVisible();
+  });
 });

--- a/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.spec.tsx
@@ -133,5 +133,6 @@ describe('Tabs', () => {
       />,
     );
     expect(screen.getByText('Services')).toBeVisible();
+    expect(screen.getByText('plus')).toBeVisible();
   });
 });

--- a/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
@@ -174,6 +174,10 @@ export const WithTabsProp = () => {
 
 WithTabsProp.parameters = {
   controls: { hideNoControlsWarning: true },
+  chromatic: {
+    // covered in the Base story
+    disableSnapshot: true,
+  },
 };
 
 export const Links = () => (
@@ -213,4 +217,8 @@ export const ControlledState = () => {
 
 ControlledState.parameters = {
   controls: { hideNoControlsWarning: true },
+  chromatic: {
+    // covered in the Base story
+    disableSnapshot: true,
+  },
 };

--- a/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
@@ -20,6 +20,7 @@ import { ArrowLeft, ExternalLink } from '@sumup-oss/icons';
 import { Body } from '../Body/index.js';
 import { Headline } from '../Headline/index.js';
 import { Button } from '../Button/index.js';
+import { TierIndicator } from '../TierIndicator/TierIndicator.js';
 import { modes } from '../../../../.storybook/modes.js';
 
 import type { TabsProps } from './Tabs.js';
@@ -126,7 +127,7 @@ const tabsWithTierIndicator = [
   {
     id: 'services',
     tab: 'Services',
-    trailingComponent: { variant: 'plus' as const },
+    trailingComponent: TierIndicator,
     panel: <ContentWithInteractiveElements index={1} />,
   },
   {

--- a/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
@@ -122,7 +122,7 @@ Stretched.args = {
   stretched: true,
 };
 
-const tabsWithTierBadge = [
+const tabsWithTierIndicator = [
   {
     id: 'services',
     tab: 'Services',
@@ -141,10 +141,10 @@ const tabsWithTierBadge = [
   },
 ];
 
-export const WithTierBadge = (args: TabsProps) => <Tabs {...args} />;
+export const WithTierIndicator = (args: TabsProps) => <Tabs {...args} />;
 
-WithTierBadge.args = {
-  items: tabsWithTierBadge,
+WithTierIndicator.args = {
+  items: tabsWithTierIndicator,
 };
 
 export const WithTabsProp = () => {

--- a/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.stories.tsx
@@ -122,6 +122,31 @@ Stretched.args = {
   stretched: true,
 };
 
+const tabsWithTierBadge = [
+  {
+    id: 'services',
+    tab: 'Services',
+    trailingComponent: { variant: 'plus' as const },
+    panel: <ContentWithInteractiveElements index={1} />,
+  },
+  {
+    id: 'items',
+    tab: 'Items',
+    panel: <ContentWithInteractiveElements index={2} />,
+  },
+  {
+    id: 'discounts',
+    tab: 'Discounts',
+    panel: <ContentWithInteractiveElements index={3} />,
+  },
+];
+
+export const WithTierBadge = (args: TabsProps) => <Tabs {...args} />;
+
+WithTierBadge.args = {
+  items: tabsWithTierBadge,
+};
+
 export const WithTabsProp = () => {
   const items = tabs.slice(0, 3);
   const [selectedId, setSelectedId] = useState(items[0].id);

--- a/packages/circuit-ui/components/Tabs/Tabs.tsx
+++ b/packages/circuit-ui/components/Tabs/Tabs.tsx
@@ -49,7 +49,11 @@ export function Tabs({
     <>
       <TabList
         as="tablist"
-        tabs={items.map(({ id, tab }) => ({ id, tab }))}
+        tabs={items.map(({ id, tab, trailingComponent }) => ({
+          id,
+          tab,
+          trailingComponent,
+        }))}
         initialSelectedIndex={initialSelectedIndex}
         onTabChange={handleTabChange}
         {...props}

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.module.css
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.module.css
@@ -24,6 +24,12 @@
   pointer-events: none;
 }
 
+.content {
+  display: flex;
+  gap: var(--cui-spacings-bit);
+  align-items: center;
+}
+
 .base:hover {
   color: var(--cui-fg-normal-hovered);
 }

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
@@ -18,6 +18,8 @@ import { createRef } from 'react';
 
 import { render, screen } from '../../../../util/test-utils.js';
 
+import { TierIndicator } from '../../../TierIndicator/TierIndicator.js';
+
 import { Tab } from './Tab.js';
 
 describe('Tab', () => {
@@ -67,7 +69,7 @@ describe('Tab', () => {
 
   it('should render a trailing component, always at size s', () => {
     const { container } = render(
-      <Tab trailingComponent={{ variant: 'plus' }}>Services</Tab>,
+      <Tab trailingComponent={TierIndicator}>Services</Tab>,
     );
     expect(screen.getByText('Services')).toBeVisible();
     expect(container.querySelector('svg')).toHaveAttribute('height', '16');

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
@@ -64,4 +64,16 @@ describe('Tab', () => {
       'page',
     );
   });
+
+  it('should render a trailing component', () => {
+    render(<Tab trailingComponent={{ variant: 'plus' }}>Services</Tab>);
+    expect(screen.getByText('Services')).toBeVisible();
+  });
+
+  it('should always render the trailing component at size s', () => {
+    const { container } = render(
+      <Tab trailingComponent={{ variant: 'plus' }}>Services</Tab>,
+    );
+    expect(container.querySelector('svg')).toHaveAttribute('height', '16');
+  });
 });

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
@@ -65,15 +65,11 @@ describe('Tab', () => {
     );
   });
 
-  it('should render a trailing component', () => {
-    render(<Tab trailingComponent={{ variant: 'plus' }}>Services</Tab>);
-    expect(screen.getByText('Services')).toBeVisible();
-  });
-
-  it('should always render the trailing component at size s', () => {
+  it('should render a trailing component, always at size s', () => {
     const { container } = render(
       <Tab trailingComponent={{ variant: 'plus' }}>Services</Tab>,
     );
+    expect(screen.getByText('Services')).toBeVisible();
     expect(container.querySelector('svg')).toHaveAttribute('height', '16');
   });
 });

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.spec.tsx
@@ -13,12 +13,12 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createRef } from 'react';
 
 import { render, screen } from '../../../../util/test-utils.js';
 
-import { TierIndicator } from '../../../TierIndicator/TierIndicator.js';
+import type { TierIndicatorProps } from '../../../TierIndicator/TierIndicator.js';
 
 import { Tab } from './Tab.js';
 
@@ -36,6 +36,7 @@ describe('Tab', () => {
     const tab = screen.getByRole('tab');
     expect(ref.current).toBe(tab);
   });
+
   it('should render with tab semantics', () => {
     const { rerender } = render(<Tab>Tab title</Tab>);
     expect(screen.getByText('Tab title')).toHaveRole('tab');
@@ -51,6 +52,7 @@ describe('Tab', () => {
     );
     expect(screen.getByText('Tab title')).not.toHaveAttribute('tabindex');
   });
+
   it('should render with listitem semantics', () => {
     const { rerender } = render(<Tab as="listitem">Tab title</Tab>);
     expect(screen.getByText('Tab title').parentElement).toHaveRole('listitem');
@@ -68,10 +70,10 @@ describe('Tab', () => {
   });
 
   it('should render a trailing component, always at size s', () => {
-    const { container } = render(
-      <Tab trailingComponent={TierIndicator}>Services</Tab>,
-    );
+    const TrailingComponent = vi.fn((_props: TierIndicatorProps) => null);
+    render(<Tab trailingComponent={TrailingComponent}>Services</Tab>);
     expect(screen.getByText('Services')).toBeVisible();
-    expect(container.querySelector('svg')).toHaveAttribute('height', '16');
+    const [props] = TrailingComponent.mock.calls[0];
+    expect(props).toStrictEqual({ variant: 'plus', size: 's' });
   });
 });

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.stories.tsx
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+import { TierIndicator } from '../../../TierIndicator/TierIndicator.js';
+
 import { Tab } from './Tab.js';
 
 export default {
@@ -36,7 +38,7 @@ export const Base = () => (
 
 export const WithTierIndicator = () => (
   <div>
-    <Tab trailingComponent={{ variant: 'plus' }}>Services</Tab>
+    <Tab trailingComponent={TierIndicator}>Services</Tab>
     <Tab>Items</Tab>
   </div>
 );

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.stories.tsx
@@ -34,7 +34,7 @@ export const Base = () => (
   </div>
 );
 
-export const WithTrailingComponent = () => (
+export const WithTierIndicator = () => (
   <div>
     <Tab trailingComponent={{ variant: 'plus' }}>Services</Tab>
     <Tab>Items</Tab>

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.stories.tsx
@@ -33,3 +33,10 @@ export const Base = () => (
     <Tab selected>Selected</Tab>
   </div>
 );
+
+export const WithTrailingComponent = () => (
+  <div>
+    <Tab trailingComponent={{ variant: 'plus' }}>Services</Tab>
+    <Tab>Items</Tab>
+  </div>
+);

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -46,8 +46,8 @@ export type TabProps = LinkElProps &
      */
     selected?: boolean;
     /**
-     * Display a `TierIndicator` badge next to the tab's label, e.g. to mark
-     * a tab as gated behind a paid plan. Always rendered at size 's'.
+     * Display a `TierIndicator` badge next to the tab's label to indicate
+     * features that are part of the plus plan
      */
     trailingComponent?: Omit<TierIndicatorProps, 'size'>;
   };

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -19,15 +19,13 @@ import {
   forwardRef,
   type AnchorHTMLAttributes,
   type ButtonHTMLAttributes,
+  type ComponentType,
 } from 'react';
 
 import { useComponents } from '../../../ComponentsContext/index.js';
 import type { EmotionAsPropType } from '../../../../types/prop-types.js';
 import { clsx } from '../../../../styles/clsx.js';
-import {
-  TierIndicator,
-  type TierIndicatorProps,
-} from '../../../TierIndicator/TierIndicator.js';
+import type { TierIndicatorProps } from '../../../TierIndicator/TierIndicator.js';
 
 import classes from './Tab.module.css';
 
@@ -49,7 +47,7 @@ export type TabProps = LinkElProps &
      * Display a `TierIndicator` badge next to the tab's label to indicate
      * features that are part of the plus plan
      */
-    trailingComponent?: Omit<TierIndicatorProps, 'size'>;
+    trailingComponent?: ComponentType<TierIndicatorProps>;
   };
 
 const tabIndex = (selected: boolean) => (selected ? undefined : -1);
@@ -64,7 +62,7 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>(
       as = 'tab',
       className,
       children,
-      trailingComponent,
+      trailingComponent: TrailingComponent,
       ...props
     },
     ref,
@@ -73,10 +71,10 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>(
     const Link = components.Link as EmotionAsPropType;
     const Element = props.href ? Link : 'button';
 
-    const content = trailingComponent ? (
+    const content = TrailingComponent ? (
       <span className={classes.content}>
         {children}
-        <TierIndicator {...trailingComponent} size="s" />
+        <TrailingComponent variant="plus" size="s" />
       </span>
     ) : (
       children

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -24,6 +24,10 @@ import {
 import { useComponents } from '../../../ComponentsContext/index.js';
 import type { EmotionAsPropType } from '../../../../types/prop-types.js';
 import { clsx } from '../../../../styles/clsx.js';
+import {
+  TierIndicator,
+  type TierIndicatorProps,
+} from '../../../TierIndicator/TierIndicator.js';
 
 import classes from './Tab.module.css';
 
@@ -41,6 +45,11 @@ export type TabProps = LinkElProps &
      * Triggers selected styles of the component
      */
     selected?: boolean;
+    /**
+     * Display a `TierIndicator` badge next to the tab's label, e.g. to mark
+     * a tab as gated behind a paid plan. Always rendered at size 's'.
+     */
+    trailingComponent?: Omit<TierIndicatorProps, 'size'>;
   };
 
 const tabIndex = (selected: boolean) => (selected ? undefined : -1);
@@ -49,10 +58,29 @@ const tabIndex = (selected: boolean) => (selected ? undefined : -1);
  * Tab component that represents a single tab inside a Tabs wrapper
  */
 export const Tab = forwardRef<HTMLButtonElement, TabProps>(
-  ({ selected = false, as = 'tab', className, ...props }, ref) => {
+  (
+    {
+      selected = false,
+      as = 'tab',
+      className,
+      children,
+      trailingComponent,
+      ...props
+    },
+    ref,
+  ) => {
     const components = useComponents();
     const Link = components.Link as EmotionAsPropType;
     const Element = props.href ? Link : 'button';
+
+    const content = trailingComponent ? (
+      <span className={classes.content}>
+        {children}
+        <TierIndicator {...trailingComponent} size="s" />
+      </span>
+    ) : (
+      children
+    );
 
     return as === 'tab' ? (
       <Element
@@ -62,7 +90,9 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>(
         aria-selected={selected}
         tabIndex={tabIndex(selected)}
         {...props}
-      />
+      >
+        {content}
+      </Element>
     ) : (
       <div role="listitem">
         <Element
@@ -70,7 +100,9 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>(
           className={clsx(classes.base, className)}
           aria-current={selected ? 'page' : undefined}
           {...props}
-        />
+        >
+          {content}
+        </Element>
       </div>
     );
   },

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.spec.tsx
@@ -18,6 +18,8 @@ import { createRef } from 'react';
 
 import { axe, render, screen, userEvent } from '../../../../util/test-utils.js';
 
+import { TierIndicator } from '../../../TierIndicator/TierIndicator.js';
+
 import { TabList } from './TabList.js';
 
 const tabs = [
@@ -140,7 +142,11 @@ describe('TabList', () => {
     render(
       <TabList
         tabs={[
-          { id: 'a', tab: 'Services', trailingComponent: { variant: 'plus' } },
+          {
+            id: 'a',
+            tab: 'Services',
+            trailingComponent: TierIndicator,
+          },
         ]}
       />,
     );

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.spec.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.spec.tsx
@@ -135,4 +135,15 @@ describe('TabList', () => {
       expect(actual).toHaveNoViolations();
     });
   });
+
+  it('should render a trailing component for a tab item', () => {
+    render(
+      <TabList
+        tabs={[
+          { id: 'a', tab: 'Services', trailingComponent: { variant: 'plus' } },
+        ]}
+      />,
+    );
+    expect(screen.getByText('Services')).toBeVisible();
+  });
 });

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.stories.tsx
@@ -67,7 +67,7 @@ export const NavigationWithTabsProp = () => (
   />
 );
 
-export const WithTierBadge = () => (
+export const WithTierIndicator = () => (
   <TabList
     tabs={[
       {

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.stories.tsx
@@ -66,3 +66,17 @@ export const NavigationWithTabsProp = () => (
     initialSelectedIndex={2}
   />
 );
+
+export const WithTierBadge = () => (
+  <TabList
+    tabs={[
+      {
+        id: 'services',
+        tab: 'Services',
+        trailingComponent: { variant: 'plus' },
+      },
+      { id: 'items', tab: 'Items' },
+      { id: 'discounts', tab: 'Discounts' },
+    ]}
+  />
+);

--- a/packages/circuit-ui/components/Tabs/components/TabList/TabList.stories.tsx
+++ b/packages/circuit-ui/components/Tabs/components/TabList/TabList.stories.tsx
@@ -14,6 +14,7 @@
  */
 
 import { Tab } from '../Tab/Tab.js';
+import { TierIndicator } from '../../../TierIndicator/TierIndicator.js';
 import { TabList } from './TabList.js';
 
 export default {
@@ -73,7 +74,7 @@ export const WithTierIndicator = () => (
       {
         id: 'services',
         tab: 'Services',
-        trailingComponent: { variant: 'plus' },
+        trailingComponent: TierIndicator,
       },
       { id: 'items', tab: 'Items' },
       { id: 'discounts', tab: 'Discounts' },

--- a/skills/circuit-ui/references/components/Tabs.mdx
+++ b/skills/circuit-ui/references/components/Tabs.mdx
@@ -133,4 +133,4 @@ Set the `trailingComponent` prop on a tab to display a `TierIndicator` badge nex
 
 However, whenever possible, communicate the value and availability of paid features within the page content itself (for example, on an "Overview" page) rather than in the navigation. This helps keep navigation clear and focused.
 
-<Story of={Stories.WithTierBadge} />
+<Story of={Stories.WithTierIndicator} />

--- a/skills/circuit-ui/references/components/Tabs.mdx
+++ b/skills/circuit-ui/references/components/Tabs.mdx
@@ -126,3 +126,11 @@ Avoid using external links, as this can create an inconsistent user experience a
 Set the `stretched` prop to true to make all tabs expand and share the available space evenly.
 
 <Story of={Stories.Stretched} />
+
+### Paid features
+
+Set the `trailingComponent` prop on a tab to display a `TierIndicator` badge next to its label, marking that tab as gated behind a paid plan. This works the same way whether you use the `items`-array API, `TabList`'s `tabs` prop, or manual `Tab` composition.
+
+However, whenever possible, communicate the value and availability of paid features within the page content itself (for example, on an "Overview" page) rather than in the navigation. This helps keep navigation clear and focused.
+
+<Story of={Stories.WithTierBadge} />

--- a/skills/circuit-ui/references/hooks/useTabState.mdx
+++ b/skills/circuit-ui/references/hooks/useTabState.mdx
@@ -133,4 +133,4 @@ Set the `trailingComponent` prop on a tab to display a `TierIndicator` badge nex
 
 However, whenever possible, communicate the value and availability of paid features within the page content itself (for example, on an "Overview" page) rather than in the navigation. This helps keep navigation clear and focused.
 
-<Story of={Stories.WithTierBadge} />
+<Story of={Stories.WithTierIndicator} />

--- a/skills/circuit-ui/references/hooks/useTabState.mdx
+++ b/skills/circuit-ui/references/hooks/useTabState.mdx
@@ -126,3 +126,11 @@ Avoid using external links, as this can create an inconsistent user experience a
 Set the `stretched` prop to true to make all tabs expand and share the available space evenly.
 
 <Story of={Stories.Stretched} />
+
+### Paid features
+
+Set the `trailingComponent` prop on a tab to display a `TierIndicator` badge next to its label, marking that tab as gated behind a paid plan. This works the same way whether you use the `items`-array API, `TabList`'s `tabs` prop, or manual `Tab` composition.
+
+However, whenever possible, communicate the value and availability of paid features within the page content itself (for example, on an "Overview" page) rather than in the navigation. This helps keep navigation clear and focused.
+
+<Story of={Stories.WithTierBadge} />


### PR DESCRIPTION
Addresses [DSYS-1824](https://sumupteam.atlassian.net/browse/DSYS-1824)

## Purpose
This adds an optional `trailingComponent` prop to Tab that renders a TierIndicator badge next to the tab's label to indicate that a feature is behind a paid plan.

## Approach and changes

- Added `trailingComponent?: ComponentType<TierIndicatorProps>` to TabProps. Consumers inject the `TierIndicator` component itself rather than passing rendered JSX or a props object.
- `Tab.tsx` now destructures children explicitly (it previously flowed through implicitly via the props spread)
- `Tabs. tsx` items mapping now forwards `trailingComponent` too (previously only `id/tab` made it through), so the badge works via the top-level `items` API, not just `TabList's` tabs prop
- Added a "Paid features" section to Tabs.mdx

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
