### PR TITLE
Improve WHCM outline styles

### DIFF
--- a/.changeset/plain-parks-walk.md
+++ b/.changeset/plain-parks-walk.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Improved some styles for Windows High Contrast Mode (text-decoration and focus-ring).

--- a/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/components/ComboboxInput/ComboboxInput.module.css
@@ -17,7 +17,7 @@
   padding: 0 var(--cui-spacings-tera) 0 0;
   margin: 0;
   appearance: none;
-  outline: 0;
+  outline-color: transparent;
   background-color: transparent;
   border: none;
   box-shadow: none;

--- a/packages/circuit-ui/components/AutocompleteInput/components/Option/Option.module.css
+++ b/packages/circuit-ui/components/AutocompleteInput/components/Option/Option.module.css
@@ -6,7 +6,7 @@
   margin-bottom: var(--cui-spacings-bit);
   cursor: pointer;
   border-radius: var(--cui-border-radius-byte);
-  transition: all var(--cui-transitions-default);
+  transition: background-color var(--cui-transitions-default);
 }
 
 .align-center {
@@ -23,8 +23,10 @@
 
 .base:focus,
 .base.focused {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--cui-border-accent);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
 }
 
 .selected {

--- a/packages/circuit-ui/components/Button/base.module.css
+++ b/packages/circuit-ui/components/Button/base.module.css
@@ -9,7 +9,7 @@
   font-size: var(--cui-body-m-font-size);
   font-weight: var(--cui-font-weight-semibold);
   text-align: center;
-  text-decoration: none;
+  text-decoration-color: transparent;
   cursor: pointer;
   border-style: solid;
   border-width: var(--cui-border-width-kilo);

--- a/packages/circuit-ui/components/Checkbox/CheckboxInput.module.css
+++ b/packages/circuit-ui/components/Checkbox/CheckboxInput.module.css
@@ -56,16 +56,16 @@
 }
 
 .base:focus + .label::before {
-  outline: 0;
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
   border-color: var(--cui-border-accent);
-  box-shadow:
-    0 0 0 2px var(--cui-bg-normal),
-    0 0 0 4px var(--cui-border-focus);
 }
 
 .base:focus:not(:focus-visible) + .label::before {
+  outline-color: transparent;
   border-color: var(--cui-border-normal);
-  box-shadow: none;
 }
 
 .base:checked:focus:not(:focus-visible) + .label::before,

--- a/packages/circuit-ui/components/ColorInput/ColorInput.module.css
+++ b/packages/circuit-ui/components/ColorInput/ColorInput.module.css
@@ -38,7 +38,7 @@
   padding: 0;
   appearance: none;
   cursor: pointer;
-  outline: none;
+  outline-color: transparent;
   border: none;
   border-radius: 6px;
   box-shadow: 0 0 0 1px var(--cui-border-normal);

--- a/packages/circuit-ui/components/DateInput/DateInput.module.css
+++ b/packages/circuit-ui/components/DateInput/DateInput.module.css
@@ -17,7 +17,7 @@
   gap: 2px;
   min-width: 170px;
   cursor: text;
-  outline: 0;
+  outline-color: transparent;
   background-color: var(--cui-bg-normal);
   border: 1px solid var(--cui-border-normal);
   box-shadow: none;

--- a/packages/circuit-ui/components/DateInput/components/DateSegment.module.css
+++ b/packages/circuit-ui/components/DateInput/components/DateSegment.module.css
@@ -26,7 +26,7 @@
 }
 
 .base:focus {
-  outline: none;
+  outline-color: transparent;
   background-color: var(--cui-bg-highlight);
 }
 

--- a/packages/circuit-ui/components/Dialog/Dialog.module.css
+++ b/packages/circuit-ui/components/Dialog/Dialog.module.css
@@ -1,7 +1,7 @@
 .base {
   padding: 0 !important;
   pointer-events: none;
-  outline: none;
+  outline-color: transparent;
   background-color: var(--cui-bg-elevated);
   border: none;
 }

--- a/packages/circuit-ui/components/ImageInput/ImageInput.module.css
+++ b/packages/circuit-ui/components/ImageInput/ImageInput.module.css
@@ -5,10 +5,10 @@
 }
 
 .input:focus + label > *:last-child {
-  outline: 0;
-  box-shadow:
-    0 0 0 2px var(--cui-bg-normal),
-    0 0 0 4px var(--cui-border-focus);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
 }
 
 .input:focus + label > *:last-child::-moz-focus-inner {
@@ -16,7 +16,7 @@
 }
 
 .input:focus:not(:focus-visible) + label > *:last-child {
-  box-shadow: none;
+  outline-color: transparent;
 }
 
 .base .label {
@@ -98,10 +98,10 @@
 /* Dragging */
 
 .label.dragging *:last-child {
-  outline: 0;
-  box-shadow:
-    0 0 0 2px var(--cui-bg-normal),
-    0 0 0 4px var(--cui-border-focus);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
 }
 
 .label.dragging *:last-child::-moz-focus-inner {

--- a/packages/circuit-ui/components/Input/Input.module.css
+++ b/packages/circuit-ui/components/Input/Input.module.css
@@ -9,7 +9,7 @@
   font-size: var(--field-input-font-size);
   line-height: var(--field-input-line-height);
   appearance: none;
-  outline: 0;
+  outline-color: transparent;
   background-color: var(--cui-bg-normal);
   border: 1px solid var(--cui-border-normal);
   border-radius: var(--field-input-border-radius);

--- a/packages/circuit-ui/components/ListItem/ListItem.module.css
+++ b/packages/circuit-ui/components/ListItem/ListItem.module.css
@@ -7,7 +7,7 @@
   margin: 0;
   color: var(--cui-fg-normal);
   text-align: left;
-  text-decoration: none;
+  text-decoration-color: transparent;
   background-color: var(--cui-bg-normal);
   border: var(--cui-border-width-mega) solid var(--cui-border-subtle);
   border-radius: var(--cui-border-radius-mega);

--- a/packages/circuit-ui/components/ListItem/ListItem.module.css
+++ b/packages/circuit-ui/components/ListItem/ListItem.module.css
@@ -43,11 +43,10 @@ button.base:hover {
 a.base:focus,
 button.base:focus {
   z-index: 2;
-  outline: 0;
-  border-color: transparent;
-  box-shadow:
-    0 0 0 4px var(--cui-bg-normal),
-    0 0 0 6px var(--cui-border-focus);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
 }
 
 a.base:focus::-moz-focus-inner,
@@ -58,8 +57,8 @@ button.base:focus::-moz-focus-inner {
 a.base:focus:not(:focus-visible),
 button.base:focus:not(:focus-visible) {
   z-index: auto;
+  outline-color: transparent;
   border-color: var(--cui-border-subtle);
-  box-shadow: none;
 }
 
 a.base:active,

--- a/packages/circuit-ui/components/RadioButtonGroup/RadioButtonInput.module.css
+++ b/packages/circuit-ui/components/RadioButtonGroup/RadioButtonInput.module.css
@@ -59,11 +59,11 @@
 }
 
 .base:focus + .label::before {
-  outline: 0;
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
   border-color: var(--cui-border-accent);
-  box-shadow:
-    0 0 0 2px var(--cui-bg-normal),
-    0 0 0 4px var(--cui-border-focus);
 }
 
 .base:focus:not(:focus-visible) + .label::before {

--- a/packages/circuit-ui/components/Select/Select.module.css
+++ b/packages/circuit-ui/components/Select/Select.module.css
@@ -15,7 +15,7 @@
   white-space: nowrap;
   appearance: none;
   cursor: pointer;
-  outline: none;
+  outline-color: transparent;
   background-color: var(--cui-bg-normal);
   border: 1px solid var(--cui-border-normal);
   box-shadow: none;

--- a/packages/circuit-ui/components/Selector/Selector.module.css
+++ b/packages/circuit-ui/components/Selector/Selector.module.css
@@ -1,12 +1,12 @@
 .base:focus + .label::before {
-  outline: 0;
-  box-shadow:
-    0 0 0 2px var(--cui-bg-normal),
-    0 0 0 4px var(--cui-border-focus);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
 }
 
 .base:focus:not(:focus-visible) + .label::before {
-  box-shadow: none;
+  outline-color: transparent;
 }
 
 /* Checked */

--- a/packages/circuit-ui/components/SideNavigation/components/Items/Items.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/Items/Items.module.css
@@ -7,7 +7,7 @@
   padding: var(--cui-spacings-byte);
   color: var(--cui-fg-normal);
   text-align: left;
-  text-decoration: none;
+  text-decoration-color: transparent;
   cursor: pointer;
   background: none;
   border: none;

--- a/packages/circuit-ui/components/SideNavigation/components/NavigationContent/NavigationContent.module.css
+++ b/packages/circuit-ui/components/SideNavigation/components/NavigationContent/NavigationContent.module.css
@@ -34,8 +34,10 @@
 
 .logo a:focus,
 .logo button:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 2px var(--cui-border-focus);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
 }
 
 .logo a:focus::-moz-focus-inner,
@@ -45,7 +47,7 @@
 
 .logo a:focus:not(:focus-visible),
 .logo button:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline-color: transparent;
 }
 
 .logo svg {

--- a/packages/circuit-ui/components/SidePanel/SidePanel.module.css
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.module.css
@@ -18,7 +18,7 @@
 }
 
 .wrapper {
-  outline: none;
+  outline-color: transparent;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.module.css
+++ b/packages/circuit-ui/components/Table/components/TableHeader/TableHeader.module.css
@@ -67,11 +67,11 @@
   display: block;
   width: 100%;
   height: 100%;
-  outline: 0;
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
   content: "";
-  box-shadow:
-    0 0 0 2px var(--cui-bg-normal),
-    0 0 0 4px var(--cui-border-focus);
 }
 
 .base[aria-sort]:focus-within,

--- a/packages/circuit-ui/components/Table/components/TableRow/TableRow.module.css
+++ b/packages/circuit-ui/components/Table/components/TableRow/TableRow.module.css
@@ -14,10 +14,9 @@ tbody .base:last-child td {
 
 .base[tabindex]:focus {
   z-index: 1;
-  outline: 0;
-  box-shadow:
-    0 0 0 2px var(--cui-bg-normal),
-    0 0 0 4px var(--cui-border-focus);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
 
   /* Chrome doesn't respect position: relative; on table elements so the transform property is used to create a separate stacking context which is needed to show the focus outline above the other table rows. */
   transform: translate(0, 0);
@@ -28,7 +27,7 @@ tbody .base:last-child td {
 }
 
 .base[tabindex]:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline-color: transparent;
 }
 
 tbody .base[tabindex]:focus td,

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.module.css
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.module.css
@@ -13,7 +13,6 @@
   white-space: nowrap;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
   background-color: var(--cui-bg-normal);
   border: none;
   border-radius: var(--cui-border-radius-bit);
@@ -34,17 +33,12 @@
   color: var(--cui-fg-normal-hovered);
 }
 
-.base:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 2px var(--cui-border-focus);
-}
-
 .base:focus::-moz-focus-inner {
   border: 0;
 }
 
 .base:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline-color: transparent;
 }
 
 .base:active {

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.module.css
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.module.css
@@ -11,7 +11,7 @@
   line-height: var(--cui-body-s-line-height);
   color: var(--cui-fg-subtle);
   white-space: nowrap;
-  text-decoration: none;
+  text-decoration-color: transparent;
   cursor: pointer;
   background-color: var(--cui-bg-normal);
   border: none;

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -28,6 +28,7 @@ import { clsx } from '../../../../styles/clsx.js';
 import type { TierIndicatorProps } from '../../../TierIndicator/TierIndicator.js';
 
 import classes from './Tab.module.css';
+import { utilClasses } from '../../../../styles/utility.js';
 
 type LinkElProps = AnchorHTMLAttributes<HTMLAnchorElement>;
 type ButtonElProps = ButtonHTMLAttributes<HTMLButtonElement>;
@@ -82,7 +83,7 @@ export function Tab({
     <Element
       ref={ref}
       role={as}
-      className={clsx(classes.base, className)}
+      className={clsx(classes.base, utilClasses.focusVisibleInset, className)}
       aria-selected={selected}
       tabIndex={tabIndex(selected)}
       {...props}
@@ -93,7 +94,7 @@ export function Tab({
     <div role="listitem">
       <Element
         ref={ref}
-        className={clsx(classes.base, className)}
+        className={clsx(classes.base, utilClasses.focusVisibleInset, className)}
         aria-current={selected ? 'page' : undefined}
         {...props}
       >

--- a/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
+++ b/packages/circuit-ui/components/Tabs/components/Tab/Tab.tsx
@@ -29,6 +29,7 @@ import type { TierIndicatorProps } from '../../../TierIndicator/TierIndicator.js
 
 import classes from './Tab.module.css';
 import { AccessibilityError } from '../../../../util/errors.js';
+import { utilClasses } from '../../../../styles/utility.js';
 
 type LinkElProps = AnchorHTMLAttributes<HTMLAnchorElement>;
 type ButtonElProps = ButtonHTMLAttributes<HTMLButtonElement>;
@@ -107,7 +108,7 @@ export function Tab({
     <Element
       ref={ref}
       role={as}
-      className={clsx(classes.base, className)}
+      className={clsx(classes.base, utilClasses.focusVisibleInset, className)}
       aria-selected={selected}
       tabIndex={tabIndex(selected)}
       {...props}
@@ -118,7 +119,7 @@ export function Tab({
     <div role="listitem">
       <Element
         ref={ref}
-        className={clsx(classes.base, className)}
+        className={clsx(classes.base, utilClasses.focusVisibleInset, className)}
         aria-current={selected ? 'page' : undefined}
         {...props}
       >

--- a/packages/circuit-ui/components/Toggletip/Toggletip.module.css
+++ b/packages/circuit-ui/components/Toggletip/Toggletip.module.css
@@ -28,7 +28,7 @@
 .content {
   padding: var(--cui-spacings-mega);
   color: var(--cui-fg-normal);
-  outline: 0;
+  outline-color: transparent;
   background-color: var(--cui-bg-elevated);
   border: var(--cui-border-width-kilo) solid var(--cui-border-subtle);
   border-radius: var(--cui-border-radius-byte);

--- a/packages/circuit-ui/components/TopNavigation/TopNavigation.module.css
+++ b/packages/circuit-ui/components/TopNavigation/TopNavigation.module.css
@@ -33,8 +33,10 @@
 
 .logo a:focus,
 .logo button:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 2px var(--cui-border-focus);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: var(--cui-border-width-mega);
 }
 
 .logo a:focus::-moz-focus-inner,
@@ -44,7 +46,7 @@
 
 .logo a:focus:not(:focus-visible),
 .logo button:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline-color: transparent;
 }
 
 @media (min-width: 1024px) {

--- a/packages/circuit-ui/styles/shared.module.css
+++ b/packages/circuit-ui/styles/shared.module.css
@@ -14,8 +14,10 @@
 }
 
 .list-item:focus {
-  outline: 0;
-  box-shadow: inset 0 0 0 2px var(--cui-border-focus);
+  outline-width: var(--cui-border-width-mega);
+  outline-style: solid;
+  outline-color: var(--cui-border-focus);
+  outline-offset: calc(-1 * var(--cui-border-width-mega));
 }
 
 .list-item:focus::-moz-focus-inner {
@@ -23,7 +25,7 @@
 }
 
 .list-item:focus:not(:focus-visible) {
-  box-shadow: none;
+  outline-color: transparent;
 }
 
 .list-item:active {

--- a/packages/circuit-ui/styles/shared.module.css
+++ b/packages/circuit-ui/styles/shared.module.css
@@ -3,7 +3,7 @@
   padding: var(--cui-spacings-byte) var(--cui-spacings-giga)
     var(--cui-spacings-byte) var(--cui-spacings-kilo);
   color: var(--cui-fg-normal);
-  text-decoration: none;
+  text-decoration-color: transparent;
   background-color: var(--cui-bg-normal);
   border: 0;
 }

--- a/packages/circuit-ui/styles/utility.module.css
+++ b/packages/circuit-ui/styles/utility.module.css
@@ -41,14 +41,14 @@ UTIL CLASSES MARKER START
 }
 
 .focus-visible:focus:not(:focus-visible) {
-  outline: 0;
+  outline-color: transparent;
 }
 
 .focus-visible-inset:focus {
   outline-width: var(--cui-border-width-mega);
   outline-style: solid;
   outline-color: var(--cui-border-focus);
-  outline-offset: -2px;
+  outline-offset: calc(-1 * var(--cui-border-width-mega));
 }
 
 .focus-visible-inset:focus::-moz-focus-inner {


### PR DESCRIPTION
## Purpose

Currently some component styles behave poorly in WHCM due to poorly styled focus states. Setting `outline: 0` prevents WHCM from correctly drawing focus rings and thus prevents users who rely on this mode from identifying what the currently focus element is, significantly deteriorating their user experience.

## Approach and changes

use `outline-color` and `text-decoration-color` properties instead of removing outline and text decoration altogether. 

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
