### PR TITLE
Fix broken card icon

### DIFF
--- a/.changeset/tired-turtles-cheer.md
+++ b/.changeset/tired-turtles-cheer.md
@@ -1,0 +1,5 @@
+---
+"@sumup-oss/icons": patch
+---
+
+Fixed the asset url for the `sumup_card` icon in the CardScheme component.

--- a/packages/icons/src/helpers.ts
+++ b/packages/icons/src/helpers.ts
@@ -14,5 +14,8 @@
  */
 
 export function getIconURL(name: string, size?: string): string {
-  return `https://circuit.sumup.com/icons/v2/${name}${size ? `_${size}` : ''}.svg`;
+  // `sumup_card` was renamed to `sumup_card_scheme` in v12, and the original
+  // file was removed from the shared icon host
+  const asset = name === 'sumup_card' ? 'sumup_card_scheme' : name;
+  return `https://circuit.sumup.com/icons/v2/${asset}${size ? `_${size}` : ''}.svg`;
 }


### PR DESCRIPTION
Addresses [DSYS-XXXX](https://sumupteam.atlassian.net/browse/DSYS-XXXX)

## Purpose

The `sumup_card` card scheme icon is broken on v11 (e.g. [Storybook › Icons › CardScheme](https://circuit-v11.sumup-vercel.app/?path=/story/icons-cardscheme--base) and any consumer using `<CardScheme name="sumup_card" />`).

The underlying asset was renamed `sumup_card` → `sumup_card_scheme` in v12, and the original file was removed from the shared icon host, which v11 still requests by its old name:

- `https://circuit.sumup.com/icons/v2/sumup_card_32.svg` → **404**
- `https://circuit.sumup.com/icons/v2/sumup_card_scheme_32.svg` → 200

## Approach and changes

- Updated `getIconURL` to map the `sumup_card` name to `sumup_card_scheme` when building the URL.

_Describe how you solved the problem_

## Definition of done

* [ ] Development completed
* [ ] Reviewers assigned
* [ ] Unit and integration tests
* [ ] Meets minimum browser support
* [ ] Meets accessibility requirements
