### PR TITLE
Fix templates workflow failure on release branches

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - "templates/**"
+    branches-ignore:
+      - "changeset-release/**"
+      - "changesets-ghcommit-temp/**"
   schedule:
     - cron: "0 3 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

This fixes `templates.yml` workflow failure on release branches

## Approach and changes

Skip the workflow on both ref patterns:

Release branches pin the templates to the version being released, which isn't on npm until the PR merges. So the install can never succeed. `changesets-ghcommit-temp/*` are staging refs changesets deletes immediately after pushing, so they're gone before the runner can clone them.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
