### PR TITLE
Skip template tests on branches that publish

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -7,6 +7,10 @@ on:
     branches-ignore:
       - "changeset-release/**"
       - "changesets-ghcommit-temp/**"
+      - "main"
+      - "next"
+      - "canary"
+      - "release/**"
   schedule:
     - cron: "0 3 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

`templates.yml`  fails on `main` and `next` after every minor release. 

## Approach and changes

Merging a release branch rewrites the templates' `@sumup-oss/circuit-ui` pin to the version being released, which triggers the templates workflow. However, publishing only happens at the end of `ci.yml`, so the version isn't on npm yet, and the install fails. Same cause as the release branch failures in [#3841](https://github.com/sumup-oss/circuit-ui/issues/3841)

- Adds the four refs that publish, per the release step in https://github.com/sumup-oss/circuit-ui/blob/main/.github/workflows/ci.yml#L58

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
