### PR TITLE
Bump temporal-polyfill to v1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28914,13 +28914,13 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.2.tgz",
-      "integrity": "sha512-pTyp/7kfStJQbJ8YOHmcJItkxvOGCZHu3PaVgLvLnxFS7O12EPiWLElnRre/rw77z4TGZX/gvdqMXWn6ispQvA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.4.tgz",
+      "integrity": "sha512-MLEU0qOD2uXlz24oINNtdLZQl8RgmMxSnRtKEGZGGetTJjlRwQJjk+VsJ4EREaUoiaTb8NJOcUiKtoAiWn9EBg==",
       "license": "MIT",
       "dependencies": {
         "temporal-spec": "1.0.1",
-        "temporal-utils": "1.0.1"
+        "temporal-utils": "1.0.2"
       }
     },
     "node_modules/temporal-spec": {
@@ -28930,9 +28930,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/temporal-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.1.tgz",
-      "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.2.tgz",
+      "integrity": "sha512-1B8Dl4KzrOvsNUlpoWGno2VLQlxroLjDgc5NBjVC9ax9ymdo+ezfyvhyjEMx+IVfhINr6CIG2gcnlP95iRrybQ==",
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -32298,7 +32298,7 @@
         "react-dom": "^19.2.6",
         "react-swipeable": "^7.0.2",
         "rollup-plugin-preserve-directives": "^0.4.0",
-        "temporal-polyfill": "^1.0.2",
+        "temporal-polyfill": "^1.0.4",
         "typescript": "^6.0.3",
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^7.3.5",
@@ -32823,7 +32823,7 @@
         "astro": "^6.4.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "temporal-polyfill": "^0.3.2"
+        "temporal-polyfill": "^1.0.4"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -32835,21 +32835,6 @@
         "eslint-plugin-testing-library": "^7.16.2",
         "typescript": "^6.0.3"
       }
-    },
-    "templates/astro/node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "temporal-spec": "0.3.1"
-      }
-    },
-    "templates/astro/node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
     },
     "templates/nextjs": {
       "name": "@sumup-oss/cna-template",
@@ -32886,21 +32871,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "templates/nextjs/node_modules/temporal-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
-      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "temporal-spec": "0.3.1"
-      }
-    },
-    "templates/nextjs/node_modules/temporal-spec": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
-      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
-      "license": "ISC"
-    },
     "templates/nextjs/template": {
       "name": "next-app",
       "version": "2.1.0",
@@ -32913,7 +32883,7 @@
         "next": "^16.2.11",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "temporal-polyfill": "^0.3.2"
+        "temporal-polyfill": "^1.0.4"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^16.2.11",

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -88,7 +88,7 @@
     "react-dom": "^19.2.6",
     "react-swipeable": "^7.0.2",
     "rollup-plugin-preserve-directives": "^0.4.0",
-    "temporal-polyfill": "^1.0.2",
+    "temporal-polyfill": "^1.0.4",
     "typescript": "^6.0.3",
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^7.3.5",

--- a/templates/astro/package.json
+++ b/templates/astro/package.json
@@ -25,7 +25,7 @@
     "astro": "^6.4.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "temporal-polyfill": "^0.3.2"
+    "temporal-polyfill": "^1.0.4"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",

--- a/templates/nextjs/template/package.json
+++ b/templates/nextjs/template/package.json
@@ -23,7 +23,7 @@
     "next": "^16.2.11",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "temporal-polyfill": "^0.3.2"
+    "temporal-polyfill": "^1.0.4"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.11",


### PR DESCRIPTION
## Purpose

Due to `temporal-utils` being incompatible with CJS, we had to downgrade it in the templates (see #3788). This has now been [fixed](https://github.com/fullcalendar/temporal-polyfill/pull/101), so we can safely upgrade. 

## Approach and changes

- Bump `temporal-polyfill` to v1.0.4 and `temporal-utils` to v1.0.2

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
