### PR TITLE
Throw development errors for legacy typography sizes

### DIFF
--- a/.changeset/polite-jeans-float.md
+++ b/.changeset/polite-jeans-float.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": minor
 ---
 
-Updated typography components to throw development-time errors when legacy sizes values are used.  
+Updated typography components to throw development-time errors when legacy size values are used.  

--- a/.changeset/polite-jeans-float.md
+++ b/.changeset/polite-jeans-float.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Updated typography components to throw development-time errors when legacy sizes values are used.  

--- a/packages/circuit-ui/components/Body/Body.spec.tsx
+++ b/packages/circuit-ui/components/Body/Body.spec.tsx
@@ -35,6 +35,50 @@ describe('Body', () => {
     expect(ref.current).toBe(paragraph);
   });
 
+  const deprecatedVariants = [
+    [
+      'highlight',
+      'The "highlight" variant has been deprecated. Use the new `weight` prop instead.',
+    ],
+    [
+      'quote',
+      'The "quote" variant has been deprecated. Use custom CSS instead.',
+    ],
+    [
+      'confirm',
+      'The "confirm" variant has been deprecated. Use the new `color` prop instead.',
+    ],
+    [
+      'alert',
+      'The "alert" variant has been deprecated. Use the new `color` prop instead.',
+    ],
+    [
+      'subtle',
+      'The "subtle" variant has been deprecated. Use the new `color` prop instead.',
+    ],
+  ] as const;
+  it.each(
+    deprecatedVariants,
+  )('[Deprecated variants] should throw an error when a deprecated "%s" variant is passed', (variant, error) => {
+    process.env.NODE_ENV = 'development';
+    // eslint-disable-next-line circuit-ui/no-deprecated-props
+    expect(() => render(<Body variant={variant}>Body</Body>)).toThrow(error);
+  });
+
+  const deprecatedSizes = [
+    ['one', 'm'],
+    ['two', 's'],
+  ] as const;
+  it.each(
+    deprecatedSizes,
+  )('[Deprecated sizes] should throw an error when legacy "%s" value is passed to the size prop', (size, alternative) => {
+    process.env.NODE_ENV = 'development';
+    expect(() => render(<Body size={size}>Body</Body>)).toThrow(
+      `[Body] The "${size}" size has been deprecated. Use the "${alternative}" size instead.`,
+    );
+    process.env.NODE_ENV = 'test';
+  });
+
   const elements = ['p', 'article', 'div'] as const;
   it.each(elements)('should render as a "%s" element', (as) => {
     const { container } = render(<Body as={as}>{as} Body</Body>);

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -17,9 +17,9 @@ import type { HTMLAttributes, Ref } from 'react';
 
 import type { AsPropType } from '../../types/prop-types.js';
 import { clsx } from '../../styles/clsx.js';
-import { deprecate } from '../../util/logger.js';
 
 import classes from './Body.module.css';
+import { CircuitError } from '../../util/errors.js';
 
 type Variant = 'highlight' | 'quote' | 'confirm' | 'alert' | 'subtle';
 
@@ -117,28 +117,35 @@ export function Body({
 }: BodyProps) {
   const Element = as || getHTMLElement(variant);
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test'
+  ) {
     if (variant) {
       if (variant === 'highlight') {
-        deprecate(
+        throw new CircuitError(
           'Body',
           'The "highlight" variant has been deprecated. Use the new `weight` prop instead.',
         );
-      } else if (variant === 'quote') {
-        deprecate(
+      }
+      if (variant === 'quote') {
+        throw new CircuitError(
           'Body',
           'The "quote" variant has been deprecated. Use custom CSS instead.',
         );
-      } else {
-        deprecate(
-          'Body',
-          `The "${variant}" variant has been deprecated. Use the new \`color\` prop instead.`,
-        );
       }
+      throw new CircuitError(
+        'Body',
+        `The "${variant}" variant has been deprecated. Use the new \`color\` prop instead.`,
+      );
     }
 
-    if (legacySize in deprecatedSizeMap) {
-      deprecate(
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test' &&
+      legacySize in deprecatedSizeMap
+    ) {
+      throw new CircuitError(
         'Body',
         `The "${legacySize}" size has been deprecated. Use the "${deprecatedSizeMap[legacySize]}" size instead.`,
       );

--- a/packages/circuit-ui/components/Display/Display.spec.tsx
+++ b/packages/circuit-ui/components/Display/Display.spec.tsx
@@ -43,6 +43,56 @@ describe('Display', () => {
     expect(ref.current).toBe(headline);
   });
 
+  it('should throw an error if the as props is missing', () => {
+    process.env.NODE_ENV = 'development';
+    // @ts-expect-error for testing purposes
+    expect(() => render(<Display>Body</Display>)).toThrow(
+      'The `as` prop is required.',
+    );
+    process.env.NODE_ENV = 'test';
+  });
+
+  const deprecatedSizes = [
+    ['one', 'l'],
+    ['two', 'm'],
+    ['three', 'm'],
+    ['four', 's'],
+  ] as const;
+  it.each(
+    deprecatedSizes,
+  )('[Deprecated sizes] should throw an error when legacy "%s" value is passed to the size prop', (size, alternative) => {
+    // eslint-disable-next-line circuit-ui/no-deprecated-props
+    process.env.NODE_ENV = 'development';
+    expect(() =>
+      render(
+        <Display as="h2" size={size}>
+          Body
+        </Display>,
+      ),
+    ).toThrow(
+      `The "${size}" size has been deprecated. Use the "${alternative}" size instead.`,
+    );
+    process.env.NODE_ENV = 'test';
+  });
+
+  const deprecatedWeights = ['regular', 'semibold'] as const;
+  it.each(
+    deprecatedWeights,
+  )('[Deprecated weights] should throw an error when legacy "%s" value is passed to the size prop', (weight) => {
+    // eslint-disable-next-line circuit-ui/no-deprecated-props
+    process.env.NODE_ENV = 'development';
+    expect(() =>
+      render(
+        <Display as="h2" weight={weight}>
+          Body
+        </Display>,
+      ),
+    ).toThrow(
+      `[Display] The "${weight}" weight has been deprecated. Use the "bold" or "black" weights instead.`,
+    );
+    process.env.NODE_ENV = 'test';
+  });
+
   it('should meet accessibility guidelines', async () => {
     const { container } = render(<Display as="h2">Display</Display>);
     const actual = await axe(container);

--- a/packages/circuit-ui/components/Display/Display.tsx
+++ b/packages/circuit-ui/components/Display/Display.tsx
@@ -17,7 +17,6 @@ import type { HTMLAttributes, Ref } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
 import { CircuitError } from '../../util/errors.js';
-import { deprecate } from '../../util/logger.js';
 
 import classes from './Display.module.css';
 
@@ -112,9 +111,10 @@ export function Display({
 
   if (
     process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
     (weight === 'regular' || weight === 'semibold')
   ) {
-    deprecate(
+    throw new CircuitError(
       'Display',
       `The "${weight}" weight has been deprecated. Use the "bold" or "black" weights instead.`,
     );
@@ -122,9 +122,10 @@ export function Display({
 
   if (
     process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
     legacySize in deprecatedSizeMap
   ) {
-    deprecate(
+    throw new CircuitError(
       'Display',
       `The "${legacySize}" size has been deprecated. Use the "${deprecatedSizeMap[legacySize]}" size instead.`,
     );

--- a/packages/circuit-ui/components/Headline/Headline.spec.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.spec.tsx
@@ -43,6 +43,38 @@ describe('Headline', () => {
     expect(ref.current).toBe(headline);
   });
 
+  it('should throw an error if the as props is missing', () => {
+    process.env.NODE_ENV = 'development';
+    // @ts-expect-error for testing purposes
+    expect(() => render(<Headline>Headline</Headline>)).toThrow(
+      'The `as` prop is required.',
+    );
+    process.env.NODE_ENV = 'test';
+  });
+
+  const deprecatedSizes = [
+    ['one', 'l'],
+    ['two', 'm'],
+    ['three', 's'],
+    ['four', 's'],
+  ] as const;
+  it.each(
+    deprecatedSizes,
+  )('[Deprecated sizes] should throw an error when legacy "%s" value is passed to the size prop', (size, alternative) => {
+    // eslint-disable-next-line circuit-ui/no-deprecated-props
+    process.env.NODE_ENV = 'development';
+    expect(() =>
+      render(
+        <Headline as="h2" size={size}>
+          Body
+        </Headline>,
+      ),
+    ).toThrow(
+      `[Headline] The "${size}" size has been deprecated. Use the "${alternative}" size instead.`,
+    );
+    process.env.NODE_ENV = 'test';
+  });
+
   it('should meet accessibility guidelines', async () => {
     const { container } = render(<Headline as="h2">Headline</Headline>);
     const actual = await axe(container);

--- a/packages/circuit-ui/components/Headline/Headline.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.tsx
@@ -17,7 +17,6 @@ import type { HTMLAttributes, Ref } from 'react';
 
 import { clsx } from '../../styles/clsx.js';
 import { CircuitError } from '../../util/errors.js';
-import { deprecate } from '../../util/logger.js';
 
 import classes from './Headline.module.css';
 
@@ -80,9 +79,10 @@ export function Headline({
 
   if (
     process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
     legacySize in deprecatedSizeMap
   ) {
-    deprecate(
+    throw new CircuitError(
       'Headline',
       `The "${legacySize}" size has been deprecated. Use the "${deprecatedSizeMap[legacySize]}" size instead.`,
     );

--- a/packages/circuit-ui/components/List/List.spec.tsx
+++ b/packages/circuit-ui/components/List/List.spec.tsx
@@ -43,6 +43,28 @@ describe('List', () => {
     expect(ref.current).toBe(list);
   });
 
+  const deprecatedSizes = [
+    ['one', 'm'],
+    ['two', 's'],
+  ] as const;
+  it.each(
+    deprecatedSizes,
+  )('[Deprecated sizes] should throw an error when legacy "%s" value is passed to the size prop', (size, alternative) => {
+    // eslint-disable-next-line circuit-ui/no-deprecated-props
+    process.env.NODE_ENV = 'development';
+    expect(() =>
+      render(
+        <List size={size}>
+          {' '}
+          <li>List</li>
+        </List>,
+      ),
+    ).toThrow(
+      `[List] The "${size}" size has been deprecated. Use the "${alternative}" size instead.`,
+    );
+    process.env.NODE_ENV = 'test';
+  });
+
   it('should meet accessibility guidelines', async () => {
     const { container } = render(
       <List>

--- a/packages/circuit-ui/components/List/List.tsx
+++ b/packages/circuit-ui/components/List/List.tsx
@@ -18,9 +18,9 @@ import type { OlHTMLAttributes, Ref } from 'react';
 import { clsx } from '../../styles/clsx.js';
 import type { BodyProps } from '../Body/index.js';
 import { deprecatedSizeMap } from '../Body/Body.js';
-import { deprecate } from '../../util/logger.js';
 
 import classes from './List.module.css';
+import { CircuitError } from '../../util/errors.js';
 
 export interface ListProps extends OlHTMLAttributes<HTMLOListElement> {
   ref?: Ref<HTMLOListElement>;
@@ -45,9 +45,10 @@ export function List({
 }: ListProps) {
   if (
     process.env.NODE_ENV !== 'production' &&
+    process.env.NODE_ENV !== 'test' &&
     legacySize in deprecatedSizeMap
   ) {
-    deprecate(
+    throw new CircuitError(
       'List',
       `The "${legacySize}" size has been deprecated. Use the "${deprecatedSizeMap[legacySize]}" size instead.`,
     );


### PR DESCRIPTION
Addresses [DSYS-1671](https://sumupteam.atlassian.net/browse/DSYS-1671)

## Purpose

We plan to remove legacy typography sizes in v13. Considering how intensively they are still used today, we want to start by throwing development-time errors in a first step to nudge developers to replace legacy values with new ones.

## Approach and changes

Throw a Circuit UI error when a legacy size value is detected in one of the following components:

- Body
- Headline
- Display
- List
- Anchor

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
