### PR TITLE
feat(storybook): enable `shouldExtractLiteralValuesFromEnum`

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -59,6 +59,7 @@ const config: StorybookConfig = {
     reactDocgenTypescriptOptions: {
       exclude: ['.storybook/**/*'],
       shouldRemoveUndefinedFromOptional: true,
+      shouldExtractLiteralValuesFromEnum: true,
       propFilter: (prop: PropItem) => {
         // @ts-expect-error deprecated tag exists
         const deprecation = prop.tags.deprecated as string;


### PR DESCRIPTION
To get nicer experience in stories -> getting proper selects for enum props.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
