### PR TITLE
Fix NODE_ENV type errors

### DIFF
--- a/packages/circuit-ui/components/Body/Body.spec.tsx
+++ b/packages/circuit-ui/components/Body/Body.spec.tsx
@@ -20,6 +20,10 @@ import { axe, render } from '../../util/test-utils.js';
 
 import { Body } from './Body.js';
 
+declare const process: {
+  env: { NODE_ENV: string };
+};
+
 describe('Body', () => {
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';

--- a/packages/circuit-ui/components/Body/Body.tsx
+++ b/packages/circuit-ui/components/Body/Body.tsx
@@ -16,10 +16,10 @@
 import type { HTMLAttributes, Ref } from 'react';
 
 import type { AsPropType } from '../../types/prop-types.js';
+import { CircuitError } from '../../util/errors.js';
 import { clsx } from '../../styles/clsx.js';
 
 import classes from './Body.module.css';
-import { CircuitError } from '../../util/errors.js';
 
 type Variant = 'highlight' | 'quote' | 'confirm' | 'alert' | 'subtle';
 
@@ -140,11 +140,7 @@ export function Body({
       );
     }
 
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      process.env.NODE_ENV !== 'test' &&
-      legacySize in deprecatedSizeMap
-    ) {
+    if (legacySize in deprecatedSizeMap) {
       throw new CircuitError(
         'Body',
         `The "${legacySize}" size has been deprecated. Use the "${deprecatedSizeMap[legacySize]}" size instead.`,

--- a/packages/circuit-ui/components/Display/Display.spec.tsx
+++ b/packages/circuit-ui/components/Display/Display.spec.tsx
@@ -20,6 +20,10 @@ import { render, axe } from '../../util/test-utils.js';
 
 import { Display } from './Display.jsx';
 
+declare const process: {
+  env: { NODE_ENV: string };
+};
+
 describe('Display', () => {
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
@@ -61,7 +65,6 @@ describe('Display', () => {
   it.each(
     deprecatedSizes,
   )('[Deprecated sizes] should throw an error when legacy "%s" value is passed to the size prop', (size, alternative) => {
-    // eslint-disable-next-line circuit-ui/no-deprecated-props
     process.env.NODE_ENV = 'development';
     expect(() =>
       render(
@@ -79,7 +82,6 @@ describe('Display', () => {
   it.each(
     deprecatedWeights,
   )('[Deprecated weights] should throw an error when legacy "%s" value is passed to the size prop', (weight) => {
-    // eslint-disable-next-line circuit-ui/no-deprecated-props
     process.env.NODE_ENV = 'development';
     expect(() =>
       render(

--- a/packages/circuit-ui/components/Headline/Headline.spec.tsx
+++ b/packages/circuit-ui/components/Headline/Headline.spec.tsx
@@ -20,6 +20,10 @@ import { axe, render } from '../../util/test-utils.js';
 
 import { Headline } from './Headline.js';
 
+declare const process: {
+  env: { NODE_ENV: string };
+};
+
 describe('Headline', () => {
   it('should merge a custom class name with the default ones', () => {
     const className = 'foo';
@@ -61,7 +65,6 @@ describe('Headline', () => {
   it.each(
     deprecatedSizes,
   )('[Deprecated sizes] should throw an error when legacy "%s" value is passed to the size prop', (size, alternative) => {
-    // eslint-disable-next-line circuit-ui/no-deprecated-props
     process.env.NODE_ENV = 'development';
     expect(() =>
       render(

--- a/packages/circuit-ui/components/List/List.spec.tsx
+++ b/packages/circuit-ui/components/List/List.spec.tsx
@@ -50,7 +50,6 @@ describe('List', () => {
   it.each(
     deprecatedSizes,
   )('[Deprecated sizes] should throw an error when legacy "%s" value is passed to the size prop', (size, alternative) => {
-    // eslint-disable-next-line circuit-ui/no-deprecated-props
     process.env.NODE_ENV = 'development';
     expect(() =>
       render(


### PR DESCRIPTION
## Purpose

`tsc -p tsconfig.json --noEmit` (run by the pre-commit hook) fails locally with 17 errors in `Body`, `Display`, `Headline`, `List` specs. #3847 missed adding the necessary type declarations.

## Approach and changes

- `Body/Display/Headline/List.spec.tsx`: add the `declare const process` shadow that 8 other spec files already use
- Removed a redundant condition in the Body component

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
