### PR TITLE
Fix className merging in AspectRatio, Slide, and SlideImage (v11)

### DIFF
--- a/.changeset/fruity-canyons-pump.md
+++ b/.changeset/fruity-canyons-pump.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/circuit-ui": patch
+---
+
+Fixed merging of custom styles in the AspectRatio, Slide, and SlideImage components.

--- a/packages/circuit-ui/components/AspectRatio/AspectRatio.spec.tsx
+++ b/packages/circuit-ui/components/AspectRatio/AspectRatio.spec.tsx
@@ -34,6 +34,17 @@ describe('AspectRatio', () => {
     expect(wrapper?.className).toContain(className);
   });
 
+  it('should merge the custom class name of the child element', () => {
+    const className = 'foo';
+    const { container } = render(
+      <AspectRatio aspectRatio={1.618}>
+        <span className={className} />
+      </AspectRatio>,
+    );
+    const child = container.querySelector('span');
+    expect(child?.className).toContain(className);
+  });
+
   it('should forward a ref', () => {
     const ref = createRef<HTMLDivElement>();
     const { container } = render(

--- a/packages/circuit-ui/components/AspectRatio/AspectRatio.tsx
+++ b/packages/circuit-ui/components/AspectRatio/AspectRatio.tsx
@@ -58,7 +58,9 @@ export const AspectRatio = forwardRef<HTMLDivElement, AspectRatioProps>(
         }}
         {...props}
       >
-        {cloneElement(child, { className: classes.child })}
+        {cloneElement(child, {
+          className: clsx(child.props.className, classes.child),
+        })}
       </div>
     );
   },

--- a/packages/circuit-ui/components/Carousel/Carousel.tsx
+++ b/packages/circuit-ui/components/Carousel/Carousel.tsx
@@ -168,7 +168,9 @@ export function Carousel({
                   alt={slide.image.alt}
                   aspectRatio={aspectRatio}
                   aria-labelledby={
-                    getAriaLabelledBy ? getAriaLabelledBy(slide, index) : null
+                    getAriaLabelledBy
+                      ? getAriaLabelledBy(slide, index)
+                      : undefined
                   }
                 />
               </Slide>

--- a/packages/circuit-ui/components/Carousel/components/Slide/Slide.spec.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Slide/Slide.spec.tsx
@@ -18,8 +18,23 @@ import { describe, expect, it } from 'vitest';
 import { axe, render } from '../../../../util/test-utils.js';
 
 import { Slide } from './Slide.js';
+import { createRef } from 'react';
 
 describe('Slide', () => {
+  it('should merge a custom class name with the default ones', () => {
+    const className = 'foo';
+    const { container } = render(<Slide className={className}>content</Slide>);
+    const slide = container.querySelector('div');
+    expect(slide?.className).toContain(className);
+  });
+
+  it('should forward a ref', () => {
+    const ref = createRef<HTMLDivElement>();
+    const { container } = render(<Slide ref={ref}>content</Slide>);
+    const slide = container.querySelector('div');
+    expect(ref.current).toBe(slide);
+  });
+
   it('should have no accessibility violation', async () => {
     const { container } = render(<Slide>content</Slide>);
     const actual = await axe(container);

--- a/packages/circuit-ui/components/Carousel/components/Slide/Slide.tsx
+++ b/packages/circuit-ui/components/Carousel/components/Slide/Slide.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import type { HTMLAttributes, ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode, Ref } from 'react';
 
 import { ANIMATION_DURATION, SlideDirection } from '../../constants.js';
 import { clsx } from '../../../../styles/clsx.js';
@@ -22,6 +22,7 @@ import * as SlideService from './SlideService.js';
 import classes from './Slide.module.css';
 
 export interface SlideProps extends HTMLAttributes<HTMLDivElement> {
+  ref?: Ref<HTMLDivElement>;
   /**
    *  Index of a slide in a carousel (required for animation).
    */
@@ -63,6 +64,7 @@ export function Slide({
   slideDirection,
   animationDuration = ANIMATION_DURATION,
   children,
+  className,
   style = {},
   ...props
 }: SlideProps) {
@@ -90,7 +92,7 @@ export function Slide({
         '--slide-animation-duration': `${animationDuration}ms`,
         ...style,
       }}
-      className={classes.base}
+      className={clsx(classes.base, className)}
       {...props}
     >
       <div

--- a/packages/circuit-ui/components/Carousel/components/SlideImage/SlideImage.spec.tsx
+++ b/packages/circuit-ui/components/Carousel/components/SlideImage/SlideImage.spec.tsx
@@ -15,9 +15,10 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { axe, render } from '../../../../util/test-utils.js';
+import { axe, render, screen } from '../../../../util/test-utils.js';
 
 import { SlideImage } from './SlideImage.js';
+import { createRef } from 'react';
 
 const image = {
   src: '/images/sumup-coffee-transaction.jpg',
@@ -25,10 +26,23 @@ const image = {
 };
 
 describe('SlideImage', () => {
+  it('should merge a custom class name with the default ones', () => {
+    const className = 'foo';
+    render(<SlideImage {...image} className={className} />);
+    const slideImage = screen.getByRole('img');
+    screen.debug();
+    expect(slideImage?.className).toContain(className);
+  });
+
+  it('should forward a ref', () => {
+    const ref = createRef<HTMLImageElement>();
+    render(<SlideImage {...image} ref={ref} />);
+    const slideImage = screen.getByRole('img');
+    expect(ref.current).toBe(slideImage);
+  });
+
   it('should have no accessibility violations', async () => {
-    const { container } = render(
-      <SlideImage src={image.src} alt={image.alt} />,
-    );
+    const { container } = render(<SlideImage {...image} />);
     const actual = await axe(container);
 
     expect(actual).toHaveNoViolations();

--- a/packages/circuit-ui/components/Carousel/components/SlideImage/SlideImage.tsx
+++ b/packages/circuit-ui/components/Carousel/components/SlideImage/SlideImage.tsx
@@ -13,25 +13,14 @@
  * limitations under the License.
  */
 
-import { Image } from '../../../Image/index.js';
+import { Image, type ImageProps } from '../../../Image/index.js';
 import { AspectRatio } from '../../../AspectRatio/index.js';
 import { ASPECT_RATIO } from '../../constants.js';
+import { clsx } from '../../../../styles/clsx.js';
 
 import classes from './SlideImage.module.css';
 
-interface SlideImageProps {
-  /**
-   * Specifies the source URL of an image.
-   */
-  src: string;
-  /**
-   * [Images must have text alternatives](https://www.w3.org/WAI/tutorials/images/)
-   * that describe the information or function represented by them. This
-   * ensures that images can be used by people with various disabilities. Pass
-   * an empty string if the image is [decorative](https://www.w3.org/WAI/tutorials/images/decorative/),
-   * or a localized description if the image is [informative](https://www.w3.org/WAI/tutorials/images/informative/).
-   */
-  alt: string;
+interface SlideImageProps extends ImageProps {
   /**
    * Image aspect ratio.
    */
@@ -39,14 +28,13 @@ interface SlideImageProps {
 }
 
 export function SlideImage({
-  src,
-  alt,
   aspectRatio = ASPECT_RATIO,
+  className,
   ...props
 }: SlideImageProps) {
   return (
     <AspectRatio aspectRatio={aspectRatio} className={classes['aspect-ratio']}>
-      <Image src={src} alt={alt} className={classes.image} {...props} />
+      <Image className={clsx(classes.image, className)} {...props} />
     </AspectRatio>
   );
 }


### PR DESCRIPTION
## Purpose

@Marczerwinski discovered that passing custom class names to the Slide component overrides the internal styles.

## Approach and changes

- Merge a custom class name with the internal ones in the AspectRatio, Slide, and SlideImage components

## Definition of done

* [x] Development completed
* [x] Reviewers assigned
* [x] Unit and integration tests
* [x] Meets minimum browser support
* [x] Meets accessibility requirements
