### PR TITLE
fix flag url

### DIFF
--- a/.changeset/puny-falcons-sleep.md
+++ b/.changeset/puny-falcons-sleep.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/icons": patch
+---
+
+Fixed asset urls in the Flag component.

--- a/.changeset/puny-falcons-sleep.md
+++ b/.changeset/puny-falcons-sleep.md
@@ -2,4 +2,4 @@
 "@sumup-oss/icons": patch
 ---
 
-Fixed asset urls in the Flag component.
+Fixed the flag asset url in the Flag component.

--- a/packages/icons/src/components/Flag/Flag.tsx
+++ b/packages/icons/src/components/Flag/Flag.tsx
@@ -129,7 +129,7 @@ export const Flag = forwardRef<HTMLImageElement, FlagProps>(
               height: `calc(${sizeValue} * 3 / 4)`,
               ...style,
             }}
-            src={getIconURL(flagName)}
+            src={getIconURL(flagName, '480')}
             {...props}
             alt={alt}
           />


### PR DESCRIPTION
## Purpose

Currently the Flag component does not provide correct flag urls as image src.

## Approach and changes

Add missing size to the `getIconURL` method.

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
