### PR TITLE
Fix Temporal date mocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23604,12 +23604,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/mockdate": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
-      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
-      "dev": true
-    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -32189,7 +32183,6 @@
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "jest-axe": "^10.0.0",
-        "mockdate": "^3.0.5",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-swipeable": "^7.0.2",

--- a/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.spec.tsx
@@ -15,7 +15,6 @@
 
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { createRef } from 'react';
-import MockDate from 'mockdate';
 import { waitFor } from '@testing-library/react';
 
 import { render, screen, axe, userEvent } from '../../util/test-utils.js';
@@ -23,6 +22,16 @@ import { useMedia } from '../../hooks/useMedia/useMedia.js';
 
 import { DateInput } from './DateInput.js';
 
+vi.mock('../../util/date.js', async (importOriginal) => {
+  const [module, { Temporal }] = await Promise.all([
+    importOriginal<typeof import('../../util/date.js')>(),
+    import('temporal-polyfill'),
+  ]);
+  return {
+    ...module,
+    getTodaysDate: vi.fn().mockReturnValue(new Temporal.PlainDate(2000, 1, 1)),
+  };
+});
 vi.mock('../../hooks/useMedia/useMedia.js');
 
 describe('DateInput', () => {
@@ -33,7 +42,7 @@ describe('DateInput', () => {
   };
 
   beforeEach(() => {
-    MockDate.set('2000-01-01');
+    vi.setSystemTime(new Date('2000-01-01T01:00+01:00'));
     (useMedia as Mock).mockReturnValue(false);
   });
 

--- a/packages/circuit-ui/components/Timestamp/Timestamp.spec.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.spec.tsx
@@ -14,18 +14,24 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import MockDate from 'mockdate';
 import { createRef } from 'react';
 
 import { render, screen, axe, act } from '../../util/test-utils.js';
 
 import { Timestamp } from './Timestamp.js';
 
-describe('Calendar', () => {
-  beforeEach(() => {
-    MockDate.set('2020-01-01T01:00+01:00');
-  });
+vi.mock('../../util/date.js', async (importOriginal) => {
+  const [module, { Temporal }] = await Promise.all([
+    importOriginal<typeof import('../../util/date.js')>(),
+    import('temporal-polyfill'),
+  ]);
+  return {
+    ...module,
+    getTodaysDate: vi.fn().mockReturnValue(new Temporal.PlainDate(2000, 1, 1)),
+  };
+});
 
+describe('Timestamp', () => {
   const baseProps = {
     datetime: '2020-01-01T00:00+01:00[Europe/Berlin]',
   };
@@ -120,6 +126,7 @@ describe('Calendar', () => {
   describe('relative variant', () => {
     beforeEach(() => {
       vi.useFakeTimers();
+      vi.setSystemTime(new Date('2020-01-01T01:00+01:00'));
     });
 
     afterEach(() => {

--- a/packages/circuit-ui/components/Timestamp/Timestamp.spec.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.spec.tsx
@@ -27,7 +27,11 @@ vi.mock('../../util/date.js', async (importOriginal) => {
   ]);
   return {
     ...module,
-    getTodaysDate: vi.fn().mockReturnValue(new Temporal.PlainDate(2000, 1, 1)),
+    getTodaysZonedDateTimeISODate: vi.fn(() =>
+      Temporal.Instant.fromEpochMilliseconds(Date.now()).toZonedDateTimeISO(
+        'Europe/Berlin',
+      ),
+    ),
   };
 });
 

--- a/packages/circuit-ui/components/Timestamp/TimestampService.ts
+++ b/packages/circuit-ui/components/Timestamp/TimestampService.ts
@@ -21,6 +21,7 @@ import {
 } from '@sumup-oss/intl';
 
 import type { Locale } from '../../util/i18n.js';
+import { getTodaysZonedDateTimeISODate } from '../../util/date.js';
 
 const DATE_STYLE_MAP = {
   long: 'long',
@@ -115,7 +116,7 @@ export function getState({
   includeTime: boolean;
 }): State {
   const zonedDateTime = Temporal.ZonedDateTime.from(datetime);
-  const now = Temporal.Now.zonedDateTimeISO();
+  const now = getTodaysZonedDateTimeISODate();
   const duration = zonedDateTime.since(now);
 
   const isBeyondThreshold =

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -78,7 +78,6 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "jest-axe": "^10.0.0",
-    "mockdate": "^3.0.5",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-swipeable": "^7.0.2",

--- a/packages/circuit-ui/util/date.ts
+++ b/packages/circuit-ui/util/date.ts
@@ -39,6 +39,10 @@ export function getTodaysDate() {
   return Temporal.Now.plainDateISO();
 }
 
+export function getTodaysZonedDateTimeISODate() {
+  return Temporal.Now.zonedDateTimeISO();
+}
+
 export function isPlainDate(date: unknown): date is Temporal.PlainDate {
   return date instanceof Temporal.PlainDate;
 }


### PR DESCRIPTION
## Purpose

CI has been failing on the next branch since https://github.com/sumup-oss/circuit-ui/commit/396faa03a0b9f8616fd11ff3e253ea99cd898456. Tests have been failing because Temporal dates were not mocked correctly when `MockDate.set`  is called. The issue [only impacts](https://github.com/vitest-dev/vitest/issues/10345#issuecomment-4447285972) node 26, which supports Temporal natively. Vitest v5 [will soon](https://github.com/vitest-dev/vitest/releases/tag/v5.0.0-rc.1#:~:text=Enable%20mocking%20Temporal%20without%20fake%20timers) support mocking `Temporal.Now` . Until then we need to workaround this internally.

## Approach and changes

- Replace `mockdate` with native `vite.setSystemDate` for `Date`
- Mock methods of date utils where `Temporal.Now` is called.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
