### PR TITLE
fix type in illustration names type

### DIFF
--- a/.changeset/purple-ghosts-own.md
+++ b/.changeset/purple-ghosts-own.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/illustrations": patch
+---
+
+Fixed a typo in illustrations' Name type.

--- a/packages/illustrations/constants.ts
+++ b/packages/illustrations/constants.ts
@@ -43,7 +43,7 @@ export const NAMES = [
   'giftcards',
   'onlinepayments',
   'paymentlinks',
-  'referrak',
+  'referral',
   'rewards',
   'taptopay',
   // General communication


### PR DESCRIPTION
Fixes a typo for referral illustration name: 'referrak' -> 'referral'

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
