### PR TITLE
Remove redundant slash in Vite config path

### DIFF
--- a/.changeset/green-places-pay.md
+++ b/.changeset/green-places-pay.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed a redundant slash in file path in global Vite css config.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,7 +29,7 @@ export function generateScopedNameFactory(directory: string) {
     const prefix = 'cui';
     const parts = [prefix];
 
-    const filePath = last(file.split('?')[0].split(`/packages/${directory}/`));
+    const filePath = last(file.split('?')[0].split(`/packages/${directory}`));
     const fileName = path.basename(filePath, '.module.css');
     const folderName = last(path.dirname(filePath).split(path.sep));
     const isComponent = filePath.includes('/components');


### PR DESCRIPTION
## Purpose

Removes an extra slash in file paths that resulted in altered generated classname for components.

## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
