### PR TITLE
override bg-normal on elevated surfaces

### DIFF
--- a/.changeset/loud-geese-send.md
+++ b/.changeset/loud-geese-send.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Improved the visual consistency of components in elevated surfaces with their containers. Children of components like Dialog and Popver now use `--cui-bg-elevated` as the value of `--cui-bg-normal`, ensuring consistent backgrounds throughout the component.

--- a/packages/circuit-ui/components/ActionMenu/ActionMenu.module.css
+++ b/packages/circuit-ui/components/ActionMenu/ActionMenu.module.css
@@ -4,7 +4,6 @@
   box-sizing: border-box;
   padding: var(--vertical-spacing) 0;
   overflow-y: auto;
-  background-color: var(--cui-bg-elevated);
   border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
   border-radius: var(--cui-border-radius-byte);
 }

--- a/packages/circuit-ui/components/ActionMenu/components/ActionMenuItem.module.css
+++ b/packages/circuit-ui/components/ActionMenu/components/ActionMenuItem.module.css
@@ -6,7 +6,6 @@
   font-size: var(--cui-body-m-font-size);
   line-height: var(--cui-body-m-line-height);
   text-align: left;
-  background: var(--cui-bg-elevated);
 }
 
 .icon {

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.module.css
@@ -2,7 +2,6 @@
   z-index: var(--cui-z-index-popover);
   max-height: min(443px, var(--results-max-height));
   overflow-y: auto;
-  background-color: var(--cui-bg-elevated);
   border-radius: var(--cui-border-radius-byte);
   box-shadow: 0 3px 8px 0 rgb(0 0 0 / 20%);
 }

--- a/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/packages/circuit-ui/components/AutocompleteInput/AutocompleteInput.tsx
@@ -66,6 +66,8 @@ import {
   type ComboboxInputProps,
 } from './components/ComboboxInput/ComboboxInput.js';
 import type { AutocompleteInputOption } from './components/Option/Option.js';
+import { clsx } from '../../styles/clsx.js';
+import { sharedClasses } from '../../styles/shared.js';
 
 export type AutocompleteInputProps = Omit<
   ComboboxInputProps,
@@ -602,7 +604,7 @@ export const AutocompleteInput = forwardRef<
         </div>
         {isOpen && (
           <div
-            className={classes.results}
+            className={clsx(sharedClasses.elevatedSurface, classes.results)}
             ref={refs.setFloating}
             style={{
               ...floatingStyles,

--- a/packages/circuit-ui/components/AutocompleteInput/components/Option/Option.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/components/Option/Option.module.css
@@ -5,7 +5,6 @@
   padding: var(--cui-spacings-byte);
   margin-bottom: var(--cui-spacings-bit);
   cursor: pointer;
-  background-color: var(--cui-bg-elevated);
   border-radius: var(--cui-border-radius-byte);
   transition: all var(--cui-transitions-default);
 }

--- a/packages/circuit-ui/components/Dialog/Dialog.tsx
+++ b/packages/circuit-ui/components/Dialog/Dialog.tsx
@@ -41,6 +41,7 @@ import { useSwipe } from '../../hooks/useSwipe/index.js';
 
 import classes from './Dialog.module.css';
 import { translations } from './translations/index.js';
+import { sharedClasses } from '../../styles/shared.js';
 
 type DataAttribute = `data-${string}`;
 
@@ -440,7 +441,12 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: The click event captures outside clicks */}
         <dialog
           onClick={onDialogClick}
-          className={clsx(classes.base, isModal && classes.modal, className)}
+          className={clsx(
+            classes.base,
+            isModal && sharedClasses.elevatedSurface,
+            isModal && classes.modal,
+            className,
+          )}
           ref={applyMultipleRefs(ref, dialogRef)}
           style={{
             ...style,

--- a/packages/circuit-ui/components/Popover/Popover.tsx
+++ b/packages/circuit-ui/components/Popover/Popover.tsx
@@ -247,6 +247,7 @@ export const Popover = forwardRef<HTMLDialogElement, PopoverProps>(
           ref={applyMultipleRefs(ref, refs.setFloating, dialogRef)}
           className={clsx(
             classes.base,
+            sharedClasses.elevatedSurface,
             isClosing ? outAnimation : inAnimation,
             isMobile && !disableModalOnMobile && classes.modal,
             isMobile && disableModalOnMobile && classes['non-modal'],

--- a/packages/circuit-ui/components/Toggletip/Toggletip.tsx
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.tsx
@@ -47,6 +47,7 @@ import { Button, type ButtonProps } from '../Button/index.js';
 import { Dialog, type PublicDialogProps } from '../Dialog/Dialog.js';
 
 import classes from './Toggletip.module.css';
+import { sharedClasses } from '../../styles/shared.js';
 
 export interface ToggletipReferenceProps {
   'id': string;
@@ -212,7 +213,11 @@ export const Toggletip = forwardRef<HTMLDialogElement, ToggletipProps>(
           data-side={side}
           aria-labelledby={headline ? headlineId : bodyId}
           aria-describedby={headline ? bodyId : undefined}
-          className={clsx(classes.base, className)}
+          className={clsx(
+            classes.base,
+            sharedClasses.elevatedSurface,
+            className,
+          )}
           closeButtonLabel={closeButtonLabel}
           style={{ ...style, ...dialogStyles }}
         >

--- a/packages/circuit-ui/styles/shared.module.css
+++ b/packages/circuit-ui/styles/shared.module.css
@@ -246,3 +246,9 @@
     transform: translateX(100%);
   }
 }
+
+.elevated-surface {
+  --cui-bg-normal: var(--cui-bg-elevated);
+
+  background-color: var(--cui-bg-elevated);
+}

--- a/packages/circuit-ui/styles/shared.ts
+++ b/packages/circuit-ui/styles/shared.ts
@@ -30,4 +30,5 @@ export const sharedClasses = {
   animationSlideRightOut: _classes['animation-slide-right-out'],
   animationSlideLeftIn: _classes['animation-slide-left-in'],
   animationSlideLeftOut: _classes['animation-slide-left-out'],
+  elevatedSurface: _classes['elevated-surface'],
 };


### PR DESCRIPTION
Addresses [DSYS-1924](https://sumupteam.atlassian.net/browse/DSYS-1924)

## Purpose

In order to remove the visual difference of components that are placed in elevated surfaces, we should condition our components that have bg-normal fills to automatically change to bg-elevated if they are placed on top of an elevated surface.

## Approach and changes

- create a new shared class `elevatedSurface` that sets an element's bg color to `--cui-bg-elevated` and overrides `--cui-bg-normal` to the same value.
- use this className in the Dialog and and other components with elevated surfaces.
- remove explicit bg-elevated styles previously used to address this problem.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
