### PR TITLE
Update no-renamed-components eslint rule

### DIFF
--- a/.changeset/forty-seas-stick.md
+++ b/.changeset/forty-seas-stick.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/eslint-plugin-circuit-ui": minor
+---
+
+Removed the Popover component (and related types) from the list of renamed components of the `no-renamed-components` eslint rule.

--- a/packages/eslint-plugin-circuit-ui/no-renamed-components/index.spec.tsx
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-components/index.spec.tsx
@@ -37,72 +37,8 @@ ruleTester.run('no-renamed-components', noRenamedComponents, {
           return <Button />
         }`,
     },
-    {
-      name: 'similar component from another package',
-      code: `
-          import {Popover} from 'some-other-package';
-   function Component() {
-          return <Popover />
-        }`,
-    },
   ],
   invalid: [
-    {
-      name: 'matched component from Circuit UI',
-      code: `
-          import {Popover} from '@sumup-oss/circuit-ui';
-   function Component() {
-          return <Popover />
-        }`,
-      output: `
-          import {ActionMenu} from '@sumup-oss/circuit-ui';
-   function Component() {
-          return <ActionMenu />
-        }`,
-      errors: [{ messageId: 'renamed' }, { messageId: 'renamed' }],
-    },
-    {
-      name: 'matched component from Circuit UI',
-      code: `import {PopoverProps} from '@sumup-oss/circuit-ui';`,
-      output: `import {ActionMenuProps} from '@sumup-oss/circuit-ui';`,
-      errors: [{ messageId: 'renamed' }],
-    },
-    {
-      name: 'matched component from Circuit UI',
-      code: `import {PopoverItemProps} from '@sumup-oss/circuit-ui';`,
-      output: `import {ActionMenuItemProps} from '@sumup-oss/circuit-ui';`,
-      errors: [{ messageId: 'renamed' }],
-    },
-    {
-      name: 'matched renamed import from Circuit UI',
-      code: `
-          import {Popover as CircuitPopover} from '@sumup-oss/circuit-ui';
-   function Component() {
-          return <CircuitPopover />
-        }`,
-      output: `
-          import {ActionMenu as CircuitPopover} from '@sumup-oss/circuit-ui';
-   function Component() {
-          return <CircuitPopover />
-        }`,
-      errors: [{ messageId: 'renamed' }],
-    },
-    {
-      name: 'matched renamed import from Circuit UI',
-      code: `
-          import {PopoverProps as CircuitPopoverProps} from '@sumup-oss/circuit-ui';`,
-      output: `
-          import {ActionMenuProps as CircuitPopoverProps} from '@sumup-oss/circuit-ui';`,
-      errors: [{ messageId: 'renamed' }],
-    },
-    {
-      name: 'matched renamed import from Circuit UI',
-      code: `
-          import {PopoverItemProps as CircuitPopoverItemProps} from '@sumup-oss/circuit-ui';`,
-      output: `
-          import {ActionMenuItemProps as CircuitPopoverItemProps} from '@sumup-oss/circuit-ui';`,
-      errors: [{ messageId: 'renamed' }],
-    },
     {
       name: 'matched Badge component from Circuit UI',
       code: `

--- a/packages/eslint-plugin-circuit-ui/no-renamed-components/index.ts
+++ b/packages/eslint-plugin-circuit-ui/no-renamed-components/index.ts
@@ -24,18 +24,6 @@ const createRule = ESLintUtils.RuleCreator<RuleDocs>(
 
 const components = [
   {
-    name: 'Popover',
-    alternative: 'ActionMenu',
-  },
-  {
-    name: 'PopoverProps',
-    alternative: 'ActionMenuProps',
-  },
-  {
-    name: 'PopoverItemProps',
-    alternative: 'ActionMenuItemProps',
-  },
-  {
     name: 'Badge',
     alternative: 'Status',
   },


### PR DESCRIPTION

## Purpose

Update the list of renamed components of the `no-renamed-components` eslint rule.

## Approach and changes

- Remove Popover and related types from the references list.
- Update tests

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
