### PR TITLE
update link to Figma

### DIFF
--- a/packages/icons/CONTRIBUTING.md
+++ b/packages/icons/CONTRIBUTING.md
@@ -7,7 +7,7 @@ This page outlines the process of contributing an icon to the `@sumup-oss/icons`
 ## Adding a new icon
 
 1. Create a new SVG file for each icon size in [`packages/icons/web/v2/`](https://github.com/sumup-oss/circuit-ui/tree/main/packages/icons/web/v2) with the name `name_size.svg` (e.g. `add_items_24`—this will generate an `<AddItems />` component).
-2. Export the icon as SVG from the [Figma icons library](https://www.figma.com/file/vnFVuPNlqF45rkw1u9toBC/SumUp-Iconography) (internal link). If the icon isn't in the library, make a request with the design team first.
+2. Export the icon as SVG from the [Figma icons library](https://www.figma.com/design/OgPQeoNZ2QoY7hZvy0ybk2/Circuit-UI-Foundation?node-id=5700-12762) (internal link). If the icon isn't in the library, make a request with the design team first.
    ![Right click on the group in Figma and choose "Copy as SVG"](https://github.com/sumup-oss/circuit-ui/raw/main/assets/contributing-icons-export.png)
 3. Paste the SVG into your file and verify the code — refer to the ["Caveats"](#caveats) section below.
 4. Commit the icons, they will automatically be optimized in the precommit hook using `svgo`.


### PR DESCRIPTION
Iconography page

The link to the [Figma icons library](https://www.figma.com/file/vnFVuPNlqF45rkw1u9toBC/SumUp-Iconography) on  the icon contribution [guide](https://circuit.sumup.com/?path=/docs/contributing-contributing-icons--docs) is obsolete.

## Purpose

Update link to correct Figma file

## Approach and changes

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
