### PR TITLE
Use the Tooltip component instead of the title attribute in IconButton

### DIFF
--- a/.changeset/cyan-flies-sleep.md
+++ b/.changeset/cyan-flies-sleep.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": minor
+---
+
+Replaced the `title` attribute in IconButton with a [Tooltip](https://circuit.sumup.com/?path=/docs/components-tooltip--docs) to display its accessible name, since `title` is not accessible. IconButton's accessible name now comes from `aria-labelledby` instead of `aria-label`/`title`.

--- a/.changeset/cyan-flies-sleep.md
+++ b/.changeset/cyan-flies-sleep.md
@@ -2,4 +2,4 @@
 "@sumup-oss/circuit-ui": minor
 ---
 
-Replaced the `title` attribute in IconButton with a [Tooltip](https://circuit.sumup.com/?path=/docs/components-tooltip--docs) to display its accessible name, since `title` is not accessible. IconButton's accessible name now comes from `aria-labelledby` instead of `aria-label`/`title`.
+Replaced the `title` attribute in IconButton with a [Tooltip](https://circuit.sumup.com/?path=/docs/components-tooltip--docs) to display its accessible name, since `title` was not accessible to keyboard users.

--- a/packages/circuit-ui/components/Button/IconButton.spec.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.spec.tsx
@@ -13,10 +13,17 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { createRef } from 'react';
 import { Close } from '@sumup-oss/icons';
 
-import { render, screen } from '../../util/test-utils.js';
+import {
+  render,
+  axe,
+  screen,
+  userEvent,
+  within,
+} from '../../util/test-utils.js';
 
 import { IconButton } from './IconButton.js';
 
@@ -33,7 +40,8 @@ describe('IconButton', () => {
 
   it('should render a visually hidden label', () => {
     render(<IconButton icon={Close}>Close</IconButton>);
-    const label = screen.getByText('Close');
+    const button = screen.getByRole('button');
+    const label = within(button).getByText('Close');
     expect(label).toBeInTheDocument();
   });
 
@@ -41,5 +49,79 @@ describe('IconButton', () => {
     render(<IconButton icon={Close}>Close</IconButton>);
     const button = screen.getByRole('button');
     expect(button).toHaveAccessibleName('Close');
+  });
+
+  it('should forward a ref to the button element', () => {
+    const ref = createRef<HTMLButtonElement>();
+    render(
+      <IconButton icon={Close} ref={ref}>
+        Close
+      </IconButton>,
+    );
+    const button = screen.getByRole('button');
+    expect(ref.current).toBe(button);
+  });
+
+  it('should merge a custom className', () => {
+    render(
+      <IconButton icon={Close} className="foo">
+        Close
+      </IconButton>,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('foo');
+  });
+
+  it('should not render a native title attribute', () => {
+    render(<IconButton icon={Close}>Close</IconButton>);
+    const button = screen.getByRole('button');
+    expect(button).not.toHaveAttribute('title');
+  });
+
+  it('should render a tooltip with the label text', () => {
+    render(<IconButton icon={Close}>Close</IconButton>);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent('Close');
+    expect(tooltip).toHaveAttribute('data-state', 'closed');
+  });
+
+  it('should open the tooltip when the button is focused', async () => {
+    render(<IconButton icon={Close}>Close</IconButton>);
+
+    await userEvent.tab();
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveAttribute('data-state', 'open');
+  });
+
+  it('should open the tooltip when the button is hovered', async () => {
+    render(<IconButton icon={Close}>Close</IconButton>);
+    const button = screen.getByRole('button');
+
+    await userEvent.hover(button);
+
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveAttribute('data-state', 'open');
+  });
+
+  it('should call a custom onFocus handler in addition to opening the tooltip', async () => {
+    const onFocus = vi.fn();
+    render(
+      <IconButton icon={Close} onFocus={onFocus}>
+        Close
+      </IconButton>,
+    );
+
+    await userEvent.tab();
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveAttribute('data-state', 'open');
+  });
+
+  it('should have no accessibility violations', async () => {
+    const { container } = render(<IconButton icon={Close}>Close</IconButton>);
+    const actual = await axe(container);
+    expect(actual).toHaveNoViolations();
   });
 });

--- a/packages/circuit-ui/components/Button/IconButton.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.tsx
@@ -15,11 +15,13 @@
 
 'use client';
 
-import type {
-  FocusEvent,
-  FocusEventHandler,
-  MouseEvent,
-  MouseEventHandler,
+import {
+  useCallback,
+  useRef,
+  type FocusEvent,
+  type FocusEventHandler,
+  type MouseEvent,
+  type MouseEventHandler,
 } from 'react';
 import type { IconComponentType } from '@sumup-oss/icons';
 
@@ -72,9 +74,14 @@ export function IconButton({
     );
   }
 
-  const renderReference = (tooltipProps: TooltipReferenceProps) => {
+  const latest = useRef({ props, size, className });
+  latest.current = { props, size, className };
+
+  const renderReference = useCallback((tooltipProps: TooltipReferenceProps) => {
+    const { current } = latest;
+
     const { onFocus, onBlur, onMouseEnter, onMouseLeave, ...restProps } =
-      props as typeof props & {
+      current.props as typeof current.props & {
         onFocus?: FocusEventHandler;
         onBlur?: FocusEventHandler;
         onMouseEnter?: MouseEventHandler;
@@ -86,7 +93,7 @@ export function IconButton({
         {...restProps}
         {...tooltipProps}
         componentName="IconButton"
-        size={size}
+        size={current.size}
         onFocus={eachFn<[FocusEvent<Element>]>([onFocus, tooltipProps.onFocus])}
         onBlur={eachFn<[FocusEvent<Element>]>([onBlur, tooltipProps.onBlur])}
         onMouseEnter={eachFn<[MouseEvent<Element>]>([
@@ -99,13 +106,13 @@ export function IconButton({
         ])}
         className={clsx(
           classes.base,
-          classes[size],
+          classes[current.size],
           tooltipProps.className,
-          className,
+          current.className,
         )}
       />
     );
-  };
+  }, []);
 
   const isDecorative =
     props['aria-hidden'] === true || props['aria-hidden'] === 'true';

--- a/packages/circuit-ui/components/Button/IconButton.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.tsx
@@ -15,10 +15,13 @@
 
 'use client';
 
+import { useCallback, useRef } from 'react';
+import type { FocusEventHandler, MouseEventHandler } from 'react';
 import type { IconComponentType } from '@sumup-oss/icons';
 
 import { clsx } from '../../styles/clsx.js';
 import { deprecate } from '../../util/logger.js';
+import { Tooltip, type TooltipReferenceProps } from '../Tooltip/index.js';
 
 import {
   BaseButton,
@@ -32,7 +35,8 @@ export type IconButtonProps = SharedButtonProps & {
    * Communicates the action that will be performed when the user interacts
    * with the button. Use one strong, clear imperative verb and follow with a
    * one-word object if needed to clarify.
-   * Displayed on hover and accessible to screen readers.
+   * Used as the button's accessible name and displayed in a tooltip on
+   * hover and keyboard focus.
    */
   children: string;
   /**
@@ -63,14 +67,67 @@ export function IconButton({
     );
   }
 
+  const latest = useRef({ props, size, className });
+  latest.current = { props, size, className };
+
+  const renderReference = useCallback((tooltipProps: TooltipReferenceProps) => {
+    const { current } = latest;
+
+    const { onFocus, onBlur, onMouseEnter, onMouseLeave, ...restProps } =
+      current.props as typeof current.props & {
+        onFocus?: FocusEventHandler;
+        onBlur?: FocusEventHandler;
+        onMouseEnter?: MouseEventHandler;
+        onMouseLeave?: MouseEventHandler;
+      };
+
+    return (
+      <BaseButton
+        {...restProps}
+        {...tooltipProps}
+        componentName="IconButton"
+        size={current.size}
+        onFocus={(event) => {
+          onFocus?.(event);
+          tooltipProps.onFocus(event);
+        }}
+        onBlur={(event) => {
+          onBlur?.(event);
+          tooltipProps.onBlur(event);
+        }}
+        onMouseEnter={(event) => {
+          onMouseEnter?.(event);
+          tooltipProps.onMouseEnter(event);
+        }}
+        onMouseLeave={(event) => {
+          onMouseLeave?.(event);
+          tooltipProps.onMouseLeave(event);
+        }}
+        className={clsx(
+          classes.base,
+          classes[current.size],
+          tooltipProps.className,
+          current.className,
+        )}
+      />
+    );
+  }, []);
+
+  const isDecorative =
+    props['aria-hidden'] === true || props['aria-hidden'] === 'true';
+
+  if (isDecorative) {
+    return (
+      <BaseButton
+        {...props}
+        componentName="IconButton"
+        size={size}
+        className={clsx(classes.base, classes[size], className)}
+      />
+    );
+  }
+
   return (
-    <BaseButton
-      componentName="IconButton"
-      className={clsx(classes.base, classes[size], className)}
-      size={size}
-      title={props.children}
-      aria-label={props.children}
-      {...props}
-    />
+    <Tooltip type="label" label={props.children} component={renderReference} />
   );
 }

--- a/packages/circuit-ui/components/Button/IconButton.tsx
+++ b/packages/circuit-ui/components/Button/IconButton.tsx
@@ -15,11 +15,16 @@
 
 'use client';
 
-import { useCallback, useRef } from 'react';
-import type { FocusEventHandler, MouseEventHandler } from 'react';
+import type {
+  FocusEvent,
+  FocusEventHandler,
+  MouseEvent,
+  MouseEventHandler,
+} from 'react';
 import type { IconComponentType } from '@sumup-oss/icons';
 
 import { clsx } from '../../styles/clsx.js';
+import { eachFn } from '../../util/helpers.js';
 import { deprecate } from '../../util/logger.js';
 import { Tooltip, type TooltipReferenceProps } from '../Tooltip/index.js';
 
@@ -67,14 +72,9 @@ export function IconButton({
     );
   }
 
-  const latest = useRef({ props, size, className });
-  latest.current = { props, size, className };
-
-  const renderReference = useCallback((tooltipProps: TooltipReferenceProps) => {
-    const { current } = latest;
-
+  const renderReference = (tooltipProps: TooltipReferenceProps) => {
     const { onFocus, onBlur, onMouseEnter, onMouseLeave, ...restProps } =
-      current.props as typeof current.props & {
+      props as typeof props & {
         onFocus?: FocusEventHandler;
         onBlur?: FocusEventHandler;
         onMouseEnter?: MouseEventHandler;
@@ -86,32 +86,26 @@ export function IconButton({
         {...restProps}
         {...tooltipProps}
         componentName="IconButton"
-        size={current.size}
-        onFocus={(event) => {
-          onFocus?.(event);
-          tooltipProps.onFocus(event);
-        }}
-        onBlur={(event) => {
-          onBlur?.(event);
-          tooltipProps.onBlur(event);
-        }}
-        onMouseEnter={(event) => {
-          onMouseEnter?.(event);
-          tooltipProps.onMouseEnter(event);
-        }}
-        onMouseLeave={(event) => {
-          onMouseLeave?.(event);
-          tooltipProps.onMouseLeave(event);
-        }}
+        size={size}
+        onFocus={eachFn<[FocusEvent<Element>]>([onFocus, tooltipProps.onFocus])}
+        onBlur={eachFn<[FocusEvent<Element>]>([onBlur, tooltipProps.onBlur])}
+        onMouseEnter={eachFn<[MouseEvent<Element>]>([
+          onMouseEnter,
+          tooltipProps.onMouseEnter,
+        ])}
+        onMouseLeave={eachFn<[MouseEvent<Element>]>([
+          onMouseLeave,
+          tooltipProps.onMouseLeave,
+        ])}
         className={clsx(
           classes.base,
-          classes[current.size],
+          classes[size],
           tooltipProps.className,
-          current.className,
+          className,
         )}
       />
     );
-  }, []);
+  };
 
   const isDecorative =
     props['aria-hidden'] === true || props['aria-hidden'] === 'true';

--- a/packages/circuit-ui/components/Pagination/Pagination.spec.tsx
+++ b/packages/circuit-ui/components/Pagination/Pagination.spec.tsx
@@ -32,14 +32,14 @@ describe('Pagination', () => {
 
   it('should disable the previous button on the first page', () => {
     render(<Pagination {...baseProps} currentPage={1} />);
-    const prevButtonEl = screen.getByText('Previous').closest('button');
+    const prevButtonEl = screen.getByRole('button', { name: 'Previous' });
 
     expect(prevButtonEl).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('should disable the next button on the last page', () => {
     render(<Pagination {...baseProps} currentPage={baseProps.totalPages} />);
-    const nextButtonEl = screen.getByText('Next').closest('button');
+    const nextButtonEl = screen.getByRole('button', { name: 'Next' });
 
     expect(nextButtonEl).toHaveAttribute('aria-disabled', 'true');
   });
@@ -48,7 +48,7 @@ describe('Pagination', () => {
     const onChange = vi.fn();
     render(<Pagination {...baseProps} onChange={onChange} currentPage={3} />);
 
-    const prevButtonEl = screen.getByText('Previous');
+    const prevButtonEl = screen.getByRole('button', { name: 'Previous' });
 
     await userEvent.click(prevButtonEl);
 
@@ -60,7 +60,7 @@ describe('Pagination', () => {
     const onChange = vi.fn();
     render(<Pagination {...baseProps} onChange={onChange} />);
 
-    const nextButtonEl = screen.getByText('Next');
+    const nextButtonEl = screen.getByRole('button', { name: 'Next' });
 
     await userEvent.click(nextButtonEl);
 

--- a/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanel.spec.tsx
@@ -70,7 +70,9 @@ describe('SidePanel', () => {
     const onClose = vi.fn();
     renderComponent({ onClose });
 
-    await userEvent.click(screen.getByTitle(closeButtonLabel));
+    await userEvent.click(
+      screen.getByRole('button', { name: closeButtonLabel }),
+    );
 
     expect(onClose).toHaveBeenCalled();
   });
@@ -95,7 +97,7 @@ describe('SidePanel', () => {
     const onClose = vi.fn();
     renderComponent({ onClose });
 
-    const sidePanel = screen.getByText('Close');
+    const sidePanel = screen.getByRole('button', { name: 'Close' });
 
     await waitFor(() => expect(sidePanel).toBeVisible());
 
@@ -109,7 +111,9 @@ describe('SidePanel', () => {
       renderComponent();
 
       expect(
-        screen.queryByTitle(baseProps.backButtonLabel as string),
+        screen.queryByRole('button', {
+          name: baseProps.backButtonLabel as string,
+        }),
       ).toBeNull();
     });
   });
@@ -120,7 +124,9 @@ describe('SidePanel', () => {
       renderComponent({ onBack });
 
       expect(
-        screen.getByTitle(baseProps.backButtonLabel as string),
+        screen.getByRole('button', {
+          name: baseProps.backButtonLabel as string,
+        }),
       ).toBeVisible();
     });
 
@@ -129,7 +135,9 @@ describe('SidePanel', () => {
       renderComponent({ onBack });
 
       await userEvent.click(
-        screen.getByTitle(baseProps.backButtonLabel as string),
+        screen.getByRole('button', {
+          name: baseProps.backButtonLabel as string,
+        }),
       );
 
       expect(onBack).toHaveBeenCalled();

--- a/packages/circuit-ui/components/SidePanel/SidePanelContext.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/SidePanelContext.spec.tsx
@@ -222,7 +222,7 @@ describe('SidePanelContext', () => {
 
         await userEvent.click(screen.getByText('Open panel'));
         await userEvent.click(screen.getByText('Open second panel'));
-        await userEvent.click(screen.getByText('Back'));
+        await userEvent.click(screen.getByRole('button', { name: 'Back' }));
         act(() => {
           vi.runAllTimers();
         });
@@ -253,7 +253,7 @@ describe('SidePanelContext', () => {
 
         await userEvent.click(screen.getByText('Open panel'));
         await userEvent.click(screen.getByText('Open second panel'));
-        await userEvent.click(screen.getByText('Back'));
+        await userEvent.click(screen.getByRole('button', { name: 'Back' }));
         act(() => {
           vi.runAllTimers();
         });

--- a/packages/circuit-ui/components/SidePanel/components/Header/Header.spec.tsx
+++ b/packages/circuit-ui/components/SidePanel/components/Header/Header.spec.tsx
@@ -42,7 +42,9 @@ describe('Header', () => {
     const onClose = vi.fn();
     renderComponent({ onClose });
 
-    await userEvent.click(screen.getByTitle(baseProps.closeButtonLabel));
+    await userEvent.click(
+      screen.getByRole('button', { name: baseProps.closeButtonLabel }),
+    );
 
     expect(onClose).toHaveBeenCalled();
   });
@@ -53,7 +55,9 @@ describe('Header', () => {
       onBack,
     });
 
-    expect(screen.getByTitle(baseProps.backButtonLabel)).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: baseProps.backButtonLabel }),
+    ).toBeVisible();
   });
 
   it('should call the onBack callback from the back button', async () => {
@@ -62,7 +66,9 @@ describe('Header', () => {
       onBack,
     });
 
-    await userEvent.click(screen.getByTitle(baseProps.backButtonLabel));
+    await userEvent.click(
+      screen.getByRole('button', { name: baseProps.backButtonLabel }),
+    );
 
     expect(onBack).toHaveBeenCalled();
   });

--- a/packages/circuit-ui/components/Tag/Tag.spec.tsx
+++ b/packages/circuit-ui/components/Tag/Tag.spec.tsx
@@ -51,7 +51,7 @@ describe('Tag', () => {
       </Tag>,
     );
 
-    await userEvent.click(screen.getByText('Remove'));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
 
     expect(onRemove).toHaveBeenCalledTimes(1);
   });

--- a/packages/circuit-ui/components/Tooltip/Tooltip.mdx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.mdx
@@ -32,6 +32,8 @@ The Tooltip works without JavaScript as long as the parent element is [positione
 
 Use the `label` type when the tooltip acts as the wrapped component's label (aka [accessible name](https://w3c.github.io/accname/#dfn-accessible-name)). The label text should state the element's function or action in one or two words maximum.
 
+[IconButton](Components/Button/IconButton/Base) already wraps itself in a label-type Tooltip by default, you don't need to compose them manually.
+
 #### Description
 
 Use the `description` type when the tooltip provides supplemental information about the wrapped component ([accessible description](https://w3c.github.io/accname/#dfn-accessible-description)). The label text should not contain information that is critical for a user to understand the wrapped element. Use sentence-case for the label text and write complete sentences with punctuation unless space is limited. Avoid exceeding 160 characters.

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -18,14 +18,14 @@ import { TransferOut, UploadCloud } from '@sumup-oss/icons';
 
 import { Stack } from '../../../../.storybook/components/index.js';
 import { clsx } from '../../styles/clsx.js';
+import { utilClasses } from '../../styles/utility.js';
 import { Button } from '../Button/index.js';
-import { BaseButton } from '../Button/base.js';
-import iconButtonClasses from '../Button/IconButton.module.css';
 import {
   Tooltip,
   type TooltipProps,
   type TooltipReferenceProps,
 } from './Tooltip.js';
+import classes from './TooltipStories.module.css';
 
 export default {
   title: 'Components/Tooltip',
@@ -79,19 +79,17 @@ export const Types = (args: TooltipProps) => (
       type="label"
       label="Transfer out"
       component={(props) => (
-        <BaseButton
+        <button
           {...props}
-          componentName="IconButton"
-          icon={TransferOut}
-          size="m"
+          type="button"
           className={clsx(
-            iconButtonClasses.base,
-            iconButtonClasses.m,
+            classes.reference,
+            utilClasses.focusVisible,
             props.className,
           )}
         >
-          Transfer out
-        </BaseButton>
+          <TransferOut aria-hidden="true" size="24" />
+        </button>
       )}
     />
     <Tooltip

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -14,11 +14,10 @@
  */
 
 import { userEvent } from 'storybook/test';
-import { TransferOut, UploadCloud } from '@sumup-oss/icons';
+import { UploadCloud } from '@sumup-oss/icons';
 
 import { Stack } from '../../../../.storybook/components/index.js';
-import { Button, IconButton } from '../Button/index.js';
-
+import { Button } from '../Button/index.js';
 import {
   Tooltip,
   type TooltipProps,
@@ -70,16 +69,6 @@ Base.play = showTooltip;
 
 export const Types = (args: TooltipProps) => (
   <Stack>
-    <Tooltip
-      {...args}
-      type="label"
-      label="Transfer out"
-      component={(props) => (
-        <IconButton {...props} icon={TransferOut} title={undefined}>
-          Transfer out
-        </IconButton>
-      )}
-    />
     <Tooltip
       {...args}
       type="description"

--- a/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/circuit-ui/components/Tooltip/Tooltip.stories.tsx
@@ -14,10 +14,13 @@
  */
 
 import { userEvent } from 'storybook/test';
-import { UploadCloud } from '@sumup-oss/icons';
+import { TransferOut, UploadCloud } from '@sumup-oss/icons';
 
 import { Stack } from '../../../../.storybook/components/index.js';
+import { clsx } from '../../styles/clsx.js';
 import { Button } from '../Button/index.js';
+import { BaseButton } from '../Button/base.js';
+import iconButtonClasses from '../Button/IconButton.module.css';
 import {
   Tooltip,
   type TooltipProps,
@@ -69,6 +72,28 @@ Base.play = showTooltip;
 
 export const Types = (args: TooltipProps) => (
   <Stack>
+    {/* IconButton already wraps itself in a label-type Tooltip by default, this recreates its underlying
+        button styling to show the `label` type for a custom reference component. */}
+    <Tooltip
+      {...args}
+      type="label"
+      label="Transfer out"
+      component={(props) => (
+        <BaseButton
+          {...props}
+          componentName="IconButton"
+          icon={TransferOut}
+          size="m"
+          className={clsx(
+            iconButtonClasses.base,
+            iconButtonClasses.m,
+            props.className,
+          )}
+        >
+          Transfer out
+        </BaseButton>
+      )}
+    />
     <Tooltip
       {...args}
       type="description"

--- a/packages/circuit-ui/components/Tooltip/TooltipStories.module.css
+++ b/packages/circuit-ui/components/Tooltip/TooltipStories.module.css
@@ -1,0 +1,27 @@
+.reference {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--cui-spacings-kilo) - var(--cui-border-width-kilo));
+  color: var(--cui-fg-normal);
+  cursor: pointer;
+  background-color: var(--cui-bg-normal);
+  border: var(--cui-border-width-kilo) solid var(--cui-border-normal);
+  border-radius: var(--cui-border-radius-kilo);
+  transition:
+    color var(--cui-transitions-default),
+    background-color var(--cui-transitions-default),
+    border-color var(--cui-transitions-default);
+}
+
+.reference:hover {
+  color: var(--cui-fg-normal-hovered);
+  background-color: var(--cui-bg-subtle-hovered);
+  border-color: var(--cui-border-normal-hovered);
+}
+
+.reference:active {
+  color: var(--cui-fg-normal-pressed);
+  background-color: var(--cui-bg-subtle-pressed);
+  border-color: var(--cui-border-normal-pressed);
+}

--- a/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.spec.tsx
+++ b/packages/circuit-ui/components/TopNavigation/components/UtilityLinks/UtilityLinks.spec.tsx
@@ -44,7 +44,7 @@ describe('UtilityLinks', () => {
 
     const link = baseProps.links[0] as UtilityLinkProps;
 
-    await userEvent.click(screen.getByText(link.label));
+    await userEvent.click(screen.getByRole('link', { name: link.label }));
 
     expect(link.onClick).toHaveBeenCalledTimes(1);
   });

--- a/skills/circuit-ui/references/components/Tooltip.mdx
+++ b/skills/circuit-ui/references/components/Tooltip.mdx
@@ -32,6 +32,8 @@ The Tooltip works without JavaScript as long as the parent element is [positione
 
 Use the `label` type when the tooltip acts as the wrapped component's label (aka [accessible name](https://w3c.github.io/accname/#dfn-accessible-name)). The label text should state the element's function or action in one or two words maximum.
 
+[IconButton](Components/Button/IconButton/Base) already wraps itself in a label-type Tooltip by default, you don't need to compose them manually.
+
 #### Description
 
 Use the `description` type when the tooltip provides supplemental information about the wrapped component ([accessible description](https://w3c.github.io/accname/#dfn-accessible-description)). The label text should not contain information that is critical for a user to understand the wrapped element. Use sentence-case for the label text and write complete sentences with punctuation unless space is limited. Avoid exceeding 160 characters.


### PR DESCRIPTION
Addresses [DSYS-993](https://sumupteam.atlassian.net/browse/DSYS-993)

## Purpose

This replaces  `IconButton`'s use of the native `title` attribute with an accessible [`Tooltip`](https://circuit.sumup.com/?path=/docs/components-tooltip--docs) because`title` isn't reliably accessible to keyboard, touch, or screen reader users.

## Approach and changes

- `IconButton` now wraps itself in a label-type `Tooltip` by default. The reference element is memoized via a ref-backed `useCallback` so the underlying `<button>` never remounts across re-renders.
- A decorative (`aria-hidden`) icon button renders without a tooltip, matching its existing accessible-name exemption.
-  Updated `Tooltip`'s `Types` story, specifically the `label`-type example (manually composed `IconButton` with `Tooltip`) which now double-wraps; replaced with a `BaseButton` example styled to match `IconButton`.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
