### PR TITLE
bump @sumup-oss/icons

### DIFF
--- a/.changeset/quiet-kings-cry.md
+++ b/.changeset/quiet-kings-cry.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Bumped the `@sumup-oss/icons` package to fix missing flags in the PhoneNumberInput component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10750,6 +10750,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -10759,6 +10760,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -32268,12 +32270,12 @@
     },
     "packages/circuit-ui": {
       "name": "@sumup-oss/circuit-ui",
-      "version": "11.19.0",
+      "version": "11.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.8",
         "@nanostores/react": "^1.1.0",
-        "@sumup-oss/illustrations": "^1.0.0",
+        "@sumup-oss/illustrations": "^1.1.0",
         "nanostores": "^1.4.1"
       },
       "devDependencies": {
@@ -32282,7 +32284,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@sumup-oss/design-tokens": "^10.0.0",
-        "@sumup-oss/icons": "^6.17.0",
+        "@sumup-oss/icons": "^6.17.2",
         "@sumup-oss/intl": "^3.5.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "7.0.0",
@@ -32318,6 +32320,19 @@
         "react": ">=18.0.0 <20.0.0",
         "react-dom": ">=18.0.0 <20.0.0",
         "temporal-polyfill": ">=0.2.0 <2.0.0"
+      }
+    },
+    "packages/circuit-ui/node_modules/@sumup-oss/icons": {
+      "version": "6.17.2",
+      "resolved": "https://registry.npmjs.org/@sumup-oss/icons/-/icons-6.17.2.tgz",
+      "integrity": "sha512-1qSx1K/A73JkliUPUcEavqnEaT/oZfqhfgmxkCdj+K79CGgixgUN6rXeEgCLy6CVutf0dpas+Femha/VH6/Lkw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0 <20.0.0"
       }
     },
     "packages/circuit-ui/node_modules/@testing-library/jest-dom": {
@@ -32763,7 +32778,7 @@
     },
     "packages/illustrations": {
       "name": "@sumup-oss/illustrations",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "fast-xml-parser": "^5.7.1",
@@ -32814,7 +32829,7 @@
       "version": "5.1.0",
       "dependencies": {
         "@astrojs/react": "^5.0.5",
-        "@sumup-oss/circuit-ui": "^11.19.0",
+        "@sumup-oss/circuit-ui": "^11.20.0",
         "@sumup-oss/design-tokens": "^10.2.0",
         "@sumup-oss/icons": "^6.17.0",
         "@sumup-oss/intl": "^3.5.1",
@@ -32840,6 +32855,18 @@
       "name": "@sumup-oss/cna-template",
       "version": "6.0.1",
       "license": "Apache-2.0"
+    },
+    "templates/nextjs/node_modules/@sumup-oss/icons": {
+      "version": "6.17.2",
+      "resolved": "https://registry.npmjs.org/@sumup-oss/icons/-/icons-6.17.2.tgz",
+      "integrity": "sha512-1qSx1K/A73JkliUPUcEavqnEaT/oZfqhfgmxkCdj+K79CGgixgUN6rXeEgCLy6CVutf0dpas+Femha/VH6/Lkw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0 <20.0.0"
+      }
     },
     "templates/nextjs/node_modules/@testing-library/jest-dom": {
       "version": "7.0.0",
@@ -32876,9 +32903,9 @@
       "version": "2.1.0",
       "dependencies": {
         "@next/bundle-analyzer": "^16.2.11",
-        "@sumup-oss/circuit-ui": "^11.19.0",
+        "@sumup-oss/circuit-ui": "^11.20.0",
         "@sumup-oss/design-tokens": "^10.2.0",
-        "@sumup-oss/icons": "^6.17.0",
+        "@sumup-oss/icons": "^6.17.2",
         "@sumup-oss/intl": "^3.5.1",
         "next": "^16.2.11",
         "react": "^19.2.6",

--- a/packages/circuit-ui/package.json
+++ b/packages/circuit-ui/package.json
@@ -72,7 +72,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@sumup-oss/design-tokens": "^10.0.0",
-    "@sumup-oss/icons": "^6.17.0",
+    "@sumup-oss/icons": "^6.17.2",
     "@sumup-oss/intl": "^3.5.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "7.0.0",

--- a/templates/nextjs/template/package.json
+++ b/templates/nextjs/template/package.json
@@ -18,7 +18,7 @@
     "@next/bundle-analyzer": "^16.2.11",
     "@sumup-oss/circuit-ui": "^11.20.0",
     "@sumup-oss/design-tokens": "^10.2.0",
-    "@sumup-oss/icons": "^6.17.0",
+    "@sumup-oss/icons": "^6.17.2",
     "@sumup-oss/intl": "^3.5.1",
     "next": "^16.2.11",
     "react": "^19.2.6",


### PR DESCRIPTION
## Purpose

Bump `@sumup-oss/icons` to fix missing flags in the PhoneNumberInput component. 
## Approach and changes

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
