### PR TITLE
Fix custom styles in NotificationBanner

### DIFF
--- a/.changeset/whole-snails-repeat.md
+++ b/.changeset/whole-snails-repeat.md
@@ -1,0 +1,6 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed merging of custom inline styles in the NotificationBanner component.
+  

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.spec.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.spec.tsx
@@ -37,6 +37,24 @@ describe('NotificationBanner', () => {
     },
   };
 
+  it('should merge a custom class name with the default ones', () => {
+    const className = 'foo';
+    const { container } = render(
+      <NotificationBanner className={className} {...baseProps} />,
+    );
+    const wrapper = container.querySelector('div');
+    expect(wrapper?.className).toContain(className);
+  });
+
+  it('should merge custom styles with the default ones', () => {
+    const style = { color: 'blue' };
+    const { container } = render(
+      <NotificationBanner style={style} {...baseProps} />,
+    );
+    const wrapper = container.querySelector('div');
+    expect(wrapper?.style.color).toBe(style.color);
+  });
+
   it('should forward a ref', () => {
     const ref = createRef<HTMLDivElement>();
     const { container } = render(

--- a/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
+++ b/packages/circuit-ui/components/NotificationBanner/NotificationBanner.tsx
@@ -153,6 +153,7 @@ export const NotificationBanner = forwardRef<
       closeButtonLabel,
       isVisible = true,
       className,
+      style,
       ...props
     },
     ref,
@@ -193,6 +194,7 @@ export const NotificationBanner = forwardRef<
       <div
         ref={applyMultipleRefs(ref, contentElement)}
         style={{
+          ...style,
           opacity: isOpen ? 1 : 0,
           height: isOpen ? height : 0,
           visibility: isOpen ? 'visible' : 'hidden',


### PR DESCRIPTION
## Purpose

@Marczerwinski discovered that passing custom styles to the NotificationBanner overrides the internal styles to animate the component.

## Approach and changes

- Merge custom styles with the internal styles, giving precedence to the internal ones.

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
