### PR TITLE
Improve focus ring

### DIFF
--- a/.changeset/chatty-turtles-bet.md
+++ b/.changeset/chatty-turtles-bet.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Improved styles of the `focusVisible` utility class to take into account the presence of a border on the element.

--- a/.changeset/chatty-turtles-bet.md
+++ b/.changeset/chatty-turtles-bet.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Changed the focus ring from using a `box-shadow` to using an `outline` to improve its visual appearance and to ensure the it stays visible in Windows High Contrast Mode.
+Changed the focus ring from using a `box-shadow` to using an `outline` to improve its visual appearance and to ensure it stays visible in Windows High Contrast Mode.

--- a/.changeset/chatty-turtles-bet.md
+++ b/.changeset/chatty-turtles-bet.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": patch
 ---
 
-Improved styles of the `focusVisible` utility class to take into account the presence of a border on the element.
+Changed the focus ring from using a `box-shadow` to using an `outline` to improve its visual appearance and to ensure the it stays visible in Windows High Contrast Mode.

--- a/packages/circuit-ui/components/Anchor/Anchor.module.css
+++ b/packages/circuit-ui/components/Anchor/Anchor.module.css
@@ -8,7 +8,6 @@
   text-align: left;
   text-decoration: underline;
   text-decoration-skip-ink: auto;
-  outline: none;
   background: none;
   border: 0;
   border-radius: var(--cui-border-radius-bit);

--- a/packages/circuit-ui/components/SideNavigation/components/Items/Items.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/Items/Items.module.css
@@ -9,7 +9,6 @@
   text-align: left;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
   background: none;
   border: none;
   border-radius: var(--cui-border-radius-byte);

--- a/packages/circuit-ui/components/Tag/Tag.module.css
+++ b/packages/circuit-ui/components/Tag/Tag.module.css
@@ -41,7 +41,6 @@ a.content,
 button.content {
   text-align: left;
   cursor: pointer;
-  outline: 0;
 }
 
 a.content:hover,

--- a/packages/circuit-ui/components/Toggle/Toggle.module.css
+++ b/packages/circuit-ui/components/Toggle/Toggle.module.css
@@ -20,7 +20,6 @@
   overflow: visible;
   appearance: none;
   cursor: pointer;
-  outline: 0;
   background-color: var(--cui-bg-normal);
   border: 1px solid var(--cui-border-normal);
   border-radius: var(--toggle-track-height);

--- a/packages/circuit-ui/styles/utility.module.css
+++ b/packages/circuit-ui/styles/utility.module.css
@@ -41,12 +41,14 @@ UTIL CLASSES MARKER START
 }
 
 .focus-visible:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline: 0;
 }
 
 .focus-visible-inset:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 2px var(--cui-border-focus);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: -2px;
 }
 
 .focus-visible-inset:focus::-moz-focus-inner {
@@ -54,7 +56,7 @@ UTIL CLASSES MARKER START
 }
 
 .focus-visible-inset:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline: 0;
 }
 
 .shadow {

--- a/packages/circuit-ui/styles/utility.module.css
+++ b/packages/circuit-ui/styles/utility.module.css
@@ -31,9 +31,8 @@ UTIL CLASSES MARKER START
 
 .focus-visible:focus {
   outline: 0;
-  box-shadow:
-    0 0 0 2px var(--cui-bg-normal),
-    0 0 0 4px var(--cui-border-focus);
+  border-color: var(--cui-border-focus);
+  box-shadow: 0 0 0 2px var(--cui-border-focus);
 }
 
 .focus-visible:focus::-moz-focus-inner {

--- a/packages/circuit-ui/styles/utility.module.css
+++ b/packages/circuit-ui/styles/utility.module.css
@@ -30,9 +30,10 @@ UTIL CLASSES MARKER START
 }
 
 .focus-visible:focus {
-  outline: 0;
-  border-color: var(--cui-border-focus);
-  box-shadow: 0 0 0 2px var(--cui-border-focus);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
 }
 
 .focus-visible:focus::-moz-focus-inner {


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

Currently `utilClasses.focusVisible` applies a double shadow effect to simulate a a focus outline. We can improve this by using the `outline-*` style properties instead.

<img width="207"  alt="Screenshot 2026-08-19 at 16 29 51" src="https://github.com/user-attachments/assets/c9ea2ace-652b-4673-bdac-bfb1a13860c0" />
<img width="207" " alt="Screenshot 2026-08-19 at 16 30 23" src="https://github.com/user-attachments/assets/cad7ef98-a233-423e-a902-0ecc435f4700" />


## Approach and changes

In the `focusVisible` and `focusVisibleInset` classes, use `offset-*` properties instead of `box-shadow`

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
