### PR TITLE
Upgrade to changesets v3

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "changelog": [
     "@changesets/changelog-github",
     { "repo": "sumup-oss/circuit-ui" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [22, 24.18.0]
+        node: [22, 24]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -55,9 +55,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Create release PR or publish to npm
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/canary' || startsWith(github.ref, 'refs/heads/release')) && matrix.node == '24.18.0'
-        uses: changesets/action@v1
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/next' || github.ref == 'refs/heads/canary' || startsWith(github.ref, 'refs/heads/release')) && matrix.node == '24'
+        uses: changesets/action@v2
         with:
-          publish: npm run release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_PAT }}
+          publish-script: npm run release
+          github-token: ${{ secrets.GH_ACTIONS_PAT }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "templates/nextjs/template"
       ],
       "devDependencies": {
-        "@changesets/changelog-github": "^0.7.0",
+        "@changesets/changelog-github": "^1.0.0",
         "@changesets/cli": "^2.31.1",
         "@emotion/eslint-plugin": "^11.12.0",
         "@storybook/addon-a11y": "^10.3.5",
@@ -2755,15 +2755,27 @@
       }
     },
     "node_modules/@changesets/changelog-github": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.7.0.tgz",
-      "integrity": "sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-1.0.0.tgz",
+      "integrity": "sha512-PNCSH5CGJrqOKxRjrMp2NLhceQv2QBs6HkjrLvYQqsEE2/ItN5R8GD/mskZZluoNWYvjPYFsY9T6swXfp5E0UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/get-github-info": "^0.8.0",
-        "@changesets/types": "^6.1.0",
-        "dotenv": "^8.1.0"
+        "@changesets/get-github-info": "^1.0.0",
+        "@changesets/types": "^7.0.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
+      }
+    },
+    "node_modules/@changesets/changelog-github/node_modules/@changesets/types": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-7.0.0.tgz",
+      "integrity": "sha512-c5GoiQyt3pxiXjrWSNoP8/GRf4kG+VnKzovx1OQM8dYYALlSwgedmkPmJ+ZqGxqwg9D3Bkj85Uo4KLd5BN3A0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/cli": {
@@ -2845,14 +2857,16 @@
       }
     },
     "node_modules/@changesets/get-github-info": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.8.0.tgz",
-      "integrity": "sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-1.0.0.tgz",
+      "integrity": "sha512-nf5zPSqEKW0eXiJ4ltbjyIQ/srUHfxbghkLCjKdOLI3LehKXhiqxXcpja39eGPaj6qqGx2lFCrLJ7VWYUf9H2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "dataloader": "^1.4.0",
-        "node-fetch": "^2.5.0"
+        "dataloader": "^2.2.3"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/get-release-plan": {
@@ -14648,11 +14662,11 @@
       }
     },
     "node_modules/dataloader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
-      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
+      "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "MIT"
     },
     "node_modules/dateformat": {
       "version": "3.0.3",
@@ -15123,15 +15137,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/dotenv-expand": {
@@ -24364,57 +24369,11 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/node-gyp": {
       "version": "12.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@changesets/changelog-github": "^1.0.0",
-        "@changesets/cli": "^2.31.1",
+        "@changesets/cli": "^3.0.0",
         "@emotion/eslint-plugin": "^11.12.0",
         "@storybook/addon-a11y": "^10.3.5",
         "@storybook/addon-docs": "^10.3.5",
@@ -2708,50 +2708,60 @@
       }
     },
     "node_modules/@changesets/apply-release-plan": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.1.tgz",
-      "integrity": "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-8.0.0.tgz",
+      "integrity": "sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/config": "^3.1.4",
-        "@changesets/get-version-range-type": "^0.4.0",
-        "@changesets/git": "^3.0.4",
-        "@changesets/should-skip-package": "^0.1.2",
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "detect-indent": "^6.0.0",
-        "fs-extra": "^7.0.1",
-        "lodash.startcase": "^4.4.0",
-        "outdent": "^0.5.0",
-        "prettier": "^2.7.1",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.3"
+        "@changesets/config": "^4.0.0",
+        "@changesets/format": "^0.1.1",
+        "@changesets/git": "^4.0.0",
+        "@changesets/should-skip-package": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "import-meta-resolve": "^4.2.0",
+        "jsonc-parser": "^3.3.1",
+        "semver": "^7.8.1"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
+    "node_modules/@changesets/apply-release-plan/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@changesets/assemble-release-plan": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.10.tgz",
-      "integrity": "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-7.0.0.tgz",
+      "integrity": "sha512-oEW8BxdA604kGGtDSCiHr5w9Tv4UWe9I2k61IBNZzCOE1kbYaJj4v+lFQNgcEZFkUc2pV/+hASErGDvpJOZCTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.4",
-        "@changesets/should-skip-package": "^0.1.2",
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "semver": "^7.5.3"
+        "@changesets/errors": "^1.0.0",
+        "@changesets/get-dependents-graph": "^3.0.0",
+        "@changesets/should-skip-package": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "semver": "^7.8.1"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/changelog-git": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.2.1.tgz",
-      "integrity": "sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-1.0.0.tgz",
+      "integrity": "sha512-3Dst2Ime2Op5nd4XmWJLPIgp11ZFqJqSkVug9izK6TDcIV4YlhPS4ECbEVR+eGI0bk0r1ItogD4j2Oli87bJrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.1.0"
+        "@changesets/types": "^7.0.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/changelog-github": {
@@ -2768,92 +2778,98 @@
         "node": "^22.11 || ^24 || >=26"
       }
     },
-    "node_modules/@changesets/changelog-github/node_modules/@changesets/types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-7.0.0.tgz",
-      "integrity": "sha512-c5GoiQyt3pxiXjrWSNoP8/GRf4kG+VnKzovx1OQM8dYYALlSwgedmkPmJ+ZqGxqwg9D3Bkj85Uo4KLd5BN3A0w==",
+    "node_modules/@changesets/cli": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-3.0.0.tgz",
+      "integrity": "sha512-V7Gm+GP5OT3mJinMI2YcJD/JyO/a4WChnaMCCzTRhWHgu1zhtsyY7zCjP6n5W6zsgSjJKs+yPmvtREvE0F2g8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/apply-release-plan": "^8.0.0",
+        "@changesets/assemble-release-plan": "^7.0.0",
+        "@changesets/changelog-git": "^1.0.0",
+        "@changesets/config": "^4.0.0",
+        "@changesets/errors": "^1.0.0",
+        "@changesets/get-dependents-graph": "^3.0.0",
+        "@changesets/git": "^4.0.0",
+        "@changesets/pre": "^3.0.0",
+        "@changesets/read": "^1.0.0",
+        "@changesets/should-skip-package": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "@changesets/write": "^1.0.0",
+        "@clack/prompts": "^1.7.0",
+        "@manypkg/get-packages": "^3.1.0",
+        "@pnpm/deps.graph-sequencer": "^1100.0.1",
+        "cac": "^7.0.0",
+        "import-meta-resolve": "^4.2.0",
+        "launch-editor": "^2.14.1",
+        "package-manager-detector": "^1.6.0",
+        "semver": "^7.8.1",
+        "tinyexec": "^1.3.0"
+      },
+      "bin": {
+        "changeset": "bin.js"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26",
+        "npm": ">=10.9.0",
+        "pnpm": ">=10.0.0",
+        "yarn": ">=4.5.2"
+      }
+    },
+    "node_modules/@changesets/config": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-4.0.0.tgz",
+      "integrity": "sha512-mw95/YrkOuhZZxfnVAA4bSXOFUi+KlhzOBTM8C4x777NhUU6HWIl9Z+K+nME+E4PVsv5NQVQwTfiHihAS1A/ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@changesets/get-dependents-graph": "^3.0.0",
+        "@changesets/should-skip-package": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "@manypkg/get-packages": "^3.1.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
+      }
+    },
+    "node_modules/@changesets/errors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-1.0.0.tgz",
+      "integrity": "sha512-ElN/mEzn6zmETgjwf5MclCMa9ef59sAR0lfO8VSYIsiRvbC2FbLB/92EoYw10Sl0kGixxHFiJZUSv7dA+YpR8g==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^22.11 || ^24 || >=26"
       }
     },
-    "node_modules/@changesets/cli": {
-      "version": "2.31.1",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.31.1.tgz",
-      "integrity": "sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==",
+    "node_modules/@changesets/format": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/format/-/format-0.1.2.tgz",
+      "integrity": "sha512-Caez5XtNXCFS/G5bwyav3wuXL0tMxVd2ZGbaumWbzN08tyzO21asCw7JZhNtVsAZDCvDRUzZN+Iit9SyRITSYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/apply-release-plan": "^7.1.1",
-        "@changesets/assemble-release-plan": "^6.0.10",
-        "@changesets/changelog-git": "^0.2.1",
-        "@changesets/config": "^3.1.4",
-        "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.4",
-        "@changesets/get-release-plan": "^4.0.16",
-        "@changesets/git": "^3.0.4",
-        "@changesets/logger": "^0.1.1",
-        "@changesets/pre": "^2.0.2",
-        "@changesets/read": "^0.6.7",
-        "@changesets/should-skip-package": "^0.1.2",
-        "@changesets/types": "^6.1.0",
-        "@changesets/write": "^0.4.0",
-        "@inquirer/external-editor": "^1.0.2",
-        "@manypkg/get-packages": "^1.1.3",
-        "ansi-colors": "^4.1.3",
-        "enquirer": "^2.4.1",
-        "fs-extra": "^7.0.1",
-        "mri": "^1.2.0",
-        "package-manager-detector": "^0.2.0",
-        "picocolors": "^1.1.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.3",
-        "spawndamnit": "^3.0.1",
-        "term-size": "^2.1.0"
+        "package-manager-detector": "^1.8.0",
+        "tinyexec": "^1.3.0"
       },
-      "bin": {
-        "changeset": "bin.js"
-      }
-    },
-    "node_modules/@changesets/config": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.4.tgz",
-      "integrity": "sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.4",
-        "@changesets/logger": "^0.1.1",
-        "@changesets/should-skip-package": "^0.1.2",
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "fs-extra": "^7.0.1",
-        "micromatch": "^4.0.8"
-      }
-    },
-    "node_modules/@changesets/errors": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
-      "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "extendable-error": "^0.1.5"
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/get-dependents-graph": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.4.tgz",
-      "integrity": "sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-3.0.0.tgz",
+      "integrity": "sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "picocolors": "^1.1.0",
-        "semver": "^7.5.3"
+        "@changesets/types": "^7.0.0",
+        "semver": "^7.8.1"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/get-github-info": {
@@ -2869,173 +2885,131 @@
         "node": "^22.11 || ^24 || >=26"
       }
     },
-    "node_modules/@changesets/get-release-plan": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.16.tgz",
-      "integrity": "sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@changesets/assemble-release-plan": "^6.0.10",
-        "@changesets/config": "^3.1.4",
-        "@changesets/pre": "^2.0.2",
-        "@changesets/read": "^0.6.7",
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3"
-      }
-    },
-    "node_modules/@changesets/get-version-range-type": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-version-range-type/-/get-version-range-type-0.4.0.tgz",
-      "integrity": "sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@changesets/git": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.4.tgz",
-      "integrity": "sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-4.0.0.tgz",
+      "integrity": "sha512-uIEswpPUgzBBqrC0qg13byNaPorzhf05LE2T+gRizEKCXvMsJC6NPJp5iNDSV/gYj4Viqh09UiOF5E7XWeH5lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/errors": "^0.2.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "is-subdir": "^1.1.1",
-        "micromatch": "^4.0.8",
-        "spawndamnit": "^3.0.1"
-      }
-    },
-    "node_modules/@changesets/logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
-      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^1.1.0"
+        "@changesets/errors": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "@manypkg/get-packages": "^3.1.0",
+        "picomatch": "^4.0.4",
+        "tinyexec": "^1.3.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/parse": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
-      "integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-1.0.0.tgz",
+      "integrity": "sha512-P0iaMb9p9CRYZiTgAllEIF9AUMQHIy1G72tKlcIqJp61icZSsKQNiOPdxAMZG8m/DvZwt/oz5xEbTpike//dWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.1.0",
-        "js-yaml": "^4.1.1"
-      }
-    },
-    "node_modules/@changesets/parse/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/@changesets/parse/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
+        "@changesets/types": "^7.0.0",
+        "yaml": "^2.9.0"
       },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/pre": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
-      "integrity": "sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-3.0.0.tgz",
+      "integrity": "sha512-Zm/6YliV/a2oeWTqHJf6KxLrQwgcK1i/BRDl2m0EKZvbnxV5fG9QRhwJJGshjsZTUTS6dkfURQ2K6aAvgNw/3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/errors": "^0.2.0",
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3",
-        "fs-extra": "^7.0.1"
+        "@changesets/errors": "^1.0.0",
+        "@changesets/types": "^7.0.0",
+        "@manypkg/get-packages": "^3.1.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/read": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
-      "integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-1.0.0.tgz",
+      "integrity": "sha512-8TdE2PwG6yArPt5Ozej83Z6iHz1G8BDBKvIEKZ455MccR4K3GNbLR2XqjBxa+5yLFnEd3xAOPXYboBg1pt8stQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/git": "^3.0.4",
-        "@changesets/logger": "^0.1.1",
-        "@changesets/parse": "^0.4.3",
-        "@changesets/types": "^6.1.0",
-        "fs-extra": "^7.0.1",
-        "p-filter": "^2.1.0",
-        "picocolors": "^1.1.0"
+        "@changesets/git": "^4.0.0",
+        "@changesets/parse": "^1.0.0",
+        "@changesets/types": "^7.0.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/should-skip-package": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.2.tgz",
-      "integrity": "sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-1.0.0.tgz",
+      "integrity": "sha512-pwqoJmbONn1XgXmZXPEExgAaT+HdZLjALFTDgIm+PnS5KeO2nLtzA2/Q+4aMFY14kFMuXKG30MObhvDzWgzDgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.1.0",
-        "@manypkg/get-packages": "^1.1.3"
+        "@changesets/types": "^7.0.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@changesets/types": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-6.1.0.tgz",
-      "integrity": "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-7.0.0.tgz",
+      "integrity": "sha512-c5GoiQyt3pxiXjrWSNoP8/GRf4kG+VnKzovx1OQM8dYYALlSwgedmkPmJ+ZqGxqwg9D3Bkj85Uo4KLd5BN3A0w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
+      }
     },
     "node_modules/@changesets/write": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.4.0.tgz",
-      "integrity": "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-1.0.0.tgz",
+      "integrity": "sha512-xCK3/4C7Z7muQB/wguE6HcbjtY9iOtaK9orZKE+7xi573cMGD8rLZz7qlo6IvK7s+SIUIKajzj1l+F1QuP97tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/types": "^6.1.0",
-        "fs-extra": "^7.0.1",
-        "human-id": "^4.1.1",
-        "prettier": "^2.7.1"
+        "@changesets/format": "^0.1.1",
+        "@changesets/types": "^7.0.0",
+        "human-id": "^4.2.0"
+      },
+      "engines": {
+        "node": "^22.11 || ^24 || >=26"
       }
     },
     "node_modules/@clack/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
       "license": "MIT",
       "dependencies": {
-        "fast-wrap-ansi": "^0.1.3",
+        "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
-      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
       "license": "MIT",
       "dependencies": {
-        "@clack/core": "1.2.0",
-        "fast-string-width": "^1.1.0",
-        "fast-wrap-ansi": "^0.1.3",
+        "@clack/core": "1.4.3",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -6121,75 +6095,45 @@
       "license": "LGPL-3.0"
     },
     "node_modules/@manypkg/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-3.1.0.tgz",
+      "integrity": "sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@types/node": "^12.7.1",
-        "find-up": "^4.1.0",
-        "fs-extra": "^8.1.0"
-      }
-    },
-    "node_modules/@manypkg/find-root/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@manypkg/find-root/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "@manypkg/tools": "^2.1.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@manypkg/get-packages": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-1.1.3.tgz",
-      "integrity": "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@manypkg/get-packages/-/get-packages-3.1.0.tgz",
+      "integrity": "sha512-0TbBVyvPrP7xGYBI/cP8UP+yl/z+HtbTttAD7FMAJgn/kXOTwh5/60TsqP9ZYY710forNfyV0N8P/IE/ujGZJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@changesets/types": "^4.0.1",
-        "@manypkg/find-root": "^1.1.0",
-        "fs-extra": "^8.1.0",
-        "globby": "^11.0.0",
-        "read-yaml-file": "^1.1.0"
-      }
-    },
-    "node_modules/@manypkg/get-packages/node_modules/@changesets/types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-4.1.0.tgz",
-      "integrity": "sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@manypkg/get-packages/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "@manypkg/find-root": "^3.1.0",
+        "@manypkg/tools": "^2.1.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@manypkg/tools": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@manypkg/tools/-/tools-2.1.2.tgz",
+      "integrity": "sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jju": "^1.4.0",
+        "tinyglobby": "^0.2.13",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@mdn/browser-compat-data": {
@@ -8585,6 +8529,19 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@pnpm/deps.graph-sequencer": {
+      "version": "1100.0.1",
+      "resolved": "https://registry.npmjs.org/@pnpm/deps.graph-sequencer/-/deps.graph-sequencer-1100.0.1.tgz",
+      "integrity": "sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.13"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.28",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
@@ -9847,33 +9804,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@sumup-oss/foundry/node_modules/fast-string-truncated-width": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
-      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@sumup-oss/foundry/node_modules/fast-string-width": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
-      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-string-truncated-width": "^3.0.2"
-      }
-    },
-    "node_modules/@sumup-oss/foundry/node_modules/fast-wrap-ansi": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
-      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-string-width": "^3.0.2"
       }
     },
     "node_modules/@sumup-oss/foundry/node_modules/is-ci": {
@@ -12755,12 +12685,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/astro/node_modules/package-manager-detector": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
-      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
-      "license": "MIT"
-    },
     "node_modules/astro/node_modules/yargs-parser": {
       "version": "22.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
@@ -13121,19 +13045,6 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
-    "node_modules/better-path-resolve": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
-      "integrity": "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-windows": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -13331,6 +13242,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/cac": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/cacache": {
@@ -14933,16 +14854,6 @@
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "license": "MIT"
     },
-    "node_modules/detect-indent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -15329,19 +15240,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/entities": {
@@ -16562,13 +16460,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
-    "node_modules/extendable-error": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
-      "integrity": "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16612,18 +16503,18 @@
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
-      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
-      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
       "license": "MIT",
       "dependencies": {
-        "fast-string-truncated-width": "^1.2.0"
+        "fast-string-truncated-width": "^3.0.2"
       }
     },
     "node_modules/fast-uri": {
@@ -16643,12 +16534,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
-      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
       "license": "MIT",
       "dependencies": {
-        "fast-string-width": "^1.1.0"
+        "fast-string-width": "^3.0.2"
       }
     },
     "node_modules/fast-xml-builder": {
@@ -17048,21 +16939,6 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
     },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
@@ -18116,9 +17992,9 @@
       }
     },
     "node_modules/human-id": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.1.tgz",
-      "integrity": "sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
+      "integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -18981,19 +18857,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-subdir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
-      "integrity": "sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "better-path-resolve": "1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-symbol": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
@@ -19118,16 +18981,6 @@
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
       "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
       "devOptional": true
-    },
-    "node_modules/is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -21202,16 +21055,6 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -21370,6 +21213,17 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/launch-editor": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+      "integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1",
+        "shell-quote": "^1.8.4"
+      }
     },
     "node_modules/lerna": {
       "version": "9.0.7",
@@ -22317,13 +22171,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "node_modules/lodash.startcase": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash.template": {
       "version": "4.18.1",
@@ -24012,15 +23859,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -24940,13 +24778,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/outdent": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
-      "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -25033,29 +24864,6 @@
         "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
         "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
         "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
-      }
-    },
-    "node_modules/p-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-filter/node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/p-finally": {
@@ -25213,14 +25021,10 @@
       "devOptional": true
     },
     "node_modules/package-manager-detector": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
-      "integrity": "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quansync": "^0.2.7"
-      }
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
     },
     "node_modules/pacote": {
       "version": "21.0.1",
@@ -25983,22 +25787,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -26200,23 +25988,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
       "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
-      "license": "MIT"
-    },
-    "node_modules/quansync": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.10.tgz",
-      "integrity": "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/antfu"
-        },
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/sxzz"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -26641,42 +26412,6 @@
       }
     },
     "node_modules/read-pkg/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-yaml-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-yaml-file/-/read-yaml-file-1.1.0.tgz",
-      "integrity": "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.5",
-        "js-yaml": "^3.6.1",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/read-yaml-file/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/read-yaml-file/node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
@@ -27642,6 +27377,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/shiki": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.2.0.tgz",
@@ -27916,17 +27664,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/spawndamnit": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
-      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "cross-spawn": "^7.0.5",
-        "signal-exit": "^4.0.1"
       }
     },
     "node_modules/spdx-correct": {
@@ -29198,18 +28935,6 @@
       "integrity": "sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==",
       "license": "MIT"
     },
-    "node_modules/term-size": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
-      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -29325,9 +29050,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -30604,16 +30329,6 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
       "dev": true
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/unplugin": {
       "version": "2.3.11",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "release": "changeset publish"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.7.0",
-    "@changesets/cli": "^2.31.1",
+    "@changesets/changelog-github": "^1.0.0",
+    "@changesets/cli": "^3.0.0",
     "@emotion/eslint-plugin": "^11.12.0",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",


### PR DESCRIPTION
## Purpose

[Changesets v3](https://changesets.dev/blog/announcing-changesets-v3) was released a couple of days ago. It removes the dependency on `node-fetch` which required us to pin the Node version in CI (see https://github.com/sumup-oss/circuit-ui/pull/3736) and contains a couple of other handy improvements such as treating peer dependency bumps as a patch instead of as a major.

## Approach and changes

- Upgrade `@changesets/*` packages following the [migration guide](https://changesets.dev/guide/migration)

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
