### PR TITLE
Make the I18nProvider required

### DIFF
--- a/.changeset/sixty-mirrors-sniff.md
+++ b/.changeset/sixty-mirrors-sniff.md
@@ -1,0 +1,18 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Made the internationalization context required to configure the display language and formatting locale for all design system components. Wrap your application in the `I18nProvider`:
+
+```tsx
+// For example /app/layout.tsx for Next.js
+import { I18nProvider } from "@sumup-oss/circuit-ui";
+
+export default function App() {
+  return (
+    <I18nProvider locale="en-US" formattingLocale="de-DE">
+      {/* children */}
+    </I18nProvider>
+  );
+}
+```

--- a/.changeset/vast-signs-scream.md
+++ b/.changeset/vast-signs-scream.md
@@ -2,5 +2,5 @@
 "@sumup-oss/circuit-ui": major
 ---
 
-Removed the deprecated `locale` prop from the CurrencyInput, PercentageInput, and TimeStamp components. Use the `I18nProvider` component or the `formattingLocale` prop instead.
+Removed the deprecated `locale` prop from the CurrencyInput, PercentageInput, and Timestamp components. Use the `I18nProvider` component or the `formattingLocale` prop instead.
   

--- a/.changeset/vast-signs-scream.md
+++ b/.changeset/vast-signs-scream.md
@@ -1,0 +1,6 @@
+---
+"@sumup-oss/circuit-ui": major
+---
+
+Removed the deprecated `locale` prop from the CurrencyInput, PercentageInput, and TimeStamp components. Use the `I18nProvider` component or the `formattingLocale` prop instead.
+  

--- a/packages/circuit-ui/components/Calendar/Calendar.mdx
+++ b/packages/circuit-ui/components/Calendar/Calendar.mdx
@@ -24,7 +24,7 @@ Use the `selection` prop to set the currently selected date or date range and th
 
 Dates are represented as [`Temporal.PlainDate` objects](https://tc39.es/proposal-temporal/docs/plaindate.html) which are time zone agnostic.
 
-Dates are formatted using the [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). The Calendar component integrates with the [internationalization context](Internationalization/Docs) to localize month and weekday names and to format dates according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level.
+Dates are formatted using the [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). The Calendar component integrates with the [internationalization context](Introduction/Internationalization/Docs) to localize month and weekday names and to format dates according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level.
 
 Use the `firstDayOfWeek` prop to set the first day of the week for the locale, either `1` (Monday) or `7` (Sunday). This information can be obtained using the [`Intl.Locale.prototype.getWeekInfo()` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo#firstday) in supported browsers.
 

--- a/packages/circuit-ui/components/Calendar/Calendar.mdx
+++ b/packages/circuit-ui/components/Calendar/Calendar.mdx
@@ -24,7 +24,7 @@ Use the `selection` prop to set the currently selected date or date range and th
 
 Dates are represented as [`Temporal.PlainDate` objects](https://tc39.es/proposal-temporal/docs/plaindate.html) which are time zone agnostic.
 
-Dates are formatted using the [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). Use the `locale` prop to explicitly set the locale (defaults to `navigator.language` in supported environments).
+Dates are formatted using the [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). The Calendar component integrates with the [internationalization context](Internationalization/Docs) to localize month and weekday names and to format dates according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level.
 
 Use the `firstDayOfWeek` prop to set the first day of the week for the locale, either `1` (Monday) or `7` (Sunday). This information can be obtained using the [`Intl.Locale.prototype.getWeekInfo()` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo#firstday) in supported browsers.
 

--- a/packages/circuit-ui/components/Calendar/Calendar.stories.tsx
+++ b/packages/circuit-ui/components/Calendar/Calendar.stories.tsx
@@ -52,9 +52,27 @@ export const Localized = ({ selection, ...args }: CalendarProps) => {
   const [date, setDate] = useState(selection);
   return (
     <Stack>
-      <Calendar {...args} selection={date} onSelect={setDate} locale="de-DE" />
-      <Calendar {...args} selection={date} onSelect={setDate} locale="bg-BG" />
-      <Calendar {...args} selection={date} onSelect={setDate} locale="pt-BR" />
+      <Calendar
+        {...args}
+        selection={date}
+        onSelect={setDate}
+        locale="de-DE"
+        formattingLocale="de-DE"
+      />
+      <Calendar
+        {...args}
+        selection={date}
+        onSelect={setDate}
+        locale="bg-BG"
+        formattingLocale="bg-BG"
+      />
+      <Calendar
+        {...args}
+        selection={date}
+        onSelect={setDate}
+        locale="pt-BR"
+        formattingLocale="pt-BR"
+      />
     </Stack>
   );
 };

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.mdx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.mdx
@@ -22,6 +22,6 @@ Use the `currency` prop to specify which currency the input should use.
 
 ### Locale
 
-Use the `locale` prop to format the currency value according to that locale's formatting style. For example, euros could be formatted differently based on locale:
+Use the `formattingLocale` prop to format the currency value according to that locale's formatting style. For example, euros could be formatted differently based on locale:
 
 <Story of={Stories.Locales} />

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -22,10 +22,10 @@ import { CurrencyInput, type CurrencyInputProps } from './CurrencyInput.js';
 
 // Note: these defaults render a '€' as an input suffix
 const defaultProps = {
-  locale: 'de-DE',
+  formattingLocale: 'de-DE',
   currency: 'EUR',
   label: 'Amount',
-};
+} satisfies CurrencyInputProps;
 
 describe('CurrencyInput', () => {
   it('should forward a ref', () => {

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.spec.tsx
@@ -36,7 +36,13 @@ describe('CurrencyInput', () => {
   });
 
   it('should format a en-GB amount correctly', async () => {
-    render(<CurrencyInput {...defaultProps} currency="GBP" locale="en-GB" />);
+    render(
+      <CurrencyInput
+        {...defaultProps}
+        currency="GBP"
+        formattingLocale="en-GB"
+      />,
+    );
 
     const input: HTMLInputElement = screen.getByRole('textbox');
 
@@ -46,7 +52,13 @@ describe('CurrencyInput', () => {
   });
 
   it('should format a de-DE amount correctly', async () => {
-    render(<CurrencyInput {...defaultProps} currency="EUR" locale="de-DE" />);
+    render(
+      <CurrencyInput
+        {...defaultProps}
+        currency="EUR"
+        formattingLocale="de-DE"
+      />,
+    );
 
     const input: HTMLInputElement = screen.getByRole('textbox');
 

--- a/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
+++ b/packages/circuit-ui/components/CurrencyInput/CurrencyInput.tsx
@@ -23,7 +23,7 @@ import type { OnValueChange } from '../../vendor/react-number-format/types.js';
 import { clsx } from '../../styles/clsx.js';
 import { idx } from '../../util/idx.js';
 import type { Locale } from '../../util/i18n.js';
-import { deprecate } from '../../util/logger.js';
+import { CircuitError } from '../../util/errors.js';
 import { useI18n } from '../../hooks/useI18n/useI18n.js';
 import { Input, type InputProps } from '../Input/index.js';
 
@@ -41,14 +41,6 @@ export interface CurrencyInputProps
    * 'EUR' for the Euro, or 'CNY' for the Chinese RMB.
    */
   currency: string;
-  /**
-   * @deprecated Use the `I18nProvider` component or the `formattingLocale` prop instead.
-   *
-   * One or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag)
-   * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
-   * When passing an array, the first supported locale is used.
-   */
-  locale?: Locale;
   /**
    * One or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag)
    * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
@@ -90,7 +82,6 @@ const DUMMY_DELIMITER = '?';
  * parser for formatting values automatically.
  */
 export function CurrencyInput({
-  locale: customLocale,
   formattingLocale: customFormattingLocale,
   currency,
   placeholder,
@@ -98,15 +89,14 @@ export function CurrencyInput({
   ref,
   ...props
 }: CurrencyInputProps) {
-  if (process.env.NODE_ENV !== 'production' && customLocale) {
-    deprecate(
+  if (process.env.NODE_ENV !== 'production' && 'locale' in props) {
+    throw new CircuitError(
       'CurrencyInput',
-      'The `locale` prop has been deprecated. Use the `I18nProvider` component or the `formattingLocale` prop instead.',
+      'The `locale` prop has been removed. Use the `I18nProvider` component or the `formattingLocale` prop instead.',
     );
   }
 
   const { formattingLocale } = useI18n({
-    locale: customLocale,
     formattingLocale: customFormattingLocale,
   });
   const currencySymbolId = useId();

--- a/packages/circuit-ui/components/DateInput/DateInput.mdx
+++ b/packages/circuit-ui/components/DateInput/DateInput.mdx
@@ -50,6 +50,6 @@ Use the `readOnly` prop to indicate that the field is not currently editable. Th
 
 ## Internationalization
 
-The DateInput integrates with the [internationalization context](Internationalization/Docs) to format the number according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level:
+The DateInput integrates with the [internationalization context](Introduction/Internationalization/Docs) to format the date according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level:
 
 <Story of={Stories.Locales} />

--- a/packages/circuit-ui/components/DateInput/DateInput.mdx
+++ b/packages/circuit-ui/components/DateInput/DateInput.mdx
@@ -50,6 +50,6 @@ Use the `readOnly` prop to indicate that the field is not currently editable. Th
 
 ## Internationalization
 
-Pass one or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) locale identifiers such as `'de-DE'` or `['GB', 'en-US']` to the `locale` prop to display the date in the local format. When passing an array, the first supported locale is used. Defaults to `navigator.language` in supported environments.
+The DateInput integrates with the [internationalization context](Internationalization/Docs) to format the number according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level:
 
 <Story of={Stories.Locales} />

--- a/packages/circuit-ui/components/DateInput/DateInput.stories.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.stories.tsx
@@ -157,13 +157,13 @@ export const Locales = (args: DateInputProps) => (
     <DateInput
       {...args}
       locale="es-CL"
-      formattingLocale="de-DE"
+      formattingLocale="es-CL"
       label="Fecha de nacimiento"
     />
     <DateInput
       {...args}
       locale="pt-BR"
-      formattingLocale="de-DE"
+      formattingLocale="pt-BR"
       label="Data de nascimento"
     />
   </Stack>

--- a/packages/circuit-ui/components/DateInput/DateInput.stories.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.stories.tsx
@@ -148,9 +148,24 @@ Disabled.args = {
 
 export const Locales = (args: DateInputProps) => (
   <Stack>
-    <DateInput {...args} locale="de-DE" label="Geburtsdatum" />
-    <DateInput {...args} locale="es-CL" label="Fecha de nacimiento" />
-    <DateInput {...args} locale="pt-BR" label="Data de nascimento" />
+    <DateInput
+      {...args}
+      locale="de-DE"
+      formattingLocale="de-DE"
+      label="Geburtsdatum"
+    />
+    <DateInput
+      {...args}
+      locale="es-CL"
+      formattingLocale="de-DE"
+      label="Fecha de nacimiento"
+    />
+    <DateInput
+      {...args}
+      locale="pt-BR"
+      formattingLocale="de-DE"
+      label="Data de nascimento"
+    />
   </Stack>
 );
 

--- a/packages/circuit-ui/components/DateInput/DateInput.tsx
+++ b/packages/circuit-ui/components/DateInput/DateInput.tsx
@@ -79,6 +79,7 @@ export interface DateInputProps
     Pick<
       CalendarProps,
       | 'locale'
+      | 'formattingLocale'
       | 'firstDayOfWeek'
       | 'prevMonthButtonLabel'
       | 'nextMonthButtonLabel'
@@ -384,7 +385,6 @@ export function DateInput({ ref, ...props }: DateInputProps) {
             hideCloseButton={!isMobile}
             aria-labelledby={idx(open && headlineId)}
             closeButtonLabel={closeCalendarButtonLabel}
-            locale={locale}
             placement={placement}
             offset={4}
             className={classes.dialog}

--- a/packages/circuit-ui/components/I18nContext/I18nContext.spec.tsx
+++ b/packages/circuit-ui/components/I18nContext/I18nContext.spec.tsx
@@ -17,12 +17,20 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { render } from '../../util/test-utils.js';
 
-import { I18nContext, I18nProvider, type I18nConfig } from './I18nContext.js';
+import {
+  I18nContext,
+  I18nProvider,
+  type I18nContextValue,
+} from './I18nContext.js';
 import { useContext } from 'react';
 
 describe('I18nContext', () => {
   describe('I18nProvider', () => {
-    function TestChild({ callback }: { callback: (i18n: I18nConfig) => void }) {
+    function TestChild({
+      callback,
+    }: {
+      callback: (i18n: I18nContextValue) => void;
+    }) {
       const i18n = useContext(I18nContext);
       callback(i18n);
       return null;
@@ -40,7 +48,6 @@ describe('I18nContext', () => {
       expect(callback).toHaveBeenCalledWith({
         locale,
         formattingLocale,
-        isDefault: false,
       });
     });
 
@@ -55,7 +62,6 @@ describe('I18nContext', () => {
       expect(callback).toHaveBeenCalledWith({
         locale,
         formattingLocale: locale,
-        isDefault: false,
       });
     });
   });

--- a/packages/circuit-ui/components/I18nContext/I18nContext.tsx
+++ b/packages/circuit-ui/components/I18nContext/I18nContext.tsx
@@ -17,22 +17,21 @@
 
 import { createContext, useMemo, type ReactNode } from 'react';
 
-import { getDefaultLocale, type Locale } from '../../util/i18n.js';
+import type { Locale } from '../../util/i18n.js';
 
 export interface I18nConfig {
   locale: Locale;
   formattingLocale: Locale;
 }
 
-interface I18nContextValue extends I18nConfig {
-  // TODO: Remove in v12 when the I18nProvider becomes required.
-  isDefault: boolean;
+export interface I18nContextValue {
+  locale: Locale | null;
+  formattingLocale: Locale | null;
 }
 
 export const I18nContext = createContext<I18nContextValue>({
-  locale: getDefaultLocale(),
-  formattingLocale: getDefaultLocale(),
-  isDefault: true,
+  locale: null,
+  formattingLocale: null,
 });
 
 export interface I18nProviderProps {
@@ -68,7 +67,7 @@ export function I18nProvider({
   formattingLocale = locale,
 }: I18nProviderProps) {
   const contextValue = useMemo(
-    () => ({ locale, formattingLocale, isDefault: false }),
+    () => ({ locale, formattingLocale }),
     [locale, formattingLocale],
   );
   return (

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.mdx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.mdx
@@ -16,7 +16,7 @@ The PercentageInput component indicates to the user that a fractional number sho
 
 ### Locale
 
-Use the `locale` prop to format the number according to that locale's formatting style.
+The PercentageInput integrates with the [internationalization context](Internationalization/Docs) to format the number according to the locale's formatting style. Use the `formattingLocale` prop to override the global locale on a component level:
 
 <Story of={Stories.Locales} />
 

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.mdx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.mdx
@@ -16,7 +16,7 @@ The PercentageInput component indicates to the user that a fractional number sho
 
 ### Locale
 
-The PercentageInput integrates with the [internationalization context](Internationalization/Docs) to format the number according to the locale's formatting style. Use the `formattingLocale` prop to override the global locale on a component level:
+The PercentageInput integrates with the [internationalization context](Introduction/Internationalization/Docs) to format the number according to the locale's formatting style. Use the `formattingLocale` prop to override the global locale on a component level:
 
 <Story of={Stories.Locales} />
 

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.spec.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.spec.tsx
@@ -24,9 +24,9 @@ import {
 } from './PercentageInput.js';
 
 const defaultProps = {
-  locale: 'de-DE',
+  formattingLocale: 'de-DE',
   label: 'Discount',
-};
+} satisfies PercentageInputProps;
 
 describe('PercentageInput', () => {
   it('should forward a ref', () => {

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.spec.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.spec.tsx
@@ -37,7 +37,7 @@ describe('PercentageInput', () => {
   });
 
   it('should format an en-GB amount', async () => {
-    render(<PercentageInput {...defaultProps} locale="en-GB" />);
+    render(<PercentageInput {...defaultProps} formattingLocale="en-GB" />);
 
     const input = screen.getByRole<HTMLInputElement>('textbox');
 
@@ -47,7 +47,7 @@ describe('PercentageInput', () => {
   });
 
   it('should format an de-DE amount', async () => {
-    render(<PercentageInput {...defaultProps} locale="de-DE" />);
+    render(<PercentageInput {...defaultProps} formattingLocale="de-DE" />);
 
     const input = screen.getByRole<HTMLInputElement>('textbox');
 

--- a/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
+++ b/packages/circuit-ui/components/PercentageInput/PercentageInput.tsx
@@ -23,7 +23,7 @@ import type { OnValueChange } from '../../vendor/react-number-format/types.js';
 import { clsx } from '../../styles/clsx.js';
 import { idx } from '../../util/idx.js';
 import type { Locale } from '../../util/i18n.js';
-import { deprecate } from '../../util/logger.js';
+import { CircuitError } from '../../util/errors.js';
 import { useI18n } from '../../hooks/useI18n/useI18n.js';
 import { Input, type InputProps } from '../Input/index.js';
 
@@ -36,14 +36,6 @@ export interface PercentageInputProps
     'placeholder' | 'ref' | 'value' | 'defaultValue' | 'type'
   > {
   ref?: Ref<HTMLInputElement>;
-  /**
-   * @deprecated Use the `I18nProvider` component or the `formattingLocale` prop instead.
-   *
-   * One or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag)
-   * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
-   * When passing an array, the first supported locale is used.
-   */
-  locale?: Locale;
   /**
    * One or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag)
    * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
@@ -78,7 +70,6 @@ const DEFAULT_FORMAT = {
  * PercentageInput component for fractional values
  */
 export function PercentageInput({
-  locale: customLocale,
   formattingLocale: customFormattingLocale,
   placeholder = '0',
   decimalScale = 0,
@@ -86,15 +77,14 @@ export function PercentageInput({
   ref,
   ...props
 }: PercentageInputProps) {
-  if (process.env.NODE_ENV !== 'production' && customLocale) {
-    deprecate(
+  if (process.env.NODE_ENV !== 'production' && 'locale' in props) {
+    throw new CircuitError(
       'PercentageInput',
-      'The `locale` prop has been deprecated. Use the `I18nProvider` component or the `formattingLocale` prop instead.',
+      'The `locale` prop has been removed. Use the `I18nProvider` component or the `formattingLocale` prop instead.',
     );
   }
 
   const { formattingLocale } = useI18n({
-    locale: customLocale,
     formattingLocale: customFormattingLocale,
   });
   const percentageSymbolId = useId();

--- a/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.stories.tsx
@@ -92,14 +92,14 @@ Relative.parameters = {
 
 export const Absolute = (args: TimestampProps) => (
   <Stack>
-    {locales.map((locale) => (
-      <Stack vertical key={locale}>
+    {locales.map((formattingLocale) => (
+      <Stack vertical key={formattingLocale}>
         {getDatetimes('absolute').map((datetime) => (
           <Timestamp
             {...args}
             key={datetime.toString()}
             datetime={datetime.toString()}
-            locale={locale}
+            formattingLocale={formattingLocale}
           />
         ))}
       </Stack>

--- a/packages/circuit-ui/components/Timestamp/Timestamp.tsx
+++ b/packages/circuit-ui/components/Timestamp/Timestamp.tsx
@@ -21,6 +21,7 @@ import { Temporal } from 'temporal-polyfill';
 import type { Locale } from '../../util/i18n.js';
 import { clsx } from '../../styles/clsx.js';
 import { useI18n } from '../../hooks/useI18n/useI18n.js';
+import { CircuitError } from '../../util/errors.js';
 
 import { getInitialState, getState } from './TimestampService.js';
 import classes from './Timestamp.module.css';
@@ -57,14 +58,6 @@ export interface TimestampProps extends HTMLAttributes<HTMLTimeElement> {
    */
   variant?: 'auto' | 'relative' | 'absolute';
   /**
-   * @deprecated Use the `I18nProvider` component or the `formattingLocale` prop instead.
-   *
-   * One or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag)
-   * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
-   * When passing an array, the first supported locale is used.
-   */
-  locale?: Locale;
-  /**
    * One or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag)
    * locale identifiers such as `'de-DE'` or `['GB', 'en-US']`.
    * When passing an array, the first supported locale is used.
@@ -80,13 +73,18 @@ export function Timestamp({
   variant = 'auto',
   formatStyle = 'long',
   includeTime = false,
-  locale: customLocale,
   formattingLocale: customFormattingLocale,
   className,
   ...props
 }: TimestampProps) {
+  if (process.env.NODE_ENV !== 'production' && 'locale' in props) {
+    throw new CircuitError(
+      'Timestamp',
+      'The `locale` prop has been removed. Use the `I18nProvider` component or the `formattingLocale` prop instead.',
+    );
+  }
+
   const { formattingLocale } = useI18n({
-    locale: customLocale,
     formattingLocale: customFormattingLocale,
   });
   const zonedDateTime = Temporal.ZonedDateTime.from(datetime);

--- a/packages/circuit-ui/hooks/useI18n/useI18n.spec.tsx
+++ b/packages/circuit-ui/hooks/useI18n/useI18n.spec.tsx
@@ -13,41 +13,29 @@
  * limitations under the License.
  */
 
-import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { renderHook } from '../../util/test-utils.js';
-import { getDefaultLocale } from '../../util/i18n.js';
 import { I18nProvider } from '../../components/I18nContext/I18nContext.js';
 
 import { useI18n } from './useI18n.js';
-
-function getMockedDefaultLocale() {
-  return ['de-DE', 'de'];
-}
-
-vi.mock('../../util/i18n.ts', () => ({
-  getDefaultLocale: vi.fn(getMockedDefaultLocale),
-}));
 
 describe('useI18n', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it('should return the default locale', () => {
-    const defaultLocale = getMockedDefaultLocale();
-    const { result } = renderHook(() => useI18n({}));
-    expect(result.current).toEqual({
-      locale: defaultLocale,
-      formattingLocale: defaultLocale,
+  it('should return the global locale', () => {
+    const globalLocale = ['de-DE', 'de'];
+    const { result } = renderHook(() => useI18n({}), {
+      wrapper: ({ children }) => (
+        <I18nProvider locale={globalLocale}>{children}</I18nProvider>
+      ),
     });
-  });
-
-  it('should prioritize custom locales over the default locales', () => {
-    const locale = 'fr-FR';
-    const formattingLocale = 'en-US';
-    const { result } = renderHook(() => useI18n({ locale, formattingLocale }));
-    expect(result.current).toEqual({ locale, formattingLocale });
+    expect(result.current).toEqual({
+      locale: globalLocale,
+      formattingLocale: globalLocale,
+    });
   });
 
   it('should prioritize custom locales over the global locales', () => {
@@ -60,21 +48,5 @@ describe('useI18n', () => {
       ),
     });
     expect(result.current).toEqual({ locale, formattingLocale });
-  });
-
-  it('should default the formattingLocale to the locale', () => {
-    const locale = 'fr-FR';
-    const { result } = renderHook(() => useI18n({ locale }));
-    expect(result.current).toEqual({ locale, formattingLocale: locale });
-  });
-
-  it('should update the locale on the client', () => {
-    const updatedLocale = 'pt-BR';
-    (getDefaultLocale as Mock).mockReturnValue(updatedLocale);
-    const { result } = renderHook(() => useI18n({}));
-    expect(result.current).toEqual({
-      locale: updatedLocale,
-      formattingLocale: updatedLocale,
-    });
   });
 });

--- a/packages/circuit-ui/hooks/useI18n/useI18n.ts
+++ b/packages/circuit-ui/hooks/useI18n/useI18n.ts
@@ -15,49 +15,35 @@
  * limitations under the License.
  */
 
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 
-import { getDefaultLocale, type Locale } from '../../util/i18n.js';
 import {
   I18nContext,
   type I18nConfig,
 } from '../../components/I18nContext/I18nContext.js';
+import { CircuitError } from '../../util/errors.js';
+import { FALLBACK_LOCALE } from '../../util/i18n.js';
 
 /**
- * Provides localization context, either from the I18nProvider or the current
- * browser/system language.
+ * Provides localization context from the I18nProvider.
  */
 export function useI18n({
   locale: customLocale,
-  // TODO: Remove this fallback in v12 once the deprecated `locale` props have been removed.
-  formattingLocale: customFormattingLocale = customLocale,
+  formattingLocale: customFormattingLocale,
 }: Partial<I18nConfig>): I18nConfig {
-  const {
-    locale: globalLocale,
-    formattingLocale: globalFormattingLocale,
-    isDefault,
-  } = useContext(I18nContext);
-  const [locale, setLocale] = useState<Locale>(customLocale || globalLocale);
-  const [formattingLocale, setFormattingLocale] = useState<Locale>(
-    customFormattingLocale || globalFormattingLocale || locale,
-  );
+  const { locale: globalLocale, formattingLocale: globalFormattingLocale } =
+    useContext(I18nContext);
 
-  // Update the locales after hydration on the client
-  useEffect(() => {
-    if (customLocale || (globalLocale && !isDefault)) {
-      return;
-    }
+  if (process.env.NODE_ENV !== 'production' && !globalLocale) {
+    throw new CircuitError(
+      'Internationalization',
+      'Missing internationalization context. Make sure the `I18nProvider` component wraps your entire app component tree.',
+    );
+  }
 
-    setLocale(getDefaultLocale());
-  }, [customLocale, globalLocale, isDefault]);
-
-  useEffect(() => {
-    if (customFormattingLocale || (globalFormattingLocale && !isDefault)) {
-      return;
-    }
-
-    setFormattingLocale(getDefaultLocale());
-  }, [customFormattingLocale, globalFormattingLocale, isDefault]);
-
-  return { locale, formattingLocale };
+  return {
+    locale: customLocale || globalLocale || FALLBACK_LOCALE,
+    formattingLocale:
+      customFormattingLocale || globalFormattingLocale || FALLBACK_LOCALE,
+  };
 }

--- a/packages/circuit-ui/hooks/useTranslations/useTranslations.spec.tsx
+++ b/packages/circuit-ui/hooks/useTranslations/useTranslations.spec.tsx
@@ -19,12 +19,20 @@ import { renderHook } from '../../util/test-utils.js';
 import type { Locale, Translations } from '../../util/i18n.js';
 
 import { useTranslations } from './useTranslations.js';
+import { I18nProvider } from '../../components/I18nContext/I18nContext.js';
+import type { PropsWithChildren } from 'react';
 
 type Props = {
   locale?: Locale;
   greeting?: string;
   foo?: string;
   onFoo?: () => void;
+};
+
+const options = {
+  wrapper: ({ children }: PropsWithChildren) => (
+    <I18nProvider locale="en-US">{children}</I18nProvider>
+  ),
 };
 
 describe('useTranslations', () => {
@@ -35,20 +43,29 @@ describe('useTranslations', () => {
 
   it('should return translations for the provided locale', () => {
     const props: Props = { locale: 'de-DE' };
-    const { result } = renderHook(() => useTranslations(props, translations));
+    const { result } = renderHook(
+      () => useTranslations(props, translations),
+      options,
+    );
     expect(result.current.locale).toBe('de-DE');
     expect(result.current.greeting).toBe('Hallo');
   });
 
   it('should return the custom translation when provided', () => {
     const props: Props = { greeting: 'Salut' };
-    const { result } = renderHook(() => useTranslations(props, translations));
+    const { result } = renderHook(
+      () => useTranslations(props, translations),
+      options,
+    );
     expect(result.current.greeting).toBe('Salut');
   });
 
   it('should forward all other props', () => {
     const props: Props = { foo: 'bar', onFoo: vi.fn() };
-    const { result } = renderHook(() => useTranslations(props, translations));
+    const { result } = renderHook(
+      () => useTranslations(props, translations),
+      options,
+    );
     expect(result.current).toEqual(expect.objectContaining(props));
   });
 });

--- a/packages/circuit-ui/util/i18n.spec.ts
+++ b/packages/circuit-ui/util/i18n.spec.ts
@@ -13,63 +13,11 @@
  * limitations under the License.
  */
 
-import {
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import {
-  FALLBACK_LOCALE,
-  findSupportedLocale,
-  getDefaultLocale,
-} from './i18n.js';
+import { FALLBACK_LOCALE, findSupportedLocale } from './i18n.js';
 
 describe('i18n', () => {
-  describe('getDefaultLocale', () => {
-    const originalWindow = window;
-    let languagesGetter: MockInstance;
-    let languageGetter: MockInstance;
-
-    beforeEach(() => {
-      window = originalWindow;
-      languagesGetter = vi.spyOn(window.navigator, 'languages', 'get');
-      languageGetter = vi.spyOn(window.navigator, 'language', 'get');
-    });
-
-    it('should return the default locale in server environments', () => {
-      // @ts-expect-error The window object is undefined in server environments
-      window = undefined;
-      const actual = getDefaultLocale();
-      expect(actual).toBe(FALLBACK_LOCALE);
-    });
-
-    it('should return the preferred locales', () => {
-      const languages = ['de-DE', 'en'];
-      languagesGetter.mockReturnValue(languages);
-      const actual = getDefaultLocale();
-      expect(actual).toEqual(languages);
-    });
-
-    it('should fall back to the preferred locale', () => {
-      const language = 'de-DE';
-      languagesGetter.mockReturnValue(undefined);
-      languageGetter.mockReturnValue(language);
-      const actual = getDefaultLocale();
-      expect(actual).toEqual(language);
-    });
-
-    it('should fall back to the default locale', () => {
-      languagesGetter.mockReturnValue(undefined);
-      languageGetter.mockReturnValue(undefined);
-      const actual = getDefaultLocale();
-      expect(actual).toEqual(FALLBACK_LOCALE);
-    });
-  });
-
   describe('findSupportedLocale', () => {
     it('should match a full locale', () => {
       const locale = 'de-DE';

--- a/packages/circuit-ui/util/i18n.ts
+++ b/packages/circuit-ui/util/i18n.ts
@@ -76,18 +76,6 @@ export type Translations<Key extends string | number | symbol> = Record<
 >;
 
 /**
- * Returns the user's preferred locale(s) in browser-like environments.
- */
-export function getDefaultLocale(): Locale {
-  if (typeof window === 'undefined') {
-    return FALLBACK_LOCALE;
-  }
-  return (navigator.languages ||
-    navigator.language ||
-    FALLBACK_LOCALE) as Locale;
-}
-
-/**
  * Returns the first supported locale.
  */
 export function findSupportedLocale(locale: Locale): SupportedLocale {

--- a/packages/circuit-ui/util/test-utils.tsx
+++ b/packages/circuit-ui/util/test-utils.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { FunctionComponent, ReactElement, PropsWithChildren } from 'react';
+import type { ReactElement, PropsWithChildren } from 'react';
 import '@testing-library/jest-dom/vitest';
 import { configureAxe } from 'jest-axe';
 import {
@@ -28,6 +28,8 @@ import {
   ComponentsContext,
   defaultComponents,
 } from '../components/ComponentsContext/ComponentsContext.js';
+import { I18nProvider } from '../components/I18nContext/I18nContext.js';
+import { FALLBACK_LOCALE } from './i18n.js';
 
 // biome-ignore lint/performance/noReExportAll: We re-export the package to override specific functions below
 export * from '@testing-library/react';
@@ -37,13 +39,15 @@ export type RenderFn<T = unknown> = (
   ...rest: any[]
 ) => T;
 
-const WithProviders: FunctionComponent<PropsWithChildren<unknown>> = ({
-  children,
-}) => (
-  <ComponentsContext.Provider value={defaultComponents}>
-    {children}
-  </ComponentsContext.Provider>
-);
+function WithProviders({ children }: PropsWithChildren<unknown>) {
+  return (
+    <I18nProvider locale={FALLBACK_LOCALE}>
+      <ComponentsContext.Provider value={defaultComponents}>
+        {children}
+      </ComponentsContext.Provider>
+    </I18nProvider>
+  );
+}
 
 const render: RenderFn<RenderResult> = (component, options: RenderOptions) =>
   renderTest(component, { wrapper: WithProviders, ...options });

--- a/skills/circuit-ui/references/components/Calendar.mdx
+++ b/skills/circuit-ui/references/components/Calendar.mdx
@@ -24,7 +24,7 @@ Use the `selection` prop to set the currently selected date or date range and th
 
 Dates are represented as [`Temporal.PlainDate` objects](https://tc39.es/proposal-temporal/docs/plaindate.html) which are time zone agnostic.
 
-Dates are formatted using the [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). The Calendar component integrates with the [internationalization context](Internationalization/Docs) to localize month and weekday names and to format dates according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level.
+Dates are formatted using the [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). The Calendar component integrates with the [internationalization context](Introduction/Internationalization/Docs) to localize month and weekday names and to format dates according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level.
 
 Use the `firstDayOfWeek` prop to set the first day of the week for the locale, either `1` (Monday) or `7` (Sunday). This information can be obtained using the [`Intl.Locale.prototype.getWeekInfo()` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo#firstday) in supported browsers.
 

--- a/skills/circuit-ui/references/components/Calendar.mdx
+++ b/skills/circuit-ui/references/components/Calendar.mdx
@@ -24,7 +24,7 @@ Use the `selection` prop to set the currently selected date or date range and th
 
 Dates are represented as [`Temporal.PlainDate` objects](https://tc39.es/proposal-temporal/docs/plaindate.html) which are time zone agnostic.
 
-Dates are formatted using the [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). Use the `locale` prop to explicitly set the locale (defaults to `navigator.language` in supported environments).
+Dates are formatted using the [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). The Calendar component integrates with the [internationalization context](Internationalization/Docs) to localize month and weekday names and to format dates according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level.
 
 Use the `firstDayOfWeek` prop to set the first day of the week for the locale, either `1` (Monday) or `7` (Sunday). This information can be obtained using the [`Intl.Locale.prototype.getWeekInfo()` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo#firstday) in supported browsers.
 

--- a/skills/circuit-ui/references/components/CurrencyInput.mdx
+++ b/skills/circuit-ui/references/components/CurrencyInput.mdx
@@ -22,6 +22,6 @@ Use the `currency` prop to specify which currency the input should use.
 
 ### Locale
 
-Use the `locale` prop to format the currency value according to that locale's formatting style. For example, euros could be formatted differently based on locale:
+Use the `formattingLocale` prop to format the currency value according to that locale's formatting style. For example, euros could be formatted differently based on locale:
 
 <Story of={Stories.Locales} />

--- a/skills/circuit-ui/references/components/DateInput.mdx
+++ b/skills/circuit-ui/references/components/DateInput.mdx
@@ -50,6 +50,6 @@ Use the `readOnly` prop to indicate that the field is not currently editable. Th
 
 ## Internationalization
 
-The DateInput integrates with the [internationalization context](Internationalization/Docs) to format the number according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level:
+The DateInput integrates with the [internationalization context](Introduction/Internationalization/Docs) to format the date according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level:
 
 <Story of={Stories.Locales} />

--- a/skills/circuit-ui/references/components/DateInput.mdx
+++ b/skills/circuit-ui/references/components/DateInput.mdx
@@ -50,6 +50,6 @@ Use the `readOnly` prop to indicate that the field is not currently editable. Th
 
 ## Internationalization
 
-Pass one or more [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag) locale identifiers such as `'de-DE'` or `['GB', 'en-US']` to the `locale` prop to display the date in the local format. When passing an array, the first supported locale is used. Defaults to `navigator.language` in supported environments.
+The DateInput integrates with the [internationalization context](Internationalization/Docs) to format the number according to the locale's formatting style. Use the `locale` and `formattingLocale` props to override the global locales on a component level:
 
 <Story of={Stories.Locales} />

--- a/skills/circuit-ui/references/components/PercentageInput.mdx
+++ b/skills/circuit-ui/references/components/PercentageInput.mdx
@@ -16,7 +16,7 @@ The PercentageInput component indicates to the user that a fractional number sho
 
 ### Locale
 
-Use the `locale` prop to format the number according to that locale's formatting style.
+The PercentageInput integrates with the [internationalization context](Internationalization/Docs) to format the number according to the locale's formatting style. Use the `formattingLocale` prop to override the global locale on a component level:
 
 <Story of={Stories.Locales} />
 

--- a/skills/circuit-ui/references/components/PercentageInput.mdx
+++ b/skills/circuit-ui/references/components/PercentageInput.mdx
@@ -16,7 +16,7 @@ The PercentageInput component indicates to the user that a fractional number sho
 
 ### Locale
 
-The PercentageInput integrates with the [internationalization context](Internationalization/Docs) to format the number according to the locale's formatting style. Use the `formattingLocale` prop to override the global locale on a component level:
+The PercentageInput integrates with the [internationalization context](Introduction/Internationalization/Docs) to format the number according to the locale's formatting style. Use the `formattingLocale` prop to override the global locale on a component level:
 
 <Story of={Stories.Locales} />
 

--- a/templates/astro/src/layouts/Root.astro
+++ b/templates/astro/src/layouts/Root.astro
@@ -12,7 +12,7 @@ interface Props {
 const { title } = Astro.props;
 ---
 
-<html lang="en">
+<html lang="en-GB">
   <head>
     <meta charset="utf-8" />
     <meta

--- a/templates/nextjs/template/app/layout.tsx
+++ b/templates/nextjs/template/app/layout.tsx
@@ -5,6 +5,7 @@ import '@sumup-oss/design-tokens/light.css';
 import '@sumup-oss/circuit-ui/styles.css';
 
 import { PreloadResources } from './preload-resources.js';
+import { I18nProvider } from '@sumup-oss/circuit-ui';
 
 export const metadata: Metadata = {
   title: {
@@ -34,10 +35,13 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const locale = 'en'
   return (
-    <html lang="en">
+    <html lang={locale}>
       <PreloadResources />
-      <body>{children}</body>
+      <body>
+        <I18nProvider locale={locale}>{children}</I18nProvider>
+      </body>
     </html>
   );
 }

--- a/templates/nextjs/template/app/layout.tsx
+++ b/templates/nextjs/template/app/layout.tsx
@@ -4,8 +4,9 @@ import '@sumup-oss/design-tokens/fonts.css';
 import '@sumup-oss/design-tokens/light.css';
 import '@sumup-oss/circuit-ui/styles.css';
 
-import { PreloadResources } from './preload-resources.js';
 import { I18nProvider } from '@sumup-oss/circuit-ui';
+
+import { PreloadResources } from './preload-resources.js';
 
 export const metadata: Metadata = {
   title: {
@@ -35,7 +36,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const locale = 'en'
+  const locale = 'en-GB';
   return (
     <html lang={locale}>
       <PreloadResources />


### PR DESCRIPTION
## Purpose

#3813 introduced the I18nProvider to configure the `locale` and `formattedLocale` on the app level. This PR makes its usage required to ensure that design system components adhere the same locale as the host app instead of inferring it from the environment.

## Approach and changes

- Remove deprecated `locale` props from individual components
- Make usage of the I18nProvider required

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
