### PR TITLE
Fix bundling of illustration styles

### DIFF
--- a/.changeset/tired-doodles-deny.md
+++ b/.changeset/tired-doodles-deny.md
@@ -1,0 +1,6 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed bundling of the styles for the recently added `@sumup-oss/illustrations` sub-dependency.
+  

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/sumup-oss/circuit-ui/tree/main/packages/circuit-ui/README.md",
   "scripts": {
-    "build": "vite build && tsc -p tsconfig.build.json && rm -rf dist/node_modules",
+    "build": "vite build && mv dist/circuit-ui/* dist && rm -rf dist/circuit-ui && tsc -p tsconfig.build.json && rm -rf dist/node_modules",
     "lint": "foundry run eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "npm run lint -- --fix",
     "test": "vitest"

--- a/packages/circuit-ui/vite.config.ts
+++ b/packages/circuit-ui/vite.config.ts
@@ -36,11 +36,12 @@ const externalPackages = [
 ];
 
 const isExternal = (id: string) =>
-  externalPackages.some(
+  id !== '@sumup-oss/illustrations/styles.css' &&
+  (externalPackages.some(
     (packageName) => id === packageName || id.startsWith(`${packageName}/`),
   ) ||
-  id === 'react/jsx-runtime' ||
-  id === '@emotion/react/jsx-runtime';
+    id === 'react/jsx-runtime' ||
+    id === '@emotion/react/jsx-runtime');
 
 export default defineConfig({
   css,


### PR DESCRIPTION
## Purpose

#3810 added `@sumup-oss/illustrations` as a sub-dependency of `@sumup-oss/circuit-ui` and imported its styles internally. Due to how Vite is configured to leave imports from external packages untouched, the styles weren't bundled into the `styles.css` file as expected and instead the style import ended up unchanged in the bundle. This broke apps and bundlers that can't process CSS imports.

## Approach and changes

- Exclude `@sumup-oss/illustrations/styles.css` from the list of external dependencies

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
