### PR TITLE
Bump temporal-polyfill to v1.0.3 in templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10792,7 +10792,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -10802,7 +10801,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -29206,9 +29204,9 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.2.tgz",
-      "integrity": "sha512-pTyp/7kfStJQbJ8YOHmcJItkxvOGCZHu3PaVgLvLnxFS7O12EPiWLElnRre/rw77z4TGZX/gvdqMXWn6ispQvA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.3.tgz",
+      "integrity": "sha512-U8vuzZBc+dfMIfl8wXWcedfI7AJCxJjjVBIRpJUvIz5+UAp555UJDHguKsfZqHWaHRSdVUThm7mqqIWhN/xPBQ==",
       "license": "MIT",
       "dependencies": {
         "temporal-spec": "1.0.1",
@@ -32611,7 +32609,7 @@
         "react-dom": "^19.2.6",
         "react-swipeable": "^7.0.2",
         "rollup-plugin-preserve-directives": "^0.4.0",
-        "temporal-polyfill": "^1.0.2",
+        "temporal-polyfill": "^1.0.3",
         "typescript": "^6.0.3",
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^7.3.5",
@@ -33163,7 +33161,7 @@
         "astro": "^6.4.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "temporal-polyfill": "^0.3.2"
+        "temporal-polyfill": "^1.0.3"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -33175,21 +33173,6 @@
         "eslint-plugin-testing-library": "^7.16.2",
         "typescript": "^6.0.3"
       }
-    },
-    "templates/astro/node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "temporal-spec": "0.3.1"
-      }
-    },
-    "templates/astro/node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
     },
     "templates/nextjs": {
       "name": "@sumup-oss/cna-template",
@@ -33226,21 +33209,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "templates/nextjs/node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "temporal-spec": "0.3.1"
-      }
-    },
-    "templates/nextjs/node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
-    },
     "templates/nextjs/template": {
       "name": "next-app",
       "version": "2.1.0",
@@ -33253,7 +33221,7 @@
         "next": "^16.2.11",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "temporal-polyfill": "^0.3.2"
+        "temporal-polyfill": "^1.0.3"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^16.2.11",

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -87,7 +87,7 @@
     "react-dom": "^19.2.6",
     "react-swipeable": "^7.0.2",
     "rollup-plugin-preserve-directives": "^0.4.0",
-    "temporal-polyfill": "^1.0.2",
+    "temporal-polyfill": "^1.0.3",
     "typescript": "^6.0.3",
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^7.3.5",

--- a/templates/astro/package.json
+++ b/templates/astro/package.json
@@ -25,7 +25,7 @@
     "astro": "^6.4.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "temporal-polyfill": "^0.3.2"
+    "temporal-polyfill": "^1.0.3"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",

--- a/templates/nextjs/template/components/DocCard/DocCard.tsx
+++ b/templates/nextjs/template/components/DocCard/DocCard.tsx
@@ -14,7 +14,12 @@ export function DocCard({ title, description, href }: DocCardProps) {
   return (
     <Card>
       <Headline as="h2" className={styles.title}>
-        <a href={href} target="_blank" aria-describedby={descriptionId}>
+        <a
+          href={href}
+          target="_blank"
+          aria-describedby={descriptionId}
+          rel="noopener"
+        >
           {title}
         </a>
       </Headline>

--- a/templates/nextjs/template/jest.config.js
+++ b/templates/nextjs/template/jest.config.js
@@ -10,6 +10,7 @@ const esModules = [
   '@nanostores/react',
   'nanostores',
   'temporal-polyfill',
+  'temporal-utils',
 ].join('|');
 
 const createJestConfig = nextJest({ dir: './' });

--- a/templates/nextjs/template/jest.config.js
+++ b/templates/nextjs/template/jest.config.js
@@ -9,6 +9,7 @@ const esModules = [
   '@sumup-oss/intl',
   '@nanostores/react',
   'nanostores',
+  'temporal-polyfill',
 ].join('|');
 
 const createJestConfig = nextJest({ dir: './' });
@@ -25,6 +26,7 @@ const customJestConfig = {
   coverageDirectory: './__coverage__',
   coverageReporters: ['cobertura', 'text-summary', 'html'],
   collectCoverageFrom: [
+    'app/**/*.(js|jsx|ts|tsx)',
     'components/**/*.(js|jsx|ts|tsx)',
     'pages/**/*.(js|jsx|ts|tsx)',
     'services/**/*.(js|jsx|ts|tsx)',

--- a/templates/nextjs/template/package.json
+++ b/templates/nextjs/template/package.json
@@ -23,7 +23,7 @@
     "next": "^16.2.11",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "temporal-polyfill": "^0.3.2"
+    "temporal-polyfill": "^1.0.3"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.11",


### PR DESCRIPTION
Fixes #3788.

## Purpose

[`temporal-polyfill` v1.0.3](https://github.com/fullcalendar/temporal-polyfill/releases/tag/temporal-polyfill%401.0.3) fixes compatibility with CJS environments.

## Approach and changes

- Re-upgrade the templates to `temporal-polyfill` v1.x
- Add `temporal-polyfill` to the list of ESM packages to transpile for Jest

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
